### PR TITLE
Fix mobilitydatabase.org link in the GTFS README.md file

### DIFF
--- a/gtfs/README.md
+++ b/gtfs/README.md
@@ -9,7 +9,7 @@ associated geographic information. GTFS-RT is a real-time extension to GTFS that
 allows public transportation agencies to provide real-time updates about their
 fleet. Over 2000 transit agencies worldwide provide GTFS and GTFS-RT data.
 
-The [Mobility Database](mobilitydatabase.org) provides a comprehensive list of GTFS
+The [Mobility Database](https://mobilitydatabase.org/) provides a comprehensive list of GTFS
 and GTFS-RT feeds from around the world. 
 
 ## Key Features:


### PR DESCRIPTION
Just a simple PR to fix the link in the GTFS README.md file.