### PR TITLE
Add AviationWeather.gov bridge (METAR, SIGMET, stations)

### DIFF
--- a/aviationweather/CONTAINER.md
+++ b/aviationweather/CONTAINER.md
@@ -1,0 +1,100 @@
+# AviationWeather.gov Bridge to Apache Kafka, Azure Event Hubs, and Fabric Event Streams
+
+This container image provides a bridge between the NOAA AviationWeather.gov API and Apache Kafka, Azure Event Hubs, and Fabric Event Streams. The bridge polls aviation weather data (METAR observations, SIGMET advisories, and station metadata) and forwards it to the configured Kafka endpoints.
+
+## AviationWeather.gov API
+
+The Aviation Weather Center (AWC), operated by NOAA's National Weather Service, provides publicly available aviation weather data. The API delivers METAR surface observations from thousands of global airports, TAF forecasts, and SIGMET advisories covering hazardous weather. Data updates approximately every minute for METARs and SIGMETs.
+
+## Functionality
+
+The bridge polls the AviationWeather.gov JSON API for METAR observations and SIGMET advisories and writes them to a Kafka topic as [CloudEvents](https://cloudevents.io/) in JSON format, documented in [EVENTS.md](EVENTS.md). Station reference data is emitted at startup and refreshed periodically. Previously seen observations are tracked in a state file to prevent duplicates.
+
+## Database Schemas and Handling
+
+If you want to build a full data pipeline with all events ingested into a
+database, the integration with Fabric Eventhouse and Azure Data Explorer is
+described in [DATABASE.md](../DATABASE.md).
+
+## Installing the Container Image
+
+Pull the container image from the GitHub Container Registry:
+
+```shell
+$ docker pull ghcr.io/clemensv/real-time-sources-aviationweather:latest
+```
+
+To use it as a base image in a Dockerfile:
+
+```dockerfile
+FROM ghcr.io/clemensv/real-time-sources-aviationweather:latest
+```
+
+## Using the Container Image
+
+The container starts the bridge, polling the AviationWeather.gov API and writing observations to Kafka, Azure Event Hubs, or Fabric Event Streams.
+
+### With a Kafka Broker
+
+Ensure you have a Kafka broker configured with TLS and SASL PLAIN authentication. Run the container:
+
+```shell
+$ docker run --rm \
+    -e KAFKA_BOOTSTRAP_SERVERS='<kafka-bootstrap-servers>' \
+    -e KAFKA_TOPIC='<kafka-topic>' \
+    -e SASL_USERNAME='<sasl-username>' \
+    -e SASL_PASSWORD='<sasl-password>' \
+    ghcr.io/clemensv/real-time-sources-aviationweather:latest
+```
+
+### With Azure Event Hubs or Fabric Event Streams
+
+Use the connection string to establish a connection to the service. Obtain the connection string from the Azure portal, Azure CLI, or the "custom endpoint" of a Fabric Event Stream.
+
+```shell
+$ docker run --rm \
+    -e CONNECTION_STRING='<connection-string>' \
+    ghcr.io/clemensv/real-time-sources-aviationweather:latest
+```
+
+### Preserving State Between Restarts
+
+To preserve deduplication state between restarts, mount a volume and set the `AVIATIONWEATHER_LAST_POLLED_FILE` environment variable:
+
+```shell
+$ docker run --rm \
+    -v /path/to/state:/mnt/fileshare \
+    -e AVIATIONWEATHER_LAST_POLLED_FILE='/mnt/fileshare/aviationweather_last_polled.json' \
+    ... other args ... \
+    ghcr.io/clemensv/real-time-sources-aviationweather:latest
+```
+
+## Environment Variables
+
+### `CONNECTION_STRING`
+
+An Azure Event Hubs-style connection string used to connect to Azure Event Hubs or Fabric Event Streams. This replaces the need for `KAFKA_BOOTSTRAP_SERVERS`, `SASL_USERNAME`, and `SASL_PASSWORD`.
+
+### `KAFKA_BOOTSTRAP_SERVERS`
+
+The address of the Kafka broker. Provide a comma-separated list of host and port pairs (e.g., `broker1:9092,broker2:9092`). The client communicates with TLS-enabled Kafka brokers.
+
+### `KAFKA_TOPIC`
+
+The Kafka topic to send messages to.
+
+### `SASL_USERNAME`
+
+The username for SASL PLAIN authentication with the Kafka broker.
+
+### `SASL_PASSWORD`
+
+The password for SASL PLAIN authentication with the Kafka broker.
+
+### `AVIATIONWEATHER_LAST_POLLED_FILE`
+
+The file path for storing deduplication state. Defaults to `/mnt/fileshare/aviationweather_last_polled.json` inside the container.
+
+### `AVIATIONWEATHER_STATIONS`
+
+Comma-separated list of ICAO station IDs to monitor. Defaults to `KJFK,KLAX,KORD,KATL,EGLL,LFPG,EDDF,RJTT,YSSY,ZBAA`.

--- a/aviationweather/Dockerfile
+++ b/aviationweather/Dockerfile
@@ -1,0 +1,24 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/aviationweather"
+LABEL org.opencontainers.image.title="AviationWeather.gov METAR/SIGMET bridge to Kafka endpoints"
+LABEL org.opencontainers.image.description="This container is a bridge between the NOAA AviationWeather.gov API (METAR observations, SIGMET advisories, station data) and Kafka endpoints. It polls aviation weather data and forwards it to the configured Kafka endpoints."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/aviationweather/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install the required Python packages
+RUN pip install .
+
+# Define environment variables (default values)
+ENV AVIATIONWEATHER_LAST_POLLED_FILE="/mnt/fileshare/aviationweather_last_polled.json"
+ENV CONNECTION_STRING=""
+
+# Run the application
+CMD ["python", "-m", "aviationweather"]

--- a/aviationweather/EVENTS.md
+++ b/aviationweather/EVENTS.md
@@ -1,0 +1,111 @@
+# AviationWeather.gov Bridge Events
+
+This document describes the events emitted by the AviationWeather.gov Bridge.
+
+- [gov.noaa.aviationweather](#message-group-govnoaaaviationweather)
+  - [gov.noaa.aviationweather.Station](#message-govnoaaaviationweatherstation)
+  - [gov.noaa.aviationweather.Metar](#message-govnoaaaviationweathermetar)
+  - [gov.noaa.aviationweather.Sigmet](#message-govnoaaaviationweathersigmet)
+
+---
+
+## Message Group: gov.noaa.aviationweather
+
+---
+
+### Message: gov.noaa.aviationweather.Station
+
+*Reference data — sent at startup and refreshed periodically.*
+
+#### CloudEvents Attributes:
+
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` | CloudEvent type | `string` | `True` | `gov.noaa.aviationweather.Station` |
+| `source` | CloudEvent source | `string` | `True` | `https://aviationweather.gov` |
+| `subject` | CloudEvent subject | `uritemplate` | `True` | `{icao_id}` |
+
+#### Schema: Station
+
+| **Field Name** | **Type** | **Unit** | **Description** |
+|----------------|----------|----------|-----------------|
+| `icao_id` | *string* | — | ICAO station identifier (e.g. 'KJFK') |
+| `iata_id` | *string* | — | IATA airport code (e.g. 'JFK') |
+| `faa_id` | *string* | — | FAA location identifier |
+| `wmo_id` | *string* | — | WMO station identifier |
+| `name` | *string* | — | Human-readable station name |
+| `latitude` | *number* | degrees | Station latitude |
+| `longitude` | *number* | degrees | Station longitude |
+| `elevation` | *number* | meters | Station elevation |
+| `state` | *string* | — | State/province code |
+| `country` | *string* | — | ISO 3166-1 alpha-2 country code |
+| `site_type` | *string* | — | Available data products (e.g. 'METAR,TAF') |
+
+---
+
+### Message: gov.noaa.aviationweather.Metar
+
+#### CloudEvents Attributes:
+
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` | CloudEvent type | `string` | `True` | `gov.noaa.aviationweather.Metar` |
+| `source` | CloudEvent source | `string` | `True` | `https://aviationweather.gov` |
+| `subject` | CloudEvent subject | `uritemplate` | `True` | `{icao_id}` |
+
+#### Schema: Metar
+
+| **Field Name** | **Type** | **Unit** | **Description** |
+|----------------|----------|----------|-----------------|
+| `icao_id` | *string* | — | ICAO station identifier |
+| `obs_time` | *string (date-time)* | — | Observation time (ISO 8601 UTC) |
+| `report_time` | *string (date-time)* | — | Report time (ISO 8601 UTC) |
+| `temp` | *number* | °C | Air temperature |
+| `dewp` | *number* | °C | Dewpoint temperature |
+| `wdir` | *integer* | degrees | Wind direction |
+| `wspd` | *integer* | knots | Sustained wind speed |
+| `wgst` | *integer* | knots | Wind gust speed |
+| `visib` | *string* | statute miles | Prevailing visibility |
+| `altim` | *number* | hPa | Altimeter setting |
+| `slp` | *number* | hPa | Sea level pressure |
+| `qc_field` | *integer* | — | Quality control flag |
+| `wx_string` | *string* | — | Present weather codes |
+| `metar_type` | *string* | — | Report type (METAR/SPECI) |
+| `raw_ob` | *string* | — | Raw METAR text |
+| `latitude` | *number* | degrees | Station latitude |
+| `longitude` | *number* | degrees | Station longitude |
+| `elevation` | *number* | meters | Station elevation |
+| `flt_cat` | *string* | — | Flight category (VFR/MVFR/IFR/LIFR) |
+| `clouds` | *string* | — | JSON-encoded cloud layers |
+| `name` | *string* | — | Station name |
+
+---
+
+### Message: gov.noaa.aviationweather.Sigmet
+
+#### CloudEvents Attributes:
+
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` | CloudEvent type | `string` | `True` | `gov.noaa.aviationweather.Sigmet` |
+| `source` | CloudEvent source | `string` | `True` | `https://aviationweather.gov` |
+| `subject` | CloudEvent subject | `uritemplate` | `True` | `{icao_id}` |
+
+#### Schema: Sigmet
+
+| **Field Name** | **Type** | **Unit** | **Description** |
+|----------------|----------|----------|-----------------|
+| `icao_id` | *string* | — | Issuing office ICAO ID |
+| `series_id` | *string* | — | SIGMET series identifier |
+| `valid_time_from` | *string (date-time)* | — | Validity start (ISO 8601 UTC) |
+| `valid_time_to` | *string (date-time)* | — | Validity end (ISO 8601 UTC) |
+| `hazard` | *string* | — | Hazard type (CONVECTIVE, TS, TURB, ICE, VA) |
+| `qualifier` | *string* | — | Hazard qualifier (EMBD, SEV, OBSC) |
+| `sigmet_type` | *string* | — | Classification (SIGMET/ISIGMET) |
+| `altitude_hi` | *integer* | feet | Upper altitude limit |
+| `altitude_low` | *integer* | feet | Lower altitude limit |
+| `movement_dir` | *string* | — | Direction of movement |
+| `movement_spd` | *string* | — | Speed of movement |
+| `severity` | *integer* | — | Severity level |
+| `raw_sigmet` | *string* | — | Raw SIGMET text |
+| `coords` | *string* | — | JSON-encoded polygon coordinates |

--- a/aviationweather/README.md
+++ b/aviationweather/README.md
@@ -1,0 +1,94 @@
+# AviationWeather.gov Bridge
+
+## Overview
+
+**AviationWeather.gov Bridge** polls the NOAA Aviation Weather Center API for METAR observations, SIGMET advisories, and station reference data, then sends them to a Kafka topic as CloudEvents. The tool tracks previously seen observations to avoid sending duplicates.
+
+## Key Features
+
+- **METAR Observations**: Fetch aviation weather observations for configurable ICAO stations from `https://aviationweather.gov/api/data/metar`.
+- **SIGMET Advisories**: Fetch both US domestic and international SIGMETs from `https://aviationweather.gov/api/data/airsigmet` and `https://aviationweather.gov/api/data/isigmet`.
+- **Station Reference Data**: Emit station metadata at startup and refresh periodically.
+- **Deduplication**: Tracks last seen METAR observation time per station and SIGMET identity to avoid reprocessing.
+- **Kafka Integration**: Send events to a Kafka topic using SASL PLAIN authentication.
+- **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+
+## Installation
+
+The tool is written in Python and requires Python 3.10 or later. You can download Python from [here](https://www.python.org/downloads/) or from the Microsoft Store if you are on Windows.
+
+### Installation Steps
+
+```bash
+pip install git+https://github.com/clemensv/real-time-sources#subdirectory=aviationweather
+```
+
+If you clone the repository:
+
+```bash
+git clone https://github.com/clemensv/real-time-sources.git
+cd real-time-sources/aviationweather
+pip install .
+```
+
+For a packaged install, consider using the [CONTAINER.md](CONTAINER.md) instructions.
+
+## How to Use
+
+After installation, the tool can be run using `python -m aviationweather`. It supports several arguments for configuring the polling process and sending data to Kafka.
+
+### Command-Line Arguments
+
+- `--last-polled-file`: Path to state file for deduplication. Defaults to `~/.aviationweather_last_polled.json`.
+- `--kafka-bootstrap-servers`: Comma-separated list of Kafka bootstrap servers.
+- `--kafka-topic`: The Kafka topic to send messages to.
+- `--sasl-username`: Username for SASL PLAIN authentication.
+- `--sasl-password`: Password for SASL PLAIN authentication.
+- `--connection-string`: Microsoft Event Hubs or Microsoft Fabric Event Stream connection string (overrides other Kafka parameters).
+- `--stations`: Comma-separated list of ICAO station IDs to monitor (default: `KJFK,KLAX,KORD,KATL,EGLL,LFPG,EDDF,RJTT,YSSY,ZBAA`).
+- `--metar-poll-interval`: METAR poll interval in seconds (default: 60).
+- `--sigmet-poll-interval`: SIGMET poll interval in seconds (default: 120).
+
+### Example Usage
+
+#### Using a Connection String
+
+```bash
+python -m aviationweather --connection-string "<your_connection_string>"
+```
+
+#### Using Kafka Parameters Directly
+
+```bash
+python -m aviationweather --kafka-bootstrap-servers "<bootstrap_servers>" --kafka-topic "<topic_name>" --sasl-username "<username>" --sasl-password "<password>"
+```
+
+#### Custom Station List
+
+```bash
+python -m aviationweather --connection-string "<conn>" --stations "KJFK,KLAX,EGLL"
+```
+
+### Connection String Format
+
+```
+Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<policy>;SharedAccessKey=<key>;EntityPath=<hub>
+```
+
+### Environment Variables
+
+- `CONNECTION_STRING`: Microsoft Event Hubs or Microsoft Fabric Event Stream connection string.
+- `AVIATIONWEATHER_LAST_POLLED_FILE`: File to store deduplication state.
+- `AVIATIONWEATHER_STATIONS`: Comma-separated list of ICAO station IDs.
+
+## Data Source
+
+The NOAA Aviation Weather Center (AWC) provides publicly available aviation weather data via a REST API. METARs are updated approximately every minute. SIGMETs cover hazardous weather conditions including convective activity, turbulence, icing, and volcanic ash.
+
+- **API base**: `https://aviationweather.gov/api/data/`
+- **Documentation**: `https://aviationweather.gov/data/api/`
+- **License**: US Public Domain
+
+## License
+
+[MIT](../LICENSE.md)

--- a/aviationweather/aviationweather/__main__.py
+++ b/aviationweather/aviationweather/__main__.py
@@ -1,0 +1,3 @@
+from aviationweather.aviationweather import main
+
+main()

--- a/aviationweather/aviationweather/aviationweather.py
+++ b/aviationweather/aviationweather/aviationweather.py
@@ -1,0 +1,670 @@
+"""
+AviationWeather.gov Bridge
+Polls the AviationWeather.gov API for METAR observations, SIGMET advisories,
+and station reference data, then sends them to a Kafka topic as CloudEvents.
+"""
+
+# pylint: disable=line-too-long
+
+import os
+import json
+import sys
+import time
+from typing import Dict, List, Optional, Set, Tuple
+from datetime import datetime, timezone
+import argparse
+import requests
+from aviationweather_producer_data import Metar, Sigmet, Station
+from aviationweather_producer_kafka_producer.producer import GovNoaaAviationweatherEventProducer
+
+
+API_BASE = "https://aviationweather.gov/api/data"
+DEFAULT_STATIONS = "KJFK,KLAX,KORD,KATL,EGLL,LFPG,EDDF,RJTT,YSSY,ZBAA"
+METAR_POLL_INTERVAL = 60
+SIGMET_POLL_INTERVAL = 120
+STATION_REFRESH_HOURS = 24
+
+
+class AviationWeatherPoller:
+    """
+    Polls AviationWeather.gov API for METAR observations, SIGMETs, and
+    station reference data, sending them to Kafka as CloudEvents.
+    """
+
+    def __init__(self, kafka_config: Dict[str, str], kafka_topic: str,
+                 last_polled_file: str, station_ids: str = DEFAULT_STATIONS,
+                 metar_poll_interval: int = METAR_POLL_INTERVAL,
+                 sigmet_poll_interval: int = SIGMET_POLL_INTERVAL):
+        """
+        Initialize the AviationWeatherPoller.
+
+        Args:
+            kafka_config: Kafka configuration settings.
+            kafka_topic: Kafka topic to send messages to.
+            last_polled_file: File to store last seen timestamps for deduplication.
+            station_ids: Comma-separated list of ICAO station IDs to monitor.
+            metar_poll_interval: Seconds between METAR polls.
+            sigmet_poll_interval: Seconds between SIGMET polls.
+        """
+        self.kafka_topic = kafka_topic
+        self.last_polled_file = last_polled_file
+        self.station_ids = station_ids
+        self.metar_poll_interval = metar_poll_interval
+        self.sigmet_poll_interval = sigmet_poll_interval
+        from confluent_kafka import Producer as KafkaProducer
+        kafka_producer = KafkaProducer(kafka_config)
+        self.producer = GovNoaaAviationweatherEventProducer(kafka_producer, kafka_topic)
+
+    @staticmethod
+    def epoch_to_iso(epoch_val) -> Optional[str]:
+        """
+        Convert a Unix epoch timestamp (int or float) to an ISO 8601 UTC string.
+
+        Args:
+            epoch_val: Unix timestamp in seconds.
+
+        Returns:
+            ISO 8601 UTC datetime string, or None on failure.
+        """
+        if epoch_val is None:
+            return None
+        try:
+            dt = datetime.fromtimestamp(int(epoch_val), tz=timezone.utc)
+            return dt.isoformat()
+        except (ValueError, TypeError, OSError):
+            return None
+
+    @staticmethod
+    def safe_int(value) -> Optional[int]:
+        """Safely convert a value to int, returning None on failure."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def safe_float(value) -> Optional[float]:
+        """Safely convert a value to float, returning None on failure."""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def fetch_metar_json(station_ids: str) -> List[dict]:
+        """
+        Fetch METAR observations from the AviationWeather.gov API.
+
+        Args:
+            station_ids: Comma-separated ICAO station identifiers.
+
+        Returns:
+            List of METAR dictionaries from the API.
+        """
+        try:
+            url = f"{API_BASE}/metar?ids={station_ids}&format=json"
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, list):
+                return data
+            return []
+        except Exception as err:
+            print(f"Error fetching METARs: {err}")
+            return []
+
+    @staticmethod
+    def fetch_station_json(station_ids: str) -> List[dict]:
+        """
+        Fetch station metadata from the AviationWeather.gov API.
+
+        Args:
+            station_ids: Comma-separated ICAO station identifiers.
+
+        Returns:
+            List of station info dictionaries from the API.
+        """
+        try:
+            url = f"{API_BASE}/stationinfo?ids={station_ids}&format=json"
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, list):
+                return data
+            return []
+        except Exception as err:
+            print(f"Error fetching station info: {err}")
+            return []
+
+    @staticmethod
+    def fetch_airsigmet_json() -> List[dict]:
+        """
+        Fetch US domestic SIGMETs (AIRMETs/SIGMETs) from the API.
+
+        Returns:
+            List of SIGMET dictionaries.
+        """
+        try:
+            url = f"{API_BASE}/airsigmet?format=json"
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, list):
+                return data
+            return []
+        except Exception as err:
+            print(f"Error fetching US SIGMETs: {err}")
+            return []
+
+    @staticmethod
+    def fetch_isigmet_json() -> List[dict]:
+        """
+        Fetch international SIGMETs from the API.
+
+        Returns:
+            List of international SIGMET dictionaries.
+        """
+        try:
+            url = f"{API_BASE}/isigmet?format=json"
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, list):
+                return data
+            return []
+        except Exception as err:
+            print(f"Error fetching international SIGMETs: {err}")
+            return []
+
+    @classmethod
+    def parse_station(cls, raw: dict) -> Optional[Station]:
+        """
+        Parse a station info API response dict into a Station dataclass.
+
+        Args:
+            raw: Station info dictionary from the API.
+
+        Returns:
+            Station dataclass or None if required fields are missing.
+        """
+        icao_id = raw.get("icaoId")
+        if not icao_id:
+            return None
+        name = raw.get("site") or raw.get("name") or icao_id
+        lat = cls.safe_float(raw.get("lat"))
+        lon = cls.safe_float(raw.get("lon"))
+        if lat is None or lon is None:
+            return None
+        site_type_list = raw.get("siteType")
+        site_type = ",".join(site_type_list) if isinstance(site_type_list, list) else None
+        return Station(
+            icao_id=icao_id,
+            iata_id=raw.get("iataId"),
+            faa_id=raw.get("faaId"),
+            wmo_id=raw.get("wmoId"),
+            name=name,
+            latitude=lat,
+            longitude=lon,
+            elevation=cls.safe_float(raw.get("elev")),
+            state=raw.get("state"),
+            country=raw.get("country"),
+            site_type=site_type,
+        )
+
+    @classmethod
+    def parse_metar(cls, raw: dict) -> Optional[Metar]:
+        """
+        Parse a METAR API response dict into a Metar dataclass.
+
+        Args:
+            raw: METAR dictionary from the API.
+
+        Returns:
+            Metar dataclass or None if required fields are missing.
+        """
+        icao_id = raw.get("icaoId")
+        if not icao_id:
+            return None
+        raw_ob = raw.get("rawOb")
+        if not raw_ob:
+            return None
+
+        obs_time_epoch = raw.get("obsTime")
+        obs_time = cls.epoch_to_iso(obs_time_epoch)
+        if not obs_time:
+            return None
+
+        report_time = raw.get("reportTime")
+        if isinstance(report_time, str):
+            try:
+                datetime.fromisoformat(report_time.replace("Z", "+00:00"))
+            except ValueError:
+                report_time = None
+
+        clouds_raw = raw.get("clouds")
+        clouds_str = json.dumps(clouds_raw) if clouds_raw is not None else None
+
+        visib = raw.get("visib")
+        visib_str = str(visib) if visib is not None else None
+
+        return Metar(
+            icao_id=icao_id,
+            obs_time=obs_time,
+            report_time=report_time,
+            temp=cls.safe_float(raw.get("temp")),
+            dewp=cls.safe_float(raw.get("dewp")),
+            wdir=cls.safe_int(raw.get("wdir")),
+            wspd=cls.safe_int(raw.get("wspd")),
+            wgst=cls.safe_int(raw.get("wgst")),
+            visib=visib_str,
+            altim=cls.safe_float(raw.get("altim")),
+            slp=cls.safe_float(raw.get("slp")),
+            qc_field=cls.safe_int(raw.get("qcField")),
+            wx_string=raw.get("wxString"),
+            metar_type=raw.get("metarType"),
+            raw_ob=raw_ob,
+            latitude=cls.safe_float(raw.get("lat")),
+            longitude=cls.safe_float(raw.get("lon")),
+            elevation=cls.safe_float(raw.get("elev")),
+            flt_cat=raw.get("fltCat"),
+            clouds=clouds_str,
+            name=raw.get("name"),
+        )
+
+    @classmethod
+    def parse_us_sigmet(cls, raw: dict) -> Optional[Sigmet]:
+        """
+        Parse a US domestic SIGMET API response dict into a Sigmet dataclass.
+
+        Args:
+            raw: US SIGMET dictionary from the API.
+
+        Returns:
+            Sigmet dataclass or None if required fields are missing.
+        """
+        icao_id = raw.get("icaoId")
+        series_id = raw.get("seriesId")
+        if not icao_id or not series_id:
+            return None
+
+        valid_from = cls.epoch_to_iso(raw.get("validTimeFrom"))
+        valid_to = cls.epoch_to_iso(raw.get("validTimeTo"))
+        if not valid_from or not valid_to:
+            return None
+
+        coords_raw = raw.get("coords")
+        coords_str = json.dumps(coords_raw) if coords_raw is not None else None
+
+        movement_dir = raw.get("movementDir")
+        movement_spd = raw.get("movementSpd")
+
+        return Sigmet(
+            icao_id=icao_id,
+            series_id=series_id,
+            valid_time_from=valid_from,
+            valid_time_to=valid_to,
+            hazard=raw.get("hazard"),
+            qualifier=None,
+            sigmet_type=raw.get("airSigmetType", "SIGMET"),
+            altitude_hi=cls.safe_int(raw.get("altitudeHi1")),
+            altitude_low=cls.safe_int(raw.get("altitudeLow1")),
+            movement_dir=str(movement_dir) if movement_dir is not None else None,
+            movement_spd=str(movement_spd) if movement_spd is not None else None,
+            severity=cls.safe_int(raw.get("severity")),
+            raw_sigmet=raw.get("rawAirSigmet"),
+            coords=coords_str,
+        )
+
+    @classmethod
+    def parse_intl_sigmet(cls, raw: dict) -> Optional[Sigmet]:
+        """
+        Parse an international SIGMET API response dict into a Sigmet dataclass.
+
+        Args:
+            raw: International SIGMET dictionary from the API.
+
+        Returns:
+            Sigmet dataclass or None if required fields are missing.
+        """
+        icao_id = raw.get("icaoId")
+        series_id = raw.get("seriesId")
+        if not icao_id or not series_id:
+            return None
+
+        valid_from = cls.epoch_to_iso(raw.get("validTimeFrom"))
+        valid_to = cls.epoch_to_iso(raw.get("validTimeTo"))
+        if not valid_from or not valid_to:
+            return None
+
+        coords_raw = raw.get("coords")
+        coords_str = json.dumps(coords_raw) if coords_raw is not None else None
+
+        return Sigmet(
+            icao_id=icao_id,
+            series_id=series_id,
+            valid_time_from=valid_from,
+            valid_time_to=valid_to,
+            hazard=raw.get("hazard"),
+            qualifier=raw.get("qualifier"),
+            sigmet_type="ISIGMET",
+            altitude_hi=cls.safe_int(raw.get("top")),
+            altitude_low=cls.safe_int(raw.get("base")),
+            movement_dir=raw.get("dir"),
+            movement_spd=raw.get("spd"),
+            severity=None,
+            raw_sigmet=raw.get("rawSigmet"),
+            coords=coords_str,
+        )
+
+    @staticmethod
+    def sigmet_dedup_key(sigmet: Sigmet) -> str:
+        """
+        Generate a deduplication key for a SIGMET.
+
+        Args:
+            sigmet: Sigmet dataclass.
+
+        Returns:
+            A string key unique to this SIGMET.
+        """
+        return f"{sigmet.icao_id}:{sigmet.series_id}:{sigmet.valid_time_from}:{sigmet.valid_time_to}"
+
+    def load_state(self) -> Dict:
+        """
+        Load the persisted state from disk.
+
+        Returns:
+            State dict with metar_timestamps and sigmet_keys.
+        """
+        try:
+            if os.path.exists(self.last_polled_file):
+                with open(self.last_polled_file, 'r', encoding='utf-8') as f:
+                    state = json.load(f)
+                    if isinstance(state, dict):
+                        return {
+                            "metar_timestamps": state.get("metar_timestamps", {}),
+                            "sigmet_keys": state.get("sigmet_keys", []),
+                        }
+        except Exception:
+            pass
+        return {"metar_timestamps": {}, "sigmet_keys": []}
+
+    def save_state(self, state: Dict):
+        """
+        Save the current state to disk for deduplication across restarts.
+
+        Args:
+            state: State dictionary.
+        """
+        try:
+            dir_name = os.path.dirname(self.last_polled_file)
+            if dir_name:
+                os.makedirs(dir_name, exist_ok=True)
+            with open(self.last_polled_file, 'w', encoding='utf-8') as f:
+                json.dump(state, f, indent=2)
+        except Exception as e:
+            print(f"Error saving state: {e}")
+
+    def emit_stations(self) -> int:
+        """
+        Fetch and emit station reference data.
+
+        Returns:
+            Number of stations emitted.
+        """
+        raw_stations = self.fetch_station_json(self.station_ids)
+        count = 0
+        for raw in raw_stations:
+            station = self.parse_station(raw)
+            if station:
+                self.producer.send_gov_noaa_aviationweather_station(
+                    station.icao_id, station, flush_producer=False)
+                count += 1
+        if count > 0:
+            self.producer.producer.flush()
+        return count
+
+    def emit_metars(self, metar_timestamps: Dict[str, str]) -> Tuple[int, Dict[str, str]]:
+        """
+        Fetch, deduplicate, and emit METAR observations.
+
+        Args:
+            metar_timestamps: Dict of icao_id -> last obs_time for dedup.
+
+        Returns:
+            Tuple of (new events count, updated timestamps dict).
+        """
+        raw_metars = self.fetch_metar_json(self.station_ids)
+        count = 0
+        for raw in raw_metars:
+            metar = self.parse_metar(raw)
+            if metar is None:
+                continue
+            if metar_timestamps.get(metar.icao_id) == metar.obs_time:
+                continue
+            self.producer.send_gov_noaa_aviationweather_metar(
+                metar.icao_id, metar, flush_producer=False)
+            metar_timestamps[metar.icao_id] = metar.obs_time
+            count += 1
+        if count > 0:
+            self.producer.producer.flush()
+        return count, metar_timestamps
+
+    def emit_sigmets(self, seen_keys: Set[str]) -> Tuple[int, Set[str]]:
+        """
+        Fetch, deduplicate, and emit SIGMETs (both US and international).
+
+        Args:
+            seen_keys: Set of previously seen SIGMET dedup keys.
+
+        Returns:
+            Tuple of (new events count, updated seen keys set).
+        """
+        all_sigmets: List[Sigmet] = []
+
+        for raw in self.fetch_airsigmet_json():
+            sigmet = self.parse_us_sigmet(raw)
+            if sigmet:
+                all_sigmets.append(sigmet)
+
+        for raw in self.fetch_isigmet_json():
+            sigmet = self.parse_intl_sigmet(raw)
+            if sigmet:
+                all_sigmets.append(sigmet)
+
+        count = 0
+        current_keys: Set[str] = set()
+        for sigmet in all_sigmets:
+            key = self.sigmet_dedup_key(sigmet)
+            current_keys.add(key)
+            if key in seen_keys:
+                continue
+            self.producer.send_gov_noaa_aviationweather_sigmet(
+                sigmet.icao_id, sigmet, flush_producer=False)
+            count += 1
+        if count > 0:
+            self.producer.producer.flush()
+        return count, current_keys
+
+    def poll_and_send(self, once: bool = False):
+        """
+        Main polling loop. Emits station reference data at startup, then
+        polls for METARs and SIGMETs, deduplicating by observation time
+        and SIGMET identity.
+
+        Args:
+            once: Run one poll iteration and return. Intended for tests.
+        """
+        print(f"Starting AviationWeather.gov poller")
+        print(f"  Stations: {self.station_ids}")
+        print(f"  METAR poll interval: {self.metar_poll_interval}s")
+        print(f"  SIGMET poll interval: {self.sigmet_poll_interval}s")
+        print(f"  Kafka topic: {self.kafka_topic}")
+
+        # Emit reference data at startup
+        print("Fetching and sending station reference data...")
+        station_count = self.emit_stations()
+        print(f"Sent {station_count} station(s) as reference data")
+
+        state = self.load_state()
+        metar_timestamps = state.get("metar_timestamps", {})
+        seen_sigmet_keys: Set[str] = set(state.get("sigmet_keys", []))
+        last_sigmet_poll = 0.0
+        last_station_refresh = time.time()
+
+        while True:
+            try:
+                now = time.time()
+
+                # Poll METARs
+                metar_count, metar_timestamps = self.emit_metars(metar_timestamps)
+                if metar_count > 0:
+                    print(f"Sent {metar_count} new METAR(s)")
+
+                # Poll SIGMETs at their own interval
+                if now - last_sigmet_poll >= self.sigmet_poll_interval:
+                    sigmet_count, seen_sigmet_keys = self.emit_sigmets(seen_sigmet_keys)
+                    if sigmet_count > 0:
+                        print(f"Sent {sigmet_count} new SIGMET(s)")
+                    last_sigmet_poll = now
+
+                # Re-emit station reference data periodically
+                if now - last_station_refresh >= STATION_REFRESH_HOURS * 3600:
+                    print("Refreshing station reference data...")
+                    refresh_count = self.emit_stations()
+                    print(f"Refreshed {refresh_count} station(s)")
+                    last_station_refresh = now
+
+                # Save state
+                state = {
+                    "metar_timestamps": metar_timestamps,
+                    "sigmet_keys": list(seen_sigmet_keys),
+                }
+                self.save_state(state)
+
+            except Exception as e:
+                print(f"Error in polling loop: {e}")
+
+            if once:
+                break
+
+            time.sleep(self.metar_poll_interval)
+
+
+def parse_connection_string(connection_string: str) -> Dict[str, str]:
+    """
+    Parse an Azure Event Hubs-style connection string and extract Kafka parameters.
+
+    Args:
+        connection_string: The connection string.
+
+    Returns:
+        Dict with bootstrap.servers, kafka_topic, sasl.username, sasl.password.
+    """
+    config_dict: Dict[str, str] = {}
+    try:
+        for part in connection_string.split(';'):
+            if 'Endpoint' in part:
+                config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                    '"').replace('sb://', '').replace('/', '') + ':9093'
+            elif 'EntityPath' in part:
+                config_dict['kafka_topic'] = part.split('=')[1].strip('"')
+            elif 'SharedAccessKeyName' in part:
+                config_dict['sasl.username'] = '$ConnectionString'
+            elif 'SharedAccessKey' in part:
+                config_dict['sasl.password'] = connection_string.strip()
+            elif 'BootstrapServer' in part:
+                config_dict['bootstrap.servers'] = part.split('=', 1)[1].strip()
+    except IndexError as e:
+        raise ValueError("Invalid connection string format") from e
+    if 'sasl.username' in config_dict:
+        config_dict['security.protocol'] = 'SASL_SSL'
+        config_dict['sasl.mechanism'] = 'PLAIN'
+    return config_dict
+
+
+def main():
+    """
+    Main function to parse arguments and start the AviationWeather.gov poller.
+    """
+    parser = argparse.ArgumentParser(description="AviationWeather.gov METAR/SIGMET Bridge")
+    parser.add_argument('--last-polled-file', type=str,
+                        help="File to store last seen state for deduplication")
+    parser.add_argument('--kafka-bootstrap-servers', type=str,
+                        help="Comma separated list of Kafka bootstrap servers")
+    parser.add_argument('--kafka-topic', type=str,
+                        help="Kafka topic to send messages to")
+    parser.add_argument('--sasl-username', type=str,
+                        help="Username for SASL PLAIN authentication")
+    parser.add_argument('--sasl-password', type=str,
+                        help="Password for SASL PLAIN authentication")
+    parser.add_argument('--connection-string', type=str,
+                        help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--stations', type=str,
+                        help=f"Comma-separated list of ICAO station IDs (default: {DEFAULT_STATIONS})")
+    parser.add_argument('--metar-poll-interval', type=int, default=METAR_POLL_INTERVAL,
+                        help=f"METAR poll interval in seconds (default: {METAR_POLL_INTERVAL})")
+    parser.add_argument('--sigmet-poll-interval', type=int, default=SIGMET_POLL_INTERVAL,
+                        help=f"SIGMET poll interval in seconds (default: {SIGMET_POLL_INTERVAL})")
+
+    args = parser.parse_args()
+
+    if not args.connection_string:
+        args.connection_string = os.getenv('CONNECTION_STRING')
+    if not args.last_polled_file:
+        args.last_polled_file = os.getenv('AVIATIONWEATHER_LAST_POLLED_FILE')
+        if not args.last_polled_file:
+            args.last_polled_file = os.path.expanduser('~/.aviationweather_last_polled.json')
+    if not args.stations:
+        args.stations = os.getenv('AVIATIONWEATHER_STATIONS', DEFAULT_STATIONS)
+
+    if args.connection_string:
+        config_params = parse_connection_string(args.connection_string)
+        kafka_bootstrap_servers = config_params.get('bootstrap.servers')
+        kafka_topic = config_params.get('kafka_topic')
+        sasl_username = config_params.get('sasl.username')
+        sasl_password = config_params.get('sasl.password')
+    else:
+        kafka_bootstrap_servers = args.kafka_bootstrap_servers
+        kafka_topic = args.kafka_topic
+        sasl_username = args.sasl_username
+        sasl_password = args.sasl_password
+
+    if not kafka_bootstrap_servers:
+        print("Error: Kafka bootstrap servers must be provided either through the command line or connection string.")
+        sys.exit(1)
+    if not kafka_topic:
+        print("Error: Kafka topic must be provided either through the command line or connection string.")
+        sys.exit(1)
+
+    tls_enabled = os.getenv('KAFKA_ENABLE_TLS', 'true').lower() not in ('false', '0', 'no')
+    kafka_config: Dict[str, str] = {
+        'bootstrap.servers': kafka_bootstrap_servers,
+    }
+    if sasl_username and sasl_password:
+        kafka_config.update({
+            'sasl.mechanisms': 'PLAIN',
+            'security.protocol': 'SASL_SSL' if tls_enabled else 'SASL_PLAINTEXT',
+            'sasl.username': sasl_username,
+            'sasl.password': sasl_password
+        })
+    elif tls_enabled:
+        kafka_config['security.protocol'] = 'SSL'
+
+    poller = AviationWeatherPoller(
+        kafka_config=kafka_config,
+        kafka_topic=kafka_topic,
+        last_polled_file=args.last_polled_file,
+        station_ids=args.stations,
+        metar_poll_interval=args.metar_poll_interval,
+        sigmet_poll_interval=args.sigmet_poll_interval,
+    )
+    poller.poll_and_send()
+
+
+if __name__ == "__main__":
+    main()

--- a/aviationweather/aviationweather_producer/aviationweather_producer_data/pyproject.toml
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_data/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aviationweather_producer_data"
+version = "0.1.0"
+description = "AviationWeather.gov producer data classes"
+requires-python = ">=3.10"
+dependencies = [
+    "dataclasses_json>=0.6.7",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/__init__.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/__init__.py
@@ -1,0 +1,3 @@
+from .station import Station
+from .metar import Metar
+from .sigmet import Sigmet

--- a/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/metar.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/metar.py
@@ -1,0 +1,86 @@
+""" Metar dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Metar:
+    """
+    METAR aviation weather observation from the AviationWeather.gov API.
+
+    Attributes:
+        icao_id (str)
+        obs_time (str)
+        report_time (typing.Optional[str])
+        temp (typing.Optional[float])
+        dewp (typing.Optional[float])
+        wdir (typing.Optional[int])
+        wspd (typing.Optional[int])
+        wgst (typing.Optional[int])
+        visib (typing.Optional[str])
+        altim (typing.Optional[float])
+        slp (typing.Optional[float])
+        qc_field (typing.Optional[int])
+        wx_string (typing.Optional[str])
+        metar_type (typing.Optional[str])
+        raw_ob (str)
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+        elevation (typing.Optional[float])
+        flt_cat (typing.Optional[str])
+        clouds (typing.Optional[str])
+        name (typing.Optional[str])
+    """
+
+
+    icao_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="icao_id"))
+    obs_time: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="obs_time"))
+    report_time: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_time"))
+    temp: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temp"))
+    dewp: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dewp"))
+    wdir: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wdir"))
+    wspd: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wspd"))
+    wgst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wgst"))
+    visib: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="visib"))
+    altim: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altim"))
+    slp: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="slp"))
+    qc_field: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="qc_field"))
+    wx_string: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wx_string"))
+    metar_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="metar_type"))
+    raw_ob: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="raw_ob"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    elevation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation"))
+    flt_cat: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="flt_cat"))
+    clouds: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="clouds"))
+    name: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Metar':
+        """Converts a dictionary to a dataclass instance."""
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """Converts the dataclass to a dictionary."""
+        return self.to_dict()
+
+    def to_byte_array(self, content_type: str = "application/json") -> bytes:
+        """Converts the dataclass to a byte array."""
+        if content_type == "application/json":
+            return json.dumps(self.to_serializer_dict()).encode("utf-8")
+        raise NotImplementedError(f"Unsupported content type: {content_type}")
+
+    def to_json(self) -> str:
+        """Converts the dataclass to a JSON string."""
+        return json.dumps(self.to_serializer_dict())

--- a/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/sigmet.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/sigmet.py
@@ -1,0 +1,72 @@
+""" Sigmet dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Sigmet:
+    """
+    SIGMET advisory from the AviationWeather.gov API.
+
+    Attributes:
+        icao_id (str)
+        series_id (str)
+        valid_time_from (str)
+        valid_time_to (str)
+        hazard (typing.Optional[str])
+        qualifier (typing.Optional[str])
+        sigmet_type (typing.Optional[str])
+        altitude_hi (typing.Optional[int])
+        altitude_low (typing.Optional[int])
+        movement_dir (typing.Optional[str])
+        movement_spd (typing.Optional[str])
+        severity (typing.Optional[int])
+        raw_sigmet (typing.Optional[str])
+        coords (typing.Optional[str])
+    """
+
+
+    icao_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="icao_id"))
+    series_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="series_id"))
+    valid_time_from: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="valid_time_from"))
+    valid_time_to: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="valid_time_to"))
+    hazard: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="hazard"))
+    qualifier: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="qualifier"))
+    sigmet_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sigmet_type"))
+    altitude_hi: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altitude_hi"))
+    altitude_low: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altitude_low"))
+    movement_dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="movement_dir"))
+    movement_spd: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="movement_spd"))
+    severity: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+    raw_sigmet: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="raw_sigmet"))
+    coords: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="coords"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Sigmet':
+        """Converts a dictionary to a dataclass instance."""
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """Converts the dataclass to a dictionary."""
+        return self.to_dict()
+
+    def to_byte_array(self, content_type: str = "application/json") -> bytes:
+        """Converts the dataclass to a byte array."""
+        if content_type == "application/json":
+            return json.dumps(self.to_serializer_dict()).encode("utf-8")
+        raise NotImplementedError(f"Unsupported content type: {content_type}")
+
+    def to_json(self) -> str:
+        """Converts the dataclass to a JSON string."""
+        return json.dumps(self.to_serializer_dict())

--- a/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/station.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_data/src/aviationweather_producer_data/station.py
@@ -1,0 +1,66 @@
+""" Station dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Station:
+    """
+    Reference record for an aviation weather reporting station.
+
+    Attributes:
+        icao_id (str)
+        iata_id (typing.Optional[str])
+        faa_id (typing.Optional[str])
+        wmo_id (typing.Optional[str])
+        name (str)
+        latitude (float)
+        longitude (float)
+        elevation (typing.Optional[float])
+        state (typing.Optional[str])
+        country (typing.Optional[str])
+        site_type (typing.Optional[str])
+    """
+
+
+    icao_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="icao_id"))
+    iata_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="iata_id"))
+    faa_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="faa_id"))
+    wmo_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wmo_id"))
+    name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name"))
+    latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    elevation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation"))
+    state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
+    country: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="country"))
+    site_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="site_type"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Station':
+        """Converts a dictionary to a dataclass instance."""
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """Converts the dataclass to a dictionary."""
+        return self.to_dict()
+
+    def to_byte_array(self, content_type: str = "application/json") -> bytes:
+        """Converts the dataclass to a byte array."""
+        if content_type == "application/json":
+            return json.dumps(self.to_serializer_dict()).encode("utf-8")
+        raise NotImplementedError(f"Unsupported content type: {content_type}")
+
+    def to_json(self) -> str:
+        """Converts the dataclass to a JSON string."""
+        return json.dumps(self.to_serializer_dict())

--- a/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/pyproject.toml
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aviationweather_producer_kafka_producer"
+version = "0.1.0"
+description = "AviationWeather.gov Kafka producer"
+requires-python = ">=3.10"
+dependencies = [
+    "confluent-kafka>=2.5.3",
+    "cloudevents>=1.11.0,<2.0.0",
+    "aviationweather_producer_data",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/src/aviationweather_producer_kafka_producer/__init__.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/src/aviationweather_producer_kafka_producer/__init__.py
@@ -1,0 +1,1 @@
+from .producer import GovNoaaAviationweatherEventProducer

--- a/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/src/aviationweather_producer_kafka_producer/producer.py
+++ b/aviationweather/aviationweather_producer/aviationweather_producer_kafka_producer/src/aviationweather_producer_kafka_producer/producer.py
@@ -1,0 +1,130 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import sys
+import json
+import uuid
+import typing
+from datetime import datetime
+from confluent_kafka import Producer, KafkaException, Message
+from cloudevents.kafka import to_binary, to_structured, KafkaMessage
+from cloudevents.http import CloudEvent
+from aviationweather_producer_data import Station
+from aviationweather_producer_data import Metar
+from aviationweather_producer_data import Sigmet
+
+class GovNoaaAviationweatherEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_gov_noaa_aviationweather_station(self,_icao_id : str, data: Station, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Station], str]=None) -> None:
+        """
+        Sends the 'gov.noaa.aviationweather.Station' event to the Kafka topic
+
+        Args:
+            _icao_id(str):  Value for placeholder icao_id in attribute subject
+            data: (Station): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Station], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+                The default key is derived from the xRegistry Kafka key declaration '{icao_id}'
+        """
+        kafka_key = "{icao_id}".format(icao_id=_icao_id)
+        attributes = {
+             "type":"gov.noaa.aviationweather.Station",
+             "source":"https://aviationweather.gov",
+             "subject":"{icao_id}".format(icao_id = _icao_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+    def send_gov_noaa_aviationweather_metar(self,_icao_id : str, data: Metar, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Metar], str]=None) -> None:
+        """
+        Sends the 'gov.noaa.aviationweather.Metar' event to the Kafka topic
+
+        Args:
+            _icao_id(str):  Value for placeholder icao_id in attribute subject
+            data: (Metar): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Metar], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+                The default key is derived from the xRegistry Kafka key declaration '{icao_id}'
+        """
+        kafka_key = "{icao_id}".format(icao_id=_icao_id)
+        attributes = {
+             "type":"gov.noaa.aviationweather.Metar",
+             "source":"https://aviationweather.gov",
+             "subject":"{icao_id}".format(icao_id = _icao_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+    def send_gov_noaa_aviationweather_sigmet(self,_icao_id : str, data: Sigmet, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Sigmet], str]=None) -> None:
+        """
+        Sends the 'gov.noaa.aviationweather.Sigmet' event to the Kafka topic
+
+        Args:
+            _icao_id(str):  Value for placeholder icao_id in attribute subject
+            data: (Sigmet): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Sigmet], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+                The default key is derived from the xRegistry Kafka key declaration '{icao_id}'
+        """
+        kafka_key = "{icao_id}".format(icao_id=_icao_id)
+        attributes = {
+             "type":"gov.noaa.aviationweather.Sigmet",
+             "source":"https://aviationweather.gov",
+             "subject":"{icao_id}".format(icao_id = _icao_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()

--- a/aviationweather/generate_producer.ps1
+++ b/aviationweather/generate_producer.ps1
@@ -1,0 +1,30 @@
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = $scriptDir
+$xregFile = Join-Path $projectRoot "xreg\aviationweather.xreg.json"
+$outputDir = Join-Path $projectRoot "aviationweather_producer"
+
+Write-Host "Generating AviationWeather producer from xRegistry definitions..." -ForegroundColor Cyan
+Write-Host "  xRegistry file: $xregFile" -ForegroundColor Gray
+Write-Host "  Output directory: $outputDir" -ForegroundColor Gray
+
+if (Test-Path $outputDir) {
+    Write-Host "  Cleaning existing output directory..." -ForegroundColor Yellow
+    Remove-Item -Path $outputDir -Recurse -Force
+}
+
+Write-Host "  Generating Kafka producer code..." -ForegroundColor Cyan
+xrcg generate --style kafkaproducer --language py --projectname aviationweather-producer --definitions $xregFile --output $outputDir
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Producer generation completed successfully" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Next steps:" -ForegroundColor Cyan
+    Write-Host "  1. Run copy_generated_producer.ps1 to copy files into the main package" -ForegroundColor Gray
+    Write-Host "  2. Run fix_imports.ps1 to fix generated import paths" -ForegroundColor Gray
+} else {
+    Write-Host "Producer generation failed with exit code: $LASTEXITCODE" -ForegroundColor Red
+    exit 1
+}

--- a/aviationweather/pyproject.toml
+++ b/aviationweather/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "aviationweather"
+version = "0.1.0"
+description = "AviationWeather.gov METAR/SIGMET bridge to Apache Kafka"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+confluent-kafka = ">=2.5.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+avro = "^1.12.1"
+aviationweather_producer_data = {path = "aviationweather_producer/aviationweather_producer_data"}
+aviationweather_producer_kafka_producer = {path = "aviationweather_producer/aviationweather_producer_kafka_producer"}
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.3.2"
+pytest-cov = ">=5.0.0"
+testcontainers = ">=4.8.1"
+requests-mock = ">=1.12.1"
+
+[tool.poetry.scripts]
+aviationweather = "aviationweather:main"

--- a/aviationweather/pytest.ini
+++ b/aviationweather/pytest.ini
@@ -1,0 +1,17 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    -v
+    --tb=short
+    --strict-markers
+    -ra
+markers =
+    unit: Unit tests that don't require external services
+    integration: Integration tests that may require external services
+    slow: Tests that take a long time to run
+    e2e: End-to-end tests against real external APIs
+filterwarnings =
+    ignore::DeprecationWarning

--- a/aviationweather/tests/test_aviationweather_unit.py
+++ b/aviationweather/tests/test_aviationweather_unit.py
@@ -1,0 +1,826 @@
+"""
+Unit tests for AviationWeather.gov bridge.
+Tests core functionality without external dependencies.
+"""
+
+import pytest
+import json
+import os
+from unittest.mock import Mock, patch, MagicMock
+from aviationweather_producer_data import Metar, Sigmet, Station
+from aviationweather.aviationweather import (
+    AviationWeatherPoller,
+    parse_connection_string,
+    API_BASE,
+    DEFAULT_STATIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample API responses matching live AviationWeather.gov structure
+# ---------------------------------------------------------------------------
+
+SAMPLE_METAR_RESPONSE = [
+    {
+        "icaoId": "KJFK",
+        "receiptTime": "2026-04-08T19:54:10.159Z",
+        "obsTime": 1775677860,
+        "reportTime": "2026-04-08T20:00:00.000Z",
+        "temp": 5.6,
+        "dewp": -5,
+        "wdir": 200,
+        "wspd": 11,
+        "wgst": None,
+        "visib": "10+",
+        "altim": 1036.7,
+        "slp": 1036.5,
+        "qcField": 4,
+        "wxString": None,
+        "metarType": "METAR",
+        "rawOb": "METAR KJFK 081951Z 20011KT 10SM FEW250 06/M05 A3061 RMK AO2 SLP365 T00561050",
+        "lat": 40.6392,
+        "lon": -73.7639,
+        "elev": 3,
+        "name": "New York/JF Kennedy Intl, NY, US",
+        "cover": "FEW",
+        "clouds": [{"cover": "FEW", "base": 25000}],
+        "fltCat": "VFR",
+    },
+    {
+        "icaoId": "EGLL",
+        "receiptTime": "2026-04-08T19:54:47.750Z",
+        "obsTime": 1775677800,
+        "reportTime": "2026-04-08T20:00:00.000Z",
+        "temp": 20,
+        "dewp": 8,
+        "wdir": 220,
+        "wspd": 6,
+        "wgst": None,
+        "visib": "6+",
+        "altim": 1021,
+        "qcField": 19,
+        "wxString": None,
+        "metarType": "METAR",
+        "rawOb": "METAR EGLL 081950Z COR AUTO 22006KT 190V260 9999 NCD 20/08 Q1021 NOSIG",
+        "lat": 51.477,
+        "lon": -0.461,
+        "elev": 26,
+        "name": "London/Heathrow Intl, EN, GB",
+        "cover": "CLR",
+        "clouds": [],
+        "fltCat": "VFR",
+    },
+]
+
+SAMPLE_STATION_RESPONSE = [
+    {
+        "id": "KJFK",
+        "icaoId": "KJFK",
+        "iataId": "JFK",
+        "faaId": "JFK",
+        "wmoId": "74486",
+        "site": "New York/JF Kennedy Intl",
+        "lat": 40.63916,
+        "lon": -73.76394,
+        "elev": 3,
+        "state": "NY",
+        "country": "US",
+        "priority": 0,
+        "siteType": ["METAR", "TAF"],
+    },
+    {
+        "id": "EGLL",
+        "icaoId": "EGLL",
+        "iataId": "LHR",
+        "faaId": None,
+        "wmoId": "03772",
+        "site": "London/Heathrow Intl",
+        "lat": 51.477,
+        "lon": -0.461,
+        "elev": 26,
+        "state": None,
+        "country": "GB",
+        "priority": 0,
+        "siteType": ["METAR", "TAF"],
+    },
+]
+
+SAMPLE_AIRSIGMET_RESPONSE = [
+    {
+        "icaoId": "KKCI",
+        "alphaChar": "W",
+        "seriesId": "6W",
+        "receiptTime": "2026-04-08T19:44:47.168Z",
+        "creationTime": "2026-04-08T19:55:00.000Z",
+        "validTimeFrom": 1775678100,
+        "validTimeTo": 1775685300,
+        "airSigmetType": "SIGMET",
+        "hazard": "CONVECTIVE",
+        "altitudeHi1": 32000,
+        "altitudeHi2": 32000,
+        "altitudeLow1": None,
+        "altitudeLow2": None,
+        "movementDir": 180,
+        "movementSpd": 40,
+        "rawAirSigmet": "WSUS33 KKCI 081955\nSIGW\nCONVECTIVE SIGMET 6W\nVALID UNTIL 2155Z",
+        "postProcessFlag": 0,
+        "severity": 5,
+        "coords": [
+            {"lat": 41.887, "lon": -123.704},
+            {"lat": 40.005, "lon": -124.23},
+        ],
+    },
+]
+
+SAMPLE_ISIGMET_RESPONSE = [
+    {
+        "icaoId": "ZHWH",
+        "firId": "ZHWH",
+        "firName": "ZHWH WUHAN",
+        "receiptTime": "2026-04-08T14:43:20.839Z",
+        "validTimeFrom": 1775664000,
+        "validTimeTo": 1775678400,
+        "seriesId": "8",
+        "hazard": "TS",
+        "qualifier": "EMBD",
+        "base": None,
+        "top": 40000,
+        "geom": "AREA",
+        "coords": [
+            {"lon": 115.377, "lat": 36.67},
+            {"lon": 112.678, "lat": 35.637},
+        ],
+        "dir": "NE",
+        "spd": "32",
+        "chng": "NC",
+        "rawSigmet": "WSCI45 ZHWH 081442\nZHWH SIGMET 8 VALID 081600/082000 ZHHH-",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helper to create a poller without real Kafka
+# ---------------------------------------------------------------------------
+
+def make_poller(last_polled_file="test_state.json", station_ids="KJFK,EGLL"):
+    """Create an AviationWeatherPoller with mocked Kafka."""
+    with patch("aviationweather.aviationweather.AviationWeatherPoller.__init__", return_value=None):
+        poller = AviationWeatherPoller.__new__(AviationWeatherPoller)
+        poller.kafka_topic = "test-topic"
+        poller.last_polled_file = last_polled_file
+        poller.station_ids = station_ids
+        poller.metar_poll_interval = 60
+        poller.sigmet_poll_interval = 120
+        mock_kafka_producer = MagicMock()
+        poller.producer = MagicMock()
+        poller.producer.producer = mock_kafka_producer
+        return poller
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_connection_string
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestParseConnectionString:
+    """Tests for the parse_connection_string helper."""
+
+    def test_event_hubs_connection_string(self):
+        conn_str = "Endpoint=sb://myns.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123;EntityPath=myhub"
+        result = parse_connection_string(conn_str)
+        assert "bootstrap.servers" in result
+        assert result["bootstrap.servers"] == "myns.servicebus.windows.net:9093"
+        assert result["kafka_topic"] == "myhub"
+        assert result["sasl.username"] == "$ConnectionString"
+        assert "sasl.password" in result
+        assert result["security.protocol"] == "SASL_SSL"
+
+    def test_plain_kafka_connection_string(self):
+        conn_str = "BootstrapServer=localhost:9092;EntityPath=my-topic"
+        result = parse_connection_string(conn_str)
+        assert result["bootstrap.servers"] == "localhost:9092"
+        assert result["kafka_topic"] == "my-topic"
+        assert "sasl.username" not in result
+
+    def test_empty_connection_string(self):
+        result = parse_connection_string("")
+        assert result == {}
+
+    def test_connection_string_with_spaces(self):
+        conn_str = "BootstrapServer= localhost:9092 ;EntityPath= test-topic "
+        result = parse_connection_string(conn_str)
+        assert result["bootstrap.servers"].strip() == "localhost:9092"
+        assert result["kafka_topic"].strip() == "test-topic"
+
+
+# ---------------------------------------------------------------------------
+# Test: epoch_to_iso
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestEpochToIso:
+    """Tests for epoch timestamp conversion."""
+
+    def test_valid_epoch(self):
+        result = AviationWeatherPoller.epoch_to_iso(1775677860)
+        assert result is not None
+        assert "2026-04-08" in result
+        assert "+00:00" in result
+
+    def test_none_epoch(self):
+        assert AviationWeatherPoller.epoch_to_iso(None) is None
+
+    def test_zero_epoch(self):
+        result = AviationWeatherPoller.epoch_to_iso(0)
+        assert result is not None
+        assert "1970-01-01" in result
+
+    def test_float_epoch(self):
+        result = AviationWeatherPoller.epoch_to_iso(1775677860.5)
+        assert result is not None
+
+    def test_string_epoch_fails(self):
+        assert AviationWeatherPoller.epoch_to_iso("not a number") is None
+
+
+# ---------------------------------------------------------------------------
+# Test: safe_int and safe_float
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestSafeConversions:
+    """Tests for safe type conversion helpers."""
+
+    def test_safe_int_valid(self):
+        assert AviationWeatherPoller.safe_int(42) == 42
+
+    def test_safe_int_float(self):
+        assert AviationWeatherPoller.safe_int(42.9) == 42
+
+    def test_safe_int_none(self):
+        assert AviationWeatherPoller.safe_int(None) is None
+
+    def test_safe_int_string(self):
+        assert AviationWeatherPoller.safe_int("not int") is None
+
+    def test_safe_float_valid(self):
+        assert AviationWeatherPoller.safe_float(3.14) == 3.14
+
+    def test_safe_float_int(self):
+        assert AviationWeatherPoller.safe_float(42) == 42.0
+
+    def test_safe_float_none(self):
+        assert AviationWeatherPoller.safe_float(None) is None
+
+    def test_safe_float_string(self):
+        assert AviationWeatherPoller.safe_float("not float") is None
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_station
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestParseStation:
+    """Tests for station parsing."""
+
+    def test_parse_valid_station(self):
+        station = AviationWeatherPoller.parse_station(SAMPLE_STATION_RESPONSE[0])
+        assert station is not None
+        assert station.icao_id == "KJFK"
+        assert station.iata_id == "JFK"
+        assert station.faa_id == "JFK"
+        assert station.wmo_id == "74486"
+        assert station.name == "New York/JF Kennedy Intl"
+        assert station.latitude == pytest.approx(40.63916)
+        assert station.longitude == pytest.approx(-73.76394)
+        assert station.elevation == 3.0
+        assert station.state == "NY"
+        assert station.country == "US"
+        assert station.site_type == "METAR,TAF"
+
+    def test_parse_station_no_faa_id(self):
+        station = AviationWeatherPoller.parse_station(SAMPLE_STATION_RESPONSE[1])
+        assert station is not None
+        assert station.icao_id == "EGLL"
+        assert station.faa_id is None
+        assert station.state is None
+
+    def test_parse_station_missing_icao(self):
+        result = AviationWeatherPoller.parse_station({"site": "test"})
+        assert result is None
+
+    def test_parse_station_missing_lat_lon(self):
+        result = AviationWeatherPoller.parse_station({"icaoId": "TEST"})
+        assert result is None
+
+    def test_parse_station_uses_name_fallback(self):
+        raw = {"icaoId": "TEST", "name": "Test Station", "lat": 10.0, "lon": 20.0}
+        station = AviationWeatherPoller.parse_station(raw)
+        assert station is not None
+        assert station.name == "Test Station"
+
+    def test_parse_station_uses_icao_as_name_fallback(self):
+        raw = {"icaoId": "TEST", "lat": 10.0, "lon": 20.0}
+        station = AviationWeatherPoller.parse_station(raw)
+        assert station is not None
+        assert station.name == "TEST"
+
+    def test_parse_station_site_type_none(self):
+        raw = {"icaoId": "TEST", "site": "Test", "lat": 10.0, "lon": 20.0}
+        station = AviationWeatherPoller.parse_station(raw)
+        assert station is not None
+        assert station.site_type is None
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_metar
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestParseMetar:
+    """Tests for METAR parsing."""
+
+    def test_parse_valid_metar(self):
+        metar = AviationWeatherPoller.parse_metar(SAMPLE_METAR_RESPONSE[0])
+        assert metar is not None
+        assert metar.icao_id == "KJFK"
+        assert "2026-04-08" in metar.obs_time
+        assert metar.temp == pytest.approx(5.6)
+        assert metar.dewp == pytest.approx(-5.0)
+        assert metar.wdir == 200
+        assert metar.wspd == 11
+        assert metar.wgst is None
+        assert metar.visib == "10+"
+        assert metar.altim == pytest.approx(1036.7)
+        assert metar.slp == pytest.approx(1036.5)
+        assert metar.flt_cat == "VFR"
+        assert metar.metar_type == "METAR"
+        assert "KJFK" in metar.raw_ob
+
+    def test_parse_metar_clouds_serialized(self):
+        metar = AviationWeatherPoller.parse_metar(SAMPLE_METAR_RESPONSE[0])
+        assert metar is not None
+        assert metar.clouds is not None
+        clouds = json.loads(metar.clouds)
+        assert isinstance(clouds, list)
+        assert len(clouds) == 1
+        assert clouds[0]["cover"] == "FEW"
+        assert clouds[0]["base"] == 25000
+
+    def test_parse_metar_empty_clouds(self):
+        metar = AviationWeatherPoller.parse_metar(SAMPLE_METAR_RESPONSE[1])
+        assert metar is not None
+        assert metar.clouds is not None
+        clouds = json.loads(metar.clouds)
+        assert clouds == []
+
+    def test_parse_metar_missing_icao(self):
+        result = AviationWeatherPoller.parse_metar({"rawOb": "test", "obsTime": 12345})
+        assert result is None
+
+    def test_parse_metar_missing_raw_ob(self):
+        result = AviationWeatherPoller.parse_metar({"icaoId": "TEST", "obsTime": 12345})
+        assert result is None
+
+    def test_parse_metar_missing_obs_time(self):
+        result = AviationWeatherPoller.parse_metar({"icaoId": "TEST", "rawOb": "test"})
+        assert result is None
+
+    def test_parse_metar_invalid_obs_time(self):
+        result = AviationWeatherPoller.parse_metar(
+            {"icaoId": "TEST", "rawOb": "test", "obsTime": "not a number"}
+        )
+        assert result is None
+
+    def test_parse_metar_null_optional_fields(self):
+        raw = {
+            "icaoId": "TEST",
+            "obsTime": 1775677860,
+            "rawOb": "METAR TEST",
+            "temp": None,
+            "dewp": None,
+            "wdir": None,
+            "wspd": None,
+            "wgst": None,
+            "visib": None,
+            "altim": None,
+            "slp": None,
+            "qcField": None,
+            "wxString": None,
+            "metarType": None,
+            "lat": None,
+            "lon": None,
+            "elev": None,
+            "fltCat": None,
+            "clouds": None,
+            "name": None,
+            "reportTime": None,
+        }
+        metar = AviationWeatherPoller.parse_metar(raw)
+        assert metar is not None
+        assert metar.temp is None
+        assert metar.clouds is None
+        assert metar.visib is None
+
+    def test_parse_metar_report_time_iso(self):
+        metar = AviationWeatherPoller.parse_metar(SAMPLE_METAR_RESPONSE[0])
+        assert metar is not None
+        assert metar.report_time == "2026-04-08T20:00:00.000Z"
+
+    def test_parse_metar_invalid_report_time(self):
+        raw = dict(SAMPLE_METAR_RESPONSE[0])
+        raw["reportTime"] = "not-a-date"
+        metar = AviationWeatherPoller.parse_metar(raw)
+        assert metar is not None
+        assert metar.report_time is None
+
+    def test_parse_metar_name_field(self):
+        metar = AviationWeatherPoller.parse_metar(SAMPLE_METAR_RESPONSE[0])
+        assert metar is not None
+        assert metar.name == "New York/JF Kennedy Intl, NY, US"
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_us_sigmet
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestParseUsSigmet:
+    """Tests for US SIGMET parsing."""
+
+    def test_parse_valid_us_sigmet(self):
+        sigmet = AviationWeatherPoller.parse_us_sigmet(SAMPLE_AIRSIGMET_RESPONSE[0])
+        assert sigmet is not None
+        assert sigmet.icao_id == "KKCI"
+        assert sigmet.series_id == "6W"
+        assert sigmet.hazard == "CONVECTIVE"
+        assert sigmet.sigmet_type == "SIGMET"
+        assert sigmet.altitude_hi == 32000
+        assert sigmet.altitude_low is None
+        assert sigmet.movement_dir == "180"
+        assert sigmet.movement_spd == "40"
+        assert sigmet.severity == 5
+        assert sigmet.qualifier is None
+        assert "2026-04-08" in sigmet.valid_time_from
+        assert "2026-04-08" in sigmet.valid_time_to
+
+    def test_parse_us_sigmet_coords_serialized(self):
+        sigmet = AviationWeatherPoller.parse_us_sigmet(SAMPLE_AIRSIGMET_RESPONSE[0])
+        assert sigmet is not None
+        coords = json.loads(sigmet.coords)
+        assert isinstance(coords, list)
+        assert len(coords) == 2
+        assert coords[0]["lat"] == pytest.approx(41.887)
+
+    def test_parse_us_sigmet_missing_icao(self):
+        result = AviationWeatherPoller.parse_us_sigmet({"seriesId": "1W"})
+        assert result is None
+
+    def test_parse_us_sigmet_missing_series(self):
+        result = AviationWeatherPoller.parse_us_sigmet({"icaoId": "KKCI"})
+        assert result is None
+
+    def test_parse_us_sigmet_missing_valid_times(self):
+        result = AviationWeatherPoller.parse_us_sigmet(
+            {"icaoId": "KKCI", "seriesId": "1W"}
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_intl_sigmet
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestParseIntlSigmet:
+    """Tests for international SIGMET parsing."""
+
+    def test_parse_valid_intl_sigmet(self):
+        sigmet = AviationWeatherPoller.parse_intl_sigmet(SAMPLE_ISIGMET_RESPONSE[0])
+        assert sigmet is not None
+        assert sigmet.icao_id == "ZHWH"
+        assert sigmet.series_id == "8"
+        assert sigmet.hazard == "TS"
+        assert sigmet.qualifier == "EMBD"
+        assert sigmet.sigmet_type == "ISIGMET"
+        assert sigmet.altitude_hi == 40000
+        assert sigmet.altitude_low is None
+        assert sigmet.movement_dir == "NE"
+        assert sigmet.movement_spd == "32"
+        assert sigmet.severity is None
+
+    def test_parse_intl_sigmet_coords(self):
+        sigmet = AviationWeatherPoller.parse_intl_sigmet(SAMPLE_ISIGMET_RESPONSE[0])
+        assert sigmet is not None
+        coords = json.loads(sigmet.coords)
+        assert isinstance(coords, list)
+        assert len(coords) == 2
+
+    def test_parse_intl_sigmet_raw_text(self):
+        sigmet = AviationWeatherPoller.parse_intl_sigmet(SAMPLE_ISIGMET_RESPONSE[0])
+        assert sigmet is not None
+        assert "ZHWH SIGMET 8" in sigmet.raw_sigmet
+
+
+# ---------------------------------------------------------------------------
+# Test: sigmet_dedup_key
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestSigmetDedupKey:
+    """Tests for SIGMET deduplication key generation."""
+
+    def test_dedup_key_format(self):
+        sigmet = Sigmet(
+            icao_id="KKCI",
+            series_id="6W",
+            valid_time_from="2026-04-08T19:55:00+00:00",
+            valid_time_to="2026-04-08T21:55:00+00:00",
+            hazard="CONVECTIVE",
+            qualifier=None,
+            sigmet_type="SIGMET",
+            altitude_hi=32000,
+            altitude_low=None,
+            movement_dir="180",
+            movement_spd="40",
+            severity=5,
+            raw_sigmet="test",
+            coords=None,
+        )
+        key = AviationWeatherPoller.sigmet_dedup_key(sigmet)
+        assert key == "KKCI:6W:2026-04-08T19:55:00+00:00:2026-04-08T21:55:00+00:00"
+
+    def test_different_sigmets_different_keys(self):
+        sigmet1 = Sigmet(
+            icao_id="KKCI", series_id="6W",
+            valid_time_from="2026-04-08T19:55:00+00:00",
+            valid_time_to="2026-04-08T21:55:00+00:00",
+            hazard=None, qualifier=None, sigmet_type=None,
+            altitude_hi=None, altitude_low=None,
+            movement_dir=None, movement_spd=None,
+            severity=None, raw_sigmet=None, coords=None,
+        )
+        sigmet2 = Sigmet(
+            icao_id="KKCI", series_id="7W",
+            valid_time_from="2026-04-08T19:55:00+00:00",
+            valid_time_to="2026-04-08T21:55:00+00:00",
+            hazard=None, qualifier=None, sigmet_type=None,
+            altitude_hi=None, altitude_low=None,
+            movement_dir=None, movement_spd=None,
+            severity=None, raw_sigmet=None, coords=None,
+        )
+        assert AviationWeatherPoller.sigmet_dedup_key(sigmet1) != AviationWeatherPoller.sigmet_dedup_key(sigmet2)
+
+
+# ---------------------------------------------------------------------------
+# Test: state persistence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestStatePersistence:
+    """Tests for load_state / save_state."""
+
+    def test_load_state_missing_file(self):
+        poller = make_poller(last_polled_file="nonexistent_file_xyz.json")
+        state = poller.load_state()
+        assert state == {"metar_timestamps": {}, "sigmet_keys": []}
+
+    def test_save_and_load_state(self, tmp_path):
+        state_file = str(tmp_path / "state.json")
+        poller = make_poller(last_polled_file=state_file)
+        state = {
+            "metar_timestamps": {"KJFK": "2026-04-08T19:51:00+00:00"},
+            "sigmet_keys": ["KKCI:6W:2026-04-08T19:55:00+00:00:2026-04-08T21:55:00+00:00"],
+        }
+        poller.save_state(state)
+        loaded = poller.load_state()
+        assert loaded["metar_timestamps"]["KJFK"] == "2026-04-08T19:51:00+00:00"
+        assert len(loaded["sigmet_keys"]) == 1
+
+    def test_load_state_corrupt_file(self, tmp_path):
+        state_file = str(tmp_path / "corrupt.json")
+        with open(state_file, 'w') as f:
+            f.write("not json")
+        poller = make_poller(last_polled_file=state_file)
+        state = poller.load_state()
+        assert state == {"metar_timestamps": {}, "sigmet_keys": []}
+
+
+# ---------------------------------------------------------------------------
+# Test: fetch methods
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestFetchMethods:
+    """Tests for API fetch methods."""
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_metar_json_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = SAMPLE_METAR_RESPONSE
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = AviationWeatherPoller.fetch_metar_json("KJFK,EGLL")
+        assert len(result) == 2
+        assert result[0]["icaoId"] == "KJFK"
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_metar_json_error(self, mock_get):
+        mock_get.side_effect = Exception("Network error")
+        result = AviationWeatherPoller.fetch_metar_json("KJFK")
+        assert result == []
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_station_json_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = SAMPLE_STATION_RESPONSE
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = AviationWeatherPoller.fetch_station_json("KJFK")
+        assert len(result) == 2
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_airsigmet_json_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = SAMPLE_AIRSIGMET_RESPONSE
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = AviationWeatherPoller.fetch_airsigmet_json()
+        assert len(result) == 1
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_isigmet_json_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = SAMPLE_ISIGMET_RESPONSE
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = AviationWeatherPoller.fetch_isigmet_json()
+        assert len(result) == 1
+
+    @patch("aviationweather.aviationweather.requests.get")
+    def test_fetch_metar_json_non_list_response(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = {"error": "bad request"}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = AviationWeatherPoller.fetch_metar_json("INVALID")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test: emit methods with mocked Kafka
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestEmitMethods:
+    """Tests for the emit_* methods with mocked Kafka."""
+
+    @patch.object(AviationWeatherPoller, "fetch_station_json")
+    def test_emit_stations(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_STATION_RESPONSE
+        poller = make_poller()
+        count = poller.emit_stations()
+        assert count == 2
+        assert poller.producer.send_gov_noaa_aviationweather_station.call_count == 2
+        poller.producer.producer.flush.assert_called()
+
+    @patch.object(AviationWeatherPoller, "fetch_metar_json")
+    def test_emit_metars_new(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_METAR_RESPONSE
+        poller = make_poller()
+        count, timestamps = poller.emit_metars({})
+        assert count == 2
+        assert "KJFK" in timestamps
+        assert "EGLL" in timestamps
+        assert poller.producer.send_gov_noaa_aviationweather_metar.call_count == 2
+
+    @patch.object(AviationWeatherPoller, "fetch_metar_json")
+    def test_emit_metars_dedup(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_METAR_RESPONSE
+        poller = make_poller()
+        # First call to get timestamps
+        _, timestamps = poller.emit_metars({})
+        # Reset mock
+        poller.producer.send_gov_noaa_aviationweather_metar.reset_mock()
+        # Second call with same timestamps
+        count, _ = poller.emit_metars(timestamps)
+        assert count == 0
+        poller.producer.send_gov_noaa_aviationweather_metar.assert_not_called()
+
+    @patch.object(AviationWeatherPoller, "fetch_airsigmet_json")
+    @patch.object(AviationWeatherPoller, "fetch_isigmet_json")
+    def test_emit_sigmets_new(self, mock_isigmet, mock_airsigmet):
+        mock_airsigmet.return_value = SAMPLE_AIRSIGMET_RESPONSE
+        mock_isigmet.return_value = SAMPLE_ISIGMET_RESPONSE
+        poller = make_poller()
+        count, keys = poller.emit_sigmets(set())
+        assert count == 2
+        assert len(keys) == 2
+        assert poller.producer.send_gov_noaa_aviationweather_sigmet.call_count == 2
+
+    @patch.object(AviationWeatherPoller, "fetch_airsigmet_json")
+    @patch.object(AviationWeatherPoller, "fetch_isigmet_json")
+    def test_emit_sigmets_dedup(self, mock_isigmet, mock_airsigmet):
+        mock_airsigmet.return_value = SAMPLE_AIRSIGMET_RESPONSE
+        mock_isigmet.return_value = SAMPLE_ISIGMET_RESPONSE
+        poller = make_poller()
+        _, keys = poller.emit_sigmets(set())
+        # Reset mock
+        poller.producer.send_gov_noaa_aviationweather_sigmet.reset_mock()
+        # Second call with seen keys
+        count, _ = poller.emit_sigmets(keys)
+        assert count == 0
+        poller.producer.send_gov_noaa_aviationweather_sigmet.assert_not_called()
+
+    @patch.object(AviationWeatherPoller, "fetch_station_json")
+    def test_emit_stations_empty(self, mock_fetch):
+        mock_fetch.return_value = []
+        poller = make_poller()
+        count = poller.emit_stations()
+        assert count == 0
+        poller.producer.producer.flush.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: poll_and_send
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestPollAndSend:
+    """Tests for the main polling loop."""
+
+    @patch.object(AviationWeatherPoller, "fetch_isigmet_json")
+    @patch.object(AviationWeatherPoller, "fetch_airsigmet_json")
+    @patch.object(AviationWeatherPoller, "fetch_metar_json")
+    @patch.object(AviationWeatherPoller, "fetch_station_json")
+    def test_poll_and_send_once(self, mock_stations, mock_metars, mock_airsigmet, mock_isigmet, tmp_path):
+        mock_stations.return_value = SAMPLE_STATION_RESPONSE
+        mock_metars.return_value = SAMPLE_METAR_RESPONSE
+        mock_airsigmet.return_value = SAMPLE_AIRSIGMET_RESPONSE
+        mock_isigmet.return_value = SAMPLE_ISIGMET_RESPONSE
+
+        state_file = str(tmp_path / "state.json")
+        poller = make_poller(last_polled_file=state_file)
+        poller.poll_and_send(once=True)
+
+        # Stations emitted
+        assert poller.producer.send_gov_noaa_aviationweather_station.call_count == 2
+        # METARs emitted
+        assert poller.producer.send_gov_noaa_aviationweather_metar.call_count == 2
+        # SIGMETs emitted
+        assert poller.producer.send_gov_noaa_aviationweather_sigmet.call_count == 2
+        # State saved
+        assert os.path.exists(state_file)
+
+
+# ---------------------------------------------------------------------------
+# Test: dataclass serialization
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestDataclassSerialization:
+    """Tests for generated dataclass serialization."""
+
+    def test_station_to_json(self):
+        station = Station(
+            icao_id="KJFK", iata_id="JFK", faa_id="JFK", wmo_id="74486",
+            name="Test", latitude=40.0, longitude=-73.0, elevation=3.0,
+            state="NY", country="US", site_type="METAR,TAF",
+        )
+        data = json.loads(station.to_json())
+        assert data["icao_id"] == "KJFK"
+        assert data["latitude"] == 40.0
+
+    def test_metar_to_json(self):
+        metar = Metar(
+            icao_id="KJFK", obs_time="2026-04-08T19:51:00+00:00",
+            report_time=None, temp=5.6, dewp=-5.0, wdir=200, wspd=11,
+            wgst=None, visib="10+", altim=1036.7, slp=1036.5, qc_field=4,
+            wx_string=None, metar_type="METAR",
+            raw_ob="METAR KJFK test", latitude=40.6, longitude=-73.7,
+            elevation=3.0, flt_cat="VFR", clouds='[{"cover":"FEW","base":25000}]',
+            name="Test",
+        )
+        data = json.loads(metar.to_json())
+        assert data["icao_id"] == "KJFK"
+        assert data["temp"] == 5.6
+
+    def test_sigmet_to_json(self):
+        sigmet = Sigmet(
+            icao_id="KKCI", series_id="6W",
+            valid_time_from="2026-04-08T19:55:00+00:00",
+            valid_time_to="2026-04-08T21:55:00+00:00",
+            hazard="CONVECTIVE", qualifier=None, sigmet_type="SIGMET",
+            altitude_hi=32000, altitude_low=None, movement_dir="180",
+            movement_spd="40", severity=5, raw_sigmet="test",
+            coords='[{"lat":41.88,"lon":-123.70}]',
+        )
+        data = json.loads(sigmet.to_json())
+        assert data["icao_id"] == "KKCI"
+        assert data["hazard"] == "CONVECTIVE"

--- a/aviationweather/xreg/aviationweather.xreg.json
+++ b/aviationweather/xreg/aviationweather.xreg.json
@@ -1,0 +1,379 @@
+{
+  "endpoints": {
+    "gov.noaa.aviationweather.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "aviationweather",
+          "key": "{icao_id}"
+        }
+      },
+      "messagegroups": [
+        "#/messagegroups/gov.noaa.aviationweather"
+      ]
+    }
+  },
+  "messagegroups": {
+    "gov.noaa.aviationweather": {
+      "messages": {
+        "gov.noaa.aviationweather.Station": {
+          "name": "Station",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "gov.noaa.aviationweather.Station"
+            },
+            "source": {
+              "value": "https://aviationweather.gov"
+            },
+            "subject": {
+              "value": "{icao_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/gov.noaa.aviationweather.jstruct/schemas/gov.noaa.aviationweather.Station"
+        },
+        "gov.noaa.aviationweather.Metar": {
+          "name": "Metar",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "gov.noaa.aviationweather.Metar"
+            },
+            "source": {
+              "value": "https://aviationweather.gov"
+            },
+            "subject": {
+              "value": "{icao_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/gov.noaa.aviationweather.jstruct/schemas/gov.noaa.aviationweather.Metar"
+        },
+        "gov.noaa.aviationweather.Sigmet": {
+          "name": "Sigmet",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "gov.noaa.aviationweather.Sigmet"
+            },
+            "source": {
+              "value": "https://aviationweather.gov"
+            },
+            "subject": {
+              "value": "{icao_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/gov.noaa.aviationweather.jstruct/schemas/gov.noaa.aviationweather.Sigmet"
+        }
+      }
+    }
+  },
+  "schemagroups": {
+    "gov.noaa.aviationweather.jstruct": {
+      "schemas": {
+        "gov.noaa.aviationweather.Station": {
+          "name": "Station",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "icao_id",
+                  "name",
+                  "latitude",
+                  "longitude"
+                ],
+                "name": "Station",
+                "properties": {
+                  "icao_id": {
+                    "type": "string",
+                    "description": "ICAO station identifier. Four-character alphanumeric code assigned by ICAO (e.g. 'KJFK' for John F. Kennedy International Airport)."
+                  },
+                  "iata_id": {
+                    "type": ["string", "null"],
+                    "description": "IATA airport code, a three-character code used by the airline industry (e.g. 'JFK'). May be null for non-airport stations."
+                  },
+                  "faa_id": {
+                    "type": ["string", "null"],
+                    "description": "FAA location identifier. Three or four character code assigned by the FAA. May be null for non-US stations."
+                  },
+                  "wmo_id": {
+                    "type": ["string", "null"],
+                    "description": "WMO station identifier. Five-digit numeric code assigned by the World Meteorological Organization. May be null."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Human-readable site name from the AviationWeather station database, e.g. 'New York/JF Kennedy Intl'."
+                  },
+                  "latitude": {
+                    "type": "double",
+                    "description": "Station latitude in decimal degrees north. Negative values indicate southern hemisphere.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "longitude": {
+                    "type": "double",
+                    "description": "Station longitude in decimal degrees east. Negative values indicate western hemisphere.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "elevation": {
+                    "type": ["double", "null"],
+                    "description": "Station field elevation in meters above mean sea level.",
+                    "unit": "m",
+                    "symbol": "m"
+                  },
+                  "state": {
+                    "type": ["string", "null"],
+                    "description": "State or province code where the station is located (e.g. 'NY'). May be null for non-US stations."
+                  },
+                  "country": {
+                    "type": ["string", "null"],
+                    "description": "Two-character ISO 3166-1 alpha-2 country code (e.g. 'US', 'GB')."
+                  },
+                  "site_type": {
+                    "type": ["string", "null"],
+                    "description": "Comma-separated list of data products available at this station from the siteType array (e.g. 'METAR,TAF')."
+                  }
+                },
+                "$id": "https://aviationweather.gov/schemas/gov/noaa/aviationweather/Station",
+                "description": "Reference record for an aviation weather reporting station. Sourced from the AviationWeather.gov station information endpoint. Fields cover ICAO, IATA, FAA, and WMO identifiers, location, elevation, and available data products."
+              }
+            }
+          }
+        },
+        "gov.noaa.aviationweather.Metar": {
+          "name": "Metar",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "icao_id",
+                  "obs_time",
+                  "raw_ob"
+                ],
+                "name": "Metar",
+                "properties": {
+                  "icao_id": {
+                    "type": "string",
+                    "description": "ICAO station identifier for the reporting station (e.g. 'KJFK')."
+                  },
+                  "obs_time": {
+                    "type": "datetime",
+                    "description": "Observation time as a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z) from the obsTime field in the API response."
+                  },
+                  "report_time": {
+                    "type": ["datetime", "null"],
+                    "description": "Report time as an ISO 8601 UTC string from the reportTime field. This is the time the observation was officially reported."
+                  },
+                  "temp": {
+                    "type": ["double", "null"],
+                    "description": "Air temperature at the station. Unit: degrees Celsius.",
+                    "unit": "CEL",
+                    "symbol": "°C"
+                  },
+                  "dewp": {
+                    "type": ["double", "null"],
+                    "description": "Dewpoint temperature at the station. Unit: degrees Celsius.",
+                    "unit": "CEL",
+                    "symbol": "°C"
+                  },
+                  "wdir": {
+                    "type": ["int32", "null"],
+                    "description": "Wind direction in degrees true (the direction from which the wind is blowing), averaged over the observation period. Value of 0 indicates variable or calm.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "wspd": {
+                    "type": ["int32", "null"],
+                    "description": "Sustained wind speed in knots.",
+                    "unit": "[kn_i]",
+                    "symbol": "kt"
+                  },
+                  "wgst": {
+                    "type": ["int32", "null"],
+                    "description": "Wind gust speed in knots. Null if no gusts reported.",
+                    "unit": "[kn_i]",
+                    "symbol": "kt"
+                  },
+                  "visib": {
+                    "type": ["string", "null"],
+                    "description": "Prevailing visibility as reported. Value is a string because it can contain qualifiers like '10+' (greater than 10 statute miles) or fractional values. Unit: statute miles."
+                  },
+                  "altim": {
+                    "type": ["double", "null"],
+                    "description": "Altimeter setting (QNH) in hectopascals.",
+                    "unit": "hPa",
+                    "symbol": "hPa"
+                  },
+                  "slp": {
+                    "type": ["double", "null"],
+                    "description": "Sea level pressure in hectopascals. May be null if not reported.",
+                    "unit": "hPa",
+                    "symbol": "hPa"
+                  },
+                  "qc_field": {
+                    "type": ["int32", "null"],
+                    "description": "Quality control flag bitmask from the qcField in the API response."
+                  },
+                  "wx_string": {
+                    "type": ["string", "null"],
+                    "description": "Present weather string using standard METAR codes (e.g. '-RA' for light rain, 'BR' for mist)."
+                  },
+                  "metar_type": {
+                    "type": ["string", "null"],
+                    "description": "METAR report type: 'METAR' for routine, 'SPECI' for special observation."
+                  },
+                  "raw_ob": {
+                    "type": "string",
+                    "description": "The full raw METAR observation text as received, e.g. 'METAR KJFK 061051Z 32013KT 10SM SCT050 05/M05 A3001'."
+                  },
+                  "latitude": {
+                    "type": ["double", "null"],
+                    "description": "Station latitude in decimal degrees north from the METAR response.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "longitude": {
+                    "type": ["double", "null"],
+                    "description": "Station longitude in decimal degrees east from the METAR response.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "elevation": {
+                    "type": ["double", "null"],
+                    "description": "Station elevation in meters above mean sea level from the METAR response.",
+                    "unit": "m",
+                    "symbol": "m"
+                  },
+                  "flt_cat": {
+                    "type": ["string", "null"],
+                    "description": "Flight category derived from ceiling and visibility: VFR, MVFR, IFR, or LIFR."
+                  },
+                  "clouds": {
+                    "type": ["string", "null"],
+                    "description": "JSON-encoded array of cloud layer objects. Each object has 'cover' (string: SKC, CLR, FEW, SCT, BKN, OVC) and 'base' (integer or null: cloud base in feet AGL). Example: '[{\"cover\":\"SCT\",\"base\":5000}]'."
+                  },
+                  "name": {
+                    "type": ["string", "null"],
+                    "description": "Human-readable station name included in the METAR response (e.g. 'New York/JF Kennedy Intl, NY, US')."
+                  }
+                },
+                "$id": "https://aviationweather.gov/schemas/gov/noaa/aviationweather/Metar",
+                "description": "METAR aviation weather observation from the AviationWeather.gov API. Reports surface conditions including temperature, dewpoint, wind, visibility, pressure, clouds, and flight category for an ICAO reporting station."
+              }
+            }
+          }
+        },
+        "gov.noaa.aviationweather.Sigmet": {
+          "name": "Sigmet",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "icao_id",
+                  "series_id",
+                  "valid_time_from",
+                  "valid_time_to"
+                ],
+                "name": "Sigmet",
+                "properties": {
+                  "icao_id": {
+                    "type": "string",
+                    "description": "ICAO identifier for the issuing office (e.g. 'KKCI' for the Kansas City Aviation Weather Center) or FIR identifier for international SIGMETs."
+                  },
+                  "series_id": {
+                    "type": "string",
+                    "description": "SIGMET series identifier combining alphanumeric sequence (e.g. '6W' for domestic, '8' for international)."
+                  },
+                  "valid_time_from": {
+                    "type": "datetime",
+                    "description": "Start of the SIGMET validity period as a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z)."
+                  },
+                  "valid_time_to": {
+                    "type": "datetime",
+                    "description": "End of the SIGMET validity period as a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z)."
+                  },
+                  "hazard": {
+                    "type": ["string", "null"],
+                    "description": "Weather hazard type: 'CONVECTIVE' for US convective SIGMETs, 'TS' (thunderstorm), 'TURB' (turbulence), 'ICE' (icing), 'VA' (volcanic ash), 'MTW' (mountain wave), etc."
+                  },
+                  "qualifier": {
+                    "type": ["string", "null"],
+                    "description": "Hazard qualifier for international SIGMETs (e.g. 'EMBD' for embedded, 'SEV' for severe, 'OBSC' for obscured). Null for US domestic SIGMETs."
+                  },
+                  "sigmet_type": {
+                    "type": ["string", "null"],
+                    "description": "SIGMET classification: 'SIGMET' for US domestic, 'ISIGMET' for international SIGMETs."
+                  },
+                  "altitude_hi": {
+                    "type": ["int32", "null"],
+                    "description": "Upper altitude limit of the hazard area in feet. From altitudeHi1 for US SIGMETs or top for international SIGMETs.",
+                    "unit": "[ft_i]",
+                    "symbol": "ft"
+                  },
+                  "altitude_low": {
+                    "type": ["int32", "null"],
+                    "description": "Lower altitude limit of the hazard area in feet. From altitudeLow1 for US SIGMETs or base for international SIGMETs.",
+                    "unit": "[ft_i]",
+                    "symbol": "ft"
+                  },
+                  "movement_dir": {
+                    "type": ["string", "null"],
+                    "description": "Direction of movement of the weather phenomenon. Numeric degrees for US SIGMETs, cardinal direction string (e.g. 'NE') for international."
+                  },
+                  "movement_spd": {
+                    "type": ["string", "null"],
+                    "description": "Speed of movement of the weather phenomenon. Numeric knots for US SIGMETs, knots string for international."
+                  },
+                  "severity": {
+                    "type": ["int32", "null"],
+                    "description": "Severity level indicator from the severity field in the US SIGMET response. Higher values indicate greater severity."
+                  },
+                  "raw_sigmet": {
+                    "type": ["string", "null"],
+                    "description": "Full raw SIGMET text as received from the upstream source."
+                  },
+                  "coords": {
+                    "type": ["string", "null"],
+                    "description": "JSON-encoded array of coordinate objects defining the hazard area polygon. Each object has 'lat' (number) and 'lon' (number). Example: '[{\"lat\":41.88,\"lon\":-123.70},{\"lat\":40.00,\"lon\":-124.23}]'."
+                  }
+                },
+                "$id": "https://aviationweather.gov/schemas/gov/noaa/aviationweather/Sigmet",
+                "description": "SIGMET (Significant Meteorological Information) advisory from the AviationWeather.gov API. Covers both US domestic convective/non-convective SIGMETs and international SIGMETs. Reports hazardous weather conditions for aviation including thunderstorms, turbulence, icing, and volcanic ash."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/docker_e2e/test_docker_kafka_flow.py
+++ b/tests/docker_e2e/test_docker_kafka_flow.py
@@ -209,6 +209,8 @@ def wsdot_image():
 @pytest.fixture(scope='module')
 def gracedb_image():
     return build_image('gracedb')
+def aviationweather_image():
+    return build_image('aviationweather')
 
 
 # ---------------------------------------------------------------------------
@@ -1138,4 +1140,18 @@ class TestWalloniaISsePDockerFlow:
             kafka, wallonia_issep_image, self.TOPIC,
             reference_types=['SensorConfiguration'],
             telemetry_types=['Observation'],
+# AviationWeather.gov (METAR observations, SIGMETs, station data)
+# ---------------------------------------------------------------------------
+
+class TestAviationWeatherDockerFlow:
+    TOPIC = 'test-aviationweather'
+
+    def test_emits_reference_and_telemetry(self, kafka: KafkaFixture, aviationweather_image):
+        _run_kafka_flow_test(
+            kafka, aviationweather_image, self.TOPIC,
+            reference_types=['Station'],
+            telemetry_types=['Metar'],
+            extra_env={
+                'AVIATIONWEATHER_STATIONS': 'KJFK,EGLL,LFPG',
+            },
         )


### PR DESCRIPTION
## AviationWeather.gov Bridge

Adds a real-time bridge for NOAA/NWS Aviation Weather Center — the authoritative source for global aviation weather.

### Event Types
- **Station** — Reference data for weather stations worldwide (ICAO ID, name, lat/lon, elevation, country)
- **Metar** — Real-time METAR observations from 10,000+ stations globally (temperature, dewpoint, wind, visibility, altimeter, flight category, clouds, raw observation)
- **Sigmet** — Active SIGMETs (US domestic + international) for convective activity, turbulence, icing, IFR conditions

### Implementation
- Polls \https://aviationweather.gov/api/data/\ REST API (JSON format)
- No authentication required (US Government public domain)
- Station reference data refreshed every 24 hours
- METAR deduplication by icao_id + obs_time
- SIGMET deduplication by icao_id + series_id + validity period
- Both US and international SIGMETs polled
- Clouds array serialized as JSON string in CloudEvents

### Testing
- 64 unit tests covering METAR/SIGMET/Station parsing, null handling, deduplication, state persistence, serialization
- Docker E2E test added to test_docker_kafka_flow.py

### Candidate
Source: tools/candidates/aviation/aviationweather-gov.md (Score: 17/18)