### PR TITLE
Add Australian State Wildfires bridge

### DIFF
--- a/australia-wildfires/CONTAINER.md
+++ b/australia-wildfires/CONTAINER.md
@@ -1,0 +1,86 @@
+# Australian State Wildfires Bridge — Container
+
+This container bridges live bushfire incident data from three Australian state
+emergency services — NSW Rural Fire Service, VicEmergency, and Queensland Fire
+Department — into Kafka endpoints as CloudEvents.
+
+All events are emitted as [CloudEvents](https://cloudevents.io/) in structured
+JSON content mode. See [EVENTS.md](EVENTS.md) for the full event catalog.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CONNECTION_STRING` | Yes | Kafka or Event Hubs connection string |
+| `KAFKA_TOPIC` | No | Override the default topic (`australia-wildfires`) |
+| `POLLING_INTERVAL` | No | Polling interval in seconds (default: `300`) |
+| `STATE_FILE` | No | Path for dedup state persistence (default: `~/.australia_wildfires_state.json`) |
+| `KAFKA_ENABLE_TLS` | No | Enable TLS for Kafka connections (default: `true`) |
+
+## Connection Strings
+
+### Plain Kafka
+
+```
+BootstrapServer=myhost:9092;EntityPath=australia-wildfires
+```
+
+### Azure Event Hubs
+
+```
+Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=...;EntityPath=australia-wildfires
+```
+
+### Microsoft Fabric Event Streams
+
+Use the Event Hubs–compatible connection string from your Fabric workspace.
+
+## Docker
+
+### Pull
+
+```bash
+docker pull ghcr.io/clemensv/real-time-sources/australia-wildfires:latest
+```
+
+### Run
+
+```bash
+docker run --rm \
+  -e CONNECTION_STRING="BootstrapServer=host.docker.internal:9092;EntityPath=australia-wildfires" \
+  ghcr.io/clemensv/real-time-sources/australia-wildfires:latest
+```
+
+## Azure Container Instance
+
+Deploy with the Azure CLI:
+
+```bash
+az container create \
+  --resource-group myRG \
+  --name australia-wildfires \
+  --image ghcr.io/clemensv/real-time-sources/australia-wildfires:latest \
+  --environment-variables CONNECTION_STRING="<your-connection-string>" \
+  --restart-policy Always
+```
+
+## Database Follow-On
+
+Ingest the Kafka topic into Azure Data Explorer or Fabric KQL Database and
+query incidents with KQL:
+
+```kql
+['australia-wildfires']
+| extend data = parse_json(tostring(data))
+| project
+    incident_id = tostring(data.incident_id),
+    state = tostring(data.state),
+    title = tostring(data.title),
+    alert_level = tostring(data.alert_level),
+    latitude = todouble(data.latitude),
+    longitude = todouble(data.longitude),
+    size_hectares = todouble(data.size_hectares),
+    type = tostring(data.type),
+    updated = todatetime(data.updated)
+| order by updated desc
+```

--- a/australia-wildfires/Dockerfile
+++ b/australia-wildfires/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires"
+LABEL org.opencontainers.image.title="Australian State Wildfires bridge to Kafka endpoints"
+LABEL org.opencontainers.image.description="This container bridges live bushfire incident data from NSW RFS, VicEmergency, and QLD Fire Department to Kafka endpoints."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/australia-wildfires/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+
+ENV CONNECTION_STRING=""
+
+CMD ["python", "-m", "australia_wildfires", "feed"]

--- a/australia-wildfires/EVENTS.md
+++ b/australia-wildfires/EVENTS.md
@@ -1,0 +1,51 @@
+# Events — Australian State Wildfires
+
+This document describes the CloudEvents emitted by the Australian State
+Wildfires bridge, derived from the xreg manifest at
+`xreg/australia_wildfires.xreg.json`.
+
+## Endpoint
+
+| Property | Value |
+|----------|-------|
+| Protocol | Kafka |
+| Topic | `australia-wildfires` |
+| Envelope | CloudEvents/1.0 structured JSON |
+| Key | `{state}/{incident_id}` |
+
+## Message Group: `AU.Gov.Emergency.Wildfires`
+
+### `AU.Gov.Emergency.Wildfires.FireIncident`
+
+Normalized bushfire or grass fire incident record aggregated from three
+Australian state emergency services.
+
+| CloudEvents Attribute | Value |
+|-----------------------|-------|
+| `type` | `AU.Gov.Emergency.Wildfires.FireIncident` |
+| `source` | `https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires` |
+| `subject` | `{state}/{incident_id}` |
+
+#### Schema: `FireIncident`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `incident_id` | string | ✅ | Stable identifier for the fire incident |
+| `state` | string | ✅ | Australian state abbreviation (NSW, VIC, QLD) |
+| `title` | string | ✅ | Human-readable title or headline |
+| `alert_level` | string | ✅ | Alert level (Advice, Watch and Act, Emergency Warning) |
+| `status` | string \| null | | Operational status of the incident |
+| `location` | string \| null | | Human-readable location description |
+| `latitude` | double \| null | | Latitude of incident centroid (WGS84, °) |
+| `longitude` | double \| null | | Longitude of incident centroid (WGS84, °) |
+| `size_hectares` | double \| null | | Estimated fire area in hectares |
+| `type` | string \| null | | Fire type classification (Bush Fire, Grass Fire, etc.) |
+| `responsible_agency` | string \| null | | Responsible fire-fighting agency |
+| `updated` | datetime | ✅ | Last update timestamp (ISO 8601 UTC) |
+| `source_url` | string | ✅ | URL to original incident details |
+
+## Data Sources
+
+- **NSW Rural Fire Service**: `https://www.rfs.nsw.gov.au/feeds/majorIncidents.json`
+- **VicEmergency**: `https://www.emergency.vic.gov.au/public/osom-geojson.json` (filtered for fire events)
+- **Queensland Fire Department**: `https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/Feeds/BushfireCurrentIncidents/bushfireAlert.json`

--- a/australia-wildfires/README.md
+++ b/australia-wildfires/README.md
@@ -1,0 +1,47 @@
+# Australian State Wildfires Bridge
+
+This bridge aggregates live bushfire incident data from three Australian state
+emergency services and emits normalized `FireIncident` CloudEvents to a Kafka
+topic.
+
+## Sources
+
+| State | Agency | Endpoint |
+|-------|--------|----------|
+| NSW | Rural Fire Service | `https://www.rfs.nsw.gov.au/feeds/majorIncidents.json` |
+| VIC | VicEmergency | `https://www.emergency.vic.gov.au/public/osom-geojson.json` |
+| QLD | Queensland Fire Department | `https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/Feeds/BushfireCurrentIncidents/bushfireAlert.json` |
+
+All three endpoints are public GeoJSON feeds requiring no authentication.
+
+## How It Works
+
+1. The bridge polls all three GeoJSON endpoints every 5 minutes (configurable).
+2. NSW features are parsed directly; VIC features are filtered for
+   `category2 == "Fire"` or CAP category containing "Fire"; QLD features are
+   included as-is (the feed is bushfire-only).
+3. Each feature is normalized into a unified `FireIncident` schema with
+   coordinates extracted from the GeoJSON geometry.
+4. Deduplication is performed by `{state}/{incident_id}` + `updated` timestamp.
+5. New or updated incidents are emitted as structured CloudEvents to Kafka.
+
+## Event Types
+
+See [EVENTS.md](EVENTS.md) for the full event catalog.
+
+## Running
+
+```bash
+# Install
+pip install -e .
+
+# List current incidents
+python -m australia_wildfires list
+
+# Feed to Kafka
+python -m australia_wildfires --connection-string "BootstrapServer=localhost:9092;EntityPath=australia-wildfires" feed
+```
+
+## Container
+
+See [CONTAINER.md](CONTAINER.md) for Docker deployment instructions.

--- a/australia-wildfires/australia_wildfires/__init__.py
+++ b/australia-wildfires/australia_wildfires/__init__.py
@@ -1,0 +1,5 @@
+"""Australian State Wildfires Bridge."""
+
+from australia_wildfires.australia_wildfires import main
+
+__all__ = ["main"]

--- a/australia-wildfires/australia_wildfires/__main__.py
+++ b/australia-wildfires/australia_wildfires/__main__.py
@@ -1,0 +1,5 @@
+"""Australian State Wildfires Bridge — __main__ entry point."""
+
+from australia_wildfires.australia_wildfires import main
+
+main()

--- a/australia-wildfires/australia_wildfires/australia_wildfires.py
+++ b/australia-wildfires/australia_wildfires/australia_wildfires.py
@@ -1,0 +1,500 @@
+"""Australian State Wildfires Bridge — fetches live bushfire incidents from NSW RFS, VicEmergency, and QLD Fire Department."""
+
+import argparse
+import json
+import sys
+import os
+import time
+import re
+import typing
+import logging
+import hashlib
+import requests
+from datetime import datetime, timezone
+
+from confluent_kafka import Producer
+
+from australia_wildfires_producer_kafka_producer.producer import AUGovEmergencyWildfiresEventProducer
+from australia_wildfires_producer_data import FireIncident
+
+logger = logging.getLogger(__name__)
+
+NSW_RFS_URL = "https://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
+VIC_EMERGENCY_URL = "https://www.emergency.vic.gov.au/public/osom-geojson.json"
+QLD_FIRE_URL = "https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/Feeds/BushfireCurrentIncidents/bushfireAlert.json"
+
+# Regex to parse key-value pairs from the NSW RFS HTML description field
+NSW_DESC_PATTERN = re.compile(
+    r"(?:ALERT LEVEL|LOCATION|COUNCIL AREA|STATUS|TYPE|FIRE|SIZE|RESPONSIBLE AGENCY|UPDATED)\s*:\s*([^<]+?)(?:<br\s*/?>|$)",
+    re.IGNORECASE,
+)
+NSW_FIELD_PATTERN = re.compile(
+    r"(ALERT LEVEL|LOCATION|COUNCIL AREA|STATUS|TYPE|FIRE|SIZE|RESPONSIBLE AGENCY|UPDATED)\s*:\s*([^<]+?)(?:\s*<br\s*/?>|$)",
+    re.IGNORECASE,
+)
+
+
+def _parse_nsw_description(description: str) -> dict[str, str]:
+    """Parse structured fields from the NSW RFS HTML description string."""
+    fields: dict[str, str] = {}
+    for match in NSW_FIELD_PATTERN.finditer(description):
+        key = match.group(1).strip().upper()
+        value = match.group(2).strip()
+        fields[key] = value
+    return fields
+
+
+def _extract_point_from_geometry(geometry: typing.Optional[dict]) -> tuple[typing.Optional[float], typing.Optional[float]]:
+    """Extract latitude and longitude from a GeoJSON geometry.
+
+    Handles Point, Polygon, MultiPolygon, and GeometryCollection types.
+    Returns (latitude, longitude) or (None, None) if no coordinates found.
+    """
+    if not geometry:
+        return None, None
+
+    geo_type = geometry.get("type", "")
+    coordinates = geometry.get("coordinates")
+
+    if geo_type == "Point" and coordinates and len(coordinates) >= 2:
+        return coordinates[1], coordinates[0]
+
+    if geo_type == "Polygon" and coordinates and len(coordinates) > 0:
+        return _polygon_centroid(coordinates[0])
+
+    if geo_type == "MultiPolygon" and coordinates and len(coordinates) > 0:
+        # Use the first polygon's outer ring
+        return _polygon_centroid(coordinates[0][0])
+
+    if geo_type == "GeometryCollection":
+        geometries = geometry.get("geometries", [])
+        # Prefer Point geometry
+        for g in geometries:
+            if g.get("type") == "Point":
+                coords = g.get("coordinates", [])
+                if len(coords) >= 2:
+                    return coords[1], coords[0]
+        # Fall back to first polygon
+        for g in geometries:
+            lat, lon = _extract_point_from_geometry(g)
+            if lat is not None:
+                return lat, lon
+
+    return None, None
+
+
+def _polygon_centroid(ring: list[list[float]]) -> tuple[typing.Optional[float], typing.Optional[float]]:
+    """Compute the centroid of a polygon ring as the average of its vertices."""
+    if not ring:
+        return None, None
+    lats = [p[1] for p in ring if len(p) >= 2]
+    lons = [p[0] for p in ring if len(p) >= 2]
+    if not lats or not lons:
+        return None, None
+    return sum(lats) / len(lats), sum(lons) / len(lons)
+
+
+def _incident_id_from_guid(guid: str) -> str:
+    """Extract a numeric incident ID from an NSW RFS GUID URL."""
+    # e.g. https://incidents.rfs.nsw.gov.au/api/v1/incidents/653509
+    parts = guid.rstrip("/").split("/")
+    if parts:
+        return parts[-1]
+    return hashlib.md5(guid.encode()).hexdigest()[:12]
+
+
+def _parse_size_hectares(size_str: str) -> typing.Optional[float]:
+    """Parse a size string like '150 ha' into a float."""
+    if not size_str:
+        return None
+    cleaned = size_str.lower().replace("ha", "").replace(",", "").strip()
+    try:
+        return float(cleaned)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_nsw_updated(updated_str: str) -> str:
+    """Parse the NSW UPDATED field (e.g. '9 Apr 2026 00:08') to ISO 8601 UTC."""
+    for fmt in ("%d %b %Y %H:%M", "%d/%m/%Y %I:%M:%S %p", "%d %b %Y %H:%M:%S"):
+        try:
+            dt = datetime.strptime(updated_str.strip(), fmt)
+            return dt.replace(tzinfo=timezone.utc).isoformat()
+        except ValueError:
+            continue
+    return datetime.now(timezone.utc).isoformat()
+
+
+class AustraliaWildfiresAPI:
+    """Client for fetching bushfire incident data from Australian state fire services."""
+
+    def __init__(self, polling_interval: int = 300):
+        self.polling_interval = polling_interval
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": "real-time-sources-australia-wildfires-bridge/1.0"})
+
+    def fetch_nsw_incidents(self) -> list[FireIncident]:
+        """Fetch and parse fire incidents from NSW Rural Fire Service."""
+        try:
+            response = self.session.get(NSW_RFS_URL, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            logger.warning("Failed to fetch NSW RFS data: %s", e)
+            return []
+
+        incidents: list[FireIncident] = []
+        for feature in data.get("features", []):
+            try:
+                incident = self._parse_nsw_feature(feature)
+                if incident:
+                    incidents.append(incident)
+            except Exception as e:
+                logger.debug("Failed to parse NSW feature: %s", e)
+        return incidents
+
+    def fetch_vic_incidents(self) -> list[FireIncident]:
+        """Fetch and parse fire incidents from VicEmergency."""
+        try:
+            response = self.session.get(VIC_EMERGENCY_URL, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            logger.warning("Failed to fetch VicEmergency data: %s", e)
+            return []
+
+        incidents: list[FireIncident] = []
+        for feature in data.get("features", []):
+            try:
+                props = feature.get("properties", {})
+                # Filter for fire events
+                category2 = (props.get("category2") or "").lower()
+                cap = props.get("cap", {}) or {}
+                cap_category = (cap.get("category") or "").lower()
+                if "fire" not in category2 and "fire" not in cap_category:
+                    continue
+                incident = self._parse_vic_feature(feature)
+                if incident:
+                    incidents.append(incident)
+            except Exception as e:
+                logger.debug("Failed to parse VIC feature: %s", e)
+        return incidents
+
+    def fetch_qld_incidents(self) -> list[FireIncident]:
+        """Fetch and parse fire incidents from Queensland Fire Department."""
+        try:
+            response = self.session.get(QLD_FIRE_URL, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            logger.warning("Failed to fetch QLD Fire data: %s", e)
+            return []
+
+        incidents: list[FireIncident] = []
+        for feature in data.get("features", []):
+            try:
+                incident = self._parse_qld_feature(feature)
+                if incident:
+                    incidents.append(incident)
+            except Exception as e:
+                logger.debug("Failed to parse QLD feature: %s", e)
+        return incidents
+
+    @staticmethod
+    def _parse_nsw_feature(feature: dict) -> typing.Optional[FireIncident]:
+        """Parse a single NSW RFS GeoJSON feature into a FireIncident."""
+        props = feature.get("properties", {})
+        geometry = feature.get("geometry")
+
+        title = props.get("title", "")
+        guid = props.get("guid", "")
+        if not guid:
+            return None
+
+        incident_id = _incident_id_from_guid(guid)
+        desc_fields = _parse_nsw_description(props.get("description", ""))
+        lat, lon = _extract_point_from_geometry(geometry)
+
+        alert_level = props.get("category", desc_fields.get("ALERT LEVEL", "Unknown"))
+        status = desc_fields.get("STATUS")
+        location = desc_fields.get("LOCATION")
+        fire_type = desc_fields.get("TYPE")
+        responsible_agency = desc_fields.get("RESPONSIBLE AGENCY")
+        size_str = desc_fields.get("SIZE", "")
+        size_hectares = _parse_size_hectares(size_str)
+
+        updated_str = desc_fields.get("UPDATED", "")
+        updated = _parse_nsw_updated(updated_str) if updated_str else datetime.now(timezone.utc).isoformat()
+
+        source_url = guid if guid.startswith("http") else f"https://www.rfs.nsw.gov.au/fire-information/fires-near-me"
+
+        return FireIncident(
+            incident_id=incident_id,
+            state="NSW",
+            title=title,
+            alert_level=alert_level,
+            status=status,
+            location=location,
+            latitude=lat,
+            longitude=lon,
+            size_hectares=size_hectares,
+            type=fire_type,
+            responsible_agency=responsible_agency,
+            updated=updated,
+            source_url=source_url,
+        )
+
+    @staticmethod
+    def _parse_vic_feature(feature: dict) -> typing.Optional[FireIncident]:
+        """Parse a single VicEmergency GeoJSON feature into a FireIncident."""
+        props = feature.get("properties", {})
+        geometry = feature.get("geometry")
+
+        source_id = props.get("sourceId") or props.get("id")
+        if not source_id:
+            return None
+
+        cap = props.get("cap", {}) or {}
+        lat, lon = _extract_point_from_geometry(geometry)
+
+        name = props.get("sourceTitle") or props.get("name") or ""
+        alert_level = props.get("category1") or props.get("action") or "Unknown"
+        status = props.get("status")
+        location = props.get("location")
+        fire_type = cap.get("event")
+        responsible_agency = cap.get("senderName")
+
+        size_hectares = None
+        size_fmt = props.get("sizeFmt")
+        if size_fmt:
+            size_hectares = _parse_size_hectares(size_fmt)
+
+        updated_str = props.get("updated") or props.get("created", "")
+        if updated_str:
+            try:
+                updated = datetime.fromisoformat(updated_str).astimezone(timezone.utc).isoformat()
+            except (ValueError, TypeError):
+                updated = datetime.now(timezone.utc).isoformat()
+        else:
+            updated = datetime.now(timezone.utc).isoformat()
+
+        source_url = f"http://emergency.vic.gov.au/respond/#!/warning/{source_id}/moreinfo"
+
+        return FireIncident(
+            incident_id=str(source_id),
+            state="VIC",
+            title=name,
+            alert_level=alert_level,
+            status=status,
+            location=location,
+            latitude=lat,
+            longitude=lon,
+            size_hectares=size_hectares,
+            type=fire_type,
+            responsible_agency=responsible_agency,
+            updated=updated,
+            source_url=source_url,
+        )
+
+    @staticmethod
+    def _parse_qld_feature(feature: dict) -> typing.Optional[FireIncident]:
+        """Parse a single QLD Fire Department GeoJSON feature into a FireIncident."""
+        props = feature.get("properties", {})
+        geometry = feature.get("geometry")
+
+        unique_id = props.get("UniqueID")
+        if not unique_id:
+            return None
+
+        lat, lon = _extract_point_from_geometry(geometry)
+
+        title = props.get("WarningTitle", "")
+        alert_level = props.get("WarningLevel", "Unknown")
+        header = props.get("Header", "")
+        call_to_action = props.get("CallToAction", "")
+
+        # Derive location from the header or title
+        location = header if header else None
+
+        # Derive fire type from CallToAction
+        fire_type = None
+        if call_to_action:
+            cta_lower = call_to_action.lower()
+            if "hazard reduction" in cta_lower:
+                fire_type = "Hazard Reduction"
+            elif "bushfire" in cta_lower or "bush fire" in cta_lower:
+                fire_type = "Bush Fire"
+            elif "grass fire" in cta_lower:
+                fire_type = "Grass Fire"
+            elif "structure fire" in cta_lower:
+                fire_type = "Structure Fire"
+            elif "smoke" in cta_lower:
+                fire_type = "Smoke Alert"
+            else:
+                fire_type = call_to_action
+
+        updated = datetime.now(timezone.utc).isoformat()
+
+        return FireIncident(
+            incident_id=str(unique_id),
+            state="QLD",
+            title=title,
+            alert_level=alert_level,
+            status=None,
+            location=location,
+            latitude=lat,
+            longitude=lon,
+            size_hectares=None,
+            type=fire_type,
+            responsible_agency="Queensland Fire Department",
+            updated=updated,
+            source_url=QLD_FIRE_URL,
+        )
+
+
+def parse_connection_string(connection_string: str) -> dict:
+    """Parse a Kafka connection string into a config dict."""
+    config: dict[str, str] = {}
+    for part in connection_string.split(";"):
+        part = part.strip()
+        if "=" in part:
+            key, value = part.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if key == "Endpoint":
+                config["bootstrap.servers"] = value.replace("sb://", "").rstrip("/") + ":9093"
+            elif key == "SharedAccessKeyName":
+                config["sasl.username"] = "$ConnectionString"
+            elif key == "SharedAccessKey":
+                config["sasl.password"] = connection_string
+            elif key == "BootstrapServer":
+                config["bootstrap.servers"] = value
+            elif key == "EntityPath":
+                config["_entity_path"] = value
+    if "sasl.username" in config:
+        config["security.protocol"] = "SASL_SSL"
+        config["sasl.mechanism"] = "PLAIN"
+    return config
+
+
+def _load_state(state_file: str) -> dict[str, str]:
+    """Load persisted dedup state from a JSON file."""
+    try:
+        if state_file and os.path.exists(state_file):
+            with open(state_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+    except Exception as e:
+        logging.warning("Could not load state from %s: %s", state_file, e)
+    return {}
+
+
+def _save_state(state_file: str, data: dict[str, str]) -> None:
+    """Save dedup state to a JSON file, keeping at most 50000 entries."""
+    if not state_file:
+        return
+    try:
+        if len(data) > 100000:
+            keys = list(data.keys())
+            data = {k: data[k] for k in keys[-50000:]}
+        with open(state_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+    except Exception as e:
+        logging.warning("Could not save state to %s: %s", state_file, e)
+
+
+def feed_incidents(
+    api: AustraliaWildfiresAPI,
+    producer: AUGovEmergencyWildfiresEventProducer,
+    previous: dict[str, str],
+) -> int:
+    """Fetch incidents from all three states and emit new or updated ones."""
+    all_incidents: list[FireIncident] = []
+    all_incidents.extend(api.fetch_nsw_incidents())
+    all_incidents.extend(api.fetch_vic_incidents())
+    all_incidents.extend(api.fetch_qld_incidents())
+
+    sent = 0
+    for incident in all_incidents:
+        dedup_key = f"{incident.state}/{incident.incident_id}"
+        if previous.get(dedup_key) == incident.updated:
+            continue
+        producer.send_au_gov_emergency_wildfires_fire_incident(
+            incident.state,
+            incident.incident_id,
+            incident,
+            flush_producer=False,
+        )
+        previous[dedup_key] = incident.updated
+        sent += 1
+
+    producer.producer.flush()
+    return sent
+
+
+def main():
+    """Main entry point for the Australian Wildfires bridge."""
+    parser = argparse.ArgumentParser(description="Australian State Wildfires Bridge")
+    parser.add_argument("--connection-string", required=False,
+                        help="Kafka/Event Hubs connection string",
+                        default=os.environ.get("KAFKA_CONNECTION_STRING") or os.environ.get("CONNECTION_STRING"))
+    parser.add_argument("--topic", required=False,
+                        help="Kafka topic",
+                        default=os.environ.get("KAFKA_TOPIC") or None)
+    parser.add_argument("--polling-interval", type=int,
+                        default=int(os.environ.get("POLLING_INTERVAL", "300")),
+                        help="Polling interval in seconds (default: 300)")
+    parser.add_argument("--state-file", type=str,
+                        default=os.environ.get("STATE_FILE",
+                                               os.path.expanduser("~/.australia_wildfires_state.json")))
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("list", help="List current incidents")
+    subparsers.add_parser("feed", help="Feed data to Kafka")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    api = AustraliaWildfiresAPI(polling_interval=args.polling_interval)
+
+    if args.command == "list":
+        for state_name, fetch_fn in [("NSW", api.fetch_nsw_incidents),
+                                      ("VIC", api.fetch_vic_incidents),
+                                      ("QLD", api.fetch_qld_incidents)]:
+            incidents = fetch_fn()
+            print(f"\n--- {state_name}: {len(incidents)} incidents ---")
+            for inc in incidents:
+                print(f"  {inc.incident_id}: {inc.title} [{inc.alert_level}] ({inc.location})")
+    elif args.command == "feed":
+        if not args.connection_string:
+            if not os.environ.get("KAFKA_BROKER"):
+                print("Error: --connection-string or KAFKA_BROKER environment variable required for feed mode")
+                sys.exit(1)
+            kafka_config: dict[str, str] = {"bootstrap.servers": os.environ["KAFKA_BROKER"]}
+        else:
+            kafka_config = parse_connection_string(args.connection_string)
+        if "_entity_path" in kafka_config and not args.topic:
+            args.topic = kafka_config.pop("_entity_path")
+        elif "_entity_path" in kafka_config:
+            kafka_config.pop("_entity_path")
+        if not args.topic:
+            args.topic = "australia-wildfires"
+        tls_enabled = os.getenv("KAFKA_ENABLE_TLS", "true").lower() not in ("false", "0", "no")
+        if "sasl.username" in kafka_config:
+            kafka_config["security.protocol"] = "SASL_SSL" if tls_enabled else "SASL_PLAINTEXT"
+        kafka_config["client.id"] = "australia-wildfires-bridge"
+        kafka_producer = Producer(kafka_config)
+        event_producer = AUGovEmergencyWildfiresEventProducer(kafka_producer, args.topic)
+        logger.info("Starting Australian Wildfires bridge, polling every %d seconds", args.polling_interval)
+        state = _load_state(args.state_file)
+        while True:
+            try:
+                count = feed_incidents(api, event_producer, state)
+                _save_state(args.state_file, state)
+                logger.info("Sent %d fire incident events", count)
+            except Exception as e:
+                logger.error("Error fetching/sending data: %s", e)
+            time.sleep(args.polling_interval)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/pyproject.toml
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "australia-wildfires-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "australia_wildfires_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/src/australia_wildfires_producer_data/__init__.py
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/src/australia_wildfires_producer_data/__init__.py
@@ -1,0 +1,3 @@
+from .fireincident import FireIncident
+
+__all__ = ["FireIncident"]

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/src/australia_wildfires_producer_data/fireincident.py
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_data/src/australia_wildfires_producer_data/fireincident.py
@@ -1,0 +1,191 @@
+""" FireIncident dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class FireIncident:
+    """
+    Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services.
+
+    Attributes:
+        incident_id (str)
+        state (str)
+        title (str)
+        alert_level (str)
+        status (typing.Optional[str])
+        location (typing.Optional[str])
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+        size_hectares (typing.Optional[float])
+        type (typing.Optional[str])
+        responsible_agency (typing.Optional[str])
+        updated (str)
+        source_url (str)
+    """
+
+
+    incident_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="incident_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
+    title: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="title"))
+    alert_level: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="alert_level"))
+    status: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="status"))
+    location: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="location"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    size_hectares: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_hectares"))
+    type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="type"))
+    responsible_agency: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="responsible_agency"))
+    updated: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="updated"))
+    source_url: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="source_url"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'FireIncident':
+        """
+        Converts a dictionary to a dataclass instance.
+
+        Args:
+            data: The dictionary to convert to a dataclass.
+
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['FireIncident']:
+        """
+        Converts the data to a dataclass based on the content type string.
+
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to.
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return FireIncident.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'FireIncident':
+        """
+        Creates an instance of the dataclass with test values.
+
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            incident_id='test-incident-001',
+            state='NSW',
+            title='Test Fire Incident',
+            alert_level='Advice',
+            status='Under control',
+            location='Test Location, NSW 2000',
+            latitude=float(-33.8688),
+            longitude=float(151.2093),
+            size_hectares=float(10.5),
+            type='Bush Fire',
+            responsible_agency='Rural Fire Service',
+            updated='2026-01-01T00:00:00+00:00',
+            source_url='https://incidents.rfs.nsw.gov.au/api/v1/incidents/000001'
+        )

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/pyproject.toml
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "australia-wildfires-producer-kafka-producer"
+description = "australia_wildfires_producer_kafka_producer Kafka producer library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"
+packages = [{include = "australia_wildfires_producer_kafka_producer", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+australia-wildfires-producer-data = {path = "../australia_wildfires_producer_data", develop = true}
+confluent-kafka = ">=2.4.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/src/australia_wildfires_producer_kafka_producer/__init__.py
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/src/australia_wildfires_producer_kafka_producer/__init__.py
@@ -1,0 +1,3 @@
+from .producer import AUGovEmergencyWildfiresEventProducer
+
+__all__ = ["AUGovEmergencyWildfiresEventProducer"]

--- a/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/src/australia_wildfires_producer_kafka_producer/producer.py
+++ b/australia-wildfires/australia_wildfires_producer/australia_wildfires_producer_kafka_producer/src/australia_wildfires_producer_kafka_producer/producer.py
@@ -1,0 +1,71 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import sys
+import json
+import uuid
+import typing
+from datetime import datetime
+from confluent_kafka import Producer, KafkaException, Message
+from cloudevents.kafka import to_binary, to_structured, KafkaMessage
+from cloudevents.http import CloudEvent
+from australia_wildfires_producer_data import FireIncident
+
+class AUGovEmergencyWildfiresEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_au_gov_emergency_wildfires_fire_incident(self,_state : str, _incident_id : str, data: FireIncident, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, FireIncident], str]=None) -> None:
+        """
+        Sends the 'AU.Gov.Emergency.Wildfires.FireIncident' event to the Kafka topic
+
+        Args:
+            _state(str):  Value for placeholder state in attribute subject
+            _incident_id(str):  Value for placeholder incident_id in attribute subject
+            data: (FireIncident): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, FireIncident], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+                The default key is derived from the xRegistry Kafka key declaration '{state}/{incident_id}'
+        """
+        kafka_key = "{state}/{incident_id}".format(state=_state, incident_id=_incident_id)
+        attributes = {
+             "type":"AU.Gov.Emergency.Wildfires.FireIncident",
+             "source":"https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires",
+             "subject":"{state}/{incident_id}".format(state = _state, incident_id = _incident_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()

--- a/australia-wildfires/generate_producer.ps1
+++ b/australia-wildfires/generate_producer.ps1
@@ -1,0 +1,5 @@
+# The checked-in xreg manifest is authoritative. Regenerate the client from it.
+
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+xrcg generate --style kafkaproducer --language py --definitions xreg\australia_wildfires.xreg.json --projectname australia_wildfires_producer --output australia_wildfires_producer

--- a/australia-wildfires/pyproject.toml
+++ b/australia-wildfires/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "australia-wildfires"
+version = "0.1.0"
+description = "Bridge between Australian state fire service bushfire incident feeds and Kafka endpoints"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+confluent-kafka = ">=2.5.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+avro = ">=1.11.3"
+australia_wildfires_producer_data = {path = "australia_wildfires_producer/australia_wildfires_producer_data"}
+australia_wildfires_producer_kafka_producer = {path = "australia_wildfires_producer/australia_wildfires_producer_kafka_producer"}
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.3.3"
+pytest-cov = ">=5.0.0"
+testcontainers = ">=4.8.1"
+requests-mock = ">=1.12.1"
+
+[tool.poetry.scripts]
+australia-wildfires = "australia_wildfires:main"

--- a/australia-wildfires/pytest.ini
+++ b/australia-wildfires/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+markers =
+    unit: marks tests as unit tests
+    integration: marks tests as integration tests

--- a/australia-wildfires/tests/test_australia_wildfires.py
+++ b/australia-wildfires/tests/test_australia_wildfires.py
@@ -1,0 +1,708 @@
+"""Unit tests for Australian State Wildfires Bridge."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from australia_wildfires_producer_data import FireIncident
+
+from australia_wildfires.australia_wildfires import (
+    AustraliaWildfiresAPI,
+    parse_connection_string,
+    feed_incidents,
+    _load_state,
+    _save_state,
+    _parse_nsw_description,
+    _extract_point_from_geometry,
+    _incident_id_from_guid,
+    _parse_size_hectares,
+    _parse_nsw_updated,
+    _polygon_centroid,
+    NSW_RFS_URL,
+    VIC_EMERGENCY_URL,
+    QLD_FIRE_URL,
+)
+
+
+# ---- Sample data from probed endpoints ----
+
+SAMPLE_NSW_FEATURE = {
+    "type": "Feature",
+    "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+            {"type": "Point", "coordinates": [151.59561, -29.72272]},
+            {
+                "type": "GeometryCollection",
+                "geometries": [
+                    {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [151.594, -29.721],
+                                [151.595, -29.722],
+                                [151.596, -29.723],
+                                [151.594, -29.721],
+                            ]
+                        ],
+                    }
+                ],
+            },
+        ],
+    },
+    "properties": {
+        "title": "(GWYDIR HWY), MATHESON",
+        "link": "https://www.rfs.nsw.gov.au/fire-information/fires-near-me",
+        "category": "Advice",
+        "guid": "https://incidents.rfs.nsw.gov.au/api/v1/incidents/653509",
+        "guid_isPermaLink": "true",
+        "pubDate": "8/04/2026 2:08:00 PM",
+        "description": "ALERT LEVEL: Advice <br />LOCATION: B76 (GWYDIR HWY), MATHESON 2370 <br />COUNCIL AREA: Glen Innes Severn <br />STATUS: Under control <br />TYPE: Grass Fire <br />FIRE: Yes <br />SIZE: 0 ha <br />RESPONSIBLE AGENCY: Rural Fire Service <br />UPDATED: 9 Apr 2026 00:08",
+    },
+}
+
+SAMPLE_NSW_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [SAMPLE_NSW_FEATURE],
+}
+
+
+SAMPLE_VIC_FIRE_FEATURE = {
+    "type": "Feature",
+    "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+            {"type": "Point", "coordinates": [143.063, -37.387]},
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [143.08, -37.39],
+                        [143.09, -37.38],
+                        [143.07, -37.37],
+                        [143.08, -37.39],
+                    ]
+                ],
+            },
+        ],
+    },
+    "properties": {
+        "feedType": "warning",
+        "cap": {
+            "category": "Fire",
+            "event": "Grass Fire",
+            "eventCode": "grassFire",
+            "urgency": "Unknown",
+            "severity": "Unknown",
+            "certainty": "Observed",
+            "contact": "test@emv.vic.gov.au",
+            "senderName": "Country Fire Authority",
+            "responseType": "None",
+        },
+        "sourceOrg": "EMV",
+        "sourceId": "41825",
+        "sourceFeed": "cop-cap",
+        "sourceTitle": "Community Information",
+        "id": "41825",
+        "category1": "Community Update",
+        "category2": "Fire",
+        "status": "Unknown",
+        "name": "Community Information",
+        "action": "Stay Informed",
+        "statewide": "N",
+        "location": "Ballyrogan, Buangor, Dobie",
+        "created": "2026-04-08T10:30:06+10:00",
+        "updated": "2026-04-08T10:30:06+10:00",
+        "webHeadline": None,
+        "webBody": "<div>Test</div>",
+        "text": "COMMUNITY INFORMATION - GRASS FIRE",
+        "sizeFmt": None,
+    },
+}
+
+SAMPLE_VIC_NON_FIRE_FEATURE = {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [144.0, -37.0]},
+    "properties": {
+        "feedType": "warning",
+        "cap": {"category": "Met", "event": "Flood"},
+        "sourceId": "99999",
+        "id": "99999",
+        "category1": "Warning",
+        "category2": "Flood",
+        "status": "Active",
+        "name": "Flood Warning",
+        "location": "Test River",
+        "created": "2026-04-08T10:00:00+10:00",
+        "updated": "2026-04-08T10:00:00+10:00",
+    },
+}
+
+SAMPLE_VIC_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [SAMPLE_VIC_FIRE_FEATURE, SAMPLE_VIC_NON_FIRE_FEATURE],
+}
+
+
+SAMPLE_QLD_FEATURE = {
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [151.926, -27.414, 0],
+                [151.919, -27.494, 0],
+                [152.047, -27.501, 0],
+                [152.053, -27.421, 0],
+                [151.926, -27.414, 0],
+            ]
+        ],
+    },
+    "properties": {
+        "OBJECTID": 2688,
+        "UniqueID": "IF39-5661721",
+        "WarningTitle": "AVOID SMOKE (HAZARD REDUCTION BURN) - Cabarlah (near Toowoomba)",
+        "WarningLevel": "Advice",
+        "CallToAction": "AVOID SMOKE (HAZARD REDUCTION BURN)",
+        "WarningText": "Test warning text",
+        "Header": "Smoke is currently affecting Cabarlah, Highfields, Ballard and surrounding areas.",
+        "Impacts": "- Smoke can make it hard for some people to breathe.",
+        "LeaveSafely": None,
+        "FurtherInformation": "Visit QFD website for more info.",
+    },
+}
+
+SAMPLE_QLD_GEOJSON = {
+    "type": "FeatureCollection",
+    "name": "QFDWarnings",
+    "features": [SAMPLE_QLD_FEATURE],
+}
+
+
+# ---- Test Classes ----
+
+
+@pytest.mark.unit
+class TestParseNSWDescription:
+    def test_parse_full_description(self):
+        desc = "ALERT LEVEL: Advice <br />LOCATION: B76 (GWYDIR HWY), MATHESON 2370 <br />COUNCIL AREA: Glen Innes Severn <br />STATUS: Under control <br />TYPE: Grass Fire <br />FIRE: Yes <br />SIZE: 0 ha <br />RESPONSIBLE AGENCY: Rural Fire Service <br />UPDATED: 9 Apr 2026 00:08"
+        fields = _parse_nsw_description(desc)
+        assert fields["ALERT LEVEL"] == "Advice"
+        assert fields["LOCATION"] == "B76 (GWYDIR HWY), MATHESON 2370"
+        assert fields["STATUS"] == "Under control"
+        assert fields["TYPE"] == "Grass Fire"
+        assert fields["SIZE"] == "0 ha"
+        assert fields["RESPONSIBLE AGENCY"] == "Rural Fire Service"
+        assert fields["UPDATED"] == "9 Apr 2026 00:08"
+
+    def test_parse_empty_description(self):
+        assert _parse_nsw_description("") == {}
+
+    def test_parse_partial_description(self):
+        desc = "ALERT LEVEL: Emergency Warning <br />STATUS: Out of control <br />"
+        fields = _parse_nsw_description(desc)
+        assert fields["ALERT LEVEL"] == "Emergency Warning"
+        assert fields["STATUS"] == "Out of control"
+        assert "LOCATION" not in fields
+
+
+@pytest.mark.unit
+class TestExtractPointFromGeometry:
+    def test_point_geometry(self):
+        geo = {"type": "Point", "coordinates": [151.2, -33.8]}
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat == pytest.approx(-33.8)
+        assert lon == pytest.approx(151.2)
+
+    def test_polygon_geometry(self):
+        geo = {
+            "type": "Polygon",
+            "coordinates": [
+                [[150.0, -33.0], [152.0, -33.0], [152.0, -35.0], [150.0, -35.0], [150.0, -33.0]]
+            ],
+        }
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat is not None
+        assert lon is not None
+        assert lat == pytest.approx(-33.8, abs=0.5)
+        assert lon == pytest.approx(150.8, abs=0.5)
+
+    def test_multipolygon_geometry(self):
+        geo = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[150.0, -33.0], [152.0, -33.0], [152.0, -35.0], [150.0, -35.0], [150.0, -33.0]]],
+            ],
+        }
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat is not None
+        assert lon is not None
+
+    def test_geometry_collection_prefers_point(self):
+        geo = {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[150.0, -33.0], [152.0, -33.0], [152.0, -35.0], [150.0, -33.0]]],
+                },
+                {"type": "Point", "coordinates": [151.5, -33.9]},
+            ],
+        }
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat == pytest.approx(-33.9)
+        assert lon == pytest.approx(151.5)
+
+    def test_geometry_collection_falls_back_to_polygon(self):
+        geo = {
+            "type": "GeometryCollection",
+            "geometries": [
+                {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [[150.0, -33.0], [152.0, -33.0], [152.0, -35.0], [150.0, -33.0]]
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat is not None
+
+    def test_empty_geometry(self):
+        lat, lon = _extract_point_from_geometry(None)
+        assert lat is None
+        assert lon is None
+
+    def test_unknown_geometry_type(self):
+        geo = {"type": "LineString", "coordinates": [[150.0, -33.0], [151.0, -34.0]]}
+        lat, lon = _extract_point_from_geometry(geo)
+        assert lat is None
+        assert lon is None
+
+
+@pytest.mark.unit
+class TestPolygonCentroid:
+    def test_simple_ring(self):
+        ring = [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]
+        lat, lon = _polygon_centroid(ring)
+        assert lat == pytest.approx(4.0)
+        assert lon == pytest.approx(4.0)
+
+    def test_empty_ring(self):
+        assert _polygon_centroid([]) == (None, None)
+
+
+@pytest.mark.unit
+class TestIncidentIdFromGuid:
+    def test_rfs_guid_url(self):
+        guid = "https://incidents.rfs.nsw.gov.au/api/v1/incidents/653509"
+        assert _incident_id_from_guid(guid) == "653509"
+
+    def test_simple_id(self):
+        assert _incident_id_from_guid("12345") == "12345"
+
+    def test_trailing_slash(self):
+        assert _incident_id_from_guid("https://example.com/incidents/999/") == "999"
+
+
+@pytest.mark.unit
+class TestParseSizeHectares:
+    def test_numeric_with_ha(self):
+        assert _parse_size_hectares("150 ha") == pytest.approx(150.0)
+
+    def test_zero(self):
+        assert _parse_size_hectares("0 ha") == pytest.approx(0.0)
+
+    def test_with_comma(self):
+        assert _parse_size_hectares("1,500 ha") == pytest.approx(1500.0)
+
+    def test_plain_number(self):
+        assert _parse_size_hectares("42") == pytest.approx(42.0)
+
+    def test_empty_string(self):
+        assert _parse_size_hectares("") is None
+
+    def test_none(self):
+        assert _parse_size_hectares(None) is None
+
+    def test_non_numeric(self):
+        assert _parse_size_hectares("unknown") is None
+
+
+@pytest.mark.unit
+class TestParseNSWUpdated:
+    def test_standard_format(self):
+        result = _parse_nsw_updated("9 Apr 2026 00:08")
+        assert "2026-04-09" in result
+        assert "+00:00" in result
+
+    def test_fallback_to_now(self):
+        result = _parse_nsw_updated("invalid date")
+        # Should return a valid ISO datetime
+        assert "T" in result
+
+
+@pytest.mark.unit
+class TestParseNSWFeature:
+    def test_parse_nsw_feature(self):
+        incident = AustraliaWildfiresAPI._parse_nsw_feature(SAMPLE_NSW_FEATURE)
+        assert incident is not None
+        assert incident.incident_id == "653509"
+        assert incident.state == "NSW"
+        assert incident.title == "(GWYDIR HWY), MATHESON"
+        assert incident.alert_level == "Advice"
+        assert incident.status == "Under control"
+        assert incident.location == "B76 (GWYDIR HWY), MATHESON 2370"
+        assert incident.latitude == pytest.approx(-29.72272)
+        assert incident.longitude == pytest.approx(151.59561)
+        assert incident.size_hectares == pytest.approx(0.0)
+        assert incident.type == "Grass Fire"
+        assert incident.responsible_agency == "Rural Fire Service"
+        assert incident.source_url == "https://incidents.rfs.nsw.gov.au/api/v1/incidents/653509"
+
+    def test_parse_nsw_feature_no_guid(self):
+        feature = {"properties": {"title": "Test"}, "geometry": None}
+        assert AustraliaWildfiresAPI._parse_nsw_feature(feature) is None
+
+
+@pytest.mark.unit
+class TestParseVICFeature:
+    def test_parse_vic_fire_feature(self):
+        incident = AustraliaWildfiresAPI._parse_vic_feature(SAMPLE_VIC_FIRE_FEATURE)
+        assert incident is not None
+        assert incident.incident_id == "41825"
+        assert incident.state == "VIC"
+        assert incident.title == "Community Information"
+        assert incident.alert_level == "Community Update"
+        assert incident.status == "Unknown"
+        assert incident.location == "Ballyrogan, Buangor, Dobie"
+        assert incident.latitude == pytest.approx(-37.387)
+        assert incident.longitude == pytest.approx(143.063)
+        assert incident.type == "Grass Fire"
+        assert incident.responsible_agency == "Country Fire Authority"
+        assert "41825" in incident.source_url
+
+    def test_parse_vic_feature_no_id(self):
+        feature = {"properties": {}, "geometry": None}
+        assert AustraliaWildfiresAPI._parse_vic_feature(feature) is None
+
+    def test_parse_vic_feature_size_fmt(self):
+        feature = dict(SAMPLE_VIC_FIRE_FEATURE)
+        feature["properties"] = dict(feature["properties"])
+        feature["properties"]["sizeFmt"] = "250 ha"
+        incident = AustraliaWildfiresAPI._parse_vic_feature(feature)
+        assert incident is not None
+        assert incident.size_hectares == pytest.approx(250.0)
+
+
+@pytest.mark.unit
+class TestParseQLDFeature:
+    def test_parse_qld_feature(self):
+        incident = AustraliaWildfiresAPI._parse_qld_feature(SAMPLE_QLD_FEATURE)
+        assert incident is not None
+        assert incident.incident_id == "IF39-5661721"
+        assert incident.state == "QLD"
+        assert "Cabarlah" in incident.title
+        assert incident.alert_level == "Advice"
+        assert incident.status is None
+        assert incident.location is not None
+        assert "Smoke" in incident.location or "Cabarlah" in incident.location
+        assert incident.latitude is not None
+        assert incident.longitude is not None
+        assert incident.type == "Hazard Reduction"
+        assert incident.responsible_agency == "Queensland Fire Department"
+        assert incident.source_url == QLD_FIRE_URL
+
+    def test_parse_qld_feature_no_unique_id(self):
+        feature = {"properties": {"WarningTitle": "Test"}, "geometry": None}
+        assert AustraliaWildfiresAPI._parse_qld_feature(feature) is None
+
+    def test_parse_qld_bushfire_type(self):
+        feature = dict(SAMPLE_QLD_FEATURE)
+        feature["properties"] = dict(feature["properties"])
+        feature["properties"]["CallToAction"] = "BUSHFIRE WARNING"
+        incident = AustraliaWildfiresAPI._parse_qld_feature(feature)
+        assert incident is not None
+        assert incident.type == "Bush Fire"
+
+    def test_parse_qld_grass_fire_type(self):
+        feature = dict(SAMPLE_QLD_FEATURE)
+        feature["properties"] = dict(feature["properties"])
+        feature["properties"]["CallToAction"] = "GRASS FIRE WARNING"
+        incident = AustraliaWildfiresAPI._parse_qld_feature(feature)
+        assert incident is not None
+        assert incident.type == "Grass Fire"
+
+
+@pytest.mark.unit
+class TestFetchNSWIncidents:
+    def test_fetch_nsw_success(self):
+        api = AustraliaWildfiresAPI()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_NSW_GEOJSON
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(api.session, "get", return_value=mock_resp):
+            incidents = api.fetch_nsw_incidents()
+        assert len(incidents) == 1
+        assert incidents[0].state == "NSW"
+
+    def test_fetch_nsw_network_error(self):
+        api = AustraliaWildfiresAPI()
+        with patch.object(api.session, "get", side_effect=Exception("timeout")):
+            incidents = api.fetch_nsw_incidents()
+        assert incidents == []
+
+
+@pytest.mark.unit
+class TestFetchVICIncidents:
+    def test_fetch_vic_filters_fire_only(self):
+        api = AustraliaWildfiresAPI()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_VIC_GEOJSON
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(api.session, "get", return_value=mock_resp):
+            incidents = api.fetch_vic_incidents()
+        # Should only include fire feature, not flood
+        assert len(incidents) == 1
+        assert incidents[0].state == "VIC"
+        assert incidents[0].incident_id == "41825"
+
+    def test_fetch_vic_network_error(self):
+        api = AustraliaWildfiresAPI()
+        with patch.object(api.session, "get", side_effect=Exception("timeout")):
+            incidents = api.fetch_vic_incidents()
+        assert incidents == []
+
+
+@pytest.mark.unit
+class TestFetchQLDIncidents:
+    def test_fetch_qld_success(self):
+        api = AustraliaWildfiresAPI()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_QLD_GEOJSON
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(api.session, "get", return_value=mock_resp):
+            incidents = api.fetch_qld_incidents()
+        assert len(incidents) == 1
+        assert incidents[0].state == "QLD"
+
+    def test_fetch_qld_network_error(self):
+        api = AustraliaWildfiresAPI()
+        with patch.object(api.session, "get", side_effect=Exception("timeout")):
+            incidents = api.fetch_qld_incidents()
+        assert incidents == []
+
+
+@pytest.mark.unit
+class TestConnectionString:
+    def test_parse_plain_bootstrap(self):
+        cs = "BootstrapServer=localhost:9092;EntityPath=my-topic"
+        config = parse_connection_string(cs)
+        assert config["bootstrap.servers"] == "localhost:9092"
+        assert config["_entity_path"] == "my-topic"
+
+    def test_parse_event_hubs(self):
+        cs = "Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123;EntityPath=topic"
+        config = parse_connection_string(cs)
+        assert "bootstrap.servers" in config
+        assert config["sasl.mechanism"] == "PLAIN"
+        assert config["security.protocol"] == "SASL_SSL"
+
+    def test_parse_empty_parts(self):
+        config = parse_connection_string("")
+        assert config == {}
+
+
+@pytest.mark.unit
+class TestFeedIncidents:
+    def test_feed_emits_new_incidents(self):
+        api = AustraliaWildfiresAPI()
+        mock_producer = MagicMock()
+        mock_producer.producer = MagicMock()
+        previous = {}
+
+        with patch.object(api, "fetch_nsw_incidents", return_value=[
+            FireIncident(incident_id="1", state="NSW", title="Test Fire", alert_level="Advice",
+                         status="Under control", location="Test", latitude=-33.0, longitude=151.0,
+                         size_hectares=10.0, type="Bush Fire", responsible_agency="RFS",
+                         updated="2026-04-09T00:00:00+00:00",
+                         source_url="https://example.com/1")
+        ]), patch.object(api, "fetch_vic_incidents", return_value=[]), \
+             patch.object(api, "fetch_qld_incidents", return_value=[]):
+            count = feed_incidents(api, mock_producer, previous)
+
+        assert count == 1
+        mock_producer.send_au_gov_emergency_wildfires_fire_incident.assert_called_once()
+        assert "NSW/1" in previous
+
+    def test_feed_deduplicates(self):
+        api = AustraliaWildfiresAPI()
+        mock_producer = MagicMock()
+        mock_producer.producer = MagicMock()
+        previous = {"NSW/1": "2026-04-09T00:00:00+00:00"}
+
+        with patch.object(api, "fetch_nsw_incidents", return_value=[
+            FireIncident(incident_id="1", state="NSW", title="Test Fire", alert_level="Advice",
+                         status="Under control", location="Test", latitude=-33.0, longitude=151.0,
+                         size_hectares=10.0, type="Bush Fire", responsible_agency="RFS",
+                         updated="2026-04-09T00:00:00+00:00",
+                         source_url="https://example.com/1")
+        ]), patch.object(api, "fetch_vic_incidents", return_value=[]), \
+             patch.object(api, "fetch_qld_incidents", return_value=[]):
+            count = feed_incidents(api, mock_producer, previous)
+
+        assert count == 0
+        mock_producer.send_au_gov_emergency_wildfires_fire_incident.assert_not_called()
+
+    def test_feed_emits_updated_incident(self):
+        api = AustraliaWildfiresAPI()
+        mock_producer = MagicMock()
+        mock_producer.producer = MagicMock()
+        previous = {"NSW/1": "2026-04-09T00:00:00+00:00"}
+
+        with patch.object(api, "fetch_nsw_incidents", return_value=[
+            FireIncident(incident_id="1", state="NSW", title="Test Fire", alert_level="Emergency Warning",
+                         status="Out of control", location="Test", latitude=-33.0, longitude=151.0,
+                         size_hectares=50.0, type="Bush Fire", responsible_agency="RFS",
+                         updated="2026-04-09T01:00:00+00:00",
+                         source_url="https://example.com/1")
+        ]), patch.object(api, "fetch_vic_incidents", return_value=[]), \
+             patch.object(api, "fetch_qld_incidents", return_value=[]):
+            count = feed_incidents(api, mock_producer, previous)
+
+        assert count == 1
+        assert previous["NSW/1"] == "2026-04-09T01:00:00+00:00"
+
+    def test_feed_multi_state(self):
+        api = AustraliaWildfiresAPI()
+        mock_producer = MagicMock()
+        mock_producer.producer = MagicMock()
+        previous = {}
+
+        nsw_incident = FireIncident(
+            incident_id="1", state="NSW", title="NSW Fire", alert_level="Advice",
+            status=None, location=None, latitude=None, longitude=None,
+            size_hectares=None, type=None, responsible_agency=None,
+            updated="2026-04-09T00:00:00+00:00", source_url="https://example.com")
+        vic_incident = FireIncident(
+            incident_id="2", state="VIC", title="VIC Fire", alert_level="Watch and Act",
+            status=None, location=None, latitude=None, longitude=None,
+            size_hectares=None, type=None, responsible_agency=None,
+            updated="2026-04-09T00:00:00+00:00", source_url="https://example.com")
+        qld_incident = FireIncident(
+            incident_id="3", state="QLD", title="QLD Fire", alert_level="Emergency Warning",
+            status=None, location=None, latitude=None, longitude=None,
+            size_hectares=None, type=None, responsible_agency=None,
+            updated="2026-04-09T00:00:00+00:00", source_url="https://example.com")
+
+        with patch.object(api, "fetch_nsw_incidents", return_value=[nsw_incident]), \
+             patch.object(api, "fetch_vic_incidents", return_value=[vic_incident]), \
+             patch.object(api, "fetch_qld_incidents", return_value=[qld_incident]):
+            count = feed_incidents(api, mock_producer, previous)
+
+        assert count == 3
+        assert len(previous) == 3
+
+
+@pytest.mark.unit
+class TestState:
+    def test_load_state_missing_file(self, tmp_path):
+        assert _load_state(str(tmp_path / "nonexistent.json")) == {}
+
+    def test_save_and_load_state(self, tmp_path):
+        path = str(tmp_path / "state.json")
+        data = {"NSW/1": "2026-04-09T00:00:00+00:00", "VIC/2": "2026-04-09T01:00:00+00:00"}
+        _save_state(path, data)
+        loaded = _load_state(path)
+        assert loaded == data
+
+    def test_save_state_truncates(self, tmp_path):
+        path = str(tmp_path / "state.json")
+        data = {str(i): str(i) for i in range(110000)}
+        _save_state(path, data)
+        loaded = _load_state(path)
+        assert len(loaded) <= 50000
+
+
+@pytest.mark.unit
+class TestFireIncidentDataclass:
+    def test_create_instance(self):
+        instance = FireIncident.create_instance()
+        assert instance.incident_id == "test-incident-001"
+        assert instance.state == "NSW"
+        assert instance.alert_level == "Advice"
+
+    def test_to_serializer_dict(self):
+        instance = FireIncident(
+            incident_id="1", state="NSW", title="Test", alert_level="Advice",
+            status=None, location=None, latitude=None, longitude=None,
+            size_hectares=None, type=None, responsible_agency=None,
+            updated="2026-01-01T00:00:00+00:00", source_url="https://example.com")
+        d = instance.to_serializer_dict()
+        assert d["incident_id"] == "1"
+        assert d["state"] == "NSW"
+        assert d["status"] is None
+
+    def test_from_serializer_dict(self):
+        d = {
+            "incident_id": "42",
+            "state": "VIC",
+            "title": "Test Fire",
+            "alert_level": "Emergency Warning",
+            "status": "Active",
+            "location": "Melbourne",
+            "latitude": -37.8,
+            "longitude": 144.9,
+            "size_hectares": 100.0,
+            "type": "Bush Fire",
+            "responsible_agency": "CFA",
+            "updated": "2026-04-09T00:00:00+00:00",
+            "source_url": "https://example.com",
+        }
+        incident = FireIncident.from_serializer_dict(d)
+        assert incident.incident_id == "42"
+        assert incident.state == "VIC"
+        assert incident.size_hectares == 100.0
+
+    def test_to_json_roundtrip(self):
+        instance = FireIncident.create_instance()
+        json_str = instance.to_json()
+        loaded = json.loads(json_str)
+        assert loaded["incident_id"] == "test-incident-001"
+        restored = FireIncident.from_data(loaded)
+        assert restored.incident_id == instance.incident_id
+
+    def test_to_byte_array_json(self):
+        instance = FireIncident.create_instance()
+        data = instance.to_byte_array("application/json")
+        assert isinstance(data, (bytes, str))
+
+    def test_from_data_none(self):
+        assert FireIncident.from_data(None) is None
+
+    def test_from_data_dict(self):
+        d = {
+            "incident_id": "1", "state": "NSW", "title": "T", "alert_level": "A",
+            "status": None, "location": None, "latitude": None, "longitude": None,
+            "size_hectares": None, "type": None, "responsible_agency": None,
+            "updated": "2026-01-01T00:00:00+00:00", "source_url": "https://x.com",
+        }
+        result = FireIncident.from_data(d)
+        assert result.incident_id == "1"
+
+
+@pytest.mark.unit
+class TestEndpointURLs:
+    def test_nsw_url(self):
+        assert "rfs.nsw.gov.au" in NSW_RFS_URL
+
+    def test_vic_url(self):
+        assert "emergency.vic.gov.au" in VIC_EMERGENCY_URL
+
+    def test_qld_url(self):
+        assert "psba-qld-gov-au" in QLD_FIRE_URL

--- a/australia-wildfires/xreg/australia_wildfires.xreg.json
+++ b/australia-wildfires/xreg/australia_wildfires.xreg.json
@@ -1,0 +1,161 @@
+{
+  "endpoints": {
+    "AU.Gov.Emergency.Wildfires.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "australia-wildfires",
+          "key": "{state}/{incident_id}"
+        }
+      },
+      "messagegroups": [
+        "#/messagegroups/AU.Gov.Emergency.Wildfires"
+      ]
+    }
+  },
+  "messagegroups": {
+    "AU.Gov.Emergency.Wildfires": {
+      "messages": {
+        "AU.Gov.Emergency.Wildfires.FireIncident": {
+          "name": "FireIncident",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "AU.Gov.Emergency.Wildfires.FireIncident"
+            },
+            "source": {
+              "value": "https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires"
+            },
+            "subject": {
+              "value": "{state}/{incident_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/AU.Gov.Emergency.Wildfires.jstruct/schemas/AU.Gov.Emergency.Wildfires.FireIncident"
+        }
+      }
+    }
+  },
+  "schemagroups": {
+    "AU.Gov.Emergency.Wildfires.jstruct": {
+      "schemas": {
+        "AU.Gov.Emergency.Wildfires.FireIncident": {
+          "name": "FireIncident",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://emergency.gov.au/schemas/AU/Gov/Emergency/Wildfires/FireIncident",
+                "type": "object",
+                "name": "FireIncident",
+                "description": "Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.",
+                "required": [
+                  "incident_id",
+                  "state",
+                  "title",
+                  "alert_level",
+                  "updated",
+                  "source_url"
+                ],
+                "properties": {
+                  "incident_id": {
+                    "type": "string",
+                    "description": "Stable identifier for the fire incident, derived from the source system. NSW: numeric incident ID extracted from the RFS GUID URL. VIC: numeric sourceId from the VicEmergency feed. QLD: alphanumeric UniqueID from the QFD feed (e.g. 'IF39-5661721')."
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "Australian state abbreviation indicating which emergency service reported this incident. One of 'NSW' (New South Wales Rural Fire Service), 'VIC' (VicEmergency / Country Fire Authority / Fire Rescue Victoria), or 'QLD' (Queensland Fire Department)."
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Human-readable title or headline for the incident as provided by the source agency. NSW: location-based title from the RFS feed (e.g. '(GWYDIR HWY), MATHESON'). VIC: warning name or sourceTitle from VicEmergency. QLD: WarningTitle from the QFD feed."
+                  },
+                  "alert_level": {
+                    "type": "string",
+                    "description": "Fire danger alert level as classified by the issuing agency. Common values across states: 'Advice' (fire is under control or low threat), 'Watch and Act' (conditions are changing, prepare to leave), 'Emergency Warning' (immediate danger, take action now). NSW uses 'category' field, VIC uses 'action' or category1, QLD uses 'WarningLevel'."
+                  },
+                  "status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Current operational status of the incident as reported by the source agency. NSW: extracted from the HTML description field (e.g. 'Under control', 'Being controlled', 'Out of control'). VIC: status field from VicEmergency (e.g. 'Unknown', 'Safe'). QLD: not typically provided, may be null."
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable location description for the incident. NSW: full location string extracted from the HTML description (e.g. 'B76 (GWYDIR HWY), MATHESON 2370'). VIC: locality names from the location field. QLD: derived from the WarningTitle or Header text."
+                  },
+                  "latitude": {
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Latitude of the incident centroid in decimal degrees (WGS84). Extracted from the GeoJSON Point geometry where available, or computed as the centroid of a Polygon geometry. Negative values indicate Southern Hemisphere.",
+                    "unit": "degree",
+                    "symbol": "°"
+                  },
+                  "longitude": {
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Longitude of the incident centroid in decimal degrees (WGS84). Extracted from the GeoJSON Point geometry where available, or computed as the centroid of a Polygon geometry.",
+                    "unit": "degree",
+                    "symbol": "°"
+                  },
+                  "size_hectares": {
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Estimated area of the fire in hectares as reported by the source agency. NSW: extracted from the SIZE field in the HTML description. VIC: parsed from sizeFmt if available. QLD: not typically provided, may be null.",
+                    "unit": "hectare",
+                    "symbol": "ha"
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Classification of the fire type as reported by the source agency. NSW: extracted from the TYPE field in the HTML description (e.g. 'Bush Fire', 'Grass Fire', 'Hazard Reduction'). VIC: event field from the CAP envelope (e.g. 'Grass Fire', 'Scrub Fire', 'Bush Fire'). QLD: derived from CallToAction text."
+                  },
+                  "responsible_agency": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the fire-fighting agency responsible for the incident. NSW: extracted from RESPONSIBLE AGENCY in the HTML description (e.g. 'Rural Fire Service', 'Fire and Rescue NSW'). VIC: senderName from the CAP envelope (e.g. 'Country Fire Authority', 'Fire Rescue Victoria'). QLD: defaults to 'Queensland Fire Department'."
+                  },
+                  "updated": {
+                    "type": "datetime",
+                    "description": "Timestamp when the incident record was last updated by the source agency, in ISO 8601 format with UTC timezone. NSW: parsed from the UPDATED field in the HTML description or pubDate. VIC: 'updated' field from the VicEmergency feed. QLD: parsed from the WarningTitle date reference or current fetch time."
+                  },
+                  "source_url": {
+                    "type": "string",
+                    "description": "URL pointing to the original incident details or the source feed. NSW: GUID permalink from the RFS feed (e.g. 'https://incidents.rfs.nsw.gov.au/api/v1/incidents/653509'). VIC: constructed URL to the VicEmergency warning page. QLD: static URL of the QFD bushfire alert feed."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/docker_e2e/test_docker_kafka_flow.py
+++ b/tests/docker_e2e/test_docker_kafka_flow.py
@@ -769,6 +769,24 @@ class TestBOMAustraliaDockerFlow:
 
 
 # ---------------------------------------------------------------------------
+# Australia Wildfires (bushfire incidents from NSW, VIC, QLD)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def australia_wildfires_image():
+    return build_image('australia-wildfires')
+
+class TestAustraliaWildfiresDockerFlow:
+    TOPIC = 'test-australia-wildfires'
+
+    def test_emits_telemetry(self, kafka: KafkaFixture, australia_wildfires_image):
+        _run_kafka_flow_test(
+            kafka, australia_wildfires_image, self.TOPIC,
+            telemetry_types=['FireIncident'],
+        )
+
+
+# ---------------------------------------------------------------------------
 # SMHI Weather (Sweden – meteorological observations)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Australian State Wildfires Bridge

Adds a real-time bridge for bushfire incident feeds from three Australian state fire services.

### Data Sources
- NSW Rural Fire Service (GeoJSON) - active fire incidents
- VicEmergency (GeoJSON, filtered for fire) - all-hazards with CAP metadata
- QLD Fire Department (GeoJSON) - bushfire alerts with polygons

### Event Type
- au.gov.emergency.FireIncident - Normalized fire incidents with alert levels, locations, and sizes

### Tests
- 59 unit tests, all passing
