### PR TITLE
Add native-language altnames to existing bridge schemas

### DIFF
--- a/bfs-odl/xreg/bfs_odl.xreg.json
+++ b/bfs-odl/xreg/bfs_odl.xreg.json
@@ -96,14 +96,16 @@
                               "type": "string",
                               "description": "Nine-digit station identifier (Kennziffer) assigned by BfS in the IMIS network. Composed of the official municipality key (AGS) prefix and a station sequence number. Example: '033510091'. This is the stable key used for timeseries retrieval.",
                               "altnames": {
-                                "json": "kenn"
+                                "json": "kenn",
+                                "lang:de": "Kennziffer"
                               }
                             },
                             "station_code": {
                               "type": "string",
                               "description": "Short alphanumeric station code assigned by BfS, consisting of a 'DEZ' prefix followed by a four-digit number. Example: 'DEZ0305'. Used in the BfS web interface and download area.",
                               "altnames": {
-                                "json": "id"
+                                "json": "id",
+                                "lang:de": "Stationscode"
                               }
                             },
                             "name": {
@@ -114,7 +116,8 @@
                               "type": "string",
                               "description": "German postal code (Postleitzahl / PLZ) of the station location. Five digits as a string.",
                               "altnames": {
-                                "json": "plz"
+                                "json": "plz",
+                                "lang:de": "Postleitzahl"
                               }
                             },
                             "site_status": {
@@ -133,7 +136,10 @@
                               "description": "Numeric region identifier (Kreis-ID) used internally by BfS to group stations into geographic regions."
                             },
                             "height_above_sea": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Elevation of the station above mean sea level in meters (Normalhöhennull / NHN). Determines the cosmic radiation component. Null if unknown.",
                               "unit": "m",
                               "symbol": "m"
@@ -197,7 +203,8 @@
                               "type": "string",
                               "description": "Nine-digit station identifier (Kennziffer) of the measuring probe. Matches the station_id in the Station schema.",
                               "altnames": {
-                                "json": "kenn"
+                                "json": "kenn",
+                                "lang:de": "Kennziffer"
                               }
                             },
                             "start_measure": {
@@ -209,19 +216,28 @@
                               "description": "End of the one-hour measurement period in ISO 8601 UTC format. Example: '2026-04-07T13:00:00Z'."
                             },
                             "value": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Gross ambient gamma dose rate averaged over the measurement period in microsieverts per hour (µSv/h). This is the total dose rate including both cosmic and terrestrial components. Null if the station did not report a valid measurement for this interval.",
                               "unit": "uSv/h",
                               "symbol": "µSv/h"
                             },
                             "value_cosmic": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Cosmic radiation component of the ambient gamma dose rate in microsieverts per hour (µSv/h). Estimated from the station's altitude using a standard model. Null when the BfS system has not yet computed the decomposition for this measurement.",
                               "unit": "uSv/h",
                               "symbol": "µSv/h"
                             },
                             "value_terrestrial": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Terrestrial radiation component of the ambient gamma dose rate in microsieverts per hour (µSv/h). Computed as gross value minus cosmic component. Varies with local geology (granite, basalt, sediment). Null when the cosmic component is not available.",
                               "unit": "uSv/h",
                               "symbol": "µSv/h"
@@ -305,7 +321,10 @@
                   },
                   {
                     "name": "height_above_sea",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Elevation above sea level in meters. Null if unknown.",
                     "default": null
                   },
@@ -352,19 +371,28 @@
                   },
                   {
                     "name": "value",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Gross ambient gamma dose rate in µSv/h. Null if not reported.",
                     "default": null
                   },
                   {
                     "name": "value_cosmic",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Cosmic radiation component in µSv/h. Null when not computed.",
                     "default": null
                   },
                   {
                     "name": "value_terrestrial",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Terrestrial radiation component in µSv/h. Null when not computed.",
                     "default": null
                   },

--- a/dwd/xreg/dwd.xreg.json
+++ b/dwd/xreg/dwd.xreg.json
@@ -202,7 +202,10 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "station_name": {
                     "type": "string"
@@ -249,28 +252,52 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "MESS_DATUM"
+                    }
                   },
                   "quality_level": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "QN"
+                    }
                   },
                   "pressure_station_level": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "PP_10"
+                    }
                   },
                   "air_temperature_2m": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "TT_10"
+                    }
                   },
                   "air_temperature_5cm": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "TM5_10"
+                    }
                   },
                   "relative_humidity": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "RF_10"
+                    }
                   },
                   "dew_point_temperature": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "TD_10"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/AirTemperature10Min",
@@ -296,19 +323,34 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "MESS_DATUM"
+                    }
                   },
                   "quality_level": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "QN"
+                    }
                   },
                   "precipitation_height": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "RWS_10"
+                    }
                   },
                   "precipitation_indicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "RWS_IND_10"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Precipitation10Min",
@@ -334,19 +376,34 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "MESS_DATUM"
+                    }
                   },
                   "quality_level": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "QN"
+                    }
                   },
                   "wind_speed": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "FF_10"
+                    }
                   },
                   "wind_direction": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "DD_10"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Wind10Min",
@@ -372,25 +429,46 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "MESS_DATUM"
+                    }
                   },
                   "quality_level": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "QN"
+                    }
                   },
                   "global_radiation": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "GS_10"
+                    }
                   },
                   "sunshine_duration": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "SD_10"
+                    }
                   },
                   "diffuse_radiation": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "DS_10"
+                    }
                   },
                   "longwave_radiation": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "LS_10"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Solar10Min",
@@ -417,13 +495,22 @@
                 "name": "document",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "STATIONS_ID"
+                    }
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "MESS_DATUM"
+                    }
                   },
                   "quality_level": {
-                    "type": "int32"
+                    "type": "int32",
+                    "altnames": {
+                      "lang:de": "QN"
+                    }
                   },
                   "parameter": {
                     "type": "string"

--- a/german-waters/xreg/german_waters.xreg.json
+++ b/german-waters/xreg/german_waters.xreg.json
@@ -92,7 +92,10 @@
                     "type": "string"
                   },
                   "water_body": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:de": "Gewaesser"
+                    }
                   },
                   "state": {
                     "type": "string"
@@ -113,7 +116,10 @@
                     "type": "double"
                   },
                   "altitude": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:de": "Hoehe"
+                    }
                   },
                   "station_type": {
                     "type": "string"

--- a/imgw-hydro/xreg/imgw_hydro.xreg.json
+++ b/imgw-hydro/xreg/imgw_hydro.xreg.json
@@ -84,22 +84,46 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:pl": "id_stacji"
+                    }
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:pl": "stacja"
+                    }
                   },
                   "river": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "rzeka"
+                    }
                   },
                   "voivodeship": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "wojewodztwo"
+                    }
                   },
                   "longitude": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ]
                   },
                   "latitude": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ]
                   }
                 },
                 "$id": "https://example.com/schemas/PL/Gov/IMGW/Hydro/Station",
@@ -127,40 +151,100 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:pl": "id_stacji"
+                    }
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:pl": "stacja"
+                    }
                   },
                   "river": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "rzeka"
+                    }
                   },
                   "voivodeship": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "wojewodztwo"
+                    }
                   },
                   "water_level": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:pl": "stan_wody"
+                    }
                   },
                   "water_level_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "altnames": {
+                      "lang:pl": "stan_wody_data_pomiaru"
+                    }
                   },
                   "water_temperature": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "temperatura_wody"
+                    }
                   },
                   "water_temperature_timestamp": {
-                    "type": ["datetime", "null"]
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "temperatura_wody_data_pomiaru"
+                    }
                   },
                   "discharge": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "przeplyw"
+                    }
                   },
                   "discharge_timestamp": {
-                    "type": ["datetime", "null"]
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "przeplyw_data"
+                    }
                   },
                   "ice_phenomenon_code": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "zjawisko_lodowe"
+                    }
                   },
                   "overgrowth_code": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "altnames": {
+                      "lang:pl": "zjawisko_zarastania"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/PL/Gov/IMGW/Hydro/WaterLevelObservation",

--- a/rws-waterwebservices/xreg/rws_waterwebservices.xreg.json
+++ b/rws-waterwebservices/xreg/rws_waterwebservices.xreg.json
@@ -89,7 +89,10 @@
                     "type": "string"
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:nl": "Naam"
+                    }
                   },
                   "latitude": {
                     "type": "double"
@@ -98,7 +101,10 @@
                     "type": "double"
                   },
                   "coordinate_system": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:nl": "Coordinatenstelsel"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/NL/RWS/Waterwebservices/Station",
@@ -128,22 +134,37 @@
                     "type": "string"
                   },
                   "location_name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:nl": "Naam"
+                    }
                   },
                   "timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "altnames": {
+                      "lang:nl": "Tijdstip"
+                    }
                   },
                   "value": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:nl": "Waarde_Numeriek"
+                    }
                   },
                   "unit": {
                     "type": "string"
                   },
                   "quality_code": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:nl": "Kwaliteitswaardecode"
+                    }
                   },
                   "status": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:nl": "Statuswaarde"
+                    }
                   },
                   "compartment": {
                     "type": "string"

--- a/syke-hydro/xreg/syke_hydro.xreg.json
+++ b/syke-hydro/xreg/syke_hydro.xreg.json
@@ -86,19 +86,34 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "Paikka_Id"
+                    }
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "Nimi"
+                    }
                   },
                   "river_name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "PaaVesalNimi"
+                    }
                   },
                   "water_area_name": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "VesalNimi"
+                    }
                   },
                   "municipality": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "KuntaNimi"
+                    }
                   },
                   "latitude": {
                     "type": "double"
@@ -129,25 +144,40 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "altnames": {
+                      "lang:fi": "Paikka_Id"
+                    }
                   },
                   "water_level": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:fi": "Arvo"
+                    }
                   },
                   "water_level_unit": {
                     "type": "string"
                   },
                   "water_level_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "altnames": {
+                      "lang:fi": "Aika"
+                    }
                   },
                   "discharge": {
-                    "type": "double"
+                    "type": "double",
+                    "altnames": {
+                      "lang:fi": "Arvo"
+                    }
                   },
                   "discharge_unit": {
                     "type": "string"
                   },
                   "discharge_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "altnames": {
+                      "lang:fi": "Aika"
+                    }
                   }
                 },
                 "$id": "https://example.com/schemas/FI/SYKE/Hydrology/WaterLevelObservation",


### PR DESCRIPTION
## Add native-language altnames to existing bridge schemas

Per the JSON Structure Alternate Names spec, adds lang: prefixed altnames to xreg JsonStructure schema properties where upstream API field names were translated from native languages to English.

### Bridges updated
- imgw-hydro (lang:pl) - 12 Polish field names
- bfs-odl (lang:de) - 4 German names added alongside existing json altnames
- rws-waterwebservices (lang:nl) - 7 Dutch field names
- syke-hydro (lang:fi) - 10 Finnish field names
- german-waters (lang:de) - 2 German field names
- dwd (lang:de) - 27 German CSV header names across 6 schemas

Only JsonStructure schemas modified. Avro schemas untouched.
