### PR TITLE
feat(bluesky): add botfinder analysis package and Fabric notebook deployer

### DIFF
--- a/bluesky/botfinder/.gitignore
+++ b/bluesky/botfinder/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/bluesky/botfinder/README.md
+++ b/bluesky/botfinder/README.md
@@ -1,0 +1,42 @@
+# botfinder
+
+Bluesky bot-network detection and dossier generation around an anchor
+account, powered by the [`bluesky` real-time-sources bridge][bridge] and a
+Microsoft Fabric KQL database.
+
+```python
+from botfinder import Config, run_full_pipeline
+
+cfg = Config(anchor_handle="niusde.bsky.social")
+result = run_full_pipeline(cfg)
+for card_id, fig in result.cards.items():
+    fig.show()
+```
+
+## Install
+
+```bash
+pip install git+https://github.com/clemensv/real-time-sources#subdirectory=bluesky/botfinder
+```
+
+In a Fabric notebook:
+
+```python
+%pip install -q git+https://github.com/clemensv/real-time-sources#subdirectory=bluesky/botfinder
+```
+
+## CLI
+
+```bash
+botfinder --anchor niusde.bsky.social --output-dir output
+```
+
+## Configuration
+
+`Config` resolves Kusto connection details in this order:
+
+1. Constructor arguments
+2. Fabric notebook context (`notebookutils.kql.listDatabases()`)
+3. Environment variables `BOTFINDER_KUSTO_URI`, `BOTFINDER_KUSTO_DATABASE`
+
+[bridge]: https://github.com/clemensv/real-time-sources/tree/main/bluesky

--- a/bluesky/botfinder/botfinder/__init__.py
+++ b/bluesky/botfinder/botfinder/__init__.py
@@ -1,0 +1,21 @@
+"""botfinder — Bluesky bot-network detection around an anchor account."""
+
+from .config import Config
+from .scoring import BotScore, compute_bot_score, compute_network_statistics
+from .acquire import AcquiredData, acquire_all
+from .pipeline import AnalysisResult, run_analysis, run_full_pipeline, FullResult
+
+__all__ = [
+    "Config",
+    "BotScore",
+    "compute_bot_score",
+    "compute_network_statistics",
+    "AcquiredData",
+    "acquire_all",
+    "AnalysisResult",
+    "run_analysis",
+    "run_full_pipeline",
+    "FullResult",
+]
+
+__version__ = "0.1.0"

--- a/bluesky/botfinder/botfinder/acquire.py
+++ b/bluesky/botfinder/botfinder/acquire.py
@@ -1,0 +1,215 @@
+"""KQL data acquisition — extract follows, profiles, blocks, likes for the
+follower cohort of the anchor account.
+
+Returns an in-memory ``AcquiredData`` bundle (no disk caching). Optional
+parquet caching is exposed via ``AcquiredData.save`` / ``AcquiredData.load``
+for local development.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from .config import Config
+from .kusto import execute_query
+
+
+@dataclass
+class AcquiredData:
+    target_did: str
+    follows_to_target: pd.DataFrame
+    profiles: pd.DataFrame
+    follows_from_cohort: pd.DataFrame
+    blocks_received: pd.DataFrame
+    likes_made: pd.DataFrame
+
+    @property
+    def cohort_dids(self) -> list[str]:
+        if self.follows_to_target.empty:
+            return []
+        return self.follows_to_target["follower_did"].dropna().unique().tolist()
+
+    def save(self, directory: Path) -> None:
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        self.follows_to_target.to_parquet(directory / "follows_to_target.parquet", index=False)
+        self.profiles.to_parquet(directory / "profiles.parquet", index=False)
+        self.follows_from_cohort.to_parquet(directory / "follows_from_cohort.parquet", index=False)
+        self.blocks_received.to_parquet(directory / "blocks_received.parquet", index=False)
+        self.likes_made.to_parquet(directory / "likes_made.parquet", index=False)
+        (directory / "target_did.txt").write_text(self.target_did, encoding="utf-8")
+
+    @classmethod
+    def load(cls, directory: Path) -> "AcquiredData":
+        directory = Path(directory)
+        return cls(
+            target_did=(directory / "target_did.txt").read_text(encoding="utf-8").strip(),
+            follows_to_target=pd.read_parquet(directory / "follows_to_target.parquet"),
+            profiles=pd.read_parquet(directory / "profiles.parquet"),
+            follows_from_cohort=pd.read_parquet(directory / "follows_from_cohort.parquet"),
+            blocks_received=pd.read_parquet(directory / "blocks_received.parquet"),
+            likes_made=pd.read_parquet(directory / "likes_made.parquet"),
+        )
+
+
+def _resolve_target_did(config: Config) -> str:
+    handle = config.anchor_handle
+    query = f"""
+    ['Bluesky.Actor.Profile_v2']
+    | where handle == "{handle}" or display_name contains "{handle.split('.')[0]}"
+    | top 1 by ___time desc
+    | project did
+    """
+    df = execute_query(config, query)
+    if df.empty:
+        raise RuntimeError(f"Could not resolve DID for @{handle}")
+    return df.iloc[0]["did"]
+
+
+def _extract_follows_to_target(config: Config, target_did: str) -> pd.DataFrame:
+    query = f"""
+    ['Bluesky.Graph.Follow_v1']
+    | where subject == "{target_did}"
+    | where ___time > ago({config.lookback_days}d)
+    | join kind=leftouter (
+        ['Bluesky.Actor.Profile_v2']
+        | summarize arg_max(___time, *) by did
+        | project follower_did=did, follower_created_at=created_at
+    ) on $left.did == $right.follower_did
+    | summarize arg_max(ingestion_time(), *) by did
+    | project follower_did=did,
+              follower_created_at=todatetime(follower_created_at),
+              follow_created_at=todatetime(created_at),
+              ingestion_time=ingestion_time()
+    | order by follow_created_at asc
+    """
+    return execute_query(config, query)
+
+
+def _batched_query(
+    config: Config,
+    dids: list[str],
+    template: str,
+    label: str,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Run a KQL query in cohort batches and concat the results."""
+    all_rows: list[pd.DataFrame] = []
+    n = len(dids)
+    if n == 0:
+        return pd.DataFrame()
+    batch = config.cohort_batch_size
+    for i in range(0, n, batch):
+        chunk = dids[i:i + batch]
+        did_list = ", ".join(f"'{d}'" for d in chunk)
+        query = template.format(did_list=did_list, lookback_days=config.lookback_days)
+        df = execute_query(config, query)
+        if not df.empty:
+            all_rows.append(df)
+        if progress:
+            print(f"  {label} batch {i // batch + 1}/{(n + batch - 1) // batch}: {len(df)} rows")
+    if not all_rows:
+        return pd.DataFrame()
+    return pd.concat(all_rows, ignore_index=True)
+
+
+_OUTBOUND_FOLLOWS_TPL = """
+let cohort = dynamic([{did_list}]);
+['Bluesky.Graph.Follow_v1']
+| where did in (cohort)
+| where ___time > ago({lookback_days}d)
+| project did, subject, follow_time=___time, created_at=todatetime(created_at)
+"""
+
+_BLOCKS_TPL = """
+let cohort = dynamic([{did_list}]);
+['Bluesky.Graph.Block_v1']
+| where subject in (cohort)
+| summarize block_count = count() by subject
+"""
+
+_LIKES_TPL = """
+let cohort = dynamic([{did_list}]);
+['Bluesky.Feed.Like_v2']
+| where did in (cohort)
+| summarize like_count = count() by did
+"""
+
+_PROFILES_TPL = """
+let targets = dynamic([{did_list}]);
+['Bluesky.Actor.Profile_v2']
+| where did in (targets)
+| summarize arg_max(___time, *) by did
+| project did, created_at, handle, display_name
+"""
+
+
+def acquire_all(config: Config, *, verbose: bool = True) -> AcquiredData:
+    """Extract everything we need for the analysis. Returns an
+    in-memory ``AcquiredData`` bundle."""
+
+    if verbose:
+        print(f"═══ Acquire: anchor=@{config.anchor_handle}, lookback={config.lookback_days}d ═══")
+
+    target_did = _resolve_target_did(config)
+    if verbose:
+        print(f"  Target DID: {target_did}")
+
+    follows_to_target = _extract_follows_to_target(config, target_did)
+    if verbose:
+        print(f"  Follows to target: {len(follows_to_target)}")
+
+    cohort_dids: list[str] = (
+        follows_to_target["follower_did"].dropna().unique().tolist()
+        if not follows_to_target.empty else []
+    )
+    if verbose:
+        print(f"  Cohort: {len(cohort_dids)}")
+
+    follows_from_cohort = _batched_query(
+        config, cohort_dids, _OUTBOUND_FOLLOWS_TPL, "outbound", progress=verbose
+    )
+    if verbose:
+        print(f"  Outbound follows: {len(follows_from_cohort)}")
+
+    blocks_received = _batched_query(
+        config, cohort_dids, _BLOCKS_TPL, "blocks", progress=verbose
+    )
+    if blocks_received.empty:
+        blocks_received = pd.DataFrame(columns=["subject", "block_count"])
+    if verbose:
+        print(f"  Blocked accounts: {len(blocks_received)}")
+
+    likes_made = _batched_query(
+        config, cohort_dids, _LIKES_TPL, "likes", progress=verbose
+    )
+    if likes_made.empty:
+        likes_made = pd.DataFrame(columns=["did", "like_count"])
+    if verbose:
+        print(f"  Accounts with likes: {len(likes_made)}")
+
+    profile_dids = list(set(cohort_dids))
+    if not follows_from_cohort.empty:
+        target_counts = follows_from_cohort["subject"].value_counts()
+        frequent_targets = target_counts[target_counts >= 5].index.tolist()
+        profile_dids = list(set(profile_dids + frequent_targets))
+    profiles = _batched_query(
+        config, profile_dids, _PROFILES_TPL, "profiles", progress=verbose
+    )
+    if profiles.empty:
+        profiles = pd.DataFrame(columns=["did", "created_at", "handle", "display_name"])
+    if verbose:
+        print(f"  Profiles: {len(profiles)}")
+
+    return AcquiredData(
+        target_did=target_did,
+        follows_to_target=follows_to_target,
+        profiles=profiles,
+        follows_from_cohort=follows_from_cohort,
+        blocks_received=blocks_received.rename(columns={}),
+        likes_made=likes_made,
+    )

--- a/bluesky/botfinder/botfinder/bluesky_api.py
+++ b/bluesky/botfinder/botfinder/bluesky_api.py
@@ -1,0 +1,236 @@
+"""Bluesky AT Protocol API client for enriching bot detection data."""
+
+import httpx
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+XRPC_BASE = "https://public.api.bsky.app/xrpc"
+
+
+@dataclass
+class BlueskyProfile:
+    did: str
+    handle: str
+    display_name: str
+    description: str
+    avatar: str
+    banner: str
+    created_at: str
+    followers_count: int
+    follows_count: int
+    posts_count: int
+    labels: list[str] = field(default_factory=list)
+    indexed_at: str = ""
+
+
+@dataclass
+class BlueskyPost:
+    uri: str
+    cid: str
+    text: str
+    created_at: str
+    reply_count: int
+    repost_count: int
+    like_count: int
+    is_reply: bool
+    is_repost: bool
+    langs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FollowRecord:
+    did: str
+    handle: str
+    display_name: str
+    created_at: str
+    indexed_at: str
+
+
+class BlueskyClient:
+    """Public Bluesky API client for bot analysis enrichment."""
+
+    def __init__(self, concurrency: int = 10, timeout: float = 30.0):
+        self._semaphore = asyncio.Semaphore(concurrency)
+        self._timeout = timeout
+
+    async def _get(self, client: httpx.AsyncClient, endpoint: str, params: dict) -> dict | None:
+        async with self._semaphore:
+            try:
+                resp = await client.get(f"{XRPC_BASE}/{endpoint}", params=params)
+                if resp.status_code == 200:
+                    return resp.json()
+                if resp.status_code == 429:
+                    retry_after = int(resp.headers.get("retry-after", "2"))
+                    await asyncio.sleep(retry_after)
+                    resp = await client.get(f"{XRPC_BASE}/{endpoint}", params=params)
+                    if resp.status_code == 200:
+                        return resp.json()
+                return None
+            except httpx.HTTPError:
+                return None
+
+    async def get_profile(self, client: httpx.AsyncClient, actor: str) -> BlueskyProfile | None:
+        data = await self._get(client, "app.bsky.actor.getProfile", {"actor": actor})
+        if not data:
+            return None
+        return BlueskyProfile(
+            did=data.get("did", actor),
+            handle=data.get("handle", ""),
+            display_name=data.get("displayName", ""),
+            description=data.get("description", ""),
+            avatar=data.get("avatar", ""),
+            banner=data.get("banner", ""),
+            created_at=data.get("createdAt", ""),
+            followers_count=data.get("followersCount", 0),
+            follows_count=data.get("followsCount", 0),
+            posts_count=data.get("postsCount", 0),
+            labels=[lbl.get("val", "") for lbl in data.get("labels", [])],
+            indexed_at=data.get("indexedAt", ""),
+        )
+
+    async def get_profiles_batch(
+        self, client: httpx.AsyncClient, actors: list[str]
+    ) -> list[BlueskyProfile]:
+        """Fetch up to 25 profiles in a single request."""
+        data = await self._get(client, "app.bsky.actor.getProfiles", {"actors": actors[:25]})
+        if not data:
+            return []
+        profiles = []
+        for p in data.get("profiles", []):
+            profiles.append(BlueskyProfile(
+                did=p.get("did", ""),
+                handle=p.get("handle", ""),
+                display_name=p.get("displayName", ""),
+                description=p.get("description", ""),
+                avatar=p.get("avatar", ""),
+                banner=p.get("banner", ""),
+                created_at=p.get("createdAt", ""),
+                followers_count=p.get("followersCount", 0),
+                follows_count=p.get("followsCount", 0),
+                posts_count=p.get("postsCount", 0),
+                labels=[lbl.get("val", "") for lbl in p.get("labels", [])],
+                indexed_at=p.get("indexedAt", ""),
+            ))
+        return profiles
+
+    async def get_author_feed(
+        self, client: httpx.AsyncClient, actor: str, limit: int = 30
+    ) -> list[BlueskyPost]:
+        """Get recent posts from an account to assess activity patterns."""
+        data = await self._get(
+            client, "app.bsky.feed.getAuthorFeed",
+            {"actor": actor, "limit": min(limit, 100), "filter": "posts_and_author_threads"},
+        )
+        if not data:
+            return []
+        posts = []
+        for item in data.get("feed", []):
+            post = item.get("post", {})
+            record = post.get("record", {})
+            posts.append(BlueskyPost(
+                uri=post.get("uri", ""),
+                cid=post.get("cid", ""),
+                text=record.get("text", ""),
+                created_at=record.get("createdAt", ""),
+                reply_count=post.get("replyCount", 0),
+                repost_count=post.get("repostCount", 0),
+                like_count=post.get("likeCount", 0),
+                is_reply="reply" in record,
+                is_repost="reason" in item and item["reason"].get("$type") == "app.bsky.feed.defs#reasonRepost",
+                langs=record.get("langs", []),
+            ))
+        return posts
+
+    async def get_follows(
+        self, client: httpx.AsyncClient, actor: str, limit: int = 100
+    ) -> list[FollowRecord]:
+        """Get accounts that an actor follows — to detect follow-overlap in the botnet."""
+        records: list[FollowRecord] = []
+        cursor = None
+        while len(records) < limit:
+            params: dict = {"actor": actor, "limit": min(100, limit - len(records))}
+            if cursor:
+                params["cursor"] = cursor
+            data = await self._get(client, "app.bsky.graph.getFollows", params)
+            if not data:
+                break
+            for f in data.get("follows", []):
+                records.append(FollowRecord(
+                    did=f.get("did", ""),
+                    handle=f.get("handle", ""),
+                    display_name=f.get("displayName", ""),
+                    created_at=f.get("createdAt", ""),
+                    indexed_at=f.get("indexedAt", ""),
+                ))
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        return records
+
+    async def get_followers(
+        self, client: httpx.AsyncClient, actor: str, limit: int = 100
+    ) -> list[FollowRecord]:
+        """Get followers of an account."""
+        records: list[FollowRecord] = []
+        cursor = None
+        while len(records) < limit:
+            params: dict = {"actor": actor, "limit": min(100, limit - len(records))}
+            if cursor:
+                params["cursor"] = cursor
+            data = await self._get(client, "app.bsky.graph.getFollowers", params)
+            if not data:
+                break
+            for f in data.get("followers", []):
+                records.append(FollowRecord(
+                    did=f.get("did", ""),
+                    handle=f.get("handle", ""),
+                    display_name=f.get("displayName", ""),
+                    created_at=f.get("createdAt", ""),
+                    indexed_at=f.get("indexedAt", ""),
+                ))
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        return records
+
+
+async def enrich_suspects(
+    dids: list[str], concurrency: int = 10
+) -> dict[str, dict]:
+    """Enrich a list of suspect DIDs with full profile + feed data from the Bluesky API.
+
+    Returns a dict keyed by DID with profile, posts, and follows data.
+    """
+    bsky = BlueskyClient(concurrency=concurrency)
+    results: dict[str, dict] = {}
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # Batch-resolve profiles (25 per request)
+        all_profiles: dict[str, BlueskyProfile] = {}
+        for i in range(0, len(dids), 25):
+            batch = dids[i:i + 25]
+            profiles = await bsky.get_profiles_batch(client, batch)
+            for p in profiles:
+                all_profiles[p.did] = p
+
+        # Fetch feeds + follows for top suspects concurrently
+        async def _enrich_one(did: str) -> None:
+            profile = all_profiles.get(did)
+            posts = await bsky.get_author_feed(client, did, limit=50)
+            follows = await bsky.get_follows(client, did, limit=100)
+            results[did] = {
+                "profile": profile,
+                "posts": posts,
+                "follows": follows,
+            }
+
+        tasks = [_enrich_one(did) for did in dids]
+        await asyncio.gather(*tasks)
+
+    return results
+
+
+def enrich_suspects_sync(dids: list[str], concurrency: int = 10) -> dict[str, dict]:
+    return asyncio.run(enrich_suspects(dids, concurrency))

--- a/bluesky/botfinder/botfinder/cards.py
+++ b/bluesky/botfinder/botfinder/cards.py
@@ -1,0 +1,760 @@
+"""Social-media-style cards (1200x675) for inline notebook display.
+
+Refactored from ``tmp/generate_cards.py`` — no kaleido / PNG export, anchor
+handle parameterised, footer date computed dynamically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .cluster import ClusterResult
+    from .cross_follow import CrossFollowResult
+    from .pipeline import AnalysisResult
+
+
+CARD_W, CARD_H = 1200, 675
+BG_COLOR = "#ffffff"
+TEXT_COLOR = "#1a1a1a"
+ACCENT = "#cc0000"
+ACCENT2 = "#cc5500"
+ACCENT3 = "#996600"
+MUTED = "#555555"
+GRID_COLOR = "#e0e0e0"
+FONT = "Roboto, sans-serif"
+FONT_BOLD = "Roboto Black, Roboto, sans-serif"
+
+_MONTHS_DE = [
+    "Januar", "Februar", "März", "April", "Mai", "Juni",
+    "Juli", "August", "September", "Oktober", "November", "Dezember",
+]
+
+
+def _footer_text() -> str:
+    now = datetime.now()
+    return (
+        f"Bot-Netzwerk-Analyse • Bluesky Firehose + AT Protocol • "
+        f"{_MONTHS_DE[now.month - 1]} {now.year}"
+    )
+
+
+def card_layout(fig: go.Figure, title: str = "", subtitle: str = "") -> go.Figure:
+    existing = list(fig.layout.annotations) if fig.layout.annotations else []
+    new_annotations = []
+    if title:
+        new_annotations.append(dict(
+            text=f"<b>{title}</b>", xref="paper", yref="paper",
+            x=0.5, y=1.14, showarrow=False, xanchor="center", yanchor="top",
+            font=dict(size=30, color=TEXT_COLOR, family=FONT_BOLD),
+        ))
+    if subtitle:
+        new_annotations.append(dict(
+            text=subtitle, xref="paper", yref="paper",
+            x=0.5, y=1.05, showarrow=False, xanchor="center", yanchor="top",
+            font=dict(size=16, color=MUTED, family=FONT),
+        ))
+    new_annotations.append(dict(
+        text=_footer_text(), xref="paper", yref="paper",
+        x=0.5, y=-0.14, showarrow=False, xanchor="center", yanchor="bottom",
+        font=dict(size=10, color="#777777", family=FONT),
+    ))
+    fig.update_layout(
+        width=CARD_W, height=CARD_H,
+        paper_bgcolor=BG_COLOR, plot_bgcolor=BG_COLOR,
+        margin=dict(l=60, r=60, t=80, b=60),
+        annotations=existing + new_annotations,
+        font=dict(color=TEXT_COLOR, family=FONT, size=14),
+    )
+    return fig
+
+
+def _date_str() -> str:
+    now = datetime.now()
+    return f"{now.day:02d}. {_MONTHS_DE[now.month - 1]} {now.year}, {now.strftime('%H:%M')} Uhr"
+
+
+# ─── Cards ────────────────────────────────────────────────────────────────
+
+def card_1_overview(scores_df: pd.DataFrame, anchor_handle: str) -> go.Figure:
+    total = len(scores_df)
+    suspicious = int((scores_df["score"] >= 0.5).sum())
+    normal = total - suspicious
+    deleted = int(scores_df["flags"].fillna("").str.contains("DELETED").sum())
+    anonymous = int(scores_df["flags"].fillna("").str.contains("ANONYMOUS_PROFILE").sum())
+    instant = int(scores_df["flags"].fillna("").str.contains("INSTANT_FOLLOW").sum())
+
+    fig = make_subplots(
+        rows=2, cols=4, row_heights=[0.55, 0.45],
+        specs=[[{"colspan": 4, "type": "indicator"}, None, None, None],
+               [{"type": "indicator"}] * 4],
+        vertical_spacing=0.08,
+    )
+    fig.add_trace(go.Indicator(
+        mode="number", value=total,
+        number=dict(font=dict(size=1, color=BG_COLOR)),
+    ), row=1, col=1)
+
+    fig.add_annotation(
+        text=f"<b>{total}</b> Follower",
+        x=0.5, y=0.78, xref="paper", yref="paper",
+        font=dict(size=62, color=TEXT_COLOR, family=FONT_BOLD), showarrow=False,
+    )
+    fig.add_annotation(
+        text=f"davon <b>{suspicious}</b> Bots, <b>{normal}</b> unauffällig",
+        x=0.5, y=0.58, xref="paper", yref="paper",
+        font=dict(size=34, color=ACCENT, family=FONT_BOLD), showarrow=False,
+    )
+    stats = [
+        (deleted, "Gelöscht", ACCENT2),
+        (instant, "Sofort-Follow", ACCENT2),
+        (anonymous, "Anonym", ACCENT2),
+        (normal, "Unauffällig", MUTED),
+    ]
+    for i, (val, label, color) in enumerate(stats):
+        fig.add_trace(go.Indicator(
+            mode="number", value=val,
+            title=dict(text=label, font=dict(size=14, color=MUTED, family=FONT)),
+            number=dict(font=dict(size=42, color=color, family=FONT_BOLD)),
+        ), row=2, col=i + 1)
+
+    return card_layout(fig,
+        title=f"Bot-Netzwerk um @{anchor_handle}",
+        subtitle=f"Analyse vom {_date_str()}",
+    )
+
+
+def card_2_anchors(nodes_df: pd.DataFrame, anchor_handle: str) -> go.Figure:
+    if nodes_df.empty:
+        return card_layout(go.Figure(), title="Anker-Konten")
+    df = nodes_df[nodes_df["handle"] != "bsky.app"].head(10).copy()
+    df = df.sort_values("suspect_followers", ascending=True)
+    colors = []
+    for h in df["handle"]:
+        if h == anchor_handle:
+            colors.append(ACCENT)
+        elif df[df["handle"] == h]["suspect_followers"].iloc[0] >= 50:
+            colors.append(ACCENT2)
+        else:
+            colors.append(ACCENT3)
+    fig = go.Figure()
+    fig.add_trace(go.Bar(
+        y=["@" + h for h in df["handle"]],
+        x=df["suspect_followers"],
+        orientation="h", marker_color=colors,
+        text=df["suspect_followers"], textposition="outside",
+        textfont=dict(size=15, color=TEXT_COLOR, family=FONT),
+    ))
+    fig.update_xaxes(showgrid=False, zeroline=False, showticklabels=False)
+    fig.update_yaxes(tickfont=dict(size=14, color=TEXT_COLOR, family=FONT), domain=[0.0, 0.82])
+    fig.update_layout(bargap=0.3, margin=dict(l=50, r=70, t=100, b=45))
+    return card_layout(fig,
+        title="Anker-Konten — Wen das Bot-Cluster pusht",
+        subtitle="Konten, die von den meisten verdächtigen Bot-Accounts gemeinsam gefolgt werden",
+    )
+
+
+def card_3_behavior(scores_df: pd.DataFrame) -> go.Figure:
+    fig = make_subplots(rows=1, cols=2, specs=[[{"type": "pie"}, {"type": "bar"}]],
+                        column_widths=[0.4, 0.6], horizontal_spacing=0.08)
+    bins = [
+        ("Hohes Risiko (≥0,6)", int((scores_df["score"] >= 0.6).sum()), ACCENT),
+        ("Mittel (0,5–0,6)", int(((scores_df["score"] >= 0.5) & (scores_df["score"] < 0.6)).sum()), ACCENT2),
+        ("Niedrig (<0,5)", int((scores_df["score"] < 0.5).sum()), "#999999"),
+    ]
+    fig.add_trace(go.Pie(
+        labels=[b[0] for b in bins], values=[b[1] for b in bins],
+        marker=dict(colors=[b[2] for b in bins]),
+        textinfo="percent+value", textfont=dict(size=14, family=FONT), hole=0.4,
+    ), row=1, col=1)
+    high_risk = scores_df[scores_df["score"] >= 0.5]
+    signals = ["temporal_proximity", "anonymity", "activity_pattern", "follow_overlap", "account_age"]
+    labels = ["Timing", "Anonymität", "Aktivität", "Überlapp.", "Alter"]
+    means = [high_risk[s].mean() if s in high_risk.columns else 0 for s in signals]
+    fig.add_trace(go.Bar(
+        x=labels, y=means,
+        marker_color=[ACCENT, ACCENT2, ACCENT3, "#1565c0", "#6a1b9a"],
+        text=[f"{m:.2f}" for m in means], textposition="outside",
+        textfont=dict(size=14, color=TEXT_COLOR, family=FONT), showlegend=False,
+    ), row=1, col=2)
+    fig.update_yaxes(range=[0, 1.08], showgrid=True, gridcolor=GRID_COLOR, row=1, col=2)
+    fig.update_xaxes(tickfont=dict(size=13, color=TEXT_COLOR, family=FONT), row=1, col=2)
+    return card_layout(fig,
+        title="Bot-Verhaltenssignale — Erkennungsmethode",
+        subtitle="5-Signal-Scoring: Timing, Profil, Aktivität, Überlappung, Kontoalter",
+    )
+
+
+def card_4_timeline(detail_df: pd.DataFrame) -> go.Figure:
+    df = detail_df.copy()
+    df["follow_created_at"] = pd.to_datetime(df["follow_created_at"], errors="coerce")
+    df = df.dropna(subset=["follow_created_at"])
+    if df.empty:
+        return card_layout(go.Figure(), title="Follow-Burst-Zeitverlauf")
+    hourly = df.set_index("follow_created_at").resample("1h").size().reset_index(name="count")
+    fig = go.Figure()
+    fig.add_trace(go.Bar(
+        x=hourly["follow_created_at"], y=hourly["count"],
+        marker_color=ACCENT, opacity=0.85,
+    ))
+    fig.update_xaxes(title_text="Datum / Zeit (UTC)", tickfont=dict(size=11, family=FONT),
+                     showgrid=False, tickangle=-45, tickformat="%d.%m. %H:%M")
+    fig.update_yaxes(title_text="Follows pro Stunde", tickfont=dict(size=13, family=FONT),
+                     showgrid=True, gridcolor=GRID_COLOR)
+    return card_layout(fig,
+        title="Follow-Burst-Zeitverlauf",
+        subtitle="Stündliche Follow-Ereignisse — Spitzen deuten auf koordinierte Bot-Aktivität hin",
+    )
+
+
+def card_5_cluster(nodes_df: pd.DataFrame, edges_df: pd.DataFrame, anchor_handle: str) -> go.Figure:
+    """Square cluster graph — concentric rings + perimeter labels."""
+    SIZE = 1200
+    if nodes_df.empty:
+        fig = go.Figure()
+        fig.update_layout(width=SIZE, height=SIZE)
+        return card_layout(fig, title="Bot-Cluster-Netzwerk")
+
+    G = nx.Graph()
+    min_suspect = 10
+    filtered = nodes_df[(nodes_df["handle"] != "bsky.app") & (nodes_df["suspect_followers"] >= min_suspect)]
+    for _, row in filtered.iterrows():
+        G.add_node(row["handle"], weight=row["suspect_followers"])
+    handles_set = set(filtered["handle"])
+    for _, row in edges_df.iterrows():
+        if row["source"] in handles_set and row["target"] in handles_set:
+            G.add_edge(row["source"], row["target"], weight=row["shared_followers"])
+    if len(G.nodes()) == 0:
+        fig = go.Figure()
+        fig.update_layout(width=SIZE, height=SIZE)
+        return card_layout(fig, title="Bot-Cluster-Netzwerk")
+
+    weights = nx.get_node_attributes(G, "weight")
+    max_w = max(weights.values()) if weights else 1
+    cluster_members = (
+        set(nodes_df[nodes_df["is_cluster_member"] == True]["handle"])
+        if "is_cluster_member" in nodes_df.columns else set(G.nodes())
+    )
+    core_nodes = [n for n in G.nodes() if n in cluster_members or n == anchor_handle]
+    periphery_nodes = [n for n in G.nodes() if n not in cluster_members and n != anchor_handle]
+    periphery_set = set(periphery_nodes)
+
+    core_sorted = sorted(core_nodes, key=lambda n: weights.get(n, 0), reverse=True)
+    pos: dict[str, np.ndarray] = {}
+    rings = [1, 5, 15, 40, 80, 200]
+    radii = [0.0, 0.18, 0.35, 0.52, 0.68, 0.80]
+    placed = 0
+    for ring_idx in range(len(rings)):
+        ring_count = rings[ring_idx] - (rings[ring_idx - 1] if ring_idx > 0 else 0)
+        radius = radii[ring_idx]
+        nodes_in_ring = core_sorted[placed:placed + ring_count]
+        if not nodes_in_ring:
+            break
+        for i, n in enumerate(nodes_in_ring):
+            if radius == 0:
+                pos[n] = np.array([0.0, 0.0])
+            else:
+                angle = 2 * np.pi * i / len(nodes_in_ring) + ring_idx * 0.3
+                pos[n] = np.array([radius * np.cos(angle), radius * np.sin(angle)])
+        placed += len(nodes_in_ring)
+    for i, n in enumerate(core_sorted[placed:]):
+        angle = 2 * np.pi * i / max(1, len(core_sorted) - placed) + 0.1
+        pos[n] = np.array([0.85 * np.cos(angle), 0.85 * np.sin(angle)])
+
+    if periphery_nodes:
+        margin = 1.05
+        n_p = len(periphery_nodes)
+        perimeter = 8 * margin
+        for i, n in enumerate(periphery_nodes):
+            t = (i / n_p) * perimeter
+            if t < 2 * margin:
+                pos[n] = np.array([-margin + t, margin])
+            elif t < 4 * margin:
+                pos[n] = np.array([margin, margin - (t - 2 * margin)])
+            elif t < 6 * margin:
+                pos[n] = np.array([margin - (t - 4 * margin), -margin])
+            else:
+                pos[n] = np.array([-margin, -margin + (t - 6 * margin)])
+
+    edge_core_x: list = []; edge_core_y: list = []
+    edge_peri_x: list = []; edge_peri_y: list = []
+    for u, v in G.edges():
+        x0, y0 = pos[u]; x1, y1 = pos[v]
+        if u in periphery_set or v in periphery_set:
+            edge_peri_x.extend([x0, x1, None]); edge_peri_y.extend([y0, y1, None])
+        else:
+            edge_core_x.extend([x0, x1, None]); edge_core_y.extend([y0, y1, None])
+
+    edge_core = go.Scatter(x=edge_core_x, y=edge_core_y, mode="lines",
+                           line=dict(width=0.4, color="rgba(200,0,0,0.15)"),
+                           hoverinfo="none", showlegend=False)
+    edge_peri = go.Scatter(x=edge_peri_x, y=edge_peri_y, mode="lines",
+                           line=dict(width=0.4, color="rgba(0,160,0,0.18)"),
+                           hoverinfo="none", showlegend=False)
+
+    node_x = [pos[n][0] for n in G.nodes()]
+    node_y = [pos[n][1] for n in G.nodes()]
+    sizes = [max(7, 45 * (weights.get(n, 0) / max_w)) for n in G.nodes()]
+    colors = []
+    for n in G.nodes():
+        if n == anchor_handle:
+            colors.append(ACCENT)
+        elif n in periphery_set:
+            colors.append("#aaaaaa")
+        elif weights.get(n, 0) >= max_w * 0.3:
+            colors.append(ACCENT2)
+        else:
+            colors.append(ACCENT3)
+
+    node_trace = go.Scatter(
+        x=node_x, y=node_y, mode="markers",
+        marker=dict(size=sizes, color=colors, line=dict(width=0.6, color="#333333")),
+        hovertext=[f"@{n}: {weights.get(n,0)} suspects, {G.degree(n)} edges" for n in G.nodes()],
+        hoverinfo="text", showlegend=False,
+    )
+
+    sorted_nodes = sorted(G.nodes(), key=lambda n: weights.get(n, 0), reverse=True)
+    top_core = [n for n in sorted_nodes if n in core_nodes][:15]
+    core_label = go.Scatter(
+        x=[pos[n][0] for n in top_core], y=[pos[n][1] for n in top_core],
+        mode="text", text=["@" + n.split(".")[0] for n in top_core],
+        textposition="top center",
+        textfont=dict(size=9, color=TEXT_COLOR, family=FONT),
+        hoverinfo="none", showlegend=False,
+    )
+
+    fig = go.Figure(data=[edge_peri, edge_core, node_trace, core_label])
+    fig.update_xaxes(visible=False, range=[-1.6, 1.6])
+    fig.update_yaxes(visible=False, range=[-1.4, 1.4], scaleanchor="x", scaleratio=1)
+    fig.update_layout(
+        width=SIZE, height=SIZE,
+        paper_bgcolor=BG_COLOR, plot_bgcolor=BG_COLOR,
+        margin=dict(l=10, r=10, t=70, b=70),
+        font=dict(color=TEXT_COLOR, family=FONT, size=14),
+        annotations=[
+            dict(text="<b>Bot-Cluster-Netzwerk</b>", xref="paper", yref="paper",
+                 x=0.5, y=1.06, showarrow=False, xanchor="center", yanchor="top",
+                 font=dict(size=28, color=TEXT_COLOR, family=FONT_BOLD)),
+            dict(text=(f"Kern: {len(core_nodes)} • Ring: {len(periphery_nodes)} • "
+                       f"Knoten = co-gefolgte Anker"),
+                 xref="paper", yref="paper",
+                 x=0.5, y=1.015, showarrow=False, xanchor="center", yanchor="top",
+                 font=dict(size=13, color=MUTED, family=FONT)),
+            dict(text=_footer_text(), xref="paper", yref="paper",
+                 x=0.5, y=-0.05, showarrow=False, xanchor="center", yanchor="top",
+                 font=dict(size=9, color="#999999", family=FONT)),
+        ],
+    )
+    return fig
+
+
+def card_6_deleted(scores_df: pd.DataFrame) -> go.Figure:
+    deleted = scores_df["flags"].fillna("").str.contains("DELETED")
+    total_deleted = int(deleted.sum())
+    total_active = len(scores_df) - total_deleted
+    pct = 100 * total_deleted / max(len(scores_df), 1)
+    fig = make_subplots(
+        rows=2, cols=1, row_heights=[0.35, 0.65],
+        specs=[[{"type": "indicator"}], [{"type": "xy"}]],
+        vertical_spacing=0.12,
+    )
+    fig.add_trace(go.Indicator(
+        mode="number", value=total_deleted,
+        number=dict(font=dict(size=64, color=ACCENT, family=FONT_BOLD), suffix=f"  ({pct:.0f}%)"),
+    ), row=1, col=1)
+    fig.add_trace(go.Bar(
+        x=[total_active, total_deleted], y=["Noch aktiv", "Gelöscht/Gesperrt"],
+        orientation="h", marker_color=["#cccccc", ACCENT],
+        text=[total_active, total_deleted], textposition="inside",
+        textfont=dict(size=18, color="white", family=FONT), showlegend=False,
+    ), row=2, col=1)
+    fig.update_xaxes(visible=False, row=2, col=1)
+    fig.update_yaxes(tickfont=dict(size=16, color=TEXT_COLOR, family=FONT), row=2, col=1)
+    fig.update_layout(margin=dict(l=50, r=50, t=120, b=45))
+    return card_layout(fig,
+        title="Kontolöschungen — Hinweis auf Bot-Bereinigung",
+        subtitle="Konten, die der Anker folgten und inzwischen gelöscht oder gesperrt wurden",
+    )
+
+
+def card_7_lifecycle(detail_df: pd.DataFrame, scores_df: pd.DataFrame) -> go.Figure:
+    merged = detail_df.merge(
+        scores_df[["did", "flags"]], left_on="follower_did", right_on="did", how="left"
+    )
+    df = merged.copy()
+    df["follower_created_at"] = pd.to_datetime(df["follower_created_at"], errors="coerce")
+    df["follow_created_at"] = pd.to_datetime(df["follow_created_at"], errors="coerce")
+    df = df.dropna(subset=["follower_created_at", "follow_created_at"])
+    if df.empty:
+        return card_layout(go.Figure(), title="Lebenszyklus-Wellen")
+    bin_freq = "1h"
+    df["created_bin"] = df["follower_created_at"].dt.floor(bin_freq)
+    df["follow_bin"] = df["follow_created_at"].dt.floor(bin_freq)
+    t_min = df["follower_created_at"].min().floor("h")
+    t_max = df["follow_created_at"].max().ceil("h")
+    all_bins = pd.date_range(t_min, t_max, freq=bin_freq)
+    created = df.groupby("created_bin").size().reindex(all_bins, fill_value=0)
+    followed = df.groupby("follow_bin").size().reindex(all_bins, fill_value=0)
+    x_labels = [t.strftime("%d.%m. %H:%M") for t in all_bins]
+    fig = go.Figure()
+    fig.add_trace(go.Bar(x=x_labels, y=created.values, name="Konten erstellt",
+                         marker_color="rgba(30,136,229,0.6)"))
+    fig.add_trace(go.Bar(x=x_labels, y=followed.values, name="Follow-Ereignisse",
+                         marker_color="rgba(204,0,0,0.5)"))
+    y_max = max(created.max(), followed.max())
+    fig.update_xaxes(title_text="Zeit (UTC)", tickfont=dict(size=11, family=FONT),
+                     showgrid=False, tickangle=-45)
+    fig.update_yaxes(title_text="Ereignisse pro Stunde", tickfont=dict(size=13, family=FONT),
+                     showgrid=True, gridcolor=GRID_COLOR, range=[0, y_max * 1.15])
+    fig.update_layout(barmode="group",
+                      legend=dict(orientation="h", yanchor="bottom", y=1.02,
+                                  xanchor="right", x=1.0,
+                                  font=dict(size=13, family=FONT)))
+    return card_layout(fig,
+        title="Lebenszyklus-Wellen — Erstellung & Follow-Aktivität",
+        subtitle="Kontoerstellungs-Bursts eng gekoppelt mit Follow-Ereignissen",
+    )
+
+
+def card_8_cumulative(detail_df: pd.DataFrame, scores_df: pd.DataFrame) -> go.Figure:
+    merged = detail_df.merge(
+        scores_df[["did", "flags"]], left_on="follower_did", right_on="did", how="left"
+    )
+    df = merged.copy()
+    df["is_deleted"] = df["flags"].fillna("").str.contains("DELETED")
+    df["follow_created_at"] = pd.to_datetime(df["follow_created_at"], errors="coerce")
+    df = df.dropna(subset=["follow_created_at"])
+    if df.empty:
+        return card_layout(go.Figure(), title="Kumulatives Netzwerk-Wachstum")
+    bin_freq = "1h"
+    df["follow_bin"] = df["follow_created_at"].dt.floor(bin_freq)
+    t_min = df["follow_created_at"].min().floor("h")
+    t_max = df["follow_created_at"].max().ceil("h")
+    all_bins = pd.date_range(t_min, t_max, freq=bin_freq)
+    follow = df.groupby("follow_bin").size().reindex(all_bins, fill_value=0)
+    deleted = df[df["is_deleted"]].groupby("follow_bin").size().reindex(all_bins, fill_value=0)
+    cum_total = follow.cumsum()
+    cum_deleted = deleted.cumsum()
+    cum_surv = cum_total - cum_deleted
+    x = all_bins.to_pydatetime().tolist()
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=x, y=cum_total.values, name="Gesamt gefolgt", mode="lines",
+                             line=dict(width=2.5, color="#555555", dash="dot")))
+    fig.add_trace(go.Scatter(x=x, y=cum_surv.values, name="Überlebend", mode="lines",
+                             line=dict(width=3, color="#2e7d32")))
+    fig.add_trace(go.Scatter(x=x, y=cum_deleted.values, name="Gelöscht", mode="lines",
+                             line=dict(width=3, color=ACCENT),
+                             fill="tozeroy", fillcolor="rgba(204,0,0,0.1)"))
+    fig.update_xaxes(title_text="Zeit (UTC)", tickfont=dict(size=11, family=FONT),
+                     showgrid=False, tickangle=-45, tickformat="%d.%m. %H:%M")
+    fig.update_yaxes(title_text="Kumulierte Konten", tickfont=dict(size=13, family=FONT),
+                     showgrid=True, gridcolor=GRID_COLOR)
+    fig.update_layout(legend=dict(orientation="h", yanchor="top", y=-0.18,
+                                  xanchor="center", x=0.5,
+                                  font=dict(size=12, family=FONT)))
+    return card_layout(fig,
+        title="Kumulatives Netzwerk-Wachstum & Schwund",
+        subtitle="Laufende Summe: Wachstum vs. Bereinigung",
+    )
+
+
+def card_9_age_at_follow(detail_df: pd.DataFrame) -> go.Figure:
+    ages = detail_df["age_at_follow_minutes"].dropna()
+    if ages.empty:
+        return card_layout(go.Figure(), title="Dauer von Erstellung bis Follow")
+    bins = [0, 1, 2, 5, 10, 30, 60, 120, 360, 1440]
+    labels = ["<1m", "1–2m", "2–5m", "5–10m", "10–30m", "30–60m", "1–2h", "2–6h", "6–24h"]
+    bucketed = pd.cut(ages, bins=bins, labels=labels, right=False)
+    counts = bucketed.value_counts().reindex(labels, fill_value=0)
+    colors = [ACCENT if i < 3 else ACCENT2 if i < 5 else ACCENT3 for i in range(len(labels))]
+    fig = go.Figure()
+    fig.add_trace(go.Bar(x=labels, y=counts.values, marker_color=colors,
+                         text=counts.values, textposition="outside",
+                         textfont=dict(size=14, family=FONT)))
+    fig.update_xaxes(title_text="Zeit von Kontoerstellung bis Follow",
+                     tickfont=dict(size=14, family=FONT))
+    fig.update_yaxes(title_text="Anzahl Konten",
+                     tickfont=dict(size=13, family=FONT), showgrid=True, gridcolor=GRID_COLOR)
+    under_5 = int(counts.iloc[:3].sum())
+    total = int(counts.sum())
+    return card_layout(fig,
+        title="Dauer von Erstellung bis Follow",
+        subtitle=f"{under_5} von {total} neuen Konten ({100*under_5/max(total,1):.0f}%) folgten "
+                 "innerhalb von 5 Min. nach Erstellung",
+    )
+
+
+def card_10_score_distribution(scores_df: pd.DataFrame) -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(go.Histogram(x=scores_df["score"], nbinsx=25,
+                               marker_color=ACCENT, opacity=0.85))
+    fig.add_vline(x=0.7, line_dash="dash", line_color="#cc0000",
+                  annotation_text="Hohe Konfidenz", annotation_position="bottom right",
+                  annotation_font=dict(size=13, family=FONT, color=ACCENT))
+    fig.add_vline(x=0.4, line_dash="dash", line_color=ACCENT2,
+                  annotation_text="Mittel", annotation_position="bottom left",
+                  annotation_font=dict(size=13, family=FONT, color=ACCENT2))
+    fig.update_xaxes(title_text="Bot-Score (0 = Mensch, 1 = Bot)",
+                     tickfont=dict(size=13, family=FONT))
+    fig.update_yaxes(title_text="Anzahl Konten",
+                     tickfont=dict(size=13, family=FONT), showgrid=True, gridcolor=GRID_COLOR)
+    return card_layout(fig,
+        title="Bot-Score-Verteilung",
+        subtitle=f"Mittelwert: {scores_df['score'].mean():.2f} — höher = bot-ähnlicheres Verhalten",
+    )
+
+
+def card_11_creation_vs_follow(detail_df: pd.DataFrame) -> go.Figure:
+    df = detail_df.dropna(subset=["age_at_follow_minutes"]).copy()
+    if df.empty:
+        return card_layout(go.Figure(), title="Kontoerstellung vs. Zeit bis Follow")
+    df["age_capped"] = df["age_at_follow_minutes"].clip(upper=120)
+    df["follower_created_at"] = pd.to_datetime(df["follower_created_at"], errors="coerce")
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(
+        x=df["follower_created_at"], y=df["age_capped"], mode="markers",
+        marker=dict(size=5, opacity=0.7, color=df["age_capped"].values,
+                    colorscale="RdYlGn", cmin=0, cmax=60, showscale=True,
+                    colorbar=dict(title=dict(text="Min", font=dict(size=12, family=FONT)),
+                                  tickfont=dict(size=11, family=FONT))),
+    ))
+    fig.add_hline(y=5, line_dash="dash", line_color=ACCENT, line_width=1.5,
+                  annotation_text="5-Min-Schwelle", annotation_position="top right",
+                  annotation_font=dict(size=12, family=FONT, color=ACCENT))
+    fig.update_xaxes(title_text="Konto erstellt am (UTC)",
+                     tickfont=dict(size=12, family=FONT))
+    fig.update_yaxes(title_text="Minuten bis Follow", tickfont=dict(size=12, family=FONT),
+                     showgrid=True, gridcolor=GRID_COLOR)
+    return card_layout(fig,
+        title="Kontoerstellung vs. Zeit bis Follow",
+        subtitle="Rote Punkte = Follow fast sofort nach Kontoerstellung",
+    )
+
+
+def card_12_amplifiers(scores_df: pd.DataFrame, cross_df: pd.DataFrame) -> go.Figure:
+    flags = scores_df["flags"].fillna("")
+    amp = scores_df[(scores_df["score"] < 0.5) & flags.str.contains("AMPLIFICATION")]
+    non_amp = scores_df[(scores_df["score"] < 0.5) & ~flags.str.contains("AMPLIFICATION")]
+    bots = scores_df[scores_df["score"] >= 0.5]
+    n_amp = len(amp)
+    n_amp_anon = int(amp["flags"].fillna("").str.contains("ANONYMOUS").sum())
+    valid = cross_df[cross_df["total_follows_fetched"] > 0] if not cross_df.empty else pd.DataFrame()
+    bot_cross = valid[valid["is_bot"]] if not valid.empty else pd.DataFrame()
+    non_bot_cross = valid[~valid["is_bot"]] if not valid.empty else pd.DataFrame()
+    bot_pct = bot_cross["cohort_pct"].mean() if not bot_cross.empty else 0
+    non_pct = non_bot_cross["cohort_pct"].mean() if not non_bot_cross.empty else 0
+    non_n = non_bot_cross["cohort_follows"].mean() if not non_bot_cross.empty else 0
+
+    fig = make_subplots(rows=1, cols=2, column_widths=[0.45, 0.55],
+                        horizontal_spacing=0.12,
+                        specs=[[{"type": "pie"}, {"type": "bar"}]])
+    fig.add_trace(go.Pie(
+        labels=[f"Bots ({len(bots)})", f"Verstärker ({n_amp})", f"Unauffällig ({len(non_amp)})"],
+        values=[len(bots), n_amp, len(non_amp)],
+        marker=dict(colors=[ACCENT, ACCENT3, "#bbbbbb"]),
+        textinfo="percent+label", textfont=dict(size=12, family=FONT),
+        hole=0.35, showlegend=False,
+    ), row=1, col=1)
+    fig.add_trace(go.Bar(
+        x=["Bots", "Verstärker/\nNon-Bots"], y=[bot_pct, non_pct],
+        marker_color=[ACCENT, ACCENT3],
+        text=[f"{v:.0f}%" for v in [bot_pct, non_pct]],
+        textposition="outside",
+        textfont=dict(size=16, family=FONT_BOLD, color=TEXT_COLOR),
+        showlegend=False, width=0.5,
+    ), row=1, col=2)
+    fig.update_yaxes(title_text="Ø Quervernetzung (%)",
+                     tickfont=dict(size=12, family=FONT),
+                     showgrid=True, gridcolor=GRID_COLOR,
+                     range=[0, max(bot_pct, non_pct, 1) * 1.3], row=1, col=2)
+    fig.update_xaxes(tickfont=dict(size=13, family=FONT), row=1, col=2)
+    return card_layout(fig,
+        title="Verstärker-Konten — Koordinierte Quervernetzung",
+        subtitle=f"{n_amp} Amplifier-Konten • Ø {non_n:.0f} gegenseitige Follows • {n_amp_anon} anonym",
+    )
+
+
+def card_13_cross_speed(per_account_df: pd.DataFrame) -> go.Figure:
+    if per_account_df.empty:
+        return card_layout(go.Figure(), title="Quervernetzungs-Geschwindigkeit")
+    df = per_account_df.copy()
+    df["first_cross_min"] = df["first_cross"] * 1440
+    df["first_cross_capped"] = df["first_cross_min"].clip(upper=120)
+    cat_order = ["Bot", "Verstärker", "Unauffällig"]
+    cat_colors = {"Bot": ACCENT, "Verstärker": ACCENT3, "Unauffällig": MUTED}
+    fig = make_subplots(rows=1, cols=2, column_widths=[0.55, 0.45],
+                        horizontal_spacing=0.12,
+                        subplot_titles=["Minuten bis erste Quervernetzung",
+                                        "Anteil < 60 Min"])
+    for cat in cat_order:
+        s = df[df["category"] == cat]
+        fig.add_trace(go.Box(y=s["first_cross_capped"], name=cat,
+                             marker_color=cat_colors[cat], boxmean=True,
+                             showlegend=False, width=0.5), row=1, col=1)
+    pcts, labels, colors = [], [], []
+    for cat in cat_order:
+        s = df[df["category"] == cat]
+        pct = 100 * (s["first_cross_min"] < 60).sum() / len(s) if len(s) else 0
+        pcts.append(pct); labels.append(cat); colors.append(cat_colors[cat])
+    fig.add_trace(go.Bar(x=labels, y=pcts, marker_color=colors,
+                         text=[f"{v:.0f}%" for v in pcts], textposition="outside",
+                         textfont=dict(size=16, family=FONT_BOLD, color=TEXT_COLOR),
+                         showlegend=False, width=0.5), row=1, col=2)
+    fig.update_yaxes(title_text="Minuten", showgrid=True, gridcolor=GRID_COLOR,
+                     tickfont=dict(size=11, family=FONT), range=[0, 125], row=1, col=1)
+    fig.update_yaxes(title_text="%", range=[0, 115], showgrid=True,
+                     gridcolor=GRID_COLOR, tickfont=dict(size=11, family=FONT), row=1, col=2)
+    fig.update_xaxes(tickfont=dict(size=12, family=FONT))
+    bot = df[df["category"] == "Bot"]
+    bot_med = bot["first_cross_min"].median() if len(bot) else 0
+    bot_pct60 = 100 * (bot["first_cross_min"] < 60).sum() / len(bot) if len(bot) else 0
+    fig = card_layout(fig,
+        title="Quervernetzungs-Geschwindigkeit",
+        subtitle=f"Bot-Median: {bot_med:.0f} Min • {bot_pct60:.0f}% der Bots vernetzen sich in < 1 Stunde")
+    fig.update_layout(margin=dict(t=140, b=65))
+    return fig
+
+
+def card_14_blocks_likes(
+    scores_df: pd.DataFrame, blocks_df: pd.DataFrame, likes_df: pd.DataFrame
+) -> go.Figure:
+    if blocks_df.empty or likes_df.empty:
+        return card_layout(go.Figure(), title="Blockiert & Liken")
+    if "subject" in blocks_df.columns:
+        blocks_df = blocks_df.rename(columns={"subject": "did"})
+    merged = scores_df.merge(blocks_df, on="did", how="left").merge(likes_df, on="did", how="left")
+    merged["block_count"] = merged["block_count"].fillna(0).astype(int)
+    merged["like_count"] = merged["like_count"].fillna(0).astype(int)
+    flags = merged["flags"].fillna("")
+    is_bot = merged["score"] >= 0.5
+    is_amp = (merged["score"] < 0.5) & flags.str.contains("AMPLIFICATION")
+    is_norm = (merged["score"] < 0.5) & ~flags.str.contains("AMPLIFICATION")
+
+    fig = make_subplots(rows=1, cols=2, column_widths=[0.5, 0.5],
+                        horizontal_spacing=0.12,
+                        subplot_titles=["Ø Blocks erhalten", "Ø Likes abgegeben"])
+    cats = ["Bots", "Verstärker", "Unauffällig"]
+    block_means = [merged[is_bot]["block_count"].mean(),
+                   merged[is_amp]["block_count"].mean(),
+                   merged[is_norm]["block_count"].mean()]
+    like_means = [merged[is_bot]["like_count"].mean(),
+                  merged[is_amp]["like_count"].mean(),
+                  merged[is_norm]["like_count"].mean()]
+    bar_colors = [ACCENT, ACCENT3, MUTED]
+    fig.add_trace(go.Bar(x=cats, y=block_means, marker_color=bar_colors,
+                         text=[f"{v:.0f}" for v in block_means], textposition="outside",
+                         textfont=dict(size=14, family=FONT_BOLD, color=TEXT_COLOR),
+                         showlegend=False, width=0.5), row=1, col=1)
+    fig.add_trace(go.Bar(x=cats, y=like_means, marker_color=bar_colors,
+                         text=[f"{v:.0f}" for v in like_means], textposition="outside",
+                         textfont=dict(size=14, family=FONT_BOLD, color=TEXT_COLOR),
+                         showlegend=False, width=0.5), row=1, col=2)
+    fig.update_yaxes(showgrid=True, gridcolor=GRID_COLOR,
+                     tickfont=dict(size=11, family=FONT))
+    fig.update_xaxes(tickfont=dict(size=12, family=FONT))
+    fig.update_yaxes(range=[0, max(block_means) * 1.25 if block_means else 1], row=1, col=1)
+    fig.update_yaxes(range=[0, max(like_means) * 1.35 if like_means else 1], row=1, col=2)
+    amp_block_median = int(merged[is_amp]["block_count"].median()) if is_amp.sum() else 0
+    return card_layout(fig,
+        title="Blockiert & Liken — Alle Kategorien betroffen",
+        subtitle=f"Verstärker-Median: {amp_block_median} Blocks erhalten",
+    )
+
+
+def card_15_block_hitlist(
+    scores_df: pd.DataFrame, blocks_df: pd.DataFrame, nodes_df: pd.DataFrame
+) -> go.Figure:
+    if blocks_df.empty:
+        return card_layout(go.Figure(), title="Block-Hitliste")
+    if "subject" in blocks_df.columns:
+        blocks_df = blocks_df.rename(columns={"subject": "did"})
+    merged = scores_df[["did", "score", "flags"]].merge(blocks_df, on="did", how="left")
+    merged["block_count"] = merged["block_count"].fillna(0).astype(int)
+    if not nodes_df.empty:
+        merged = merged.merge(
+            nodes_df[["did", "handle"]].drop_duplicates(), on="did", how="left"
+        )
+    else:
+        merged["handle"] = pd.NA
+    merged["category"] = "Unauffällig"
+    merged.loc[merged["score"] >= 0.5, "category"] = "Bot"
+    flags = merged["flags"].fillna("")
+    merged.loc[(merged["score"] < 0.5) & flags.str.contains("AMPLIFICATION"), "category"] = "Verstärker"
+    top = merged.nlargest(15, "block_count").copy()
+    if top.empty or top["block_count"].max() == 0:
+        return card_layout(go.Figure(), title="Block-Hitliste",
+                           subtitle="Keine Block-Daten verfügbar")
+    top["label"] = top["handle"].apply(
+        lambda h: f"@{h.replace('.bsky.social', '')}" if pd.notna(h) else "(anonym)"
+    )
+    top = top.sort_values("block_count", ascending=True)
+    cat_colors = {"Bot": ACCENT, "Verstärker": ACCENT3, "Unauffällig": MUTED}
+    colors = [cat_colors[c] for c in top["category"]]
+    fig = go.Figure()
+    fig.add_trace(go.Bar(
+        y=top["label"], x=top["block_count"], orientation="h",
+        marker_color=colors,
+        text=[f"{v:,}".replace(",", ".") for v in top["block_count"]],
+        textposition="outside",
+        textfont=dict(size=13, family=FONT_BOLD, color=TEXT_COLOR),
+        showlegend=False,
+    ))
+    fig.update_xaxes(showgrid=True, gridcolor=GRID_COLOR,
+                     tickfont=dict(size=11, family=FONT))
+    fig.update_yaxes(tickfont=dict(size=12, family=FONT))
+    fig.update_layout(xaxis_range=[0, top["block_count"].max() * 1.18])
+    median_all = int(merged["block_count"].median())
+    return card_layout(fig,
+        title="Block-Hitliste — Meistgeblockte im Cluster",
+        subtitle=f"Median über alle {len(merged)} Konten: {median_all} Blocks",
+    )
+
+
+# ─── Orchestrator ─────────────────────────────────────────────────────────
+
+def render_all_cards(
+    analysis: "AnalysisResult",
+    cluster: "ClusterResult",
+    cross: "CrossFollowResult",
+) -> dict[str, go.Figure]:
+    """Render every available card. Returns a dict keyed by card id."""
+    cfg = analysis.config
+    scores = analysis.scores_df
+    detail = analysis.detail_df
+    nodes = cluster.nodes_df
+    edges = cluster.edges_df
+    blocks = analysis.acquired.blocks_received
+    likes = analysis.acquired.likes_made
+    sample = cross.sample
+    per_acct = cross.per_account
+
+    cards: dict[str, go.Figure] = {
+        "card_01_overview": card_1_overview(scores, cfg.anchor_handle),
+        "card_02_anchors": card_2_anchors(nodes, cfg.anchor_handle),
+        "card_03_behavior": card_3_behavior(scores),
+        "card_04_timeline": card_4_timeline(detail),
+        "card_05_cluster": card_5_cluster(nodes, edges, cfg.anchor_handle),
+        "card_06_deleted": card_6_deleted(scores),
+        "card_07_lifecycle": card_7_lifecycle(detail, scores),
+        "card_08_cumulative": card_8_cumulative(detail, scores),
+        "card_09_age_at_follow": card_9_age_at_follow(detail),
+        "card_10_score_dist": card_10_score_distribution(scores),
+        "card_11_scatter": card_11_creation_vs_follow(detail),
+    }
+    if not sample.empty:
+        cards["card_12_amplifiers"] = card_12_amplifiers(scores, sample)
+    if not per_acct.empty:
+        cards["card_13_cross_speed"] = card_13_cross_speed(per_acct)
+    if not blocks.empty and not likes.empty:
+        cards["card_14_blocks_likes"] = card_14_blocks_likes(scores, blocks, likes)
+    if not blocks.empty:
+        cards["card_15_block_hitlist"] = card_15_block_hitlist(scores, blocks, nodes)
+    return cards

--- a/bluesky/botfinder/botfinder/cli.py
+++ b/bluesky/botfinder/botfinder/cli.py
@@ -1,0 +1,140 @@
+"""Command-line entry point for the botfinder pipeline.
+
+Usage::
+
+    botfinder --anchor niusde.bsky.social --lookback 7 --skip-api \\
+        --output-dir botfinder-output
+
+Reads ``BOTFINDER_KUSTO_URI`` and ``BOTFINDER_KUSTO_DATABASE`` env vars
+unless overridden with ``--kusto-uri`` / ``--kusto-database``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import plotly.io as pio
+
+from .config import Config
+from .pipeline import run_full_pipeline
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="botfinder",
+                                description="Bluesky bot-cluster analysis")
+    p.add_argument("--anchor", required=True,
+                   help="Bluesky handle of the cluster anchor (e.g. niusde.bsky.social)")
+    p.add_argument("--lookback", type=int, default=90,
+                   help="Lookback window in days (default 90)")
+    p.add_argument("--max-followers", type=int, default=5000,
+                   help="Cap on followers fetched via public API (default 5000)")
+    p.add_argument("--enrich-limit", type=int, default=400,
+                   help="Cap on profiles enriched via API (default 400)")
+    p.add_argument("--api-concurrency", type=int, default=10)
+    p.add_argument("--skip-api", action="store_true",
+                   help="Skip Bluesky public API calls (KQL only)")
+    p.add_argument("--kusto-uri", default=None,
+                   help="Kusto cluster URI (overrides BOTFINDER_KUSTO_URI)")
+    p.add_argument("--kusto-database", default=None,
+                   help="Kusto database name (overrides BOTFINDER_KUSTO_DATABASE)")
+    p.add_argument("--output-dir", default="botfinder-output",
+                   help="Directory for HTML dossier and per-card files")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    overrides: dict = {}
+    if args.kusto_uri:
+        overrides["kusto_uri"] = args.kusto_uri
+    if args.kusto_database:
+        overrides["kusto_database"] = args.kusto_database
+
+    config = Config(
+        anchor_handle=args.anchor,
+        lookback_days=args.lookback,
+        max_followers=args.max_followers,
+        enrich_limit=args.enrich_limit,
+        api_concurrency=args.api_concurrency,
+        skip_api=args.skip_api,
+        **overrides,
+    )
+
+    if not config.kusto_uri or not config.kusto_database:
+        print("ERROR: Kusto URI/database not set. Use --kusto-uri/--kusto-database "
+              "or set BOTFINDER_KUSTO_URI / BOTFINDER_KUSTO_DATABASE.", file=sys.stderr)
+        return 2
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"=== botfinder run for @{args.anchor} ===")
+    print(f"  cluster:  {config.kusto_uri}")
+    print(f"  database: {config.kusto_database}")
+    print(f"  output:   {out.resolve()}")
+
+    result = run_full_pipeline(config)
+
+    # Per-card HTML
+    card_dir = out / "cards"
+    card_dir.mkdir(exist_ok=True)
+    for card_id, fig in result.cards.items():
+        path = card_dir / f"{card_id}.html"
+        pio.write_html(fig, str(path), full_html=True, include_plotlyjs="cdn")
+    print(f"  Wrote {len(result.cards)} cards to {card_dir}")
+
+    # Dossier
+    try:
+        from .dossier import render_dossier
+        scores = result.analysis.scores_df
+        if scores.empty:
+            stats = {
+                "total_suspects": 0, "high_confidence_bots": 0, "medium_confidence_bots": 0,
+                "pct_instant_follow": 0.0, "pct_anonymous": 0.0,
+                "mean_score": 0.0, "p90_score": 0.0,
+            }
+        else:
+            total = len(scores)
+            stats = {
+                "total_suspects": total,
+                "high_confidence_bots": int((scores["score"] >= 0.7).sum()),
+                "medium_confidence_bots": int(((scores["score"] >= 0.4) & (scores["score"] < 0.7)).sum()),
+                "pct_instant_follow": 100 * scores["flags"].fillna("").str.contains("INSTANT_FOLLOW").sum() / total,
+                "pct_anonymous":      100 * scores["flags"].fillna("").str.contains("ANONYMOUS_PROFILE").sum() / total,
+                "mean_score": float(scores["score"].mean()),
+                "p90_score":  float(scores["score"].quantile(0.9)),
+            }
+        top_suspects = []
+        if not scores.empty:
+            top = scores.nlargest(50, "score")
+            for _, row in top.iterrows():
+                flags_str = row.get("flags", "") or ""
+                top_suspects.append({
+                    "handle":          row.get("handle", "") or "",
+                    "display_name":    row.get("display_name", "") or "",
+                    "total_score":     float(row["score"]),
+                    "flags":           [f for f in flags_str.split(",") if f],
+                    "posts_count":     0,
+                    "followers_count": 0,
+                    "age_minutes":     -1,
+                    "source":          row.get("source", "") or "",
+                })
+        figures = [fig for _, fig in result.cards.items()]
+        dossier_path = out / f"dossier_{config.anchor_slug}.html"
+        render_dossier(
+            target_handle=config.anchor_handle,
+            stats=stats, figures=figures, top_suspects=top_suspects,
+            lookback_days=config.lookback_days, output_path=dossier_path,
+        )
+        print(f"  Wrote HTML dossier to {dossier_path}")
+    except Exception as e:
+        print(f"  WARNING: dossier render failed: {e}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bluesky/botfinder/botfinder/cluster.py
+++ b/bluesky/botfinder/botfinder/cluster.py
@@ -1,0 +1,267 @@
+"""Build the follow co-occurrence cluster graph for the suspect cohort.
+
+Pure-functional refactor of ``scripts/cluster_graph.py`` and
+``tmp/cluster_graph.py``. Returns a :class:`ClusterResult` dataclass with
+nodes, edges and an interactive Plotly figure ready for inline display.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+import networkx as nx
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from .bluesky_api import BlueskyClient
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .pipeline import AnalysisResult
+
+
+@dataclass
+class ClusterResult:
+    nodes_df: pd.DataFrame
+    edges_df: pd.DataFrame
+    figure: go.Figure
+    target_did: str
+    target_handle: str
+
+
+async def _fetch_follows_for_suspects(
+    suspect_dids: list[str],
+    concurrency: int,
+    limit_per_account: int,
+) -> dict[str, list[str]]:
+    bsky = BlueskyClient(concurrency=concurrency)
+    results: dict[str, list[str]] = {}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _get_one(did: str):
+            async with sem:
+                try:
+                    follows = await bsky.get_follows(client, did, limit=limit_per_account)
+                    results[did] = [f.did for f in follows]
+                except Exception:
+                    results[did] = []
+
+        await asyncio.gather(*[_get_one(did) for did in suspect_dids])
+    return results
+
+
+async def _resolve_handles(dids: list[str], concurrency: int = 25) -> dict[str, str]:
+    bsky = BlueskyClient(concurrency=concurrency)
+    handles: dict[str, str] = {}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for i in range(0, len(dids), 25):
+            batch = dids[i: i + 25]
+            try:
+                profiles = await bsky.get_profiles_batch(client, batch)
+                for p in profiles:
+                    handles[p.did] = p.handle or p.did[:16]
+            except Exception:
+                for d in batch:
+                    handles[d] = d[:16]
+    return handles
+
+
+def _build_graph(
+    suspect_follows: dict[str, list[str]],
+    min_followers: int,
+) -> tuple[nx.Graph, dict[str, int]]:
+    target_counts: Counter = Counter()
+    for did, follows in suspect_follows.items():
+        for fdid in follows:
+            target_counts[fdid] += 1
+
+    significant = {d: c for d, c in target_counts.items() if c >= min_followers}
+    G = nx.Graph()
+    for d, c in significant.items():
+        G.add_node(d, weight=c)
+
+    target_list = list(significant.keys())
+    suspect_to_targets: dict[str, set[str]] = defaultdict(set)
+    for s_did, follows in suspect_follows.items():
+        for fdid in follows:
+            if fdid in significant:
+                suspect_to_targets[s_did].add(fdid)
+
+    for i in range(len(target_list)):
+        for j in range(i + 1, len(target_list)):
+            t1, t2 = target_list[i], target_list[j]
+            shared = sum(1 for ts in suspect_to_targets.values() if t1 in ts and t2 in ts)
+            if shared >= min_followers:
+                G.add_edge(t1, t2, weight=shared)
+    return G, significant
+
+
+def _render_figure(
+    G: nx.Graph,
+    handles: dict[str, str],
+    target_did: str,
+    target_handle: str,
+) -> go.Figure:
+    if len(G.nodes()) == 0:
+        return go.Figure().update_layout(title="No significant cluster found")
+
+    try:
+        pos = nx.spring_layout(G, k=2.0 / np.sqrt(len(G.nodes())), iterations=100, seed=42, weight="weight")
+    except Exception:
+        pos = nx.circular_layout(G)
+
+    weights = nx.get_node_attributes(G, "weight")
+    max_w = max(weights.values()) if weights else 1
+
+    node_x, node_y, node_text, node_size, node_color = [], [], [], [], []
+    for node in G.nodes():
+        x, y = pos[node]
+        node_x.append(x); node_y.append(y)
+        w = weights.get(node, 0)
+        handle = handles.get(node, node[:16])
+        node_text.append(f"@{handle}<br>Suspects following: {w}<br>Connections: {G.degree(node)}")
+        node_size.append(max(10, 60 * (w / max_w)))
+        if node == target_did:
+            node_color.append("crimson")
+        elif w >= max_w * 0.5:
+            node_color.append("darkorange")
+        elif w >= max_w * 0.25:
+            node_color.append("gold")
+        else:
+            node_color.append("lightblue")
+
+    edge_traces = []
+    edge_weights = [G[u][v].get("weight", 1) for u, v in G.edges()]
+    max_edge = max(edge_weights) if edge_weights else 1
+    for (u, v), ew in zip(G.edges(), edge_weights):
+        x0, y0 = pos[u]; x1, y1 = pos[v]
+        width = max(0.5, 4 * (ew / max_edge))
+        opacity = max(0.2, 0.8 * (ew / max_edge))
+        edge_traces.append(go.Scatter(
+            x=[x0, x1, None], y=[y0, y1, None], mode="lines",
+            line=dict(width=width, color=f"rgba(80,80,80,{opacity})"),
+            hoverinfo="none", showlegend=False,
+        ))
+
+    node_trace = go.Scatter(
+        x=node_x, y=node_y, mode="markers+text",
+        text=[handles.get(n, n[:12]) for n in G.nodes()],
+        textposition="top center",
+        textfont=dict(size=9, color="#1a1a1a"),
+        marker=dict(size=node_size, color=node_color, line=dict(width=1, color="#333333")),
+        hovertext=node_text, hoverinfo="text", showlegend=False,
+    )
+
+    fig = go.Figure(data=edge_traces + [node_trace])
+    fig.update_layout(
+        title=dict(
+            text=f"Follow Cluster Network — @{target_handle}<br>"
+                 "<sup>Node size = #suspects following, edges = shared followers</sup>",
+            font=dict(size=16),
+        ),
+        template="plotly_white", width=1400, height=900,
+        xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+        yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+        margin=dict(l=20, r=20, t=80, b=20),
+    )
+    return fig
+
+
+def build_cluster_graph(
+    analysis: "AnalysisResult",
+    *,
+    min_followers: int = 5,
+    classify_top: int = 200,
+    verbose: bool = True,
+) -> ClusterResult:
+    config = analysis.config
+    scores_df = analysis.scores_df
+    suspects = scores_df[scores_df["score"] >= config.cluster_score_threshold]
+    suspect_dids = suspects.sort_values("score", ascending=False)["did"].tolist()
+    if verbose:
+        print(f"  Cluster suspects (score≥{config.cluster_score_threshold}): {len(suspect_dids)}")
+
+    if not suspect_dids:
+        empty = pd.DataFrame()
+        return ClusterResult(empty, empty, go.Figure(), analysis.acquired.target_did, config.anchor_handle)
+
+    suspect_follows = asyncio.run(
+        _fetch_follows_for_suspects(suspect_dids, config.api_concurrency, limit_per_account=200)
+    )
+    if verbose:
+        total = sum(len(f) for f in suspect_follows.values())
+        print(f"  Suspect follow edges fetched: {total}")
+
+    G, target_weights = _build_graph(suspect_follows, min_followers=min_followers)
+    if verbose:
+        print(f"  Graph: {len(G.nodes())} nodes / {len(G.edges())} edges")
+
+    target_dids = list(G.nodes())
+    handles = asyncio.run(_resolve_handles(target_dids, concurrency=25)) if target_dids else {}
+
+    edges_data = [
+        {"source": handles.get(u, u), "target": handles.get(v, v), "shared_followers": G[u][v]["weight"]}
+        for u, v in G.edges()
+    ]
+    edges_df = pd.DataFrame(edges_data) if edges_data else pd.DataFrame(
+        columns=["source", "target", "shared_followers"]
+    )
+
+    nodes_data = [
+        {
+            "did": n,
+            "handle": handles.get(n, n),
+            "suspect_followers": target_weights.get(n, 0),
+            "graph_degree": G.degree(n),
+        }
+        for n in G.nodes()
+    ]
+    nodes_df = pd.DataFrame(nodes_data).sort_values("suspect_followers", ascending=False)
+
+    # Anchor classification
+    if not nodes_df.empty:
+        top_anchor_dids = nodes_df.head(classify_top)["did"].tolist()
+        top10_set = set(nodes_df.head(10)["did"].tolist())
+        suspect_did_set = set(suspect_dids)
+        all_cluster = top10_set | suspect_did_set
+
+        anchor_follows = asyncio.run(
+            _fetch_follows_for_suspects(top_anchor_dids, config.api_concurrency, limit_per_account=500)
+        )
+        cluster_member: dict[str, int] = {}
+        for did in top_anchor_dids:
+            follows_set = set(anchor_follows.get(did, []))
+            overlap = follows_set & all_cluster
+            overlap.discard(did)
+            cluster_member[did] = len(overlap)
+        nodes_df["follows_cluster_members"] = nodes_df["did"].map(
+            lambda d: cluster_member.get(d, -1)
+        )
+        nodes_df["is_cluster_member"] = nodes_df["follows_cluster_members"].apply(
+            lambda x: x >= 5 if x >= 0 else True
+        )
+
+        # Demote periphery accounts that get blocked a lot — they're active
+        if not analysis.acquired.blocks_received.empty:
+            blocks = analysis.acquired.blocks_received.rename(columns={"subject": "did"})
+            nodes_df = nodes_df.merge(blocks, on="did", how="left")
+            nodes_df["block_count"] = nodes_df["block_count"].fillna(0).astype(int)
+            demoted = (~nodes_df["is_cluster_member"]) & (nodes_df["block_count"] > 5)
+            nodes_df.loc[demoted, "is_cluster_member"] = True
+        else:
+            nodes_df["block_count"] = 0
+
+    figure = _render_figure(G, handles, analysis.acquired.target_did, config.anchor_handle)
+
+    return ClusterResult(
+        nodes_df=nodes_df,
+        edges_df=edges_df,
+        figure=figure,
+        target_did=analysis.acquired.target_did,
+        target_handle=config.anchor_handle,
+    )

--- a/bluesky/botfinder/botfinder/config.py
+++ b/bluesky/botfinder/botfinder/config.py
@@ -1,0 +1,92 @@
+"""Configuration for the botfinder pipeline."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Config:
+    """Pipeline configuration.
+
+    The Kusto cluster URI and database can be supplied directly,
+    discovered from a Fabric notebook context (via
+    ``Config.from_fabric_context``), or read from the environment
+    variables ``BOTFINDER_KUSTO_URI`` and ``BOTFINDER_KUSTO_DATABASE``.
+    """
+
+    anchor_handle: str
+    kusto_uri: Optional[str] = None
+    kusto_database: Optional[str] = None
+    lookback_days: int = 90
+    max_followers: int = 5000
+    enrich_limit: int = 400
+    api_concurrency: int = 10
+    cluster_score_threshold: float = 0.45
+    bot_score_threshold: float = 0.5
+    cohort_batch_size: int = 200
+    skip_api: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.kusto_uri:
+            self.kusto_uri = os.environ.get("BOTFINDER_KUSTO_URI")
+        if not self.kusto_database:
+            self.kusto_database = os.environ.get("BOTFINDER_KUSTO_DATABASE")
+
+    @property
+    def anchor_slug(self) -> str:
+        """Filesystem-safe representation of the anchor handle."""
+        return self.anchor_handle.replace(".", "_").replace("/", "_")
+
+    @classmethod
+    def from_fabric_context(
+        cls,
+        anchor_handle: str,
+        database_name: Optional[str] = None,
+        *,
+        kusto_uri: Optional[str] = None,
+        kusto_database: Optional[str] = None,
+        **overrides,
+    ) -> "Config":
+        """Build a Config using the bound Fabric notebook KQL database.
+
+        Resolution order for ``kusto_uri`` / ``kusto_database``:
+
+        1. Explicit keyword arguments (e.g. from a notebook parameters cell).
+        2. ``notebookutils.kql.listDatabases()`` when running inside Fabric.
+        3. Environment variables ``BOTFINDER_KUSTO_URI`` /
+           ``BOTFINDER_KUSTO_DATABASE`` (handled in :py:meth:`__post_init__`).
+        """
+        kusto_database = kusto_database or database_name
+
+        if not kusto_uri or not kusto_database:
+            try:  # pragma: no cover — only available inside Fabric
+                import notebookutils  # type: ignore
+
+                dbs = notebookutils.kql.listDatabases()  # type: ignore[attr-defined]
+                chosen = None
+                if database_name:
+                    chosen = next(
+                        (d for d in dbs if d.get("databaseName") == database_name),
+                        None,
+                    )
+                if chosen is None and dbs:
+                    chosen = dbs[0]
+                if chosen is not None:
+                    kusto_uri = kusto_uri or chosen.get("queryServiceUri")
+                    kusto_database = kusto_database or chosen.get("databaseName")
+            except Exception:
+                pass
+
+        return cls(
+            anchor_handle=anchor_handle,
+            kusto_uri=kusto_uri,
+            kusto_database=kusto_database,
+            **overrides,
+        )
+
+    @classmethod
+    def from_env(cls, anchor_handle: str, **overrides) -> "Config":
+        return cls(anchor_handle=anchor_handle, **overrides)

--- a/bluesky/botfinder/botfinder/cross_follow.py
+++ b/bluesky/botfinder/botfinder/cross_follow.py
@@ -1,0 +1,176 @@
+"""Cross-following analysis — sample cohort accounts and measure how many
+others in the cohort each one follows. Powers cards 12–13.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+import pandas as pd
+
+from .bluesky_api import BlueskyClient
+from .kusto import execute_query
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .pipeline import AnalysisResult
+
+
+@dataclass
+class CrossFollowResult:
+    sample: pd.DataFrame  # API-sampled bot vs. non-bot cross-follow rates
+    speed: pd.DataFrame  # KQL-derived per-event days_to_cross_follow
+    per_account: pd.DataFrame  # min/median days per account
+
+
+async def _measure_via_api(
+    scores_df: pd.DataFrame, sample_size: int, concurrency: int
+) -> pd.DataFrame:
+    all_dids = set(scores_df["did"].tolist())
+    all_handles = set(scores_df["handle"].dropna().tolist())
+
+    bot_pool = scores_df[scores_df["score"] >= 0.5]
+    non_pool = scores_df[scores_df["score"] < 0.5]
+    bot_n = min(sample_size // 2, len(bot_pool))
+    non_n = min(sample_size // 2, len(non_pool))
+    sample = pd.concat([
+        bot_pool.sample(bot_n, random_state=42) if bot_n else bot_pool.head(0),
+        non_pool.sample(non_n, random_state=42) if non_n else non_pool.head(0),
+    ])
+
+    client_obj = BlueskyClient(concurrency=concurrency, timeout=30.0)
+    results = []
+
+    async with httpx.AsyncClient(timeout=30.0) as http_client:
+        for _, row in sample.iterrows():
+            did = row["did"]
+            handle = row.get("handle", "")
+            score = row["score"]
+            try:
+                follows = await client_obj.get_follows(http_client, did, limit=200)
+                followed_dids = {f.did for f in follows}
+                followed_handles = {f.handle for f in follows}
+                cohort_overlap = max(
+                    len(followed_dids & all_dids),
+                    len(followed_handles & all_handles),
+                )
+                total = len(follows)
+                results.append({
+                    "did": did, "handle": handle, "score": score,
+                    "is_bot": score >= 0.5,
+                    "total_follows_fetched": total,
+                    "cohort_follows": cohort_overlap,
+                    "cohort_pct": (cohort_overlap / total * 100) if total > 0 else 0,
+                })
+            except Exception:
+                results.append({
+                    "did": did, "handle": handle, "score": score,
+                    "is_bot": score >= 0.5,
+                    "total_follows_fetched": 0, "cohort_follows": 0, "cohort_pct": 0,
+                })
+            await asyncio.sleep(0.05)
+
+    return pd.DataFrame(results)
+
+
+def _kql_cross_speed(
+    analysis: "AnalysisResult",
+    anchor_dids: list[str],
+    verbose: bool,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    config = analysis.config
+    scores_df = analysis.scores_df
+    detail_df = analysis.detail_df
+    cohort_dids = scores_df["did"].tolist()
+    if not anchor_dids or not cohort_dids:
+        empty = pd.DataFrame()
+        return empty, empty
+
+    BATCH = config.cohort_batch_size
+    anchor_str = ",".join(f'"{d}"' for d in anchor_dids)
+    rows = []
+    for i in range(0, len(cohort_dids), BATCH):
+        batch = cohort_dids[i:i + BATCH]
+        batch_str = ",".join(f'"{d}"' for d in batch)
+        query = f"""
+        let anchors = dynamic([{anchor_str}]);
+        let cohort = dynamic([{batch_str}]);
+        ['Bluesky.Graph.Follow_v1']
+        | where did in (cohort) and subject in (anchors)
+        | project did, subject, follow_time = ___time
+        """
+        df = execute_query(config, query)
+        if not df.empty:
+            rows.append(df)
+        if verbose:
+            print(f"  cross-speed batch {i // BATCH + 1}/{(len(cohort_dids) + BATCH - 1) // BATCH}: {len(df)}")
+
+    cross = pd.concat(rows, ignore_index=True) if rows else pd.DataFrame(
+        columns=["did", "subject", "follow_time"]
+    )
+
+    creation_map = (
+        detail_df.set_index("follower_did")["follower_created_at"].to_dict()
+        if not detail_df.empty else {}
+    )
+    cross["created_at"] = cross["did"].map(creation_map)
+    cross["follow_time"] = pd.to_datetime(cross["follow_time"], utc=True, errors="coerce")
+    cross["created_at"] = pd.to_datetime(cross["created_at"], utc=True, errors="coerce")
+    cross = cross.dropna(subset=["created_at", "follow_time"])
+    cross["days_to_cross_follow"] = (
+        (cross["follow_time"] - cross["created_at"]).dt.total_seconds() / 86400
+    )
+    cross = cross[cross["days_to_cross_follow"] >= 0]
+
+    cross = cross.merge(scores_df[["did", "score", "flags"]], on="did", how="left")
+    cross["category"] = "Unauffällig"
+    cross.loc[cross["score"] >= 0.5, "category"] = "Bot"
+    cross.loc[
+        (cross["score"] < 0.5)
+        & (cross["flags"].fillna("").str.contains("AMPLIFICATION", na=False)),
+        "category",
+    ] = "Verstärker"
+
+    if cross.empty:
+        per = pd.DataFrame(columns=["did", "first_cross", "median_cross", "n_cross", "category", "score"])
+    else:
+        per = cross.groupby("did").agg(
+            first_cross=("days_to_cross_follow", "min"),
+            median_cross=("days_to_cross_follow", "median"),
+            n_cross=("days_to_cross_follow", "count"),
+            category=("category", "first"),
+            score=("score", "first"),
+        ).reset_index()
+
+    return cross, per
+
+
+def measure_cross_following(
+    analysis: "AnalysisResult",
+    *,
+    sample_size: int = 80,
+    verbose: bool = True,
+) -> CrossFollowResult:
+    config = analysis.config
+    scores_df = analysis.scores_df
+
+    sample_df = pd.DataFrame()
+    if not config.skip_api and not scores_df.empty:
+        sample_df = asyncio.run(
+            _measure_via_api(scores_df, sample_size, config.api_concurrency)
+        )
+
+    # KQL speed needs anchor dids — i.e. cluster nodes outside the cohort.
+    # We let the caller pass them via re-running with cluster info; here we
+    # do a best-effort using outbound follows already in acquired data.
+    anchor_dids: list[str] = []
+    if not analysis.acquired.follows_from_cohort.empty:
+        target_counts = analysis.acquired.follows_from_cohort["subject"].value_counts()
+        cohort_set = set(scores_df["did"].tolist())
+        anchor_dids = [d for d in target_counts.head(50).index.tolist() if d not in cohort_set]
+
+    speed_df, per_account = _kql_cross_speed(analysis, anchor_dids, verbose=verbose)
+
+    return CrossFollowResult(sample=sample_df, speed=speed_df, per_account=per_account)

--- a/bluesky/botfinder/botfinder/dossier.py
+++ b/bluesky/botfinder/botfinder/dossier.py
@@ -1,0 +1,172 @@
+"""HTML dossier report generator using Jinja2 templates."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import plotly.io as pio
+from jinja2 import Template
+
+from .scoring import BotScore
+
+
+DOSSIER_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Bot Network Dossier — @{{ target_handle }}</title>
+<style>
+:root { --bg: #ffffff; --surface: #f5f5f5; --accent: #cc0000; --text: #1a1a1a; --muted: #555555; }
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); padding: 2rem; line-height: 1.6; }
+h1 { color: var(--accent); margin-bottom: 0.5rem; font-size: 2rem; }
+h2 { color: var(--accent); margin: 2rem 0 1rem; border-bottom: 1px solid var(--accent); padding-bottom: 0.3rem; }
+h3 { color: var(--text); margin: 1.5rem 0 0.5rem; }
+.subtitle { color: var(--muted); margin-bottom: 2rem; }
+.kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+.kpi { background: var(--surface); border-radius: 8px; padding: 1.2rem; text-align: center; border-left: 4px solid var(--accent); }
+.kpi .value { font-size: 2rem; font-weight: bold; color: var(--accent); }
+.kpi .label { font-size: 0.85rem; color: var(--muted); margin-top: 0.3rem; }
+.chart-container { background: var(--surface); border-radius: 8px; padding: 1rem; margin: 1.5rem 0; }
+.methodology { background: var(--surface); border-radius: 8px; padding: 1.5rem; margin: 1.5rem 0; }
+.methodology ul { margin-left: 1.5rem; }
+.methodology li { margin: 0.5rem 0; }
+table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }
+th, td { padding: 0.5rem 0.8rem; text-align: left; border-bottom: 1px solid #ddd; }
+th { background: var(--surface); color: var(--accent); position: sticky; top: 0; }
+tr:hover { background: rgba(233,69,96,0.1); }
+.score-high { color: #cc0000; font-weight: bold; }
+.score-medium { color: #cc5500; }
+.score-low { color: #228b22; }
+.flag { display: inline-block; background: var(--accent); color: white; font-size: 0.7rem;
+        padding: 0.1rem 0.4rem; border-radius: 3px; margin: 0.1rem; }
+.findings { background: var(--surface); border-radius: 8px; padding: 1.5rem; margin: 1.5rem 0;
+            border-left: 4px solid var(--accent); }
+.footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #333; color: var(--muted); font-size: 0.8rem; }
+</style>
+</head>
+<body>
+
+<h1>🚨 Bot Network Dossier</h1>
+<p class="subtitle">Target: <strong>@{{ target_handle }}</strong> — Generated {{ generated_at }}</p>
+
+<h2>Executive Summary</h2>
+<div class="findings">
+<p>Analysis of <strong>{{ stats.total_suspects }}</strong> followers of <strong>@{{ target_handle }}</strong>
+reveals a coordinated inauthentic behavior (CIB) pattern consistent with a manufactured follower network:</p>
+<ul style="margin: 1rem 0 0 1.5rem;">
+<li><strong>{{ stats.high_confidence_bots }}</strong> accounts ({{ "%.0f"|format(stats.high_confidence_bots / stats.total_suspects * 100) }}%) scored as <em>high-confidence bots</em> (score ≥ 0.7)</li>
+<li><strong>{{ stats.medium_confidence_bots }}</strong> accounts ({{ "%.0f"|format(stats.medium_confidence_bots / stats.total_suspects * 100) }}%) scored as <em>medium-confidence bots</em> (score 0.4–0.7)</li>
+<li><strong>{{ "%.0f"|format(stats.pct_instant_follow) }}%</strong> of recent followers followed within 5 minutes of account creation</li>
+<li><strong>{{ "%.0f"|format(stats.pct_anonymous) }}%</strong> have anonymous/incomplete profiles</li>
+<li>Account creations cluster in tight temporal bursts indicating automation</li>
+</ul>
+</div>
+
+<h2>Key Performance Indicators</h2>
+<div class="kpi-grid">
+<div class="kpi"><div class="value">{{ stats.total_suspects }}</div><div class="label">Total Followers Analyzed</div></div>
+<div class="kpi"><div class="value">{{ stats.high_confidence_bots }}</div><div class="label">High-Confidence Bots</div></div>
+<div class="kpi"><div class="value">{{ "%.0f"|format(stats.pct_instant_follow) }}%</div><div class="label">Instant Follows (&lt;5 min)</div></div>
+<div class="kpi"><div class="value">{{ "%.0f"|format(stats.pct_anonymous) }}%</div><div class="label">Anonymous Profiles</div></div>
+<div class="kpi"><div class="value">{{ "%.2f"|format(stats.mean_score) }}</div><div class="label">Mean Bot Score</div></div>
+<div class="kpi"><div class="value">{{ "%.2f"|format(stats.p90_score) }}</div><div class="label">P90 Bot Score</div></div>
+</div>
+
+<h2>Temporal Analysis</h2>
+{% for chart_html in chart_htmls[:4] %}
+<div class="chart-container">{{ chart_html }}</div>
+{% endfor %}
+
+<h2>Bot Score Analysis</h2>
+{% for chart_html in chart_htmls[4:6] %}
+<div class="chart-container">{{ chart_html }}</div>
+{% endfor %}
+
+{% if chart_htmls|length > 6 %}
+<h2>Network Coordination</h2>
+{% for chart_html in chart_htmls[6:] %}
+<div class="chart-container">{{ chart_html }}</div>
+{% endfor %}
+{% endif %}
+
+<h2>Top Suspect Accounts</h2>
+<div style="overflow-x: auto; max-height: 600px; overflow-y: auto;">
+<table>
+<thead>
+<tr><th>Handle</th><th>Display Name</th><th>Bot Score</th><th>Flags</th><th>Posts</th><th>Followers</th><th>Age@Follow</th><th>Source</th></tr>
+</thead>
+<tbody>
+{% for row in top_suspects %}
+<tr>
+<td><a href="https://bsky.app/profile/{{ row.handle }}" target="_blank" style="color: var(--accent);">@{{ row.handle }}</a></td>
+<td>{{ row.display_name or '—' }}</td>
+<td class="{{ 'score-high' if row.total_score >= 0.7 else 'score-medium' if row.total_score >= 0.4 else 'score-low' }}">{{ "%.2f"|format(row.total_score) }}</td>
+<td>{% for f in row.flags %}<span class="flag">{{ f }}</span>{% endfor %}</td>
+<td>{{ row.posts_count }}</td>
+<td>{{ row.followers_count }}</td>
+<td>{{ row.age_minutes if row.age_minutes >= 0 else '—' }} {{ 'min' if row.age_minutes >= 0 else '' }}</td>
+<td>{{ row.source }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</div>
+
+<h2>Methodology</h2>
+<div class="methodology">
+<h3>Detection Signals (Weighted Composite Score)</h3>
+<ul>
+<li><strong>Temporal Proximity (30%)</strong> — Time between account creation and first follow of target. Instant follows (&lt;5 min) are the strongest single indicator of automation.</li>
+<li><strong>Follow Overlap (20%)</strong> — Coordination signal: suspect accounts following the same set of other targets indicates botnet control from a single operator.</li>
+<li><strong>Activity Pattern (20%)</strong> — Post behavior analysis: high repost ratio, no original content, multilingual posting, and low engagement received.</li>
+<li><strong>Anonymity (15%)</strong> — Profile completeness: missing avatar, display name, bio, or algorithmically-generated handle patterns.</li>
+<li><strong>Account Age (15%)</strong> — Absolute age of the account. Brand-new accounts (&lt;24h) created in temporal clusters are highly suspicious.</li>
+</ul>
+<h3>Data Sources</h3>
+<ul>
+<li>Bluesky Firehose — Real-time ingestion of profiles, follows, and posts</li>
+<li>Bluesky AT Protocol — Profile enrichment, feed analysis, follow graph traversal</li>
+</ul>
+<h3>Academic Basis</h3>
+<ul>
+<li>Yang & Menczer (2023) "Anatomy of an AI-powered malicious social botnet" — arXiv:2307.16336</li>
+<li>DFRLab "#BotSpot: Twelve Ways to Spot a Bot" — Activity, Anonymity, Amplification framework</li>
+<li>Botometer/BotometerLite — Indiana University OSoMe</li>
+</ul>
+</div>
+
+<div class="footer">
+<p>Generated by <code>nius-bot-dossier</code> | Analysis period: last {{ lookback_days }} days | Target: @{{ target_handle }}</p>
+<p>This report uses heuristic scoring. High scores indicate bot-like behavior but are not definitive proof. Human review recommended.</p>
+</div>
+
+</body>
+</html>"""
+
+
+def render_dossier(
+    target_handle: str,
+    stats: dict,
+    figures: list,
+    top_suspects: list[dict],
+    lookback_days: int,
+    output_path: Path,
+) -> Path:
+    """Render the full HTML dossier report."""
+    chart_htmls = []
+    for fig in figures:
+        html = pio.to_html(fig, full_html=False, include_plotlyjs="cdn" if not chart_htmls else False)
+        chart_htmls.append(html)
+
+    template = Template(DOSSIER_TEMPLATE)
+    html_content = template.render(
+        target_handle=target_handle,
+        stats=stats,
+        chart_htmls=chart_htmls,
+        top_suspects=top_suspects,
+        lookback_days=lookback_days,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    )
+
+    output_path.write_text(html_content, encoding="utf-8")
+    return output_path

--- a/bluesky/botfinder/botfinder/kusto.py
+++ b/bluesky/botfinder/botfinder/kusto.py
@@ -1,0 +1,39 @@
+"""Kusto client wrapping ``azure-kusto-data`` with parameterised
+cluster + database settings."""
+
+from __future__ import annotations
+
+from azure.identity import DefaultAzureCredential
+from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
+import pandas as pd
+
+from .config import Config
+
+
+def _client(config: Config) -> KustoClient:
+    if not config.kusto_uri:
+        raise RuntimeError(
+            "Config.kusto_uri is not set. Pass it explicitly, set "
+            "BOTFINDER_KUSTO_URI, or use Config.from_fabric_context(...)."
+        )
+    credential = DefaultAzureCredential()
+    kcsb = KustoConnectionStringBuilder.with_azure_token_credential(
+        config.kusto_uri, credential
+    )
+    return KustoClient(kcsb)
+
+
+def execute_query(config: Config, query: str) -> pd.DataFrame:
+    """Execute a KQL query against the configured database and
+    return a DataFrame."""
+    if not config.kusto_database:
+        raise RuntimeError(
+            "Config.kusto_database is not set. Pass it explicitly or set "
+            "BOTFINDER_KUSTO_DATABASE."
+        )
+    client = _client(config)
+    response = client.execute(config.kusto_database, query)
+    table = response.primary_results[0]
+    columns = [col.column_name for col in table.columns]
+    rows = [[row[col] for col in columns] for row in table]
+    return pd.DataFrame(rows, columns=columns)

--- a/bluesky/botfinder/botfinder/pipeline.py
+++ b/bluesky/botfinder/botfinder/pipeline.py
@@ -1,0 +1,293 @@
+"""High-level pipeline: enrich the cohort via the Bluesky API, score every
+account, and orchestrate cluster/cross-follow/lifecycle/cards.
+
+This module is the public entry point. Two flavours:
+
+- :func:`run_analysis` — scoring only, returns :class:`AnalysisResult`.
+- :func:`run_full_pipeline` — adds cluster, cross-follow, lifecycle and
+  card rendering, returns :class:`FullResult`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import numpy as np
+import pandas as pd
+
+from .acquire import AcquiredData, acquire_all
+from .bluesky_api import (
+    BlueskyClient,
+    BlueskyProfile,
+    FollowRecord,
+    enrich_suspects_sync,
+)
+from .config import Config
+from .scoring import (
+    BotScore,
+    _is_random_handle,
+    compute_bot_score,
+    compute_network_statistics,
+)
+
+
+@dataclass
+class AnalysisResult:
+    config: Config
+    acquired: AcquiredData
+    detail_df: pd.DataFrame
+    scores_df: pd.DataFrame
+    overlap_df: pd.DataFrame
+    network_stats: dict
+    enriched: dict[str, dict]
+    api_followers: list[FollowRecord]
+
+
+@dataclass
+class FullResult:
+    analysis: AnalysisResult
+    cluster_nodes: pd.DataFrame
+    cluster_edges: pd.DataFrame
+    cross_follow_per_account: pd.DataFrame
+    cards: dict[str, Any]  # card_id -> plotly.Figure
+
+    @property
+    def scores_df(self) -> pd.DataFrame:
+        return self.analysis.scores_df
+
+
+def _fetch_all_followers_via_api(
+    target_handle: str, max_followers: int, concurrency: int
+) -> list[FollowRecord]:
+    async def _fetch():
+        bsky = BlueskyClient(concurrency=concurrency)
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            return await bsky.get_followers(client, target_handle, limit=max_followers)
+    return asyncio.run(_fetch())
+
+
+def _compute_follow_overlap_from_data(
+    suspect_dids: list[str],
+    outbound_follows_df: pd.DataFrame,
+    target_did: str,
+) -> pd.DataFrame:
+    if outbound_follows_df.empty:
+        return pd.DataFrame()
+    suspect_follows = outbound_follows_df[outbound_follows_df["did"].isin(suspect_dids)]
+    if suspect_follows.empty:
+        return pd.DataFrame()
+    target_counts = suspect_follows.groupby("subject")["did"].nunique().reset_index()
+    target_counts.columns = ["subject", "followers"]
+    target_counts = target_counts[
+        (target_counts["subject"] != target_did) & (target_counts["followers"] > 5)
+    ].sort_values("followers", ascending=False).head(50)
+    return target_counts
+
+
+def run_analysis(
+    config: Config,
+    acquired: AcquiredData | None = None,
+    *,
+    verbose: bool = True,
+) -> AnalysisResult:
+    """Acquire (if needed), enrich via the API, and score the cohort."""
+    if acquired is None:
+        acquired = acquire_all(config, verbose=verbose)
+
+    # KQL detail
+    kql_df = acquired.follows_to_target.copy()
+    if not kql_df.empty:
+        kql_df["follower_created_at"] = pd.to_datetime(
+            kql_df["follower_created_at"], utc=True
+        )
+        kql_df["follow_created_at"] = pd.to_datetime(
+            kql_df["follow_created_at"], utc=True
+        )
+        kql_df["age_at_follow_minutes"] = (
+            (kql_df["follow_created_at"] - kql_df["follower_created_at"]).dt.total_seconds() / 60
+        )
+    kql_df["source"] = "kql"
+
+    if verbose:
+        print(f"  KQL followers with timing: {len(kql_df)}")
+
+    # API extension
+    api_followers: list[FollowRecord] = []
+    if not config.skip_api:
+        api_followers = _fetch_all_followers_via_api(
+            config.anchor_handle, config.max_followers, config.api_concurrency
+        )
+        if verbose:
+            print(f"  API followers fetched: {len(api_followers)}")
+
+    kql_dids = set(kql_df["follower_did"].dropna().tolist()) if not kql_df.empty else set()
+    older_followers = [f for f in api_followers if f.did not in kql_dids]
+
+    older_rows = []
+    for f in older_followers:
+        try:
+            created_dt = pd.to_datetime(f.created_at, utc=True)
+        except (ValueError, TypeError):
+            created_dt = pd.NaT
+        older_rows.append({
+            "follower_did": f.did,
+            "follower_created_at": created_dt,
+            "follow_created_at": pd.NaT,
+            "age_at_follow_minutes": np.nan,
+            "source": "api",
+        })
+    older_df = pd.DataFrame(older_rows) if older_rows else pd.DataFrame(columns=kql_df.columns)
+    detail_df = pd.concat([kql_df, older_df], ignore_index=True)
+    if verbose:
+        print(f"  Combined cohort: {len(detail_df)}")
+
+    # Enrichment via API
+    enriched: dict[str, dict] = {}
+    if not config.skip_api:
+        kql_priority: list[str] = []
+        if not kql_df.empty:
+            kql_priority = (
+                kql_df.nsmallest(min(200, len(kql_df)), "age_at_follow_minutes")[
+                    "follower_did"
+                ].tolist()
+            )
+        older_suspicious = [
+            f for f in older_followers
+            if not f.display_name or _is_random_handle(f.handle)
+        ]
+        older_sample_dids = [f.did for f in older_suspicious[:100]]
+        remaining_older = [f for f in older_followers if f.did not in set(older_sample_dids)]
+        random.seed(42)
+        budget = max(0, config.enrich_limit - len(older_sample_dids) - len(kql_priority))
+        older_random_sample = (
+            random.sample(remaining_older, min(budget, len(remaining_older)))
+            if remaining_older and budget > 0 else []
+        )
+        older_sample_dids += [f.did for f in older_random_sample]
+
+        all_enrich_dids = list(dict.fromkeys(kql_priority + older_sample_dids))[: config.enrich_limit]
+        if verbose:
+            print(f"  Enriching {len(all_enrich_dids)} accounts via Bluesky API...")
+        if all_enrich_dids:
+            enriched = enrich_suspects_sync(all_enrich_dids, concurrency=config.api_concurrency)
+
+    # Follow overlap
+    overlap_df = pd.DataFrame()
+    if not acquired.follows_from_cohort.empty and not kql_df.empty:
+        instant_dids = kql_df[kql_df["age_at_follow_minutes"] < 60]["follower_did"].tolist()
+        overlap_df = _compute_follow_overlap_from_data(
+            instant_dids, acquired.follows_from_cohort, acquired.target_did
+        )
+    common_targets = set(overlap_df["subject"].tolist()) if not overlap_df.empty else set()
+
+    # Profile creation lookup
+    profile_created_at: dict[str, str] = {}
+    if not acquired.profiles.empty:
+        for _, row in acquired.profiles.iterrows():
+            profile_created_at[row["did"]] = str(row.get("created_at", ""))
+
+    # Scoring
+    scores: list[BotScore] = []
+    for _, row in detail_df.iterrows():
+        did = row["follower_did"]
+        enrichment = enriched.get(did, {})
+        profile = enrichment.get("profile") if enrichment else None
+        if profile is None:
+            created_at_val = str(row.get("follower_created_at", ""))
+            if not created_at_val or created_at_val == "NaT":
+                created_at_val = profile_created_at.get(did, "")
+            profile = BlueskyProfile(
+                did=did,
+                handle="unknown",
+                display_name="",
+                description="",
+                avatar="",
+                banner="",
+                followers_count=0,
+                follows_count=0,
+                posts_count=0,
+                created_at=created_at_val,
+            )
+        posts = enrichment.get("posts", []) if enrichment else []
+        follows_list = enrichment.get("follows", []) if enrichment else []
+        follows_dids = [f.did for f in follows_list] if follows_list else []
+
+        score = compute_bot_score(
+            did=did,
+            profile=profile,
+            posts=posts,
+            age_at_follow_minutes=row["age_at_follow_minutes"],
+            suspect_follows_dids=follows_dids,
+            common_targets=common_targets,
+            total_suspects=len(detail_df),
+            lookback_days=config.lookback_days,
+        )
+        scores.append(score)
+
+    scores_df = pd.DataFrame([
+        {
+            "did": s.did,
+            "handle": s.handle,
+            "display_name": s.display_name,
+            "score": s.total_score,
+            "flags": ",".join(s.flags),
+            "source": "kql" if s.did in kql_dids else "api",
+            **s.signals,
+        }
+        for s in scores
+    ])
+
+    network_stats = compute_network_statistics(scores)
+
+    if verbose:
+        n_bots = int((scores_df["score"] >= config.bot_score_threshold).sum()) if not scores_df.empty else 0
+        print(f"  Bots (≥{config.bot_score_threshold}): {n_bots}")
+
+    return AnalysisResult(
+        config=config,
+        acquired=acquired,
+        detail_df=detail_df,
+        scores_df=scores_df,
+        overlap_df=overlap_df,
+        network_stats=network_stats,
+        enriched=enriched,
+        api_followers=api_followers,
+    )
+
+
+def run_full_pipeline(
+    config: Config,
+    acquired: AcquiredData | None = None,
+    *,
+    verbose: bool = True,
+) -> FullResult:
+    """Full pipeline: analysis + cluster graph + cross-follow + cards."""
+    from .cluster import build_cluster_graph
+    from .cross_follow import measure_cross_following
+    from .cards import render_all_cards
+
+    analysis = run_analysis(config, acquired, verbose=verbose)
+
+    if verbose:
+        print("═══ Cluster graph ═══")
+    cluster = build_cluster_graph(analysis, verbose=verbose)
+
+    if verbose:
+        print("═══ Cross-follow analysis ═══")
+    cross = measure_cross_following(analysis, verbose=verbose)
+
+    if verbose:
+        print("═══ Render cards ═══")
+    cards = render_all_cards(analysis, cluster, cross)
+
+    return FullResult(
+        analysis=analysis,
+        cluster_nodes=cluster.nodes_df,
+        cluster_edges=cluster.edges_df,
+        cross_follow_per_account=cross.per_account,
+        cards=cards,
+    )

--- a/bluesky/botfinder/botfinder/queries.py
+++ b/bluesky/botfinder/botfinder/queries.py
@@ -1,0 +1,144 @@
+"""KQL queries for bot network analysis."""
+
+TARGET_RESOLUTION = """
+['Bluesky.Actor.Profile_v2']
+| where display_name contains "{target_handle}"
+| top 1 by ___time desc
+| project did
+"""
+
+NEW_FOLLOWERS_DETAIL = """
+let target_did = toscalar(
+    ['Bluesky.Actor.Profile_v2']
+    | where display_name contains "{target_handle}"
+    | top 1 by ___time desc
+    | project did
+);
+let follows = ['Bluesky.Graph.Follow_v1']
+| where subject == target_did
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project follower_did=did, follower_display_name=display_name,
+              follower_handle=handle, follower_created_at=created_at,
+              follower_description=description, follower_avatar=avatar
+) on $left.did == $right.follower_did
+| summarize arg_max(ingestion_time(), *) by follower_did
+| project follower_did, follower_display_name, follower_handle,
+          follower_created_at=todatetime(follower_created_at),
+          follow_created_at=todatetime(created_at),
+          follower_description, follower_avatar
+| where isnotempty(follower_created_at) and follower_created_at > ago({lookback_days}d);
+follows
+| extend age_at_follow_minutes = datetime_diff('minute', follow_created_at, follower_created_at)
+| order by follower_created_at asc
+"""
+
+FOLLOW_TIMECHART = """
+let target_did = toscalar(
+    ['Bluesky.Actor.Profile_v2']
+    | where display_name contains "{target_handle}"
+    | top 1 by ___time desc
+    | project did
+);
+let follows = ['Bluesky.Graph.Follow_v1']
+| where subject == target_did
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project follower_did=did, follower_created_at=created_at
+) on $left.did == $right.follower_did
+| summarize arg_max(ingestion_time(), *) by follower_did
+| project follower_did, follower_created_at=todatetime(follower_created_at),
+          follow_created_at=todatetime(created_at)
+| where isnotempty(follower_created_at) and follower_created_at > ago({lookback_days}d);
+follows
+| summarize count() by bin(follow_created_at, {bin_size})
+| order by follow_created_at asc
+"""
+
+ACCOUNT_CREATION_TIMECHART = """
+let target_did = toscalar(
+    ['Bluesky.Actor.Profile_v2']
+    | where display_name contains "{target_handle}"
+    | top 1 by ___time desc
+    | project did
+);
+let follows = ['Bluesky.Graph.Follow_v1']
+| where subject == target_did
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project follower_did=did, follower_created_at=created_at
+) on $left.did == $right.follower_did
+| summarize arg_max(ingestion_time(), *) by follower_did
+| project follower_did, follower_created_at=todatetime(follower_created_at),
+          follow_created_at=todatetime(created_at)
+| where isnotempty(follower_created_at) and follower_created_at > ago({lookback_days}d);
+follows
+| summarize count() by bin(follower_created_at, {bin_size})
+| order by follower_created_at asc
+"""
+
+FOLLOW_OVERLAP = """
+let target_did = toscalar(
+    ['Bluesky.Actor.Profile_v2']
+    | where display_name contains "{target_handle}"
+    | top 1 by ___time desc
+    | project did
+);
+let suspect_dids = ['Bluesky.Graph.Follow_v1']
+| where subject == target_did
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project follower_did=did, follower_created_at=created_at
+) on $left.did == $right.follower_did
+| summarize arg_max(ingestion_time(), *) by follower_did
+| where isnotempty(follower_created_at) and todatetime(follower_created_at) > ago({lookback_days}d)
+| where datetime_diff('minute', todatetime(created_at), todatetime(follower_created_at)) < 60
+| project follower_did;
+['Bluesky.Graph.Follow_v1']
+| where did in (suspect_dids)
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project target_did2=did, target_display_name=display_name, target_handle=handle
+) on $left.subject == $right.target_did2
+| summarize followers=dcount(did), follower_list=make_set(did, 100) by subject, target_display_name, target_handle
+| where followers > 5
+| order by followers desc
+| take 50
+"""
+
+SUMMARY_STATS = """
+let target_did = toscalar(
+    ['Bluesky.Actor.Profile_v2']
+    | where display_name contains "{target_handle}"
+    | top 1 by ___time desc
+    | project did
+);
+let follows = ['Bluesky.Graph.Follow_v1']
+| where subject == target_did
+| join kind=leftouter (
+    ['Bluesky.Actor.Profile_v2']
+    | project follower_did=did, follower_created_at=created_at,
+              follower_display_name=display_name, follower_avatar=avatar,
+              follower_description=description
+) on $left.did == $right.follower_did
+| summarize arg_max(ingestion_time(), *) by follower_did
+| project follower_did, follower_created_at=todatetime(follower_created_at),
+          follow_created_at=todatetime(created_at),
+          follower_display_name, follower_avatar, follower_description
+| where isnotempty(follower_created_at) and follower_created_at > ago({lookback_days}d)
+| extend age_at_follow_minutes = datetime_diff('minute', follow_created_at, follower_created_at);
+follows
+| summarize
+    total_new_followers = count(),
+    median_age_minutes = percentile(age_at_follow_minutes, 50),
+    p10_age_minutes = percentile(age_at_follow_minutes, 10),
+    p90_age_minutes = percentile(age_at_follow_minutes, 90),
+    under_1h = countif(age_at_follow_minutes < 60),
+    under_5m = countif(age_at_follow_minutes < 5),
+    under_1m = countif(age_at_follow_minutes < 1),
+    no_display_name = countif(isempty(follower_display_name)),
+    no_avatar = countif(isempty(follower_avatar)),
+    no_description = countif(isempty(follower_description)),
+    earliest_account = min(follower_created_at),
+    latest_account = max(follower_created_at)
+"""

--- a/bluesky/botfinder/botfinder/scoring.py
+++ b/bluesky/botfinder/botfinder/scoring.py
@@ -1,0 +1,311 @@
+"""Bot behavior scoring and network analysis.
+
+Implements heuristics based on DFRLab's bot detection methodology and
+academic research on coordinated inauthentic behavior (CIB):
+
+Signals scored:
+1. Account age at first follow (temporal proximity)
+2. Profile completeness (anonymity)
+3. Activity volume and patterns
+4. Follow overlap (coordinated following)
+5. Posting behavior (amplification vs. original content)
+6. Handle pattern analysis (random alphanumeric handles)
+7. Temporal burst detection (synchronized account creation)
+"""
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+
+from .bluesky_api import BlueskyProfile, BlueskyPost
+
+
+@dataclass
+class BotScore:
+    did: str
+    handle: str
+    display_name: str
+    total_score: float  # 0.0 (human) to 1.0 (certain bot)
+    signals: dict[str, float] = field(default_factory=dict)
+    flags: list[str] = field(default_factory=list)
+
+
+def score_temporal_proximity(age_at_follow_minutes: float) -> float:
+    """Score based on how quickly after creation the account followed the target.
+
+    < 1 min: 1.0 (instant follow = strong bot signal)
+    < 5 min: 0.9
+    < 30 min: 0.7
+    < 60 min: 0.5
+    < 240 min (4h): 0.3
+    > 24h: 0.0
+    NaN: 0.0 (unknown — don't penalize)
+    """
+    if pd.isna(age_at_follow_minutes):
+        return 0.0  # Unknown timing — rely on other signals
+    if age_at_follow_minutes < 1:
+        return 1.0
+    if age_at_follow_minutes < 5:
+        return 0.9
+    if age_at_follow_minutes < 30:
+        return 0.7
+    if age_at_follow_minutes < 60:
+        return 0.5
+    if age_at_follow_minutes < 240:
+        return 0.3
+    if age_at_follow_minutes < 1440:
+        return 0.1
+    return 0.0
+
+
+def score_profile_completeness(profile: BlueskyProfile | None, handle: str = "") -> float:
+    """Score anonymity — incomplete profiles are more suspicious.
+
+    Unresolvable/deleted account: 1.0 (strongest signal)
+    Missing avatar: +0.25
+    Missing display name: +0.25
+    Missing description/bio: +0.25
+    Default/random handle: +0.25
+    """
+    if not profile:
+        if not handle:
+            return 1.0  # Deleted/suspended account that still appears as follower
+        return 0.75  # Can't resolve but has a handle
+    score = 0.0
+    if not profile.avatar:
+        score += 0.25
+    if not profile.display_name:
+        score += 0.25
+    if not profile.description:
+        score += 0.25
+    if _is_random_handle(profile.handle):
+        score += 0.25
+    return score
+
+
+def _is_random_handle(handle: str) -> bool:
+    """Detect likely auto-generated handles (alphanumeric gibberish)."""
+    local_part = handle.split(".")[0] if "." in handle else handle
+    if not local_part:
+        return True
+    if len(local_part) > 12 and re.match(r"^[a-z0-9]+$", local_part):
+        digit_ratio = sum(c.isdigit() for c in local_part) / len(local_part)
+        if digit_ratio > 0.4:
+            return True
+    if re.match(r"^[a-z]{2,4}\d{5,}$", local_part):
+        return True
+    return False
+
+
+def score_activity_pattern(posts: list[BlueskyPost], profile: BlueskyProfile | None) -> float:
+    """Score based on posting behavior analysis.
+
+    High amplification (repost ratio): suspicious
+    No original content: suspicious
+    Zero posts from a new account following someone: strong signal
+    Burst posting: suspicious
+    """
+    if not posts:
+        if profile and profile.posts_count == 0:
+            return 0.8  # Zero posts = purpose-built follow account
+        if not profile:
+            return 0.6  # Can't assess, but absence of data for new account is suspicious
+        return 0.3  # Has posts but we didn't fetch them
+
+    total = len(posts)
+    reposts = sum(1 for p in posts if p.is_repost)
+    replies = sum(1 for p in posts if p.is_reply)
+    original = total - reposts - replies
+
+    score = 0.0
+
+    # High repost ratio
+    repost_ratio = reposts / total if total > 0 else 0
+    if repost_ratio > 0.9:
+        score += 0.4
+    elif repost_ratio > 0.7:
+        score += 0.2
+
+    # No original content
+    if original == 0 and total > 5:
+        score += 0.3
+
+    # Check for language diversity (multilingual bots)
+    all_langs = set()
+    for p in posts:
+        all_langs.update(p.langs)
+    if len(all_langs) > 3:
+        score += 0.2
+
+    # Low engagement received
+    avg_likes = np.mean([p.like_count for p in posts]) if posts else 0
+    if avg_likes < 0.5 and total > 10:
+        score += 0.1
+
+    return min(score, 1.0)
+
+
+def score_follow_overlap(
+    suspect_follows: list[str], common_targets: set[str], total_suspects: int
+) -> float:
+    """Score based on how many of the same accounts this suspect follows
+    compared to other suspects in the cluster.
+
+    High overlap = coordinated behavior.
+    """
+    if not suspect_follows or not common_targets:
+        return 0.0
+    overlap = len(set(suspect_follows) & common_targets)
+    ratio = overlap / max(len(common_targets), 1)
+    return min(ratio, 1.0)
+
+
+def score_account_age(created_at: str, lookback_days: int = 7) -> float:
+    """Score based on account age. Accounts created within the analysis window are suspicious."""
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        age_hours = (datetime.now(timezone.utc) - created).total_seconds() / 3600
+        lookback_hours = lookback_days * 24
+        if age_hours < 6:
+            return 1.0
+        if age_hours < 24:
+            return 0.9
+        if age_hours < 48:
+            return 0.8
+        if age_hours < 72:
+            return 0.7
+        if age_hours < lookback_hours:
+            return 0.6
+        return 0.0
+    except (ValueError, TypeError):
+        return 0.5
+
+
+def compute_bot_score(
+    did: str,
+    profile: BlueskyProfile | None,
+    posts: list[BlueskyPost],
+    age_at_follow_minutes: float,
+    suspect_follows_dids: list[str],
+    common_targets: set[str],
+    total_suspects: int,
+    lookback_days: int = 7,
+) -> BotScore:
+    """Compute composite bot score from all signals."""
+    signals = {}
+    flags = []
+
+    # Signal 1: Temporal proximity
+    signals["temporal_proximity"] = score_temporal_proximity(age_at_follow_minutes)
+    if signals["temporal_proximity"] >= 0.9:
+        flags.append("INSTANT_FOLLOW")
+
+    # Signal 2: Profile completeness
+    handle_str = profile.handle if profile else ""
+    signals["anonymity"] = score_profile_completeness(profile, handle=handle_str)
+    if signals["anonymity"] >= 0.75:
+        flags.append("ANONYMOUS_PROFILE")
+    if signals["anonymity"] >= 1.0:
+        flags.append("DELETED_OR_SUSPENDED")
+
+    # Signal 3: Activity pattern
+    signals["activity_pattern"] = score_activity_pattern(posts, profile)
+    if signals["activity_pattern"] >= 0.6:
+        flags.append("AMPLIFICATION_BOT")
+
+    # Signal 4: Follow overlap
+    signals["follow_overlap"] = score_follow_overlap(
+        suspect_follows_dids, common_targets, total_suspects
+    )
+    if signals["follow_overlap"] >= 0.5:
+        flags.append("COORDINATED_FOLLOWING")
+
+    # Signal 5: Account age
+    created_at = profile.created_at if profile else ""
+    signals["account_age"] = score_account_age(created_at, lookback_days)
+    if signals["account_age"] >= 0.7:
+        flags.append("BRAND_NEW_ACCOUNT")
+
+    # Adaptive weighted composite score
+    # When temporal_proximity is unknown (API-sourced older accounts),
+    # redistribute its weight to other signals
+    has_timing = not pd.isna(age_at_follow_minutes)
+    if has_timing:
+        weights = {
+            "temporal_proximity": 0.30,
+            "anonymity": 0.15,
+            "activity_pattern": 0.20,
+            "follow_overlap": 0.20,
+            "account_age": 0.15,
+        }
+    else:
+        # No timing data — weight shifts to profile + activity + overlap
+        weights = {
+            "temporal_proximity": 0.00,
+            "anonymity": 0.25,
+            "activity_pattern": 0.30,
+            "follow_overlap": 0.30,
+            "account_age": 0.15,
+        }
+    total_score = sum(signals[k] * weights[k] for k in weights)
+
+    handle = profile.handle if profile else ""
+    display_name = profile.display_name if profile else ""
+
+    return BotScore(
+        did=did,
+        handle=handle,
+        display_name=display_name,
+        total_score=total_score,
+        signals=signals,
+        flags=flags,
+    )
+
+
+def detect_temporal_bursts(
+    df: pd.DataFrame, time_col: str, window: str = "5min", threshold: int = 5
+) -> pd.DataFrame:
+    """Detect bursts of coordinated activity within tight time windows.
+
+    Returns DataFrame with burst windows and account counts.
+    """
+    df = df.copy()
+    df[time_col] = pd.to_datetime(df[time_col])
+    binned = df.set_index(time_col).resample(window).size().reset_index(name="count")
+    bursts = binned[binned["count"] >= threshold].copy()
+    bursts["burst_intensity"] = bursts["count"] / bursts["count"].mean() if len(bursts) > 0 else 0
+    return bursts
+
+
+def compute_network_statistics(scores: list[BotScore]) -> dict:
+    """Aggregate network-level statistics for the dossier."""
+    if not scores:
+        return {}
+
+    total = len(scores)
+    high_confidence = [s for s in scores if s.total_score >= 0.7]
+    medium_confidence = [s for s in scores if 0.4 <= s.total_score < 0.7]
+    low_confidence = [s for s in scores if s.total_score < 0.4]
+
+    all_scores = [s.total_score for s in scores]
+    flag_counts: dict[str, int] = {}
+    for s in scores:
+        for f in s.flags:
+            flag_counts[f] = flag_counts.get(f, 0) + 1
+
+    return {
+        "total_suspects": total,
+        "high_confidence_bots": len(high_confidence),
+        "medium_confidence_bots": len(medium_confidence),
+        "low_confidence": len(low_confidence),
+        "mean_score": float(np.mean(all_scores)),
+        "median_score": float(np.median(all_scores)),
+        "p90_score": float(np.percentile(all_scores, 90)),
+        "flag_distribution": flag_counts,
+        "pct_instant_follow": flag_counts.get("INSTANT_FOLLOW", 0) / total * 100,
+        "pct_anonymous": flag_counts.get("ANONYMOUS_PROFILE", 0) / total * 100,
+        "pct_coordinated": flag_counts.get("COORDINATED_FOLLOWING", 0) / total * 100,
+    }

--- a/bluesky/botfinder/notebook/botfinder.ipynb
+++ b/bluesky/botfinder/notebook/botfinder.ipynb
@@ -1,0 +1,247 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "kqlDatabases": []
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bluesky Bot-Cluster Analyse\n",
+    "\n",
+    "Diese Notebook erstellt einen vollständigen Bot-Cluster-Report rund um einen Bluesky-Anker-Account. Die einzige Konfiguration ist der `ANCHOR_HANDLE` in der Parameterzelle weiter unten.\n",
+    "\n",
+    "**Voraussetzungen**\n",
+    "- Notebook ist mit einer Bluesky-KQL-Datenbank verbunden (KQL-Tab links). `deploy-fabric-notebook.ps1` setzt diese Bindung automatisch.\n",
+    "- Identität, mit der das Notebook ausgeführt wird, hat Reader-Rechte auf der Eventhouse-Datenbank.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Modul aus dem real-time-sources Repo installieren\n",
+    "%pip install -q git+https://github.com/clemensv/real-time-sources@main#subdirectory=bluesky/botfinder\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS ===\n",
+    "# Inhaltliche Variable: ANCHOR_HANDLE.\n",
+    "# KUSTO_URI / KUSTO_DATABASE werden vom Deploy-Skript pro Workspace gesetzt.\n",
+    "ANCHOR_HANDLE  = \"niusde.bsky.social\"\n",
+    "LOOKBACK_DAYS  = 90\n",
+    "MAX_FOLLOWERS  = 5000\n",
+    "ENRICH_LIMIT   = 400\n",
+    "SKIP_API       = False\n",
+    "\n",
+    "# Workspace-spezifische Defaults — vom Deploy-Skript überschrieben.\n",
+    "KUSTO_URI      = \"\"\n",
+    "KUSTO_DATABASE = \"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from botfinder import Config, run_full_pipeline\n",
+    "\n",
+    "config = Config.from_fabric_context(\n",
+    "    anchor_handle=ANCHOR_HANDLE,\n",
+    "    kusto_uri=KUSTO_URI or None,\n",
+    "    kusto_database=KUSTO_DATABASE or None,\n",
+    "    lookback_days=LOOKBACK_DAYS,\n",
+    "    max_followers=MAX_FOLLOWERS,\n",
+    "    enrich_limit=ENRICH_LIMIT,\n",
+    "    skip_api=SKIP_API,\n",
+    ")\n",
+    "print(f\"Cluster:  {config.kusto_uri}\")\n",
+    "print(f\"Database: {config.kusto_database}\")\n",
+    "print(f\"Anchor:   @{config.anchor_handle}\")\n",
+    "assert config.kusto_uri and config.kusto_database, (\n",
+    "    \"KQL database not configured. Re-deploy this notebook via \"\n",
+    "    \"deploy-fabric-notebook.ps1 or set KUSTO_URI / KUSTO_DATABASE \"\n",
+    "    \"in the parameters cell.\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vollständige Pipeline ausführen\n",
+    "Akquise (KQL) → API-Anreicherung → Scoring → Cluster-Graph → Cross-Follow → Karten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "result = run_full_pipeline(config)\n",
+    "scores = result.analysis.scores_df\n",
+    "print(f\"Cohort: {len(scores)} accounts\")\n",
+    "print(f\"Bots:   {(scores['score'] >= config.bot_score_threshold).sum()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KPI-Übersicht"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "scores = result.analysis.scores_df\n",
+    "flags = scores['flags'].fillna('')\n",
+    "kpis = pd.DataFrame([\n",
+    "    {'Metrik': 'Cohort total',        'Wert': len(scores)},\n",
+    "    {'Metrik': 'Bots (score≥0.5)',    'Wert': int((scores['score'] >= 0.5).sum())},\n",
+    "    {'Metrik': 'Sofort-Follow',       'Wert': int(flags.str.contains('INSTANT_FOLLOW').sum())},\n",
+    "    {'Metrik': 'Anonyme Profile',     'Wert': int(flags.str.contains('ANONYMOUS_PROFILE').sum())},\n",
+    "    {'Metrik': 'Gelöschte Profile',   'Wert': int(flags.str.contains('DELETED').sum())},\n",
+    "    {'Metrik': 'Cluster-Knoten',      'Wert': len(result.cluster_nodes)},\n",
+    "    {'Metrik': 'Cluster-Kanten',      'Wert': len(result.cluster_edges)},\n",
+    "])\n",
+    "display(kpis)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Top-Verdächtige"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "top = scores.nlargest(20, 'score')[['handle', 'display_name', 'score', 'flags']]\n",
+    "display(top)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Karten\n",
+    "Jede Karte ist eine eigenständige Plotly-Visualisierung im 1200×675-Format (Karte 5 ist 1200×1200)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "for card_id, fig in result.cards.items():\n",
+    "    print(card_id)\n",
+    "    fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## HTML-Dossier ins Lakehouse schreiben (optional)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from botfinder.dossier import render_dossier\n",
+    "\n",
+    "try:\n",
+    "    out = Path('/lakehouse/default/Files/botfinder')\n",
+    "    out.mkdir(parents=True, exist_ok=True)\n",
+    "    figures = list(result.cards.values())\n",
+    "    flags = scores['flags'].fillna('')\n",
+    "    total = len(scores)\n",
+    "    stats = {\n",
+    "        'total_suspects':         total,\n",
+    "        'high_confidence_bots':   int((scores['score'] >= 0.7).sum()),\n",
+    "        'medium_confidence_bots': int(((scores['score'] >= 0.4) & (scores['score'] < 0.7)).sum()),\n",
+    "        'pct_instant_follow':     100 * flags.str.contains('INSTANT_FOLLOW').sum() / max(total, 1),\n",
+    "        'pct_anonymous':          100 * flags.str.contains('ANONYMOUS_PROFILE').sum() / max(total, 1),\n",
+    "        'mean_score':             float(scores['score'].mean()),\n",
+    "        'p90_score':              float(scores['score'].quantile(0.9)),\n",
+    "    }\n",
+    "    suspects = []\n",
+    "    for _, row in scores.nlargest(50, 'score').iterrows():\n",
+    "        suspects.append({\n",
+    "            'handle':          row.get('handle') or '',\n",
+    "            'display_name':    row.get('display_name') or '',\n",
+    "            'total_score':     float(row['score']),\n",
+    "            'flags':           [f for f in (row.get('flags') or '').split(',') if f],\n",
+    "            'posts_count':     0, 'followers_count': 0, 'age_minutes': -1,\n",
+    "            'source':          row.get('source') or '',\n",
+    "        })\n",
+    "    path = out / f'dossier_{config.anchor_slug}.html'\n",
+    "    render_dossier(config.anchor_handle, stats, figures, suspects, config.lookback_days, path)\n",
+    "    print(f'Dossier written to {path}')\n",
+    "except Exception as e:\n",
+    "    print(f'(Lakehouse write skipped: {e})')\n"
+   ]
+  }
+ ]
+}

--- a/bluesky/botfinder/notebook/build_notebook.py
+++ b/bluesky/botfinder/notebook/build_notebook.py
@@ -1,0 +1,204 @@
+"""Build the botfinder Fabric notebook programmatically.
+
+Run::
+
+    python build_notebook.py
+
+Outputs ``botfinder.ipynb`` next to this script.
+
+The notebook is **workspace-agnostic**: the parameters cell carries empty
+defaults for ``KUSTO_URI`` / ``KUSTO_DATABASE``; the deploy script
+:script:`deploy-fabric-notebook.ps1` patches both the parameters cell and
+``metadata.dependencies.kqlDatabases`` when the notebook is uploaded.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+NB_PATH = Path(__file__).parent / "botfinder.ipynb"
+
+
+def code(src: str, tags: list[str] | None = None) -> dict:
+    cell = {
+        "cell_type": "code",
+        "metadata": {"language": "python"},
+        "execution_count": None,
+        "outputs": [],
+        "source": src.splitlines(keepends=True),
+    }
+    if tags:
+        cell["metadata"]["tags"] = tags
+    return cell
+
+
+def md(src: str) -> dict:
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": src.splitlines(keepends=True),
+    }
+
+
+CELLS = [
+    md(
+        "# Bluesky Bot-Cluster Analyse\n\n"
+        "Diese Notebook erstellt einen vollständigen Bot-Cluster-Report rund um einen "
+        "Bluesky-Anker-Account. Die einzige Konfiguration ist der `ANCHOR_HANDLE` "
+        "in der Parameterzelle weiter unten.\n\n"
+        "**Voraussetzungen**\n"
+        "- Notebook ist mit einer Bluesky-KQL-Datenbank verbunden (KQL-Tab links). "
+        "`deploy-fabric-notebook.ps1` setzt diese Bindung automatisch.\n"
+        "- Identität, mit der das Notebook ausgeführt wird, hat Reader-Rechte auf "
+        "der Eventhouse-Datenbank.\n"
+    ),
+    code(
+        "# Modul aus dem real-time-sources Repo installieren\n"
+        "%pip install -q "
+        "git+https://github.com/clemensv/real-time-sources@main#subdirectory=bluesky/botfinder\n"
+    ),
+    code(
+        "# === PARAMETERS ===\n"
+        "# Inhaltliche Variable: ANCHOR_HANDLE.\n"
+        "# KUSTO_URI / KUSTO_DATABASE werden vom Deploy-Skript pro Workspace gesetzt.\n"
+        'ANCHOR_HANDLE  = "niusde.bsky.social"\n'
+        "LOOKBACK_DAYS  = 90\n"
+        "MAX_FOLLOWERS  = 5000\n"
+        "ENRICH_LIMIT   = 400\n"
+        "SKIP_API       = False\n"
+        "\n"
+        "# Workspace-spezifische Defaults — vom Deploy-Skript überschrieben.\n"
+        'KUSTO_URI      = ""\n'
+        'KUSTO_DATABASE = ""\n',
+        tags=["parameters"],
+    ),
+    code(
+        "from botfinder import Config, run_full_pipeline\n"
+        "\n"
+        "config = Config.from_fabric_context(\n"
+        "    anchor_handle=ANCHOR_HANDLE,\n"
+        "    kusto_uri=KUSTO_URI or None,\n"
+        "    kusto_database=KUSTO_DATABASE or None,\n"
+        "    lookback_days=LOOKBACK_DAYS,\n"
+        "    max_followers=MAX_FOLLOWERS,\n"
+        "    enrich_limit=ENRICH_LIMIT,\n"
+        "    skip_api=SKIP_API,\n"
+        ")\n"
+        'print(f"Cluster:  {config.kusto_uri}")\n'
+        'print(f"Database: {config.kusto_database}")\n'
+        'print(f"Anchor:   @{config.anchor_handle}")\n'
+        "assert config.kusto_uri and config.kusto_database, (\n"
+        '    "KQL database not configured. Re-deploy this notebook via "\n'
+        '    "deploy-fabric-notebook.ps1 or set KUSTO_URI / KUSTO_DATABASE "\n'
+        '    "in the parameters cell."\n'
+        ")\n"
+    ),
+    md("## Vollständige Pipeline ausführen\n"
+       "Akquise (KQL) → API-Anreicherung → Scoring → Cluster-Graph → "
+       "Cross-Follow → Karten."),
+    code(
+        "result = run_full_pipeline(config)\n"
+        "scores = result.analysis.scores_df\n"
+        'print(f"Cohort: {len(scores)} accounts")\n'
+        "print(f\"Bots:   {(scores['score'] >= config.bot_score_threshold).sum()}\")\n"
+    ),
+    md("## KPI-Übersicht"),
+    code(
+        "import pandas as pd\n"
+        "scores = result.analysis.scores_df\n"
+        "flags = scores['flags'].fillna('')\n"
+        "kpis = pd.DataFrame([\n"
+        "    {'Metrik': 'Cohort total',        'Wert': len(scores)},\n"
+        "    {'Metrik': 'Bots (score≥0.5)',    'Wert': int((scores['score'] >= 0.5).sum())},\n"
+        "    {'Metrik': 'Sofort-Follow',       'Wert': int(flags.str.contains('INSTANT_FOLLOW').sum())},\n"
+        "    {'Metrik': 'Anonyme Profile',     'Wert': int(flags.str.contains('ANONYMOUS_PROFILE').sum())},\n"
+        "    {'Metrik': 'Gelöschte Profile',   'Wert': int(flags.str.contains('DELETED').sum())},\n"
+        "    {'Metrik': 'Cluster-Knoten',      'Wert': len(result.cluster_nodes)},\n"
+        "    {'Metrik': 'Cluster-Kanten',      'Wert': len(result.cluster_edges)},\n"
+        "])\n"
+        "display(kpis)\n"
+    ),
+    md("## Top-Verdächtige"),
+    code(
+        "top = scores.nlargest(20, 'score')[['handle', 'display_name', 'score', 'flags']]\n"
+        "display(top)\n"
+    ),
+    md("## Karten\n"
+       "Jede Karte ist eine eigenständige Plotly-Visualisierung im 1200×675-Format "
+       "(Karte 5 ist 1200×1200)."),
+    code(
+        "for card_id, fig in result.cards.items():\n"
+        "    print(card_id)\n"
+        "    fig.show()\n"
+    ),
+    md("## HTML-Dossier ins Lakehouse schreiben (optional)"),
+    code(
+        "from pathlib import Path\n"
+        "from botfinder.dossier import render_dossier\n"
+        "\n"
+        "try:\n"
+        "    out = Path('/lakehouse/default/Files/botfinder')\n"
+        "    out.mkdir(parents=True, exist_ok=True)\n"
+        "    figures = list(result.cards.values())\n"
+        "    flags = scores['flags'].fillna('')\n"
+        "    total = len(scores)\n"
+        "    stats = {\n"
+        "        'total_suspects':         total,\n"
+        "        'high_confidence_bots':   int((scores['score'] >= 0.7).sum()),\n"
+        "        'medium_confidence_bots': int(((scores['score'] >= 0.4) & (scores['score'] < 0.7)).sum()),\n"
+        "        'pct_instant_follow':     100 * flags.str.contains('INSTANT_FOLLOW').sum() / max(total, 1),\n"
+        "        'pct_anonymous':          100 * flags.str.contains('ANONYMOUS_PROFILE').sum() / max(total, 1),\n"
+        "        'mean_score':             float(scores['score'].mean()),\n"
+        "        'p90_score':              float(scores['score'].quantile(0.9)),\n"
+        "    }\n"
+        "    suspects = []\n"
+        "    for _, row in scores.nlargest(50, 'score').iterrows():\n"
+        "        suspects.append({\n"
+        "            'handle':          row.get('handle') or '',\n"
+        "            'display_name':    row.get('display_name') or '',\n"
+        "            'total_score':     float(row['score']),\n"
+        "            'flags':           [f for f in (row.get('flags') or '').split(',') if f],\n"
+        "            'posts_count':     0, 'followers_count': 0, 'age_minutes': -1,\n"
+        "            'source':          row.get('source') or '',\n"
+        "        })\n"
+        "    path = out / f'dossier_{config.anchor_slug}.html'\n"
+        "    render_dossier(config.anchor_handle, stats, figures, suspects, config.lookback_days, path)\n"
+        "    print(f'Dossier written to {path}')\n"
+        "except Exception as e:\n"
+        "    print(f'(Lakehouse write skipped: {e})')\n"
+    ),
+]
+
+
+NB = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {
+        "kernelspec": {
+            "name": "synapse_pyspark",
+            "display_name": "Synapse PySpark",
+            "language": "Python",
+        },
+        "language_info": {"name": "python"},
+        "microsoft": {
+            "language": "python",
+            "language_group": "synapse_pyspark",
+            "ms_spell_check": {"ms_spell_check_language": "en"},
+        },
+        # Populated by deploy-fabric-notebook.ps1 with the workspace's
+        # KQL database id at deploy time. Empty here keeps the repo copy
+        # workspace-agnostic.
+        "dependencies": {"kqlDatabases": []},
+    },
+    "cells": CELLS,
+}
+
+
+def main() -> None:
+    NB_PATH.write_text(json.dumps(NB, indent=1, ensure_ascii=False), encoding="utf-8")
+    print(f"Wrote {NB_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bluesky/botfinder/pyproject.toml
+++ b/bluesky/botfinder/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "botfinder"
+version = "0.1.0"
+description = "Bluesky bot-network detection and dossier generation around an anchor account"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Clemens Vasters" }]
+dependencies = [
+    "azure-kusto-data>=4.6.0",
+    "azure-identity>=1.17.0",
+    "httpx>=0.27.0",
+    "pandas>=2.2.0",
+    "plotly>=5.24.0",
+    "jinja2>=3.1.0",
+    "numpy>=1.26.0",
+    "networkx>=3.2",
+    "pyarrow>=15.0.0",
+]
+
+[project.optional-dependencies]
+fabric = [
+    # Fabric notebooks ship pandas/plotly/numpy/networkx out of the box;
+    # this extra is for parity when running outside Fabric.
+]
+
+[project.scripts]
+botfinder = "botfinder.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["botfinder"]

--- a/tools/deploy-fabric/deploy-fabric-notebook.ps1
+++ b/tools/deploy-fabric/deploy-fabric-notebook.ps1
@@ -1,0 +1,249 @@
+<#
+.SYNOPSIS
+    Deploys the bluesky/botfinder Fabric notebook into a Fabric workspace
+    and binds it to the source's KQL database.
+
+.DESCRIPTION
+    Companion to deploy-fabric.ps1. Run after the source's KQL database is
+    deployed. Steps:
+
+    1. Resolves the Fabric workspace, eventhouse and KQL database.
+    2. Loads the notebook JSON from this repo
+       (bluesky/botfinder/notebook/botfinder.ipynb).
+    3. Patches metadata.dependencies.kqlDatabases to bind the notebook to
+       the resolved KQL database (workspaceId / itemId / displayName).
+    4. Creates or updates the notebook item in the Fabric workspace.
+
+    Parameters mirror deploy-fabric.ps1 — only the bluesky source is supported.
+
+.PARAMETER Source
+    Source name. Default 'bluesky'. Used to locate the notebook in the repo.
+
+.PARAMETER ResourceGroup
+    Azure resource group (kept for parity with deploy-fabric.ps1; not used).
+
+.PARAMETER Location
+    Azure region (kept for parity; not used).
+
+.PARAMETER SubscriptionId
+    Azure subscription ID. If set, runs 'az account set' first.
+
+.PARAMETER Workspace
+    Fabric workspace name or GUID.
+
+.PARAMETER Eventhouse
+    Fabric eventhouse name or GUID.
+
+.PARAMETER DatabaseName
+    KQL database name. Defaults to the source name (with '-' replaced by '_').
+
+.PARAMETER NotebookName
+    Display name for the Fabric notebook item. Default 'botfinder'.
+
+.PARAMETER NotebookPath
+    Override the notebook file path. Default resolves to the script's repo
+    location (../../bluesky/botfinder/notebook/botfinder.ipynb).
+
+.PARAMETER WhatIf
+    Print actions without contacting Fabric.
+
+.EXAMPLE
+    ./deploy-fabric-notebook.ps1 -Source bluesky -ResourceGroup rg-streams `
+        -Workspace "c98acd97-4363-4296-8323-b6ab21e53903" -Eventhouse bluesky
+#>
+
+param(
+    [string]$Source = "bluesky",
+    [string]$ResourceGroup,
+    [string]$Location,
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Workspace,
+
+    [string]$Eventhouse,
+    [string]$DatabaseName,
+    [string]$NotebookName = "botfinder",
+    [string]$NotebookPath,
+
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+$FabricApi = "https://api.fabric.microsoft.com/v1"
+$guidRx = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+if (-not $DatabaseName)            { $DatabaseName = $Source -replace '-', '_' }
+if ([string]::IsNullOrWhiteSpace($Eventhouse)) { $Eventhouse = $Source -replace '-', '_' }
+
+if (-not $NotebookPath) {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+    $NotebookPath = Join-Path $repoRoot "$Source/botfinder/notebook/botfinder.ipynb"
+}
+
+function Write-Step { param([string]$Step, [string]$Msg) Write-Host "`n[$Step] $Msg" -ForegroundColor Yellow }
+function Write-OK   { param([string]$Msg) Write-Host "  $Msg" -ForegroundColor Green }
+function Write-Info { param([string]$Msg) Write-Host "  $Msg" -ForegroundColor DarkYellow }
+
+function Invoke-FabricApi {
+    param([string]$Method, [string]$Url, [object]$Body)
+    $azArgs = @("rest", "--method", $Method, "--url", $Url,
+                "--resource", "https://api.fabric.microsoft.com")
+    if ($Body) {
+        $bodyFile = Join-Path $env:TEMP "fabric_body_$(Get-Random).json"
+        $json = if ($Body -is [string]) { $Body } else { $Body | ConvertTo-Json -Depth 30 -Compress }
+        [System.IO.File]::WriteAllText($bodyFile, $json, [System.Text.UTF8Encoding]::new($false))
+        $azArgs += @("--body", "@$bodyFile", "--headers", "Content-Type=application/json")
+    }
+    $result = & az @azArgs 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "Fabric API error ($Method $Url): $($result | Out-String)" }
+    if ($result) { return $result | ConvertFrom-Json }
+    return $null
+}
+
+Write-Host "=== botfinder Notebook Deployment ===" -ForegroundColor Cyan
+Write-Host "  Source:        $Source"        -ForegroundColor White
+Write-Host "  Workspace:     $Workspace"     -ForegroundColor White
+Write-Host "  Eventhouse:    $Eventhouse"    -ForegroundColor White
+Write-Host "  KQL Database:  $DatabaseName"  -ForegroundColor White
+Write-Host "  Notebook:      $NotebookName"  -ForegroundColor White
+Write-Host "  Notebook file: $NotebookPath"  -ForegroundColor White
+
+if ($SubscriptionId) {
+    az account set --subscription $SubscriptionId 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to set subscription '$SubscriptionId'" }
+    Write-OK "Subscription set: $SubscriptionId"
+}
+
+if (-not (Test-Path $NotebookPath)) {
+    throw "Notebook file not found: $NotebookPath"
+}
+
+# 1. Resolve workspace
+Write-Step "1/4" "Resolving Fabric workspace..."
+if ($Workspace -match $guidRx) {
+    $WorkspaceId = $Workspace
+} else {
+    $allWs = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces"
+    $ws = $allWs.value | Where-Object { $_.displayName -eq $Workspace } | Select-Object -First 1
+    if (-not $ws) { throw "Workspace '$Workspace' not found." }
+    $WorkspaceId = $ws.id
+}
+$wsInfo = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId"
+Write-OK "Workspace: $($wsInfo.displayName) ($WorkspaceId)"
+
+# 2. Resolve eventhouse + database
+Write-Step "2/4" "Resolving KQL database..."
+$ehList = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId/eventhouses"
+if ($Eventhouse -match $guidRx) {
+    $eh = $ehList.value | Where-Object { $_.id -eq $Eventhouse } | Select-Object -First 1
+} else {
+    $eh = $ehList.value | Where-Object { $_.displayName -eq $Eventhouse } | Select-Object -First 1
+}
+if (-not $eh) { throw "Eventhouse '$Eventhouse' not found in workspace." }
+Write-OK "Eventhouse: $($eh.displayName) ($($eh.id))"
+
+$dbList = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId/kqlDatabases"
+$db = $dbList.value | Where-Object { $_.displayName -eq $DatabaseName } | Select-Object -First 1
+if (-not $db) { throw "KQL database '$DatabaseName' not found. Run deploy-fabric.ps1 first." }
+Write-OK "KQL database: $($db.displayName) ($($db.id))"
+
+$queryUri = $eh.properties.queryServiceUri
+if (-not $queryUri) { throw "Eventhouse '$($eh.displayName)' has no queryServiceUri." }
+Write-OK "Query URI:    $queryUri"
+
+# 3. Patch notebook metadata.dependencies.kqlDatabases AND parameters cell
+Write-Step "3/4" "Patching notebook KQL binding and parameters..."
+$nbJson = Get-Content -LiteralPath $NotebookPath -Raw -Encoding UTF8
+$nb = $nbJson | ConvertFrom-Json
+if (-not $nb.metadata)              { $nb | Add-Member -NotePropertyName metadata     -NotePropertyValue ([pscustomobject]@{}) -Force }
+if (-not $nb.metadata.dependencies) { $nb.metadata | Add-Member -NotePropertyName dependencies -NotePropertyValue ([pscustomobject]@{}) -Force }
+$kqlBinding = @(
+    [pscustomobject]@{
+        name        = $db.displayName
+        displayName = $db.displayName
+        workspaceId = $WorkspaceId
+        itemId      = $db.id
+    }
+)
+$nb.metadata.dependencies | Add-Member -NotePropertyName kqlDatabases -NotePropertyValue $kqlBinding -Force
+
+# Patch the parameters cell — replace KUSTO_URI / KUSTO_DATABASE defaults so
+# the notebook works even if notebookutils.kql.listDatabases() is unavailable.
+$paramsPatched = $false
+foreach ($cell in $nb.cells) {
+    if ($cell.cell_type -ne 'code') { continue }
+    $tags = @()
+    if ($cell.metadata -and $cell.metadata.tags) { $tags = @($cell.metadata.tags) }
+    if ($tags -notcontains 'parameters') { continue }
+
+    $srcLines = @($cell.source) | ForEach-Object { $_ }
+    $newLines = foreach ($line in $srcLines) {
+        if     ($line -match '^\s*KUSTO_URI\s*=')      { "KUSTO_URI      = `"$queryUri`"`n" }
+        elseif ($line -match '^\s*KUSTO_DATABASE\s*=') { "KUSTO_DATABASE = `"$($db.displayName)`"`n" }
+        else                                           { $line }
+    }
+    $cell.source = @($newLines)
+    $paramsPatched = $true
+    break
+}
+if ($paramsPatched) { Write-OK "Patched parameters cell with KUSTO_URI / KUSTO_DATABASE" }
+else                { Write-Info "No 'parameters'-tagged cell found — skipped param patch" }
+
+$tmpNb = Join-Path $env:TEMP "botfinder_patched_$(Get-Random).ipynb"
+[System.IO.File]::WriteAllText($tmpNb, ($nb | ConvertTo-Json -Depth 50), [System.Text.UTF8Encoding]::new($false))
+Write-OK "Patched notebook written to $tmpNb"
+
+# 4. Create or update notebook item
+Write-Step "4/4" "Uploading notebook to Fabric..."
+$nbBytes  = [System.IO.File]::ReadAllBytes($tmpNb)
+$nbBase64 = [Convert]::ToBase64String($nbBytes)
+$definition = @{
+    format = "ipynb"
+    parts  = @(
+        @{ path = "notebook-content.ipynb"; payload = $nbBase64; payloadType = "InlineBase64" }
+    )
+}
+
+$nbList = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId/notebooks"
+$existing = $nbList.value | Where-Object { $_.displayName -eq $NotebookName } | Select-Object -First 1
+
+if ($WhatIf) {
+    if ($existing) {
+        Write-Info "[WhatIf] Would call updateDefinition for notebook '$NotebookName' ($($existing.id))"
+    } else {
+        Write-Info "[WhatIf] Would create notebook '$NotebookName'"
+    }
+    Write-Host "`n=== Done (WhatIf) ===" -ForegroundColor Cyan
+    return
+}
+
+if ($existing) {
+    Invoke-FabricApi -Method POST `
+        -Url "$FabricApi/workspaces/$WorkspaceId/notebooks/$($existing.id)/updateDefinition" `
+        -Body @{ definition = $definition } | Out-Null
+    Write-OK "Updated existing notebook '$NotebookName' ($($existing.id))"
+    $notebookId = $existing.id
+} else {
+    $createBody = @{ displayName = $NotebookName; definition = $definition }
+    $createResp = Invoke-FabricApi -Method POST `
+        -Url "$FabricApi/workspaces/$WorkspaceId/notebooks" -Body $createBody
+    if ($createResp -and $createResp.id) {
+        $notebookId = $createResp.id
+    } else {
+        $nbList = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId/notebooks"
+        $created = $nbList.value | Where-Object { $_.displayName -eq $NotebookName } | Select-Object -First 1
+        if (-not $created) { throw "Notebook '$NotebookName' was not found after create." }
+        $notebookId = $created.id
+    }
+    Write-OK "Created notebook '$NotebookName' ($notebookId)"
+}
+
+Write-Host "`n=== Notebook Deployment Complete ===" -ForegroundColor Cyan
+Write-Host "  Notebook:     $NotebookName ($notebookId)" -ForegroundColor Gray
+Write-Host "  Workspace:    $($wsInfo.displayName)"      -ForegroundColor Gray
+Write-Host "  KQL Database: $($db.displayName) ($($db.id))" -ForegroundColor Gray
+Write-Host ""
+Write-Host "  Open in Fabric portal:" -ForegroundColor White
+Write-Host "    https://app.fabric.microsoft.com/groups/$WorkspaceId/synapsenotebooks/$notebookId" -ForegroundColor Cyan
+Write-Host ""

--- a/tools/deploy-fabric/deploy-fabric-notebook.ps1
+++ b/tools/deploy-fabric/deploy-fabric-notebook.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Deploys the bluesky/botfinder Fabric notebook into a Fabric workspace
     and binds it to the source's KQL database.
@@ -168,7 +168,7 @@ $kqlBinding = @(
 )
 $nb.metadata.dependencies | Add-Member -NotePropertyName kqlDatabases -NotePropertyValue $kqlBinding -Force
 
-# Patch the parameters cell — replace KUSTO_URI / KUSTO_DATABASE defaults so
+# Patch the parameters cell - replace KUSTO_URI / KUSTO_DATABASE defaults so
 # the notebook works even if notebookutils.kql.listDatabases() is unavailable.
 $paramsPatched = $false
 foreach ($cell in $nb.cells) {
@@ -187,8 +187,8 @@ foreach ($cell in $nb.cells) {
     $paramsPatched = $true
     break
 }
-if ($paramsPatched) { Write-OK "Patched parameters cell with KUSTO_URI / KUSTO_DATABASE" }
-else                { Write-Info "No 'parameters'-tagged cell found — skipped param patch" }
+if ($paramsPatched) { Write-OK 'Patched parameters cell with KUSTO_URI / KUSTO_DATABASE' }
+else                { Write-Info "No parameters-tagged cell found - skipped param patch" }
 
 $tmpNb = Join-Path $env:TEMP "botfinder_patched_$(Get-Random).ipynb"
 [System.IO.File]::WriteAllText($tmpNb, ($nb | ConvertTo-Json -Depth 50), [System.Text.UTF8Encoding]::new($false))


### PR DESCRIPTION
Adds an installable Python package + Fabric notebook + deploy script to run a complete Bluesky bot-cluster analysis around an anchor account.

## What's new

### `bluesky/botfinder/`
Installable Python package (hatchling). Public API:

```python
from botfinder import Config, run_full_pipeline
result = run_full_pipeline(Config(anchor_handle='niusde.bsky.social'))
for cid, fig in result.cards.items():
    fig.show()
```

CLI entry point:

```bash
pip install git+https://github.com/clemensv/real-time-sources#subdirectory=bluesky/botfinder
botfinder --anchor niusde.bsky.social --output-dir output
```

Modules: `config`, `kusto`, `queries`, `bluesky_api`, `scoring`, `acquire`, `pipeline`, `cluster`, `cross_follow`, `cards` (15 social-media cards), `dossier` (Jinja2 HTML report), `cli`.

### `bluesky/botfinder/notebook/`
- `build_notebook.py` — builder script.
- `botfinder.ipynb` — workspace-agnostic Fabric notebook with a single `ANCHOR_HANDLE` knob in a papermill `parameters` cell. `KUSTO_URI` / `KUSTO_DATABASE` defaults are injected by the deploy script.

### `tools/deploy-fabric/deploy-fabric-notebook.ps1`
Companion to `deploy-fabric.ps1`. Same parameter shape:

```powershell
./deploy-fabric-notebook.ps1 -Source bluesky -Workspace <id> -Eventhouse OpenData
```

It resolves the workspace + eventhouse + KQL database, then patches both `metadata.dependencies.kqlDatabases` and the parameters cell defaults before create-or-updating the notebook item via the Fabric API. Supports `-WhatIf`.

## Validation

- `pip install -e ./botfinder` — OK
- `botfinder --anchor niusde.bsky.social --lookback 7 --skip-api` — 1772-account cohort, 1447 bots, 14 cards + dossier rendered
- Deployed to workspace `c98acd97-4363-4296-8323-b6ab21e53903` (Real-Time Open Data), bound to KQL DB `bluesky`