### PR TITLE
botfinder: comprehensive docstrings for all modules

### DIFF
--- a/bluesky/botfinder/botfinder/__init__.py
+++ b/bluesky/botfinder/botfinder/__init__.py
@@ -1,4 +1,11 @@
-"""botfinder — Bluesky bot-network detection around an anchor account."""
+"""Public package surface for the botfinder analysis pipeline.
+
+The package starts from an anchor Bluesky handle, acquires follower and
+firehose data, computes per-account bot scores, and then builds downstream
+artifacts such as co-follow graphs, cross-follow measurements, and HTML
+dossiers. This module re-exports the primary dataclasses and orchestration
+functions that notebooks, scripts, and the CLI use.
+"""
 
 from .config import Config
 from .scoring import BotScore, compute_bot_score, compute_network_statistics

--- a/bluesky/botfinder/botfinder/_async.py
+++ b/bluesky/botfinder/botfinder/_async.py
@@ -1,5 +1,10 @@
-"""Asyncio helper that works both in plain Python and inside Jupyter/Fabric
-notebooks (where an event loop is already running).
+"""Async runtime bridge used by the pipeline and API helpers.
+
+Several pipeline stages call async Bluesky HTTP helpers from synchronous
+entry points such as the CLI, notebooks, or reporting code. This module
+provides the compatibility shim that runs a coroutine either on the normal
+event-loop-free process or on a dedicated worker-thread loop when Fabric or
+Jupyter already owns the main loop.
 """
 
 from __future__ import annotations
@@ -9,12 +14,20 @@ from typing import Any, Coroutine
 
 
 def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
-    """Run ``coro`` to completion and return its result.
-
-    - If no event loop is running (CLI / scripts), uses :func:`asyncio.run`.
-    - If a loop is already running (Jupyter / Fabric notebooks), executes the
-      coroutine on a fresh loop in a worker thread to avoid the
-      ``asyncio.run() cannot be called from a running event loop`` error.
+    """Execute an async helper from synchronous botfinder code.
+    
+    Args:
+        coro: Coroutine object produced by an async helper such as a Bluesky API
+            fetch or co-follow graph enrichment call.
+    
+    Returns:
+        Any: The coroutine result after it has run to completion.
+    
+    Notes:
+        In CLI and script usage the function delegates to ``asyncio.run``. In
+        Fabric notebooks and Jupyter, where a loop is already active, it spins
+        up a fresh event loop in a worker thread so the rest of the pipeline can
+        keep a synchronous API.
     """
     try:
         asyncio.get_running_loop()
@@ -26,6 +39,7 @@ def run_async(coro: Coroutine[Any, Any, Any]) -> Any:
     result: dict[str, Any] = {}
 
     def _runner() -> None:
+        """Run the coroutine on a dedicated event loop inside the worker thread."""
         loop = asyncio.new_event_loop()
         try:
             asyncio.set_event_loop(loop)

--- a/bluesky/botfinder/botfinder/acquire.py
+++ b/bluesky/botfinder/botfinder/acquire.py
@@ -1,9 +1,11 @@
-"""KQL data acquisition — extract follows, profiles, blocks, likes for the
-follower cohort of the anchor account.
+"""Acquire the raw cohort tables that feed scoring and graph analysis.
 
-Returns an in-memory ``AcquiredData`` bundle (no disk caching). Optional
-parquet caching is exposed via ``AcquiredData.save`` / ``AcquiredData.load``
-for local development.
+This stage resolves the anchor handle to a stable DID, queries the Bluesky
+firehose stored in Kusto/Fabric for recent follows into that anchor, and
+then collects the auxiliary tables needed downstream: cohort profile rows,
+outbound follow edges, blocks received, and like counts. The result is an
+in-memory ``AcquiredData`` bundle consumed by ``pipeline.run_analysis`` and,
+through it, all later scoring, clustering, and dossier steps.
 """
 
 from __future__ import annotations
@@ -20,6 +22,26 @@ from .kusto import execute_query
 
 @dataclass
 class AcquiredData:
+    """Container for all raw tables fetched during acquisition.
+    
+    The bundle represents the cohort before any heuristic scoring is applied.
+    ``run_analysis`` reads ``follows_to_target`` as its primary cohort table,
+    uses ``profiles`` to backfill account creation timestamps and handles, and
+    passes ``follows_from_cohort`` plus the block/like aggregates into overlap
+    and cluster computations.
+    
+    Attributes:
+        target_did: Permanent DID for the anchor account being investigated.
+        follows_to_target: Follow events where cohort accounts followed the
+            anchor inside the lookback window.
+        profiles: Latest known profile rows for cohort members and frequently
+            co-followed targets.
+        follows_from_cohort: Outbound follow edges from cohort accounts to
+            other Bluesky accounts, used for overlap and graph analysis.
+        blocks_received: Aggregate count of blocks received by cohort accounts.
+        likes_made: Aggregate count of likes emitted by cohort accounts.
+    """
+
     target_did: str
     follows_to_target: pd.DataFrame
     profiles: pd.DataFrame
@@ -29,11 +51,32 @@ class AcquiredData:
 
     @property
     def cohort_dids(self) -> list[str]:
+        """Return the unique follower DIDs that make up the anchor cohort.
+        
+        Returns:
+            list[str]: Unique DIDs from ``follows_to_target`` in first-seen order.
+            Returns an empty list when the anchor has no qualifying follows in the
+            current analysis window.
+        """
         if self.follows_to_target.empty:
             return []
         return self.follows_to_target["follower_did"].dropna().unique().tolist()
 
     def save(self, directory: Path) -> None:
+        """Persist the acquired tables for repeatable local analysis.
+        
+        Args:
+            directory: Destination directory where each table is written as a
+                parquet file plus a text file for the anchor DID.
+        
+        Returns:
+            None
+        
+        Notes:
+            This is intended for developer workflows so later scoring or card work
+            can iterate without re-querying Kusto. The pipeline itself keeps
+            acquisition in memory.
+        """
         directory = Path(directory)
         directory.mkdir(parents=True, exist_ok=True)
         self.follows_to_target.to_parquet(directory / "follows_to_target.parquet", index=False)
@@ -45,6 +88,15 @@ class AcquiredData:
 
     @classmethod
     def load(cls, directory: Path) -> "AcquiredData":
+        """Reload a previously saved acquisition bundle from disk.
+        
+        Args:
+            directory: Directory created by :meth:`save`.
+        
+        Returns:
+            AcquiredData: Bundle reconstructed from the parquet snapshots and
+            ``target_did.txt``.
+        """
         directory = Path(directory)
         return cls(
             target_did=(directory / "target_did.txt").read_text(encoding="utf-8").strip(),
@@ -57,7 +109,18 @@ class AcquiredData:
 
 
 def _resolve_target_did(config: Config) -> str:
-    """Resolve target handle to DID via Bluesky API."""
+    """Resolve the anchor handle to its permanent Bluesky DID.
+    
+    Args:
+        config: Runtime configuration containing ``anchor_handle``.
+    
+    Returns:
+        str: DID for the anchor account.
+    
+    Notes:
+        DIDs are used throughout the pipeline because handles can change while
+        firehose records and KQL templates are keyed on the stable identifier.
+    """
     import httpx
     handle = config.anchor_handle
     try:
@@ -72,6 +135,22 @@ def _resolve_target_did(config: Config) -> str:
 
 
 def _extract_follows_to_target(config: Config, target_did: str) -> pd.DataFrame:
+    """Fetch recent follow events into the anchor and join account creation time.
+    
+    Args:
+        config: Runtime configuration containing the Kusto connection and
+            lookback window.
+        target_did: DID of the anchor account under investigation.
+    
+    Returns:
+        pd.DataFrame: One row per cohort member with ``follower_did``, account
+        creation time, follow time, and Kusto ingestion time.
+    
+    Notes:
+        The join against ``Bluesky.Actor.Profile_v2`` is what enables the later
+        temporal-proximity signal: how quickly after account creation each
+        follower attached to the anchor.
+    """
     query = f"""
     ['Bluesky.Graph.Follow_v1']
     | where subject == "{target_did}"
@@ -98,7 +177,26 @@ def _batched_query(
     label: str,
     progress: bool = True,
 ) -> pd.DataFrame:
-    """Run a KQL query in cohort batches and concat the results."""
+    """Execute a parameterised KQL template over cohort-sized DID batches.
+    
+    Args:
+        config: Runtime configuration with Kusto connection details and batch
+            size.
+        dids: Cohort or target DIDs to inject into the query template.
+        template: KQL template expecting ``did_list`` and ``lookback_days``
+            placeholders.
+        label: Human-readable label for progress output.
+        progress: Whether to print per-batch row counts.
+    
+    Returns:
+        pd.DataFrame: Concatenated rows from all successful batches, or an
+        empty frame when no rows are returned.
+    
+    Notes:
+        The firehose tables can be large; batching avoids oversized
+        ``dynamic`` literals while still letting downstream scoring see the full
+        cohort.
+    """
     all_rows: list[pd.DataFrame] = []
     n = len(dids)
     if n == 0:
@@ -150,8 +248,24 @@ let targets = dynamic([{did_list}]);
 
 
 def acquire_all(config: Config, *, verbose: bool = True) -> AcquiredData:
-    """Extract everything we need for the analysis. Returns an
-    in-memory ``AcquiredData`` bundle."""
+    """Acquire the complete raw dataset required by the botfinder pipeline.
+    
+    Args:
+        config: Runtime configuration describing the anchor account, lookback
+            window, Kusto connection, and batching parameters.
+        verbose: Whether to print stage-by-stage acquisition progress.
+    
+    Returns:
+        AcquiredData: Raw cohort bundle consumed by scoring, cluster
+        detection, and cross-follow analysis.
+    
+    Notes:
+        The function first builds the anchor cohort from follows into the
+        anchor, then enriches that cohort with outbound follows, received
+        blocks, likes, and the latest profiles for both cohort members and
+        frequently followed targets. Those downstream tables power overlap-based
+        coordination signals and the co-follow graph.
+    """
 
     if verbose:
         print(f"═══ Acquire: anchor=@{config.anchor_handle}, lookback={config.lookback_days}d ═══")

--- a/bluesky/botfinder/botfinder/bluesky_api.py
+++ b/bluesky/botfinder/botfinder/bluesky_api.py
@@ -1,4 +1,11 @@
-"""Bluesky AT Protocol API client for enriching bot detection data."""
+"""Async Bluesky AT Protocol client used to enrich KQL-derived cohorts.
+
+The acquisition stage gets broad firehose coverage from Kusto, but several
+scoring and graph signals need live public API lookups: profiles, recent
+posts, follows, and followers. This module wraps the public ``bsky.app``
+XRPC endpoints into typed dataclasses that downstream scoring, cluster, and
+cross-follow stages can consume without parsing raw JSON repeatedly.
+"""
 
 import httpx
 import asyncio
@@ -11,6 +18,26 @@ XRPC_BASE = "https://public.api.bsky.app/xrpc"
 
 @dataclass
 class BlueskyProfile:
+    """Normalized snapshot of a Bluesky actor profile.
+    
+    The scoring stage uses these fields to judge anonymity and account age, and
+    the dossier uses handles and display names to make suspect rows readable.
+    
+    Attributes:
+        did: Permanent decentralized identifier for the account.
+        handle: Current Bluesky handle, which may change over time.
+        display_name: Human-readable profile name shown in the UI.
+        description: Profile bio text.
+        avatar: Avatar URL; missing avatars are part of the anonymity signal.
+        banner: Banner image URL.
+        created_at: Account creation timestamp from the public API.
+        followers_count: Number of followers the account currently has.
+        follows_count: Number of accounts the actor follows.
+        posts_count: Number of posts on the account.
+        labels: Moderation or classification labels returned by Bluesky.
+        indexed_at: When Bluesky last indexed this profile snapshot.
+    """
+
     did: str
     handle: str
     display_name: str
@@ -27,6 +54,14 @@ class BlueskyProfile:
 
 @dataclass
 class BlueskyPost:
+    """Normalized author-feed item used for activity-pattern scoring.
+    
+    The scoring stage looks at repost ratios, reply-heavy behavior,
+    language diversity, and low-engagement posting to detect amplification
+    accounts that mainly boost political narratives instead of acting like
+    organic users.
+    """
+
     uri: str
     cid: str
     text: str
@@ -41,6 +76,13 @@ class BlueskyPost:
 
 @dataclass
 class FollowRecord:
+    """Compact follow-edge record returned by Bluesky graph endpoints.
+    
+    Instances represent either who an account follows or who follows it,
+    depending on the endpoint. These records feed cohort extension, co-follow
+    overlap measurements, and cross-follow sampling.
+    """
+
     did: str
     handle: str
     display_name: str
@@ -49,13 +91,41 @@ class FollowRecord:
 
 
 class BlueskyClient:
-    """Public Bluesky API client for bot analysis enrichment."""
+    """Rate-limited async client for the public Bluesky XRPC API.
+    
+    The client centralizes retry, concurrency control, and JSON-to-dataclass
+    conversion so the rest of the pipeline can ask domain-level questions such
+    as which profiles look anonymous, what suspects post, and which other
+    political targets they follow.
+    """
 
     def __init__(self, concurrency: int = 10, timeout: float = 30.0):
+        """Configure concurrency and timeout limits for Bluesky API calls.
+        
+        Args:
+            concurrency: Maximum number of concurrent requests allowed from this
+                client instance.
+            timeout: Request timeout in seconds.
+        """
         self._semaphore = asyncio.Semaphore(concurrency)
         self._timeout = timeout
 
     async def _get(self, client: httpx.AsyncClient, endpoint: str, params: dict) -> dict | None:
+        """Issue a single XRPC GET request with lightweight rate-limit handling.
+        
+        Args:
+            client: Shared async HTTP client.
+            endpoint: XRPC method path relative to ``XRPC_BASE``.
+            params: Query-string parameters for the endpoint.
+        
+        Returns:
+            dict | None: Parsed JSON response on success, otherwise ``None``.
+        
+        Notes:
+            The public Bluesky API occasionally returns HTTP 429 while crawling
+            suspect cohorts. The helper honors ``retry-after`` once so scoring and
+            graph stages degrade gracefully instead of failing the run.
+        """
         async with self._semaphore:
             try:
                 resp = await client.get(f"{XRPC_BASE}/{endpoint}", params=params)
@@ -72,6 +142,16 @@ class BlueskyClient:
                 return None
 
     async def get_profile(self, client: httpx.AsyncClient, actor: str) -> BlueskyProfile | None:
+        """Fetch one profile for a DID or handle.
+        
+        Args:
+            client: Shared async HTTP client.
+            actor: DID or handle to resolve.
+        
+        Returns:
+            BlueskyProfile | None: Normalized profile, or ``None`` when the account
+            is unavailable or the request fails.
+        """
         data = await self._get(client, "app.bsky.actor.getProfile", {"actor": actor})
         if not data:
             return None
@@ -93,7 +173,17 @@ class BlueskyClient:
     async def get_profiles_batch(
         self, client: httpx.AsyncClient, actors: list[str]
     ) -> list[BlueskyProfile]:
-        """Fetch up to 25 profiles in a single request."""
+        """Fetch a batch of profile snapshots for enrichment-heavy stages.
+        
+        Args:
+            client: Shared async HTTP client.
+            actors: DIDs or handles to resolve. Bluesky accepts at most 25 per
+                request, so larger input is truncated by this helper.
+        
+        Returns:
+            list[BlueskyProfile]: Parsed profile dataclasses for all rows the API
+            returned successfully.
+        """
         data = await self._get(client, "app.bsky.actor.getProfiles", {"actors": actors[:25]})
         if not data:
             return []
@@ -118,7 +208,22 @@ class BlueskyClient:
     async def get_author_feed(
         self, client: httpx.AsyncClient, actor: str, limit: int = 30
     ) -> list[BlueskyPost]:
-        """Get recent posts from an account to assess activity patterns."""
+        """Fetch recent posts from a suspect for activity-pattern scoring.
+        
+        Args:
+            client: Shared async HTTP client.
+            actor: DID or handle whose author feed should be inspected.
+            limit: Maximum number of feed items to inspect.
+        
+        Returns:
+            list[BlueskyPost]: Recent posts normalized into scoring-friendly
+            dataclasses.
+        
+        Notes:
+            The scoring module uses this feed to spot amplification-heavy
+            accounts that mostly repost, rarely create original content, and
+            receive little engagement.
+        """
         data = await self._get(
             client, "app.bsky.feed.getAuthorFeed",
             {"actor": actor, "limit": min(limit, 100), "filter": "posts_and_author_threads"},
@@ -146,7 +251,22 @@ class BlueskyClient:
     async def get_follows(
         self, client: httpx.AsyncClient, actor: str, limit: int = 100
     ) -> list[FollowRecord]:
-        """Get accounts that an actor follows — to detect follow-overlap in the botnet."""
+        """Fetch accounts followed by an actor.
+        
+        Args:
+            client: Shared async HTTP client.
+            actor: DID or handle whose outbound follows should be fetched.
+            limit: Maximum number of follow edges to collect.
+        
+        Returns:
+            list[FollowRecord]: Follow edges suitable for co-follow overlap and
+            cluster-graph construction.
+        
+        Notes:
+            Shared outbound follows are one of the clearest coordination signals in
+            this project: bot operators often point many throwaway accounts at the
+            same political targets.
+        """
         records: list[FollowRecord] = []
         cursor = None
         while len(records) < limit:
@@ -172,7 +292,17 @@ class BlueskyClient:
     async def get_followers(
         self, client: httpx.AsyncClient, actor: str, limit: int = 100
     ) -> list[FollowRecord]:
-        """Get followers of an account."""
+        """Fetch followers of an anchor account from the public API.
+        
+        Args:
+            client: Shared async HTTP client.
+            actor: DID or handle whose followers should be enumerated.
+            limit: Maximum number of followers to return.
+        
+        Returns:
+            list[FollowRecord]: Follower records used to extend the cohort beyond
+            the KQL lookback window.
+        """
         records: list[FollowRecord] = []
         cursor = None
         while len(records) < limit:
@@ -199,9 +329,21 @@ class BlueskyClient:
 async def enrich_suspects(
     dids: list[str], concurrency: int = 10
 ) -> dict[str, dict]:
-    """Enrich a list of suspect DIDs with full profile + feed data from the Bluesky API.
-
-    Returns a dict keyed by DID with profile, posts, and follows data.
+    """Enrich suspect accounts with the API data needed for scoring.
+    
+    Args:
+        dids: Suspect or priority cohort DIDs selected by ``run_analysis``.
+        concurrency: Maximum parallel request count for the underlying client.
+    
+    Returns:
+        dict[str, dict]: Mapping from DID to a dictionary containing a profile
+        snapshot, recent posts, and outbound follows.
+    
+    Notes:
+        This function bridges acquisition and scoring. KQL provides the broad
+        cohort, while this helper selectively enriches the most suspicious or
+        analytically useful accounts so later heuristics can inspect anonymity,
+        posting behavior, and follow overlap in detail.
     """
     bsky = BlueskyClient(concurrency=concurrency)
     results: dict[str, dict] = {}
@@ -217,6 +359,7 @@ async def enrich_suspects(
 
         # Fetch feeds + follows for top suspects concurrently
         async def _enrich_one(did: str) -> None:
+            """Fetch per-account activity and follow data for one suspect DID."""
             profile = all_profiles.get(did)
             posts = await bsky.get_author_feed(client, did, limit=50)
             follows = await bsky.get_follows(client, did, limit=100)
@@ -233,5 +376,14 @@ async def enrich_suspects(
 
 
 def enrich_suspects_sync(dids: list[str], concurrency: int = 10) -> dict[str, dict]:
+    """Run :func:`enrich_suspects` from synchronous pipeline code.
+    
+    Args:
+        dids: Suspect DIDs to enrich.
+        concurrency: Maximum parallel request count.
+    
+    Returns:
+        dict[str, dict]: Same structure as :func:`enrich_suspects`.
+    """
     from ._async import run_async
     return run_async(enrich_suspects(dids, concurrency))

--- a/bluesky/botfinder/botfinder/cli.py
+++ b/bluesky/botfinder/botfinder/cli.py
@@ -1,12 +1,9 @@
-"""Command-line entry point for the botfinder pipeline.
+"""Command-line entry point for running the full botfinder workflow.
 
-Usage::
-
-    botfinder --anchor niusde.bsky.social --lookback 7 --skip-api \\
-        --output-dir botfinder-output
-
-Reads ``BOTFINDER_KUSTO_URI`` and ``BOTFINDER_KUSTO_DATABASE`` env vars
-unless overridden with ``--kusto-uri`` / ``--kusto-database``.
+The CLI turns user-supplied runtime parameters into a :class:`Config`, runs
+the full acquisition → scoring → graph/card pipeline, and writes the two
+primary deliverables: per-card Plotly HTML files and a consolidated dossier
+for the anchor account under investigation.
 """
 
 from __future__ import annotations
@@ -22,6 +19,12 @@ from .pipeline import run_full_pipeline
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser for a botfinder run.
+    
+    Returns:
+        argparse.ArgumentParser: Parser configured with analysis, API, Kusto,
+        and output options for the end-to-end pipeline.
+    """
     p = argparse.ArgumentParser(prog="botfinder",
                                 description="Bluesky bot-cluster analysis")
     p.add_argument("--anchor", required=True,
@@ -45,6 +48,21 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments, run the pipeline, and write report artifacts.
+    
+    Args:
+        argv: Optional argument vector for testing. When ``None``, arguments
+            are read from ``sys.argv``.
+    
+    Returns:
+        int: Process exit code. ``0`` means success, while ``2`` indicates a
+        missing Kusto configuration.
+    
+    Notes:
+        The CLI intentionally keeps orchestration thin: acquisition, scoring,
+        clustering, and reporting remain in library modules so notebooks and
+        tests can reuse the same logic.
+    """
     args = _build_parser().parse_args(argv)
 
     overrides: dict = {}

--- a/bluesky/botfinder/botfinder/cluster.py
+++ b/bluesky/botfinder/botfinder/cluster.py
@@ -1,8 +1,12 @@
-"""Build the follow co-occurrence cluster graph for the suspect cohort.
+"""Build the co-follow graph for highly scored suspects.
 
-Pure-functional refactor of ``scripts/cluster_graph.py`` and
-``tmp/cluster_graph.py``. Returns a :class:`ClusterResult` dataclass with
-nodes, edges and an interactive Plotly figure ready for inline display.
+After scoring identifies suspect followers of the anchor account, this
+module asks which other accounts those suspects also follow. It converts
+those shared outbound follows into a co-follow network where nodes are
+target accounts and edges indicate that many suspects found both accounts.
+The resulting tables and figure feed downstream cards and help investigators
+spot coordinated political clusters, including camouflage targets
+surrounding the anchor.
 """
 
 from __future__ import annotations
@@ -27,6 +31,17 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @dataclass
 class ClusterResult:
+    """Outputs of the suspect co-follow graph stage.
+    
+    Attributes:
+        nodes_df: One row per significant co-follow target with handle, number
+            of suspect followers, graph degree, and cluster-membership flags.
+        edges_df: One row per pair of targets sharing enough suspect followers
+            to be considered coordinated.
+        figure: Interactive Plotly network figure for card/report rendering.
+        target_did: DID of the analyzed anchor account.
+        target_handle: Human-readable handle of the anchor account.
+    """
     nodes_df: pd.DataFrame
     edges_df: pd.DataFrame
     figure: go.Figure
@@ -39,12 +54,28 @@ async def _fetch_follows_for_suspects(
     concurrency: int,
     limit_per_account: int,
 ) -> dict[str, list[str]]:
+    """Fetch outbound follows for suspect accounts selected by the scorer.
+    
+    Args:
+        suspect_dids: Cohort DIDs whose scores exceed the cluster threshold.
+        concurrency: Maximum parallel Bluesky API calls.
+        limit_per_account: Maximum follow edges to fetch per suspect.
+    
+    Returns:
+        dict[str, list[str]]: Mapping of suspect DID to followed target DIDs.
+    
+    Notes:
+        The graph stage only needs outbound follows, not full profile data. It
+        tolerates per-account API failures by substituting an empty follow list
+        so one bad actor does not abort cluster construction.
+    """
     bsky = BlueskyClient(concurrency=concurrency)
     results: dict[str, list[str]] = {}
     async with httpx.AsyncClient(timeout=30.0) as client:
         sem = asyncio.Semaphore(concurrency)
 
         async def _get_one(did: str):
+            """Fetch one suspect's follow list while honoring shared concurrency limits."""
             async with sem:
                 try:
                     follows = await bsky.get_follows(client, did, limit=limit_per_account)
@@ -57,6 +88,16 @@ async def _fetch_follows_for_suspects(
 
 
 async def _resolve_handles(dids: list[str], concurrency: int = 25) -> dict[str, str]:
+    """Resolve graph node DIDs to readable handles for reports and charts.
+    
+    Args:
+        dids: Target account DIDs appearing as graph nodes.
+        concurrency: Maximum parallel profile lookups.
+    
+    Returns:
+        dict[str, str]: Mapping from DID to resolved handle, falling back to a
+        shortened DID when profile lookup fails.
+    """
     bsky = BlueskyClient(concurrency=concurrency)
     handles: dict[str, str] = {}
     async with httpx.AsyncClient(timeout=30.0) as client:
@@ -76,6 +117,22 @@ def _build_graph(
     suspect_follows: dict[str, list[str]],
     min_followers: int,
 ) -> tuple[nx.Graph, dict[str, int]]:
+    """Convert suspect follow lists into a weighted co-follow network.
+    
+    Args:
+        suspect_follows: Mapping from suspect DID to the targets that account
+            follows.
+        min_followers: Minimum number of suspects that must follow a target, or
+            a target pair, before it is retained in the graph.
+    
+    Returns:
+        tuple[nx.Graph, dict[str, int]]: Weighted undirected graph plus a count
+        of how many suspects followed each retained target.
+    
+    Notes:
+        The filtering step removes one-off follows so the graph emphasizes
+        repeated coordination patterns rather than normal user idiosyncrasies.
+    """
     target_counts: Counter = Counter()
     for did, follows in suspect_follows.items():
         for fdid in follows:
@@ -108,6 +165,22 @@ def _render_figure(
     target_did: str,
     target_handle: str,
 ) -> go.Figure:
+    """Render the co-follow graph as an interactive Plotly network figure.
+    
+    Args:
+        G: Weighted graph produced by :func:`_build_graph`.
+        handles: Mapping from node DID to readable handle.
+        target_did: DID of the analyzed anchor account.
+        target_handle: Handle of the analyzed anchor account.
+    
+    Returns:
+        go.Figure: Plotly figure suitable for the dossier and standalone cards.
+    
+    Notes:
+        The anchor is highlighted separately from highly connected neighbor
+        nodes so investigators can quickly see whether suspect followers are
+        also converging on allied or opponent political accounts.
+    """
     if len(G.nodes()) == 0:
         return go.Figure().update_layout(title="No significant cluster found")
 
@@ -180,6 +253,27 @@ def build_cluster_graph(
     classify_top: int = 200,
     verbose: bool = True,
 ) -> ClusterResult:
+    """Build the suspect co-follow graph from a scored analysis result.
+    
+    Args:
+        analysis: Output of ``run_analysis`` containing scored suspects and raw
+            cohort tables.
+        min_followers: Minimum suspect support required to keep a target node
+            or edge in the graph.
+        classify_top: Number of top nodes to probe further when deciding
+            whether they behave like true cluster members.
+        verbose: Whether to print progress information.
+    
+    Returns:
+        ClusterResult: Node table, edge table, and network figure for
+        downstream card rendering and investigation.
+    
+    Notes:
+        The post-processing step tries to separate central cluster targets from
+        peripheral accounts. It also demotes heavily blocked periphery accounts
+        less aggressively because repeated blocks can indicate real activity
+        rather than a passive bot lure.
+    """
     config = analysis.config
     scores_df = analysis.scores_df
     suspects = scores_df[scores_df["score"] >= config.cluster_score_threshold]

--- a/bluesky/botfinder/botfinder/config.py
+++ b/bluesky/botfinder/botfinder/config.py
@@ -1,4 +1,11 @@
-"""Configuration for the botfinder pipeline."""
+"""Runtime configuration for the botfinder pipeline.
+
+This module centralizes the knobs that shape one analysis run: which anchor
+account to inspect, how far back to query the firehose, how aggressively to
+use the public Bluesky API, and where to find the backing Kusto/Fabric
+database. Downstream acquisition, scoring, clustering, and CLI code all
+read from the same ``Config`` object.
+"""
 
 from __future__ import annotations
 
@@ -9,12 +16,28 @@ from typing import Optional
 
 @dataclass
 class Config:
-    """Pipeline configuration.
-
-    The Kusto cluster URI and database can be supplied directly,
-    discovered from a Fabric notebook context (via
-    ``Config.from_fabric_context``), or read from the environment
-    variables ``BOTFINDER_KUSTO_URI`` and ``BOTFINDER_KUSTO_DATABASE``.
+    """Parameters controlling one end-to-end anchor analysis.
+    
+    The object is intentionally small but high leverage: acquisition uses the
+    Kusto connection and lookback window, scoring uses the thresholds and API
+    budgets, and reporting uses the anchor handle and derived slug.
+    
+    Attributes:
+        anchor_handle: Handle of the anchor account being investigated.
+        kusto_uri: Kusto or Fabric query endpoint containing firehose tables.
+        kusto_database: Database name holding the Bluesky firehose tables.
+        lookback_days: Analysis window for recent follows into the anchor.
+        max_followers: Maximum number of followers fetched from the public API
+            when extending the cohort beyond KQL timing data.
+        enrich_limit: Maximum number of accounts enriched with profile/feed
+            detail from the public API.
+        api_concurrency: Shared concurrency limit for Bluesky API calls.
+        cluster_score_threshold: Minimum bot score for inclusion in the
+            co-follow graph stage.
+        bot_score_threshold: Threshold used when summarizing likely bots.
+        cohort_batch_size: Number of DIDs per batched KQL query.
+        skip_api: Whether to disable live Bluesky enrichment and rely on KQL
+            data only.
     """
 
     anchor_handle: str
@@ -30,6 +53,11 @@ class Config:
     skip_api: bool = False
 
     def __post_init__(self) -> None:
+        """Fill missing Kusto connection settings from environment variables.
+        
+        Returns:
+            None
+        """
         if not self.kusto_uri:
             self.kusto_uri = os.environ.get("BOTFINDER_KUSTO_URI")
         if not self.kusto_database:
@@ -37,7 +65,12 @@ class Config:
 
     @property
     def anchor_slug(self) -> str:
-        """Filesystem-safe representation of the anchor handle."""
+        """Return a filesystem-safe version of the anchor handle.
+        
+        Returns:
+            str: Handle with characters such as ``.`` and ``/`` replaced so it can
+            be used in output filenames like the dossier HTML path.
+        """
         return self.anchor_handle.replace(".", "_").replace("/", "_")
 
     @classmethod
@@ -50,14 +83,25 @@ class Config:
         kusto_database: Optional[str] = None,
         **overrides,
     ) -> "Config":
-        """Build a Config using the bound Fabric notebook KQL database.
-
-        Resolution order for ``kusto_uri`` / ``kusto_database``:
-
-        1. Explicit keyword arguments (e.g. from a notebook parameters cell).
-        2. ``notebookutils.kql.listDatabases()`` when running inside Fabric.
-        3. Environment variables ``BOTFINDER_KUSTO_URI`` /
-           ``BOTFINDER_KUSTO_DATABASE`` (handled in :py:meth:`__post_init__`).
+        """Construct configuration from an attached Microsoft Fabric notebook.
+        
+        Args:
+            anchor_handle: Handle of the anchor account to investigate.
+            database_name: Preferred Fabric KQL database name when more than one
+                database is attached.
+            kusto_uri: Explicit Kusto endpoint override.
+            kusto_database: Explicit Kusto database override.
+            **overrides: Additional :class:`Config` field overrides such as API
+                limits or thresholds.
+        
+        Returns:
+            Config: Configuration with the best available Kusto connection details
+            populated.
+        
+        Notes:
+            Resolution order is explicit keyword arguments first, then the bound
+            Fabric notebook context via ``notebookutils.kql.listDatabases()``, and
+            finally environment-variable fallback in ``__post_init__``.
         """
         kusto_database = kusto_database or database_name
 
@@ -89,4 +133,15 @@ class Config:
 
     @classmethod
     def from_env(cls, anchor_handle: str, **overrides) -> "Config":
+        """Construct configuration using environment-based Kusto discovery.
+        
+        Args:
+            anchor_handle: Handle of the anchor account to investigate.
+            **overrides: Optional field overrides applied on top of environment
+                defaults.
+        
+        Returns:
+            Config: Configuration instance populated via ``BOTFINDER_*``
+            environment variables where needed.
+        """
         return cls(anchor_handle=anchor_handle, **overrides)

--- a/bluesky/botfinder/botfinder/cross_follow.py
+++ b/bluesky/botfinder/botfinder/cross_follow.py
@@ -1,5 +1,11 @@
-"""Cross-following analysis — sample cohort accounts and measure how many
-others in the cohort each one follows. Powers cards 12–13.
+"""Measure how suspects discover and follow the surrounding network.
+
+This stage looks beyond the anchor account itself. It samples cohort
+members to measure how densely they follow other members of the cohort via
+the public API, and it queries Kusto to estimate how quickly accounts
+cross-follow prominent related targets after account creation. The outputs
+help distinguish organic users from tightly coordinated bot or TARN
+behavior.
 """
 
 from __future__ import annotations
@@ -21,6 +27,17 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @dataclass
 class CrossFollowResult:
+    """Outputs of the cross-follow analysis stage.
+    
+    Attributes:
+        sample: API-sampled per-account cross-follow overlap inside the cohort,
+            useful for comparing high-score suspects with low-score accounts.
+        speed: Event-level KQL table containing ``days_to_cross_follow`` for
+            how quickly cohort accounts followed related targets after
+            creation.
+        per_account: Account-level summary of first and median cross-follow
+            delays, consumed by downstream cards and investigation notebooks.
+    """
     sample: pd.DataFrame  # API-sampled bot vs. non-bot cross-follow rates
     speed: pd.DataFrame  # KQL-derived per-event days_to_cross_follow
     per_account: pd.DataFrame  # min/median days per account
@@ -29,6 +46,24 @@ class CrossFollowResult:
 async def _measure_via_api(
     scores_df: pd.DataFrame, sample_size: int, concurrency: int
 ) -> pd.DataFrame:
+    """Sample bots and non-bots, then measure cohort-overlap in their follows.
+    
+    Args:
+        scores_df: Scored cohort table from ``run_analysis``.
+        sample_size: Total number of accounts to sample across bot and non-bot
+            buckets.
+        concurrency: Maximum parallel Bluesky API calls.
+    
+    Returns:
+        pd.DataFrame: Per-account sample with the share of fetched follows that
+        point back into the analyzed cohort.
+    
+    Notes:
+        Dense cross-following is a coordination signal: managed networks often
+        discover and follow one another quickly, while ordinary followers are
+        less likely to point so much of their follow graph back at the same
+        political cohort.
+    """
     all_dids = set(scores_df["did"].tolist())
     all_handles = set(scores_df["handle"].dropna().tolist())
 
@@ -81,6 +116,24 @@ def _kql_cross_speed(
     anchor_dids: list[str],
     verbose: bool,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Measure time from account creation to cross-following related targets.
+    
+    Args:
+        analysis: Result of ``run_analysis`` containing cohort timing data and
+            bot scores.
+        anchor_dids: Candidate related-target DIDs whose inbound follows should
+            be measured.
+        verbose: Whether to print batch progress.
+    
+    Returns:
+        tuple[pd.DataFrame, pd.DataFrame]: Event-level and account-level tables
+        describing ``days_to_cross_follow``.
+    
+    Notes:
+        This is the stage that helps surface TARN-like behavior: accounts that
+        exhibit rapid coordinated follow timing, but toward adjacent political
+        targets instead of the primary anchor, possibly as camouflage.
+    """
     config = analysis.config
     scores_df = analysis.scores_df
     detail_df = analysis.detail_df
@@ -154,6 +207,23 @@ def measure_cross_following(
     sample_size: int = 80,
     verbose: bool = True,
 ) -> CrossFollowResult:
+    """Run the full cross-follow analysis for a scored cohort.
+    
+    Args:
+        analysis: Output of ``run_analysis`` with scores and raw acquisition
+            tables.
+        sample_size: Number of accounts to inspect in the API sample.
+        verbose: Whether to print progress information.
+    
+    Returns:
+        CrossFollowResult: Sample overlap metrics plus KQL-derived
+        cross-follow speed tables.
+    
+    Notes:
+        The function derives related targets opportunistically from outbound
+        follows already acquired for the cohort. That makes the stage useful
+        even when no explicit external target list is supplied.
+    """
     config = analysis.config
     scores_df = analysis.scores_df
 

--- a/bluesky/botfinder/botfinder/dossier.py
+++ b/bluesky/botfinder/botfinder/dossier.py
@@ -1,4 +1,11 @@
-"""HTML dossier report generator using Jinja2 templates."""
+"""Render the final HTML dossier that summarizes one analysis run.
+
+The dossier is the human-readable endpoint of the pipeline. It takes
+aggregate statistics from scoring, Plotly figures from the card stage, and
+curated top suspect rows, then combines them into a single HTML briefing
+suitable for reviewing suspected coordinated inauthentic behavior around
+the anchor account.
+"""
 
 from datetime import datetime, timezone
 from pathlib import Path
@@ -152,7 +159,24 @@ def render_dossier(
     lookback_days: int,
     output_path: Path,
 ) -> Path:
-    """Render the full HTML dossier report."""
+    """Render the final HTML dossier for one anchor account.
+    
+    Args:
+        target_handle: Handle of the analyzed anchor account.
+        stats: Aggregate network metrics computed from the scored cohort.
+        figures: Plotly figures, typically the rendered analysis cards.
+        top_suspects: High-score suspect rows prepared for tabular display.
+        lookback_days: Lookback window used during acquisition.
+        output_path: Destination path for the rendered HTML file.
+    
+    Returns:
+        Path: The path that was written.
+    
+    Notes:
+        Plotly is embedded inline so the dossier remains a self-contained
+        investigative artifact linking narrative explanation, charts, and the
+        most suspicious accounts from the scored cohort.
+    """
     chart_htmls = []
     for fig in figures:
         html = pio.to_html(fig, full_html=False, include_plotlyjs="cdn" if not chart_htmls else False)

--- a/bluesky/botfinder/botfinder/kusto.py
+++ b/bluesky/botfinder/botfinder/kusto.py
@@ -1,5 +1,10 @@
-"""Kusto client wrapping ``azure-kusto-data`` with parameterised
-cluster + database settings."""
+"""Kusto access layer for querying Bluesky firehose data in Fabric/ADX.
+
+The acquisition and cross-follow stages depend on KQL queries over firehose
+tables such as follows, profiles, blocks, and likes. This module hides the
+authentication and response-shaping details so higher-level pipeline code
+can focus on domain queries and receive plain pandas DataFrames.
+"""
 
 from __future__ import annotations
 
@@ -10,8 +15,11 @@ from .config import Config
 
 
 def _fabric_token_provider():
-    """Return a callable that yields a Kusto access token via
-    ``notebookutils.credentials.getToken``. Returns ``None`` outside Fabric.
+    """Get a Fabric notebook token provider when running inside Fabric.
+    
+    Returns:
+        Callable | None: Zero-argument callable producing a Kusto token, or
+        ``None`` when ``notebookutils`` is unavailable outside Fabric.
     """
     try:  # pragma: no cover - only available inside Fabric
         import notebookutils  # type: ignore
@@ -23,6 +31,19 @@ def _fabric_token_provider():
 
 
 def _client(config: Config) -> KustoClient:
+    """Create an authenticated Kusto client for the configured environment.
+    
+    Args:
+        config: Runtime configuration with the Kusto endpoint.
+    
+    Returns:
+        KustoClient: Authenticated client ready to execute KQL.
+    
+    Notes:
+        Fabric notebooks use notebook-scoped tokens, while local CLI usage
+        falls back to ``DefaultAzureCredential``. This keeps the rest of the
+        pipeline environment-agnostic.
+    """
     if not config.kusto_uri:
         raise RuntimeError(
             "Config.kusto_uri is not set. Pass it explicitly, set "
@@ -45,8 +66,21 @@ def _client(config: Config) -> KustoClient:
 
 
 def execute_query(config: Config, query: str) -> pd.DataFrame:
-    """Execute a KQL query against the configured database and
-    return a DataFrame."""
+    """Execute a KQL query and return the primary result as a DataFrame.
+    
+    Args:
+        config: Runtime configuration containing the Kusto endpoint and
+            database.
+        query: Fully rendered KQL query string.
+    
+    Returns:
+        pd.DataFrame: Primary query result table converted to pandas.
+    
+    Notes:
+        This is the boundary between KQL templates and Python analysis code.
+        All downstream scoring and graph steps expect tabular pandas input, so
+        the helper normalizes the SDK response immediately.
+    """
     if not config.kusto_database:
         raise RuntimeError(
             "Config.kusto_database is not set. Pass it explicitly or set "

--- a/bluesky/botfinder/botfinder/pipeline.py
+++ b/bluesky/botfinder/botfinder/pipeline.py
@@ -1,11 +1,10 @@
-"""High-level pipeline: enrich the cohort via the Bluesky API, score every
-account, and orchestrate cluster/cross-follow/lifecycle/cards.
+"""High-level orchestration for the botfinder analysis workflow.
 
-This module is the public entry point. Two flavours:
-
-- :func:`run_analysis` — scoring only, returns :class:`AnalysisResult`.
-- :func:`run_full_pipeline` — adds cluster, cross-follow, lifecycle and
-  card rendering, returns :class:`FullResult`.
+This module connects the pipeline stages end to end. It starts from raw
+cohort acquisition, optionally extends the cohort through the public
+Bluesky API, computes per-account bot scores, derives overlap statistics,
+and finally feeds cluster, cross-follow, and card-generation stages. It
+exposes a scoring-only entry point and a full reporting entry point.
 """
 
 from __future__ import annotations
@@ -37,6 +36,22 @@ from .scoring import (
 
 @dataclass
 class AnalysisResult:
+    """Outputs of the scoring-focused portion of the pipeline.
+    
+    Attributes:
+        config: Runtime configuration used for the run.
+        acquired: Raw acquisition bundle returned by ``acquire_all``.
+        detail_df: Cohort-level detail table combining KQL-timed followers with
+            older API-only followers.
+        scores_df: Flattened per-account bot score table used by nearly every
+            downstream stage.
+        overlap_df: Table of frequently co-followed targets among instant or
+            highly suspicious followers.
+        network_stats: Aggregate statistics derived from the bot scores.
+        enriched: API enrichment payloads keyed by suspect DID.
+        api_followers: Followers fetched from the public API to extend the
+            cohort beyond the KQL lookback window.
+    """
     config: Config
     acquired: AcquiredData
     detail_df: pd.DataFrame
@@ -49,6 +64,15 @@ class AnalysisResult:
 
 @dataclass
 class FullResult:
+    """Outputs of the full end-to-end pipeline including presentation artifacts.
+    
+    Attributes:
+        analysis: Scoring-stage result from ``run_analysis``.
+        cluster_nodes: Co-follow graph node table.
+        cluster_edges: Co-follow graph edge table.
+        cross_follow_per_account: Account-level cross-follow timing summary.
+        cards: Mapping from card identifier to rendered Plotly figure.
+    """
     analysis: AnalysisResult
     cluster_nodes: pd.DataFrame
     cluster_edges: pd.DataFrame
@@ -57,13 +81,30 @@ class FullResult:
 
     @property
     def scores_df(self) -> pd.DataFrame:
+        """Expose the scored cohort table directly on the full result object.
+        
+        Returns:
+            pd.DataFrame: Alias for ``analysis.scores_df``.
+        """
         return self.analysis.scores_df
 
 
 def _fetch_all_followers_via_api(
     target_handle: str, max_followers: int, concurrency: int
 ) -> list[FollowRecord]:
+    """Fetch the anchor's follower list from the public API.
+    
+    Args:
+        target_handle: Handle of the anchor account.
+        max_followers: Maximum number of follower records to collect.
+        concurrency: Maximum parallel Bluesky API calls.
+    
+    Returns:
+        list[FollowRecord]: Follower records used to extend the cohort beyond
+        KQL-timed follow events.
+    """
     async def _fetch():
+        """Run the async follower crawl used by the synchronous pipeline wrapper."""
         bsky = BlueskyClient(concurrency=concurrency)
         async with httpx.AsyncClient(timeout=30.0) as client:
             return await bsky.get_followers(client, target_handle, limit=max_followers)
@@ -76,6 +117,24 @@ def _compute_follow_overlap_from_data(
     outbound_follows_df: pd.DataFrame,
     target_did: str,
 ) -> pd.DataFrame:
+    """Summarize which external targets are shared across suspect follows.
+    
+    Args:
+        suspect_dids: DIDs selected for overlap analysis, usually very fast
+            followers of the anchor.
+        outbound_follows_df: Cohort outbound follow edges collected during
+            acquisition.
+        target_did: DID of the anchor account so it can be excluded.
+    
+    Returns:
+        pd.DataFrame: Ranked table of frequently co-followed targets and the
+        number of suspect accounts following each one.
+    
+    Notes:
+        This is the first overlap signal feeding the scorer. If many rapid
+        followers also converge on the same political targets, that suggests a
+        centrally managed follow program rather than organic discovery.
+    """
     if outbound_follows_df.empty:
         return pd.DataFrame()
     suspect_follows = outbound_follows_df[outbound_follows_df["did"].isin(suspect_dids)]
@@ -95,7 +154,26 @@ def run_analysis(
     *,
     verbose: bool = True,
 ) -> AnalysisResult:
-    """Acquire (if needed), enrich via the API, and score the cohort."""
+    """Run acquisition, optional enrichment, and bot scoring for one anchor.
+    
+    Args:
+        config: Runtime configuration for the analysis.
+        acquired: Optional precomputed acquisition bundle. When omitted, the
+            function calls ``acquire_all`` first.
+        verbose: Whether to print progress for the acquisition and scoring
+            stages.
+    
+    Returns:
+        AnalysisResult: Detailed cohort tables, bot scores, overlap summaries,
+        and enrichment payloads.
+    
+    Notes:
+        The function merges two cohort views: recent followers with precise KQL
+        timing and older followers discoverable only through the public API. It
+        then prioritizes enrichment budget toward the fastest followers and the
+        most suspicious older accounts before computing the composite bot score
+        for every cohort member.
+    """
     if acquired is None:
         acquired = acquire_all(config, verbose=verbose)
 
@@ -266,7 +344,22 @@ def run_full_pipeline(
     *,
     verbose: bool = True,
 ) -> FullResult:
-    """Full pipeline: analysis + cluster graph + cross-follow + cards."""
+    """Run the full botfinder workflow from acquisition to report figures.
+    
+    Args:
+        config: Runtime configuration for the analysis.
+        acquired: Optional precomputed acquisition bundle.
+        verbose: Whether to print progress across all stages.
+    
+    Returns:
+        FullResult: Scored analysis plus cluster tables, cross-follow
+        summaries, and rendered Plotly cards.
+    
+    Notes:
+        This is the entry point used by the CLI. It preserves the staged data
+        flow so intermediate outputs remain available for notebooks and for the
+        dossier generator.
+    """
     from .cluster import build_cluster_graph
     from .cross_follow import measure_cross_following
     from .cards import render_all_cards

--- a/bluesky/botfinder/botfinder/scoring.py
+++ b/bluesky/botfinder/botfinder/scoring.py
@@ -1,16 +1,12 @@
-"""Bot behavior scoring and network analysis.
+"""Heuristic bot-scoring logic for Bluesky political-network analysis.
 
-Implements heuristics based on DFRLab's bot detection methodology and
-academic research on coordinated inauthentic behavior (CIB):
-
-Signals scored:
-1. Account age at first follow (temporal proximity)
-2. Profile completeness (anonymity)
-3. Activity volume and patterns
-4. Follow overlap (coordinated following)
-5. Posting behavior (amplification vs. original content)
-6. Handle pattern analysis (random alphanumeric handles)
-7. Temporal burst detection (synchronized account creation)
+This module converts raw acquisition tables and optional API enrichment
+into a composite 0–1 bot score for each cohort account. The signals are
+tuned for the project's domain: accounts that are created shortly before
+following the anchor, expose little identity information, mostly amplify
+content, and share a follow graph with other suspects are more likely to
+belong to a coordinated network rather than to genuine supporters or
+opponents.
 """
 
 import re
@@ -25,6 +21,17 @@ from .bluesky_api import BlueskyProfile, BlueskyPost
 
 @dataclass
 class BotScore:
+    """Structured result of scoring one cohort account.
+    
+    Attributes:
+        did: Permanent DID of the scored account.
+        handle: Current handle, if known.
+        display_name: Current display name, if known.
+        total_score: Composite bot-likelihood score from 0.0 to 1.0.
+        signals: Individual signal scores that explain the composite result.
+        flags: Human-readable labels for notable suspicious behaviors such as
+            instant follows or anonymous profiles.
+    """
     did: str
     handle: str
     display_name: str
@@ -34,15 +41,20 @@ class BotScore:
 
 
 def score_temporal_proximity(age_at_follow_minutes: float) -> float:
-    """Score based on how quickly after creation the account followed the target.
-
-    < 1 min: 1.0 (instant follow = strong bot signal)
-    < 5 min: 0.9
-    < 30 min: 0.7
-    < 60 min: 0.5
-    < 240 min (4h): 0.3
-    > 24h: 0.0
-    NaN: 0.0 (unknown — don't penalize)
+    """Score how quickly an account followed the anchor after creation.
+    
+    Args:
+        age_at_follow_minutes: Minutes between account creation and the follow
+            event into the anchor.
+    
+    Returns:
+        float: Suspicion score between 0.0 and 1.0.
+    
+    Notes:
+        This signal targets throwaway accounts created specifically to attach to
+        the anchor. Following within minutes is one of the clearest indicators
+        of automation or preplanned coordination in the cohort. Unknown timing
+        is treated as neutral rather than suspicious.
     """
     if pd.isna(age_at_follow_minutes):
         return 0.0  # Unknown timing — rely on other signals
@@ -62,13 +74,20 @@ def score_temporal_proximity(age_at_follow_minutes: float) -> float:
 
 
 def score_profile_completeness(profile: BlueskyProfile | None, handle: str = "") -> float:
-    """Score anonymity — incomplete profiles are more suspicious.
-
-    Unresolvable/deleted account: 1.0 (strongest signal)
-    Missing avatar: +0.25
-    Missing display name: +0.25
-    Missing description/bio: +0.25
-    Default/random handle: +0.25
+    """Score how anonymous or disposable an account appears.
+    
+    Args:
+        profile: Resolved Bluesky profile, if one could be fetched.
+        handle: Fallback handle string when the full profile is unavailable.
+    
+    Returns:
+        float: Suspicion score between 0.0 and 1.0.
+    
+    Notes:
+        Accounts with no avatar, no display name, no bio, and random-looking
+        handles are more likely to be throwaway bot identities. Completely
+        unresolvable accounts are scored most strongly because suspension or
+        deletion is common among abusive campaign accounts.
     """
     if not profile:
         if not handle:
@@ -87,7 +106,20 @@ def score_profile_completeness(profile: BlueskyProfile | None, handle: str = "")
 
 
 def _is_random_handle(handle: str) -> bool:
-    """Detect likely auto-generated handles (alphanumeric gibberish)."""
+    """Detect whether a handle looks auto-generated rather than human chosen.
+    
+    Args:
+        handle: Bluesky handle to inspect.
+    
+    Returns:
+        bool: ``True`` when the local part resembles alphanumeric gibberish or
+        a short prefix followed by a long digit suffix.
+    
+    Notes:
+        Random handles are not proof of abuse on their own, but in this domain
+        they are a useful anonymity signal when combined with instant follows
+        and sparse profile metadata.
+    """
     local_part = handle.split(".")[0] if "." in handle else handle
     if not local_part:
         return True
@@ -101,12 +133,20 @@ def _is_random_handle(handle: str) -> bool:
 
 
 def score_activity_pattern(posts: list[BlueskyPost], profile: BlueskyProfile | None) -> float:
-    """Score based on posting behavior analysis.
-
-    High amplification (repost ratio): suspicious
-    No original content: suspicious
-    Zero posts from a new account following someone: strong signal
-    Burst posting: suspicious
+    """Score how much an account behaves like an amplifier instead of a person.
+    
+    Args:
+        posts: Recent author-feed posts fetched from the Bluesky API.
+        profile: Profile snapshot for context such as total post count.
+    
+    Returns:
+        float: Suspicion score between 0.0 and 1.0.
+    
+    Notes:
+        Accounts with no original content, extreme repost ratios,
+        multilingual spray patterns, and near-zero engagement are more
+        consistent with networked amplification than with ordinary political
+        participation.
     """
     if not posts:
         if profile and profile.posts_count == 0:
@@ -151,10 +191,23 @@ def score_activity_pattern(posts: list[BlueskyPost], profile: BlueskyProfile | N
 def score_follow_overlap(
     suspect_follows: list[str], common_targets: set[str], total_suspects: int
 ) -> float:
-    """Score based on how many of the same accounts this suspect follows
-    compared to other suspects in the cluster.
-
-    High overlap = coordinated behavior.
+    """Score how strongly an account's follow graph overlaps suspect targets.
+    
+    Args:
+        suspect_follows: Target DIDs followed by the account being scored.
+        common_targets: Targets already identified as frequent co-follows among
+            suspicious accounts.
+        total_suspects: Total number of scored cohort accounts.
+    
+    Returns:
+        float: Suspicion score between 0.0 and 1.0.
+    
+    Notes:
+        A high score means the account is following the same external political
+        targets as other suspects, which is a coordination signal. The
+        ``total_suspects`` argument is kept for weighting symmetry with other
+        scorers even though the current implementation only uses the shared
+        target set.
     """
     if not suspect_follows or not common_targets:
         return 0.0
@@ -164,7 +217,20 @@ def score_follow_overlap(
 
 
 def score_account_age(created_at: str, lookback_days: int = 7) -> float:
-    """Score based on account age. Accounts created within the analysis window are suspicious."""
+    """Score how newly created the account is relative to the analysis window.
+    
+    Args:
+        created_at: Account creation timestamp from the profile or firehose.
+        lookback_days: Width of the acquisition window for the anchor analysis.
+    
+    Returns:
+        float: Suspicion score between 0.0 and 1.0.
+    
+    Notes:
+        Brand-new accounts are more suspicious in this project because mass
+        follower campaigns often mint large numbers of fresh identities shortly
+        before they begin following political targets.
+    """
     try:
         created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
         age_hours = (datetime.now(timezone.utc) - created).total_seconds() / 3600
@@ -194,7 +260,30 @@ def compute_bot_score(
     total_suspects: int,
     lookback_days: int = 7,
 ) -> BotScore:
-    """Compute composite bot score from all signals."""
+    """Combine all bot signals into one explainable composite score.
+    
+    Args:
+        did: DID of the account being scored.
+        profile: Optional profile snapshot for anonymity and age signals.
+        posts: Recent posts used for activity-pattern scoring.
+        age_at_follow_minutes: Minutes from account creation to following the
+            anchor, if known.
+        suspect_follows_dids: Targets followed by this account.
+        common_targets: Frequent co-follow targets derived from the suspect
+            cohort.
+        total_suspects: Total number of scored cohort accounts.
+        lookback_days: Analysis lookback window used by the account-age scorer.
+    
+    Returns:
+        BotScore: Composite score plus per-signal explanations and flags.
+    
+    Notes:
+        Timing is weighted most heavily when it is available because instant
+        follows are especially diagnostic. For older API-only followers with no
+        precise follow timestamp, that weight is redistributed to profile,
+        activity, and overlap signals so they are not unfairly penalized for
+        missing data.
+    """
     signals = {}
     flags = []
 
@@ -268,9 +357,21 @@ def compute_bot_score(
 def detect_temporal_bursts(
     df: pd.DataFrame, time_col: str, window: str = "5min", threshold: int = 5
 ) -> pd.DataFrame:
-    """Detect bursts of coordinated activity within tight time windows.
-
-    Returns DataFrame with burst windows and account counts.
+    """Detect tight temporal bursts in account or follow timestamps.
+    
+    Args:
+        df: Input DataFrame containing a timestamp column.
+        time_col: Column name holding the timestamps to bucket.
+        window: Resampling window such as ``"5min"``.
+        threshold: Minimum event count required to label a bucket as a burst.
+    
+    Returns:
+        pd.DataFrame: Burst windows with event counts and a relative intensity
+        score.
+    
+    Notes:
+        Temporal clustering is a common sign of centrally managed campaign
+        behavior, such as account farms being created or deployed in batches.
     """
     df = df.copy()
     df[time_col] = pd.to_datetime(df[time_col])
@@ -281,7 +382,20 @@ def detect_temporal_bursts(
 
 
 def compute_network_statistics(scores: list[BotScore]) -> dict:
-    """Aggregate network-level statistics for the dossier."""
+    """Aggregate cohort-wide statistics from per-account bot scores.
+    
+    Args:
+        scores: Per-account score results for the analyzed cohort.
+    
+    Returns:
+        dict: Summary metrics used by the dossier and CLI, including score
+        distribution and flag prevalence.
+    
+    Notes:
+        This is the bridge from individual suspect scoring to anchor-level
+        narrative claims such as how many followers look highly automated and
+        what fraction of the cohort followed instantly or anonymously.
+    """
     if not scores:
         return {}
 

--- a/bluesky/botfinder/notebook/botfinder.ipynb
+++ b/bluesky/botfinder/notebook/botfinder.ipynb
@@ -46,8 +46,8 @@
     "# Upgrade plotly to a recent version (Fabric ships an older default)\n",
     "%pip install -q --upgrade plotly\n",
     "# Install module from the real-time-sources repo (SHA-pinned)\n",
-    "%pip install -q --upgrade --force-reinstall --no-cache-dir --no-deps git+https://github.com/clemensv/real-time-sources@373e3f9c66ddc15a9d9d06cacfcd79000b424f5d#subdirectory=bluesky/botfinder\n",
-    "%pip install -q git+https://github.com/clemensv/real-time-sources@373e3f9c66ddc15a9d9d06cacfcd79000b424f5d#subdirectory=bluesky/botfinder\n"
+    "%pip install -q --upgrade --force-reinstall --no-cache-dir --no-deps git+https://github.com/clemensv/real-time-sources@main#subdirectory=bluesky/botfinder\n",
+    "%pip install -q git+https://github.com/clemensv/real-time-sources@main#subdirectory=bluesky/botfinder\n"
    ]
   },
   {

--- a/bluesky/botfinder/notebook/build_notebook.py
+++ b/bluesky/botfinder/notebook/build_notebook.py
@@ -56,12 +56,12 @@ CELLS = [
     code(
         "# Upgrade plotly to a recent version (Fabric ships an older default)\n"
         "%pip install -q --upgrade plotly\n"
-        "# Install module from the real-time-sources repo (SHA-pinned)\n"
+        "# Install module from the real-time-sources repo (latest main)\n"
         "%pip install -q --upgrade --force-reinstall --no-cache-dir --no-deps "
-        "git+https://github.com/clemensv/real-time-sources@373e3f9c66ddc15a9d9d06cacfcd79000b424f5d"
+        "git+https://github.com/clemensv/real-time-sources@main"
         "#subdirectory=bluesky/botfinder\n"
         "%pip install -q "
-        "git+https://github.com/clemensv/real-time-sources@373e3f9c66ddc15a9d9d06cacfcd79000b424f5d"
+        "git+https://github.com/clemensv/real-time-sources@main"
         "#subdirectory=bluesky/botfinder\n"
     ),
     code(


### PR DESCRIPTION
Adds detailed Google-style docstrings to every module, class, and function in the botfinder package (916 lines of documentation added). Also updates notebook pip install to use \@main\ instead of pinned SHA.