### PR TITLE
feat(portal): add 'notebook' capability flag for Fabric notebook deploys

### DIFF
--- a/.github/workflows/update-ghpages-catalog.yml
+++ b/.github/workflows/update-ghpages-catalog.yml
@@ -85,7 +85,8 @@ jobs:
                   f"cat: {js_string(item['cat'])}, "
                   f"key: {js_bool(item['key'])}, "
                   f"desc: {js_string(item['desc'])}, "
-                  f"kql: {js_bool(item['kql'])} "
+                  f"kql: {js_bool(item['kql'])}, "
+                  f"notebook: {js_bool(item.get('notebook', False))} "
                   '},'
               )
 

--- a/catalog.json
+++ b/catalog.json
@@ -101,7 +101,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Germany — federal waterways, ~3,000 stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "rws-waterwebservices",


### PR DESCRIPTION
Companion to the ghpages-side PR (#TBD) and the in-flight `fabric-notebook-prototype` work.

## What changes

- `catalog.json`: flip `pegelonline` to `notebook: true`. Other entries are unchanged; the flag is sparse.
- `.github/workflows/update-ghpages-catalog.yml`: emit `notebook: <bool>` on every SOURCES line so the portal can read it.

## Why

The Fabric notebook deploy path now exists end-to-end (see `fabric-notebook-prototype` branch and the new `fabric-notebook-deployment` skill). The portal needs a per-source flag to decide whether to show the new 'Fabric Notebook' button.

## Rollout

1. Merge this PR first. The sync workflow propagates the flag to `ghpages/app.js`.
2. Merge the ghpages PR which wires the button click and adds the notebook-mode deploy form.
3. New sources turn the flag on by adding `notebook/<source>-feed.ipynb` per the skill and flipping `notebook: true` in `catalog.json`.