### PR TITLE
feat(fabric-notebook): publish per-source wheel bundles + auto-download

### DIFF
--- a/.github/workflows/publish-notebook-wheels.yml
+++ b/.github/workflows/publish-notebook-wheels.yml
@@ -1,0 +1,166 @@
+name: Publish Notebook Wheels
+
+# Build per-source wheel bundles for sources marked `notebook: true` in
+# catalog.json and publish them as assets on the `notebook-wheels` release
+# so deploy-feeder-notebook.ps1 can download them from Cloud Shell without
+# needing to build them locally.
+#
+# The release tag is fixed (`notebook-wheels`) and recreated on every push.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'catalog.json'
+      - '**/pyproject.toml'
+      - '**/poetry.lock'
+      - '**/notebook/*.ipynb'
+      - 'tools/deploy-fabric/strip-wheel-pathdeps.py'
+      - '.github/workflows/publish-notebook-wheels.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      sources: ${{ steps.pick.outputs.sources }}
+      count: ${{ steps.pick.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: pick
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, pathlib
+          catalog = json.loads(pathlib.Path('catalog.json').read_text(encoding='utf-8'))
+          ids = [c['id'] for c in catalog if c.get('notebook')]
+          print(f"sources={json.dumps(ids)}")
+          print(f"count={len(ids)}")
+          PY
+      - run: |
+          echo "Selected sources: ${{ steps.pick.outputs.sources }}"
+          echo "Count: ${{ steps.pick.outputs.count }}"
+
+  build:
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJson(needs.discover.outputs.sources) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Verify notebook + producer present
+        run: |
+          test -f "${{ matrix.source }}/notebook/${{ matrix.source }}-feed.ipynb" \
+            || { echo "::error::Missing notebook for ${{ matrix.source }}"; exit 1; }
+          test -d "${{ matrix.source }}/${{ matrix.source }}_producer" \
+            || { echo "::error::Missing generated producer for ${{ matrix.source }}"; exit 1; }
+
+      - name: Build wheels
+        working-directory: ${{ matrix.source }}
+        run: |
+          python -m pip install --upgrade pip wheel poetry-core
+          mkdir -p ../_wheels-out
+          # Bridge package
+          python -m pip wheel --no-deps --no-build-isolation \
+            --wheel-dir ../_wheels-out .
+          # Producer sub-packages (skip any without pyproject.toml such as samples/)
+          for sub in ${{ matrix.source }}_producer/*/ ; do
+            if [ -f "$sub/pyproject.toml" ]; then
+              echo "Building $sub"
+              python -m pip wheel --no-deps --no-build-isolation \
+                --wheel-dir ../_wheels-out "$sub"
+            fi
+          done
+
+      - name: Strip poetry path-deps from wheel METADATA
+        run: |
+          python tools/deploy-fabric/strip-wheel-pathdeps.py _wheels-out/*.whl
+
+      - name: Compute commit short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Write manifest
+        run: |
+          python - <<'PY'
+          import json, pathlib, datetime, os
+          out = pathlib.Path('_wheels-out')
+          wheels = sorted(p.name for p in out.glob('*.whl'))
+          manifest = {
+              'source': '${{ matrix.source }}',
+              'commit': '${{ github.sha }}',
+              'shortCommit': '${{ steps.sha.outputs.short }}',
+              'built_utc': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+              'wheels': wheels,
+          }
+          (out / 'manifest.json').write_text(json.dumps(manifest, indent=2))
+          print(json.dumps(manifest, indent=2))
+          PY
+
+      - name: Bundle wheels
+        run: |
+          cd _wheels-out
+          zip -j "../${{ matrix.source }}-notebook-wheels.zip" *.whl manifest.json
+          ls -la ../${{ matrix.source }}-notebook-wheels.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.source }}-notebook-wheels
+          path: ${{ matrix.source }}-notebook-wheels.zip
+          retention-days: 7
+
+  publish:
+    needs: [discover, build]
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: bundles
+          pattern: '*-notebook-wheels'
+          merge-multiple: true
+
+      - name: List bundles
+        run: ls -la bundles/
+
+      - name: Recreate `notebook-wheels` release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if gh release view notebook-wheels >/dev/null 2>&1; then
+            gh release delete notebook-wheels --yes --cleanup-tag
+          fi
+          notes=$(cat <<EOF
+          Per-source wheel bundles for Fabric notebook deployments.
+
+          Each \`<source>-notebook-wheels.zip\` contains the bridge wheel,
+          the 2 generated producer sub-package wheels, and a \`manifest.json\`
+          with the source commit SHA. Path-dep \`file://\` URLs are stripped
+          from wheel METADATA.
+
+          Consumed by \`tools/deploy-fabric/deploy-feeder-notebook.ps1\`.
+          Refreshed on every push to \`main\` that touches a notebook source
+          or the wheel build pipeline.
+
+          Built from commit ${{ github.sha }}.
+          EOF
+          )
+          gh release create notebook-wheels \
+            --title "Notebook wheels (latest from main)" \
+            --notes "$notes" \
+            --target ${{ github.sha }} \
+            bundles/*.zip

--- a/.github/workflows/publish-notebook-wheels.yml
+++ b/.github/workflows/publish-notebook-wheels.yml
@@ -17,6 +17,11 @@ on:
       - '**/notebook/*.ipynb'
       - 'tools/deploy-fabric/strip-wheel-pathdeps.py'
       - '.github/workflows/publish-notebook-wheels.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/publish-notebook-wheels.yml'
+      - 'tools/deploy-fabric/strip-wheel-pathdeps.py'
   workflow_dispatch:
 
 permissions:
@@ -123,7 +128,7 @@ jobs:
 
   publish:
     needs: [discover, build]
-    if: needs.discover.outputs.count != '0'
+    if: needs.discover.outputs.count != '0' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tools/deploy-fabric/deploy-feeder-notebook.ps1
+++ b/tools/deploy-fabric/deploy-feeder-notebook.ps1
@@ -114,6 +114,8 @@ param(
 
     [string]$EnvironmentName,
     [switch]$SkipEnvironment,
+    [switch]$BuildWheelsLocally,
+    [string]$WheelsBundleUrl,
 
     [string]$DefaultLakehouse,
     [int]$ScheduleIntervalMinutes = 15,
@@ -173,6 +175,46 @@ function Invoke-FabricApiRaw {
     }
     $result = & az @azArgs 2>&1
     return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Body = ($result | Out-String) }
+}
+
+function Get-PrebuiltWheels {
+    <#
+    Download the per-source wheel bundle from the `notebook-wheels` release
+    (built by .github/workflows/publish-notebook-wheels.yml). Returns the
+    array of extracted .whl FileInfo objects in a fresh temp dir.
+
+    -WheelsBundleUrl overrides the default release-asset URL. Useful for
+    pinning to a specific commit or using a fork.
+    #>
+    param([string]$Source, [string]$Repo, [string]$WheelsBundleUrl)
+
+    if (-not $WheelsBundleUrl) {
+        $WheelsBundleUrl = "https://github.com/$Repo/releases/download/notebook-wheels/$Source-notebook-wheels.zip"
+    }
+
+    $outDir = Join-Path $TempDir "feeder-wheels-$Source-$(Get-Random)"
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    $zipFile = Join-Path $outDir "$Source-notebook-wheels.zip"
+
+    Write-Info "  downloading $WheelsBundleUrl"
+    try {
+        Invoke-WebRequest -Uri $WheelsBundleUrl -OutFile $zipFile -ErrorAction Stop
+    } catch {
+        throw "Failed to download wheel bundle from $WheelsBundleUrl`: $($_.Exception.Message)`nIf the source's wheels haven't been published yet, rerun with -BuildWheelsLocally."
+    }
+
+    Expand-Archive -LiteralPath $zipFile -DestinationPath $outDir -Force
+    Remove-Item $zipFile
+
+    $manifestFile = Join-Path $outDir "manifest.json"
+    if (Test-Path $manifestFile) {
+        $manifest = Get-Content $manifestFile -Raw | ConvertFrom-Json
+        Write-OK "  bundle built from commit $($manifest.shortCommit) at $($manifest.built_utc)"
+    }
+
+    $wheels = Get-ChildItem -LiteralPath $outDir -Filter *.whl
+    if (-not $wheels) { throw "No wheels found in $WheelsBundleUrl" }
+    return ,$wheels
 }
 
 function Build-SourceWheels {
@@ -382,8 +424,20 @@ $EnvironmentId = $null
 if (-not $SkipEnvironment) {
     Write-Step "B/2.5" "Building source wheels and publishing Fabric Environment '$EnvironmentName'..."
 
-    $wheels = Build-SourceWheels -Source $Source -RepoRoot $repoRoot
-    Write-OK "Built $($wheels.Count) wheel(s):"
+    $wheels = if ($BuildWheelsLocally) {
+        Write-Info "Building wheels locally (-BuildWheelsLocally)..."
+        Build-SourceWheels -Source $Source -RepoRoot $repoRoot
+    } else {
+        Write-Info "Downloading pre-built wheel bundle from GitHub release..."
+        try {
+            Get-PrebuiltWheels -Source $Source -Repo $Repo -WheelsBundleUrl $WheelsBundleUrl
+        } catch {
+            Write-Info "  bundle download failed; falling back to local build."
+            Write-Info "  ($($_.Exception.Message))"
+            Build-SourceWheels -Source $Source -RepoRoot $repoRoot
+        }
+    }
+    Write-OK "Got $($wheels.Count) wheel(s):"
     foreach ($w in $wheels) { Write-Info "  $($w.Name)" }
 
     # Resolve-or-create the environment item.


### PR DESCRIPTION
Option A from earlier discussion. Eliminates the local `pip wheel` build from Cloud Shell deploys and removes PyPI access as a hard dependency.

## What changes

### `.github/workflows/publish-notebook-wheels.yml` (new)

On push to `main` that touches a notebook source's `pyproject.toml`, `poetry.lock`, the notebook itself, or this workflow:

1. **discover** job reads `catalog.json`, picks sources with `notebook: true`.
2. **build** job (matrix over those sources) installs Python 3.11, runs `pip wheel --no-deps` on bridge + 2 producer sub-packages, strips poetry path-deps via `tools/deploy-fabric/strip-wheel-pathdeps.py`, writes `manifest.json` with the source commit SHA, and zips into `<source>-notebook-wheels.zip`.
3. **publish** job recreates the fixed-tag `notebook-wheels` release with all bundles as assets.

Today only `pegelonline` is included; matrix grows automatically as new sources flip `notebook: true`.

### `tools/deploy-fabric/deploy-feeder-notebook.ps1`

- New `-BuildWheelsLocally` switch (default off): keeps the old behavior for dev workflow.
- New `-WheelsBundleUrl` override: for pinning to a specific commit or testing forks.
- Default behavior: downloads `https://github.com/clemensv/real-time-sources/releases/download/notebook-wheels/<source>-notebook-wheels.zip`, unpacks, uses those wheels.
- Auto-fallback: if download fails, automatically builds locally so the script still works without the release.
- `Get-PrebuiltWheels` prints the source commit + build timestamp from `manifest.json` so it's clear which version landed in the Fabric Environment.

## Verification

- PowerShell parse-check passes.
- YAML parse-check passes.
- Workflow logic verified against the existing local `Build-SourceWheels` (same wheel list, same path-dep stripping).

## Dependency chain

This is a prerequisite for the portal PRs (#234, #235) which point Cloud Shell at `deploy-feeder-notebook.ps1`. Merge order:

1. **This PR** ΓåÆ triggers the workflow ΓåÆ first `notebook-wheels` release becomes available.
2. **#234** (catalog flag + sync workflow).
3. **#235** (ghpages button wiring).