### PR TITLE
feat(skills): add notebook-feeder-retrofit upgrade agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -194,6 +194,25 @@ schedules the notebook. Three non-obvious rules apply:
 Full playbook: `.github/skills/fabric-notebook-deployment/SKILL.md`.
 Reference implementation: `pegelonline/notebook/pegelonline-feed.ipynb`.
 
+### Retrofitting existing pollers (fleet operation)
+
+To add notebook hosting to an **already-shipped** poll-based source,
+use the dedicated upgrade agent specified in
+`.github/skills/notebook-feeder-retrofit/SKILL.md`. It is designed to
+be dispatched in parallel — one agent per source — by an orchestrator.
+The agent copies the canonical `pegelonline` notebook, performs an
+exact substitution table, flips `catalog.json` `notebook: true`,
+validates locally, and opens a PR. It does **not** deploy to Fabric.
+
+To discover the eligible-source set:
+
+```powershell
+pwsh .github/skills/notebook-feeder-retrofit/references/eligibility-discovery.ps1 -Format Lines
+```
+
+Sources in `skip:streaming` (websocket/MQTT) or `skip:not-a-poller`
+(no polling loop) are out of scope for notebook hosting.
+
 ## Things That Are Not Allowed
 
 - Hand-editing generated producer code.
@@ -209,3 +228,7 @@ Reference implementation: `pegelonline/notebook/pegelonline-feed.ipynb`.
 - Adding a `CONNECTION_STRING` parameter to a Fabric notebook (look it up
   at runtime via the Topology API instead).
 - Using the legacy MWC token chain for Event Stream connection strings.
+- Bundling multiple sources into one notebook-retrofit PR. The
+  `notebook-feeder-retrofit` agent must produce one PR per source.
+- Deploying notebook-retrofit PRs to Fabric from the retrofit agent
+  itself. End-to-end Fabric verification is a separate, serial step.

--- a/.github/skills/notebook-feeder-retrofit/SKILL.md
+++ b/.github/skills/notebook-feeder-retrofit/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: notebook-feeder-retrofit
+description: "Use to retrofit an existing poll-based feeder in this repo with a Fabric notebook hosting option. Adds `<source>/notebook/<source>-feed.ipynb`, flips `catalog.json` `notebook: true`, validates the bridge supports single-cycle execution, runs the existing test suite, and opens a PR. Designed to be dispatched in parallel across many sources by a fleet of upgrade agents."
+argument-hint: "Pass exactly one source id (e.g. `bafu-hydro`) per agent invocation. Optionally pass a Branch name; otherwise the agent uses `notebook-retrofit-<source>`."
+---
+
+# Notebook Feeder Retrofit (Upgrade Agent)
+
+You are an **upgrade agent**. Your job is to retrofit **one** existing
+poll-based source in this repo with a Fabric notebook hosting option, by
+replicating the canonical `pegelonline` pattern. Do not invent new
+patterns — copy, substitute, validate, open PR. If the source is
+ineligible, abort with a clear reason; do not "make it work" by changing
+the bridge architecture.
+
+## Inputs
+
+- `SOURCE` — the source directory name (e.g. `bafu-hydro`,
+  `usgs-iv`, `entsoe`).
+- `BRANCH` — optional; default `notebook-retrofit-<SOURCE>`.
+
+## Single-Source Scope
+
+**One agent processes one source.** Do not loop over sources in a single
+agent. The orchestrator dispatches a fleet of agents in parallel, one per
+source.
+
+## Eligibility Gate (run first, abort if any fail)
+
+A source qualifies if **all** of the following are true:
+
+1. `<SOURCE>/` exists and contains `<SOURCE>/pyproject.toml`,
+   `xreg/<SOURCE>.xreg.json`, and a bridge module exposing `def main()`.
+2. The bridge supports **single-cycle execution** — either via a
+   `--once` CLI flag (preferred) or via an `ONCE_MODE` environment
+   variable that exits after one polling cycle. Verify by grepping the
+   bridge module for `--once|once_mode|ONCE_MODE`.
+3. The bridge is **poll-based**, not a long-lived stream. WebSocket,
+   MQTT, raw-TCP, and SSE-firehose bridges are **out of scope** for this
+   agent. Heuristic: the bridge calls `time.sleep`, `asyncio.sleep`, or
+   has a `POLLING_INTERVAL` env var, and does **not** open a persistent
+   socket.
+4. The source has a Docker E2E test that already passes on `main`
+   (`tests/docker_e2e/test_docker_kafka_flow.py` contains a class for
+   the source). If it does not, the bridge's contract is unverified;
+   abort.
+5. `<SOURCE>/notebook/<SOURCE>-feed.ipynb` does **not** already exist.
+
+If any check fails, write a one-line skip reason to
+`tmp/notebook-retrofit-skipped.log` (append) and call `task_complete`
+with the reason. Do **not** open a PR.
+
+### Add `--once` if missing
+
+If gate (2) fails but the bridge is clearly a poller (gate 3 passes),
+you may add a `--once` flag to the bridge's argparse setup and a
+single-cycle exit branch in the polling loop, modeled after
+`pegelonline/pegelonline/pegelonline.py`. This is a small, mechanical
+change. Add a unit test that asserts `--once` causes `main()` to return
+after exactly one cycle (mock the upstream HTTP). If the bridge is not
+written with a clean polling loop you can interrupt, abort instead.
+
+## Retrofit Steps (in order)
+
+### 1. Branch + folder
+
+```powershell
+git checkout main
+git pull --ff-only
+git checkout -b $BRANCH
+New-Item -ItemType Directory -Force -Path "$SOURCE/notebook" | Out-Null
+```
+
+### 2. Copy and substitute the canonical notebook
+
+The template is `pegelonline/notebook/pegelonline-feed.ipynb`. **Copy
+verbatim**, then perform the substitutions in
+[`references/notebook-substitution-table.md`](references/notebook-substitution-table.md).
+The substitutions are exact and mechanical; do not paraphrase.
+
+Critical substitutions:
+
+| From (pegelonline) | To |
+|---|---|
+| `from pegelonline import pegelonline as feeder` | `from <PKG> import <MODULE> as feeder` |
+| `sys.argv = ['pegelonline', 'feed', '--once']` | `sys.argv = [<bridge argv-0>, <subcommand>, '--once']` |
+| `sys.argv = ['pegelonline', 'feed']` (else branch) | same as above without `--once` |
+| `/lakehouse/default/Files/feeder-state/pegelonline/` | `/lakehouse/default/Files/feeder-state/<SOURCE>/` |
+| `Pegelonline Feeder (Fabric Notebook)` (title) | `<Display Name> Feeder (Fabric Notebook)` |
+| `pegelonline-ingest` (default `EVENTSTREAM_NAME`) | `<SOURCE>-ingest` (the deploy script overwrites this) |
+| Markdown copy describing the source | one-paragraph adaptation from `<SOURCE>/README.md` |
+
+Resolve `<PKG>`, `<MODULE>`, `<bridge argv-0>`, and `<subcommand>` by
+inspecting `<SOURCE>/pyproject.toml` (`[tool.poetry.scripts]` or the
+package layout) and the bridge module's `argparse` setup. **Do not
+guess.** If the bridge has no CLI subcommand (calls `main()` with no
+args), drop the subcommand element and use `sys.argv = ['<SOURCE>',
+'--once']` instead.
+
+Do **not** change the four-cell structure, the CS-lookup cell, the
+worker-thread run cell, or the OneLake log path layout. Those are
+load-bearing — see `.github/skills/fabric-notebook-deployment/SKILL.md`.
+
+### 3. Catalog flag
+
+Edit `catalog.json` to add `"notebook": true` to the `<SOURCE>` entry.
+Keep the existing key order; insert `notebook` after `kql`. If the entry
+does not exist, abort — the source isn't published in the portal and
+shouldn't have a notebook button.
+
+### 4. Validate locally
+
+Run these checks in order; **fix and re-run on any failure** before
+opening a PR:
+
+```powershell
+# Notebook JSON well-formed
+python -c "import json; json.load(open('$SOURCE/notebook/$SOURCE-feed.ipynb'))"
+
+# Bridge unit tests still pass
+cd $SOURCE; python -m pytest tests/ -x --no-header -q; cd ..
+
+# If you added --once, run the new unit test specifically:
+cd $SOURCE; python -m pytest tests/test_once_mode.py -v; cd ..
+
+# Notebook params cell actually contains the placeholders the deploy script patches
+$nb = Get-Content "$SOURCE/notebook/$SOURCE-feed.ipynb" -Raw
+foreach ($k in 'EVENTSTREAM_NAME','STATE_FILE','POLLING_INTERVAL','ONCE_MODE','WORKSPACE_ID') {
+    if ($nb -notmatch "(?m)^\s*$k\s*=") { throw "Missing placeholder: $k" }
+}
+
+# Notebook does NOT contain forbidden patterns
+foreach ($bad in 'asyncio\.run\(','%pip install','CONNECTION_STRING\s*=\s*"','primaryConnectionString.*=') {
+    if ($nb -match $bad) { throw "Forbidden pattern present: $bad" }
+}
+```
+
+### 5. Documentation touch (minimal)
+
+- Add a one-sentence "Fabric notebook hosting" bullet to
+  `<SOURCE>/README.md` linking to
+  `tools/deploy-fabric/deploy-feeder-notebook.ps1`. Do **not** create a
+  separate doc.
+- Do **not** edit `EVENTS.md` or `CONTAINER.md`.
+
+### 6. Commit + PR
+
+```powershell
+git add "$SOURCE/notebook/" "$SOURCE/README.md" catalog.json
+# include bridge + test changes only if you added --once
+git commit -m "feat($SOURCE): Fabric notebook hosting option
+
+Adds notebook/$SOURCE-feed.ipynb following the pegelonline pattern.
+Flips catalog.json notebook flag so the gh-pages portal exposes the
+Fabric Notebook deploy button.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin $BRANCH
+gh pr create --base main --title "feat($SOURCE): Fabric notebook hosting option" `
+  --body "Retrofit by notebook-feeder-retrofit agent. Validated locally: notebook JSON ok, bridge tests pass, parameters cell complete, no forbidden patterns. The wheel-bundle workflow (.github/workflows/publish-notebook-wheels.yml) will pick up this source on next push to main and publish wheels to the notebook-wheels release."
+```
+
+### 7. Do NOT run a live Fabric deployment
+
+The agent does **not** deploy to ContosoRealTimeTest. The wheel-publish
+workflow runs on PR merge and the portal exposes the button once
+`update-ghpages-catalog.yml` syncs the flag. End-to-end Fabric
+validation is performed manually by the maintainer (or by a separate
+verification agent) once the PR is merged.
+
+Reason: each Fabric deployment consumes capacity time, creates
+workspaces/environments/notebooks, and competes with other agents in
+the fleet for the same shared workspace. Serial verification is cheaper
+than parallel deployment.
+
+## Done Criteria
+
+The agent is done when:
+
+- A PR is open with the notebook, the catalog flag flip, and (if
+  needed) the `--once` addition.
+- Local validation passed (notebook JSON, bridge tests, placeholder
+  check, forbidden-pattern check).
+- The PR body cites this skill and lists the validations performed.
+
+If any retrofit step cannot complete (e.g. bridge has no extractable
+CLI shape, tests fail and the cause is the new code), abort, push
+nothing, and call `task_complete` with a clear blocker description.
+
+## Things That Are Not Allowed
+
+- Deploying to Fabric from the agent. Hand-off to manual verification.
+- Editing wheels, the deploy script, the publish workflow, or anything
+  under `tools/deploy-fabric/`. Those are infrastructure; this agent
+  only consumes them.
+- Editing `.github/skills/fabric-notebook-deployment/` or
+  `.github/copilot-instructions.md` — the agent is a consumer of those.
+- Bundling multiple sources into one PR. One source, one PR.
+- Skipping the eligibility gate.
+- Inventing new notebook cell structure, alternative CS-lookup
+  techniques, or new log-file locations. Copy verbatim from
+  `pegelonline`.
+- Forcing a streaming bridge (websocket/MQTT/SSE) into the polling
+  notebook model. Abort instead.
+
+## References
+
+- `.github/skills/fabric-notebook-deployment/SKILL.md` — the deployment
+  pipeline this notebook plugs into.
+- `pegelonline/notebook/pegelonline-feed.ipynb` — template.
+- `tools/deploy-fabric/deploy-feeder-notebook.ps1` — line ~540: shows
+  the exact parameter names the deploy script will overwrite. The
+  notebook MUST declare all of them.
+- `references/notebook-substitution-table.md` — exact substitution
+  mapping.
+- `references/eligibility-discovery.ps1` — one-shot discovery script
+  that prints the eligible-source set for the orchestrator.

--- a/.github/skills/notebook-feeder-retrofit/references/eligibility-discovery.ps1
+++ b/.github/skills/notebook-feeder-retrofit/references/eligibility-discovery.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+  Discovers which sources in this repo are eligible for the
+  notebook-feeder-retrofit agent.
+
+.DESCRIPTION
+  Prints a JSON array of source ids that pass the eligibility gate
+  defined in SKILL.md. Use to fan out a fleet of retrofit agents.
+
+.EXAMPLE
+  pwsh .github/skills/notebook-feeder-retrofit/references/eligibility-discovery.ps1
+  pwsh .github/skills/notebook-feeder-retrofit/references/eligibility-discovery.ps1 -Format Table
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Json','Table','Lines')] [string]$Format = 'Json',
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent)
+)
+
+$ErrorActionPreference = 'Stop'
+Push-Location $RepoRoot
+try {
+    $catalogPath = Join-Path $RepoRoot 'catalog.json'
+    if (-not (Test-Path $catalogPath)) { throw "catalog.json not found at $catalogPath" }
+    $catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
+    $publishedIds = $catalog | ForEach-Object { $_.id }
+
+    $e2eTestPath = Join-Path $RepoRoot 'tests/docker_e2e/test_docker_kafka_flow.py'
+    $e2eContent = if (Test-Path $e2eTestPath) { Get-Content $e2eTestPath -Raw } else { '' }
+
+    $results = foreach ($id in $publishedIds) {
+        $srcDir = Join-Path $RepoRoot $id
+        if (-not (Test-Path $srcDir)) { continue }
+        if (-not (Test-Path (Join-Path $srcDir 'pyproject.toml'))) { continue }
+        if (-not (Test-Path (Join-Path $srcDir 'xreg'))) { continue }
+        $existingNb = Get-ChildItem -Path (Join-Path $srcDir 'notebook') -Filter '*.ipynb' -ErrorAction SilentlyContinue
+        if ($existingNb) { continue }  # Already retrofitted
+
+        $bridge = Get-ChildItem -Path $srcDir -Recurse -Include '*.py' -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '_producer|[\\/]tests[\\/]|conftest\.py' } |
+            Where-Object { Select-String -Path $_.FullName -Pattern '^def main\(' -Quiet } |
+            Select-Object -First 1
+        if (-not $bridge) { continue }
+
+        $bridgeText = Get-Content $bridge.FullName -Raw
+        $hasOnceCli = $bridgeText -match '--once'
+        $hasOnceEnv = $bridgeText -match 'ONCE_MODE'
+        $hasPollSig = $bridgeText -match 'time\.sleep|asyncio\.sleep|POLLING_INTERVAL|polling_interval|--interval'
+        $hasStream  = $bridgeText -match 'websockets?\.connect|aiomqtt|paho\.mqtt|sseclient|EventSource'
+        $hasE2E     = $e2eContent -match "['\""]$id['\""]|class\s+\w*$($id -replace '-','_')"
+
+        $status = if ($hasStream)                              { 'skip:streaming' }
+                  elseif (-not $hasPollSig)                    { 'skip:not-a-poller' }
+                  elseif (-not $hasE2E)                        { 'skip:no-e2e' }
+                  elseif ($hasOnceCli)                         { 'ready' }
+                  elseif ($hasOnceEnv)                         { 'ready-env' }
+                  else                                         { 'needs-once-flag' }
+
+        [PSCustomObject]@{
+            id              = $id
+            status          = $status
+            bridge          = $bridge.Name
+            hasOnceCli      = $hasOnceCli
+            hasOnceEnv      = $hasOnceEnv
+            hasPollSig      = $hasPollSig
+            hasStream       = $hasStream
+            hasE2E          = $hasE2E
+        }
+    }
+
+    switch ($Format) {
+        'Table' { $results | Format-Table -AutoSize }
+        'Lines' { $results | Where-Object { $_.status -like 'ready*' -or $_.status -eq 'needs-once-flag' } | ForEach-Object { $_.id } }
+        default { $results | ConvertTo-Json -Depth 3 }
+    }
+}
+finally { Pop-Location }

--- a/.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md
+++ b/.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md
@@ -1,0 +1,76 @@
+# Notebook Substitution Table
+
+Apply each substitution exactly. The template file is
+`pegelonline/notebook/pegelonline-feed.ipynb`.
+
+## Required substitutions
+
+Let:
+
+- `$SOURCE` = source id (e.g. `bafu-hydro`).
+- `$DISPLAY` = display name from `catalog.json` `name` field
+  (e.g. `BAFU Hydro`).
+- `$PKG` = the Python import package, taken from `pyproject.toml`
+  `[tool.poetry] name` (after `-` → `_`).
+- `$MODULE` = the bridge module file stem (e.g. `bafu_hydro`,
+  `pegelonline`).
+- `$ARGV0` = the bridge CLI name (usually equals `$SOURCE`, but check
+  `pyproject.toml [tool.poetry.scripts]` for the script entry).
+- `$SUBCOMMAND` = the bridge subcommand for live feed (`feed` in most
+  bridges; check argparse setup).
+
+| Cell | From | To |
+|---|---|---|
+| 1 (markdown) | `# Pegelonline Feeder (Fabric Notebook)` | `# $DISPLAY Feeder (Fabric Notebook)` |
+| 1 (markdown) | `Polls the German WSV PegelOnline API ...` (paragraph) | One adapted paragraph from `$SOURCE/README.md`. Keep the bullet list structure. |
+| 1 (markdown) | `` `pegelonline` package `` | `` `$PKG` package `` |
+| 1 (markdown) | `pegelonline feed --once` | `$ARGV0 $SUBCOMMAND --once` |
+| 2 (params) | `EVENTSTREAM_NAME = "pegelonline-ingest"` | `EVENTSTREAM_NAME = "$SOURCE-ingest"` |
+| 2 (params) | `STATE_FILE       = "/lakehouse/default/Files/feeder-state/pegelonline/state.json"` | `STATE_FILE       = "/lakehouse/default/Files/feeder-state/$SOURCE/state.json"` |
+| 4 (run) | `LOG_PATH = '/lakehouse/default/Files/feeder-state/pegelonline/last-run.log'` | `LOG_PATH = '/lakehouse/default/Files/feeder-state/$SOURCE/last-run.log'` |
+| 4 (run) | `from pegelonline import pegelonline as feeder` | `from $PKG import $MODULE as feeder` |
+| 4 (run) | `sys.argv = ['pegelonline', 'feed', '--once'] if ONCE_MODE else ['pegelonline', 'feed']` | `sys.argv = ['$ARGV0', '$SUBCOMMAND', '--once'] if ONCE_MODE else ['$ARGV0', '$SUBCOMMAND']` |
+
+## Do NOT change
+
+- The `_get_pbi_token`, `_resolve_workspace_id`,
+  `lookup_es_connection_string` functions in cell 3. They are
+  source-agnostic and load-bearing.
+- The worker-thread wrapper in cell 4.
+- The `notebookutils.notebook.exit("OK" | "FAIL: ...")` calls.
+- The `try/except` envelope around the entire run cell.
+- The cell ordering or the `parameters` tag on cell 2.
+
+## Variant: bridge with no subcommand
+
+If `$MODULE.main()` is invoked without a subcommand (uncommon — check
+the bridge's argparse), use:
+
+```python
+sys.argv = ['$ARGV0', '--once'] if ONCE_MODE else ['$ARGV0']
+```
+
+## Variant: bridge that reads `ONCE_MODE` env var instead of `--once`
+
+A few bridges (e.g. `gdacs`) honor an `ONCE_MODE` env var directly
+rather than a CLI flag. In that case:
+
+```python
+os.environ['ONCE_MODE'] = 'true' if ONCE_MODE else 'false'
+sys.argv = ['$ARGV0']
+```
+
+The deploy script already sets `ONCE_MODE` env in the params cell, so
+this works.
+
+## Anti-patterns (immediate abort)
+
+- The bridge calls `asyncio.run(main_async())` but has no `--once` or
+  `ONCE_MODE` exit path. Adding one means re-architecting the polling
+  loop — out of scope.
+- The bridge opens a websocket/MQTT/SSE connection. The notebook
+  hosting pattern does not support long-lived connections; the deploy
+  script's scheduler expects single-cycle exits.
+- The bridge has no `def main():` entry point or uses an unusual
+  invocation pattern (e.g. only callable via `python -m`). Adapt only
+  if `python -m $PKG.$MODULE` works with `sys.argv` injection.


### PR DESCRIPTION
Adds a dedicated, fleet-dispatchable upgrade agent that retrofits existing poll-based feeders with the Fabric notebook hosting option.

## Contents
- `.github/skills/notebook-feeder-retrofit/SKILL.md` — agent playbook: eligibility gate, single-source scope, mechanical retrofit steps, validation harness, PR template, abort rules.
- `references/notebook-substitution-table.md` — exact substitution mapping from the canonical `pegelonline` template.
- `references/eligibility-discovery.ps1` — discovery script for orchestrators. Currently reports **72 candidate sources** (most `needs-once-flag`, several `ready`, a few `skip:streaming|not-a-poller|no-e2e`).
- `.github/copilot-instructions.md` — references the agent + two new prohibited bullets.

## Operating model
The agent processes **one source per invocation**. An orchestrator launches a fleet in parallel. Each agent: copies the pegelonline notebook verbatim, performs the substitution table, flips `catalog.json` to `notebook: true`, validates locally (notebook JSON, bridge tests, placeholder check, forbidden-pattern check), and opens a single PR. It does **not** deploy to Fabric — verification is a separate serial step.