### PR TITLE
fix(ci): correct YAML indentation in test-docker-e2e matrix

### DIFF
--- a/.github/workflows/test-docker-e2e.yml
+++ b/.github/workflows/test-docker-e2e.yml
@@ -62,9 +62,9 @@ jobs:
           - { dir: uba-airdata, module: uba_airdata }
           - { dir: usgs-earthquakes, module: usgs_earthquakes }
           - { dir: usgs-iv, module: usgs_iv }
-           - { dir: waterinfo-vmm, module: waterinfo_vmm }
-           - { dir: wsdot, module: wsdot }
-           - { dir: xceed, module: xceed }
+          - { dir: waterinfo-vmm, module: waterinfo_vmm }
+          - { dir: wsdot, module: wsdot }
+          - { dir: xceed, module: xceed }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -115,9 +115,9 @@ jobs:
           - { dir: uk-ea-flood-monitoring, test_class: TestUKEADockerFlow }
           - { dir: usgs-earthquakes, test_class: TestUSGSEarthquakesDockerFlow }
           - { dir: usgs-iv, test_class: TestUSGSIVDockerFlow }
-           - { dir: waterinfo-vmm, test_class: TestWaterinfoVMMDockerFlow }
-           - { dir: wsdot, test_class: TestWSDOTDockerFlow }
-           - { dir: xceed, test_class: TestXceedDockerFlow }
+          - { dir: waterinfo-vmm, test_class: TestWaterinfoVMMDockerFlow }
+          - { dir: wsdot, test_class: TestWSDOTDockerFlow }
+          - { dir: xceed, test_class: TestXceedDockerFlow }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Lines 65-67 had 11-space indentation instead of 10, causing the workflow to fail parsing with `expected <block end>, but found '<block sequence start>'`. Pre-existing issue surfaced when investigating the recent main branch failures.