### PR TITLE
fix(deploy-feeder-notebook): download notebook from raw when not in working tree

### DIFF
--- a/tools/deploy-fabric/deploy-feeder-notebook.ps1
+++ b/tools/deploy-fabric/deploy-feeder-notebook.ps1
@@ -141,7 +141,19 @@ if (-not $EnvironmentName)         { $EnvironmentName = "$Source-feeder-env" }
 $repoRoot     = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $notebookPath = Join-Path $repoRoot "$Source/notebook/$Source-feed.ipynb"
 if (-not (Test-Path $notebookPath)) {
-    throw "Notebook not found: $notebookPath`nAdd <source>/notebook/<source>-feed.ipynb to enable notebook deploy for this source."
+    # Cloud Shell / standalone usage: only the helper scripts were downloaded,
+    # not the full repo. Try to fetch the notebook from GitHub raw.
+    $rawNbUrl = "https://raw.githubusercontent.com/$Repo/$Branch/$Source/notebook/$Source-feed.ipynb"
+    $localNb  = Join-Path $TempDir "$Source-feed_$(Get-Random).ipynb"
+    Write-Host "Notebook not in working tree; downloading from $rawNbUrl" -ForegroundColor DarkYellow
+    try {
+        Invoke-WebRequest -Uri $rawNbUrl -OutFile $localNb -UseBasicParsing -ErrorAction Stop
+        $notebookPath = $localNb
+    } catch {
+        throw "Notebook not found locally and could not be downloaded from $rawNbUrl. " +
+              "Source '$Source' may not have a Fabric notebook published yet (expected " +
+              "$Source/notebook/$Source-feed.ipynb in the repo). Underlying error: $($_.Exception.Message)"
+    }
 }
 
 function Write-Step { param([string]$Step, [string]$Msg) Write-Host "`n[$Step] $Msg" -ForegroundColor Yellow }


### PR DESCRIPTION
When portal users paste the deploy command into Cloud Shell, only the three helper scripts are downloaded (deploy-feeder-notebook.ps1, deploy-fabric.ps1, strip-wheel-pathdeps.py). The script then fails with `Notebook not found: /pegelonline/notebook/pegelonline-feed.ipynb` because the rest of the repo is not on disk.

Fix: fall back to downloading the notebook from `raw.githubusercontent.com/\/\/\/notebook/\-feed.ipynb` when the local path is missing. Preserves the in-repo dev experience (local notebook used if present).