### PR TITLE
fix(deploy-fabric): use cross-platform \ for body files

### DIFF
--- a/tools/deploy-fabric/deploy-fabric.ps1
+++ b/tools/deploy-fabric/deploy-fabric.ps1
@@ -148,7 +148,7 @@ function Invoke-FabricApi {
     $azArgs = @("rest", "--method", $Method, "--url", $Url,
                 "--resource", "https://api.fabric.microsoft.com")
     if ($Body) {
-        $bodyFile = Join-Path $env:TEMP "fabric_body_$(Get-Random).json"
+        $bodyFile = Join-Path $TempDir "fabric_body_$(Get-Random).json"
         $json = if ($Body -is [string]) { $Body } else { $Body | ConvertTo-Json -Depth 20 -Compress }
         [System.IO.File]::WriteAllText($bodyFile, $json, [System.Text.UTF8Encoding]::new($false))
         $azArgs += @("--body", "@$bodyFile", "--headers", "Content-Type=application/json")
@@ -173,7 +173,7 @@ function Invoke-KqlScript {
         csl = ".execute database script <|`n$ScriptContent"
         db  = $Database
     }
-    $bodyFile = Join-Path $env:TEMP "kql_body_$(Get-Random).json"
+    $bodyFile = Join-Path $TempDir "kql_body_$(Get-Random).json"
     [System.IO.File]::WriteAllText(
         $bodyFile,
         ($body | ConvertTo-Json -Compress),


### PR DESCRIPTION
`\C:\Users\clemensv\AppData\Local\Temp` is null on Linux PowerShell (Azure Cloud Shell). When `Invoke-FabricApi` or `Invoke-KqlScript` wrote a body to `Join-Path \C:\Users\clemensv\AppData\Local\Temp ...`, PowerShell threw `Cannot bind argument to parameter 'Path' because it is null`. Swap both call sites to the already-computed `\` (which falls back to `\` and then to `[System.IO.Path]::GetTempPath()`).

Repro from portal Cloud Shell, observed at Eventhouse-create POST.