### PR TITLE
feat(bafu-hydro): Fabric notebook hosting option

### DIFF
--- a/bafu-hydro/README.md
+++ b/bafu-hydro/README.md
@@ -26,6 +26,7 @@ only new or changed readings.
   the upstream update cadence
 - **Kafka integration**: SASL PLAIN authentication for Event Hubs / Fabric Event
   Streams
+- **Fabric notebook hosting**: deploy as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) (see `notebook/bafu-hydro-feed.ipynb`).
 
 ## Data Source
 

--- a/bafu-hydro/bafu_hydro/bafu_hydro.py
+++ b/bafu-hydro/bafu_hydro/bafu_hydro.py
@@ -208,7 +208,10 @@ def main():
     parser.add_argument('--state-file', type=str,
                         default=os.environ.get('STATE_FILE', os.path.expanduser('~/.bafu_hydro_state.json')))
     subparsers = parser.add_subparsers(dest='command')
-    subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser = subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers.add_parser('list', help='List all stations')
 
     args = parser.parse_args()
@@ -253,6 +256,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if getattr(args, 'once', False):
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/bafu-hydro/notebook/bafu-hydro-feed.ipynb
+++ b/bafu-hydro/notebook/bafu-hydro-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BAFU Hydro Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Swiss Federal Office for the Environment (BAFU/FOEN) hydrology network via the community [existenz.ch](https://api.existenz.ch) API for water level, discharge, and temperature measurements across ~300 Swiss river and lake gauging stations, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `bafu_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No in-cell `%pip` magic is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `bafu-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"bafu-hydro-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/bafu-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/bafu-hydro/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing bafu_hydro package from Fabric Environment...')\n",
+    "    from bafu_hydro import bafu_hydro as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['bafu-hydro', 'feed', '--once'] if ONCE_MODE else ['bafu-hydro', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/bafu-hydro/tests/test_once_mode.py
+++ b/bafu-hydro/tests/test_once_mode.py
@@ -1,0 +1,86 @@
+"""Verify the --once flag causes main() to exit after one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import bafu_hydro.bafu_hydro as bridge
+
+
+SAMPLE_LOCATIONS = {
+    "payload": {
+        "2018": {
+            "details": {
+                "id": 2018,
+                "name": "Rhein - Basel",
+                "water-body-name": "Rhein",
+                "water-body-type": "river",
+                "lat": 47.5596,
+                "lon": 7.5886,
+            }
+        }
+    }
+}
+
+SAMPLE_LATEST = {
+    "payload": [
+        {"loc": 2018, "par": bridge.PAR_HEIGHT, "val": 2.56, "timestamp": 1700000000},
+    ]
+}
+
+
+def _fake_get(url, *args, **kwargs):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    if "locations" in url:
+        resp.json.return_value = SAMPLE_LOCATIONS
+    else:
+        resp.json.return_value = SAMPLE_LATEST
+    return resp
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "bafu-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "bafu-hydro",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+        "--once",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with patch.object(bridge, "Producer") as ProducerCls, \
+         patch.object(bridge.requests, "get", side_effect=_fake_get), \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProducerCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "bafu-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "bafu-hydro",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with patch.object(bridge, "Producer") as ProducerCls, \
+         patch.object(bridge.requests, "get", side_effect=_fake_get), \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProducerCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()

--- a/catalog.json
+++ b/catalog.json
@@ -5,7 +5,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Switzerland — ~300 stations, FOEN",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "cdec-reservoirs",


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (see .github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- Add `bafu-hydro/notebook/bafu-hydro-feed.ipynb` following the canonical `pegelonline` pattern (four-cell structure, runtime Event Stream CS lookup, worker-thread feeder run, OneLake log).
- Add `--once` flag (and `ONCE_MODE` env var) to the `feed` subcommand so scheduled Fabric runs exit after one polling cycle.
- Add `tests/test_once_mode.py` covering both `--once` and `ONCE_MODE=true`.
- Flip `catalog.json` `notebook: true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Add a one-line Fabric notebook hosting bullet to `bafu-hydro/README.md`.

## Local validation

- Notebook JSON parses (`python -c 'import json; json.load(...)'`): OK
- All 34 `bafu-hydro` unit tests pass (including 2 new once-mode tests).
- Parameters cell contains all five placeholders (EVENTSTREAM_NAME, STATE_FILE, POLLING_INTERVAL, ONCE_MODE, WORKSPACE_ID): OK
- No forbidden patterns (`asyncio.run(`, `%pip install`, hardcoded `CONNECTION_STRING=`, `primaryConnectionString=`): OK

The wheel-bundle workflow (.github/workflows/publish-notebook-wheels.yml) will pick up this source on next push to main and publish wheels to the notebook-wheels release. End-to-end Fabric deployment is intentionally out of scope for this agent.