### PR TITLE
fix(canada-aqhi): parallelize observation/forecast fetches per cycle

### DIFF
--- a/canada-aqhi/Dockerfile
+++ b/canada-aqhi/Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.title="Canada AQHI bridge to Kafka"
 LABEL org.opencontainers.image.description="Bridges Canada Air Quality Health Index observations and forecasts from Environment and Climate Change Canada to Kafka and CloudEvents."
 LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/canada-aqhi/CONTAINER.md"
 LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.version="0.1.1"
 
 WORKDIR /app
 COPY . /app

--- a/canada-aqhi/canada_aqhi/canada_aqhi.py
+++ b/canada-aqhi/canada_aqhi/canada_aqhi.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, Optional, Sequence
 
@@ -247,7 +248,7 @@ class CanadaAQHIBridge:
         response.raise_for_status()
         return response.json()
 
-    def fetch_text(self, url: str, *, timeout: int = 30) -> Optional[str]:
+    def fetch_text(self, url: str, *, timeout: int = 15) -> Optional[str]:
         try:
             response = self.session.get(url, timeout=timeout)
             if response.status_code == 404:
@@ -510,11 +511,12 @@ class CanadaAQHIBridge:
         communities: Iterable[dict[str, Any]],
     ) -> int:
         sent = 0
-        for entry in communities:
-            observation_url = entry.get("observation_url")
-            if not observation_url:
-                continue
-            xml_text = self.fetch_text(observation_url)
+        entries = [e for e in communities if e.get("observation_url")]
+        if not entries:
+            return 0
+        with ThreadPoolExecutor(max_workers=min(16, len(entries))) as pool:
+            xml_texts = list(pool.map(lambda e: self.fetch_text(e["observation_url"]), entries))
+        for entry, xml_text in zip(entries, xml_texts):
             if not xml_text:
                 continue
             parsed = self.parse_observation_xml(xml_text)
@@ -545,11 +547,12 @@ class CanadaAQHIBridge:
         communities: Iterable[dict[str, Any]],
     ) -> int:
         sent = 0
-        for entry in communities:
-            forecast_url = entry.get("forecast_url")
-            if not forecast_url:
-                continue
-            xml_text = self.fetch_text(forecast_url)
+        entries = [e for e in communities if e.get("forecast_url")]
+        if not entries:
+            return 0
+        with ThreadPoolExecutor(max_workers=min(16, len(entries))) as pool:
+            xml_texts = list(pool.map(lambda e: self.fetch_text(e["forecast_url"]), entries))
+        for entry, xml_text in zip(entries, xml_texts):
             if not xml_text:
                 continue
             parsed = self.parse_forecast_xml(xml_text)


### PR DESCRIPTION
Follow-up to the early-exit fix already merged on main. The Docker E2E `canada-aqhi` job still timed out at 300 s because `emit_observations` and `emit_forecasts` walked the (up to `MAX_COMMUNITIES`) catalog **sequentially**, each call blocking on a 30 s HTTP timeout. With `MAX_COMMUNITIES=10` that's up to 600 s of worst-case fetch latency per cycle.

### Change
- `emit_observations` / `emit_forecasts` now fetch all per-community XML payloads concurrently via a bounded `ThreadPoolExecutor` (max 16 workers), then iterate the results sequentially through the (non-thread-safe) Kafka producer. Ordering and dedup semantics are unchanged.
- `fetch_text` default timeout lowered from 30 s to 15 s so a single slow upstream blocks at most one worker for a bounded window.
- Bumped `canada-aqhi/Dockerfile` image version label so the e2e `paths:` filter actually re-runs the matrix.

### Verification
- `canada-aqhi` unit + integration tests: **25/25 pass** locally.
- Awaiting Docker E2E job on this PR to confirm the 300 s budget is met.