### PR TITLE
docs(bootstrap-real-time-source): notebook hosting is required for pollers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,11 +172,14 @@ KAFKA_ENABLE_TLS=false
 - Root `README.md` — organized by topic category; add new sources to the
   appropriate section.
 
-## Fabric Notebook Hosting (optional per source)
+## Fabric Notebook Hosting (required for poll-based sources)
 
-A source may optionally ship a Fabric notebook feeder under
-`<source>/notebook/<source>-feed.ipynb`. This is a separate deployment
-option from ACI+Fabric and uses `tools/deploy-fabric/deploy-feeder-notebook.ps1`
+Every poll-based source ships a Fabric notebook feeder under
+`<source>/notebook/<source>-feed.ipynb` and sets `notebook: true` in its
+`catalog.json` entry. Streaming bridges (WebSocket / MQTT / raw TCP /
+SSE firehose) are out of scope and skip this artifact. This is a
+separate deployment option from ACI+Fabric and uses
+`tools/deploy-fabric/deploy-feeder-notebook.ps1`
 which builds a per-source Fabric Environment with the producer + bridge
 wheels, binds Lakehouse + KQL + Environment to the notebook, looks up the
 Event Stream connection string at runtime via the public Topology API, and

--- a/.github/skills/bootstrap-real-time-source/SKILL.md
+++ b/.github/skills/bootstrap-real-time-source/SKILL.md
@@ -31,6 +31,7 @@ argument-hint: "Describe the upstream source, transport, auth model, cadence, st
 - Plan to consume `xrcg` output as generated. Do not design a source around post-generation Python edits, vendored rewrites, or import-fixup scripts as a normal integration step.
 - If the upstream review is not strong enough to support exhaustive field descriptions in the eventual schemas, the source is not ready for contract authoring.
 - A new source is not done when the manifest generates or the unit tests pass; it is done when the source's repo-level Docker E2E test is passing if the source is expected to ship as a containerized bridge.
+- **Poll-based sources must ship a Fabric notebook alongside the container.** If the bridge is a poller (HTTP/file fetch on a fixed cadence, not a long-lived stream), the source's deliverables include `<source>/notebook/<source>-feed.ipynb` and a `notebook: true` flag in `catalog.json`, so the gh-pages portal exposes the Fabric Notebook deploy button. Streaming bridges (WebSocket / MQTT / raw TCP / SSE firehose) do not qualify and must skip the notebook artifact. See [`notebook-feeder-retrofit`](../notebook-feeder-retrofit/SKILL.md) for the canonical pegelonline pattern; new sources follow the same shape from day one rather than being retrofitted later.
 
 ## Procedure
 
@@ -42,7 +43,8 @@ argument-hint: "Describe the upstream source, transport, auth model, cadence, st
 6. Split the source into event families (including reference types) and determine whether their identities can share one message group, preserving meaningful upstream schema and subtype distinctions unless you can prove they are semantically identical.
 7. Lay out the source folder using the scaffold in [bootstrap checklist](references/bootstrap-checklist.md).
 8. Use `xreg-source-contract` for contract work, `stream-bridge-implementation` for runtime work, and `container-and-delivery` for packaging and documentation.
-9. Treat the source as incomplete until its expected repo-level Docker E2E coverage is passing.
+9. **If the source is a poller, add a Fabric notebook hosting option.** Copy `pegelonline/notebook/pegelonline-feed.ipynb` verbatim, perform the substitutions in `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md`, place the result at `<source>/notebook/<source>-feed.ipynb`, and set `notebook: true` in the source's `catalog.json` entry. Ensure the bridge supports `--once` (single-cycle execution) — this is mandatory for the notebook flow because Fabric runs the notebook on a schedule, not as a daemon. Skip this step for streaming bridges.
+10. Treat the source as incomplete until its expected repo-level Docker E2E coverage is passing.
 
 ## Outputs
 
@@ -55,6 +57,11 @@ argument-hint: "Describe the upstream source, transport, auth model, cadence, st
 ## References
 
 - [Bootstrap checklist](references/bootstrap-checklist.md)
+- [`xreg-source-contract`](../xreg-source-contract/SKILL.md) — contract authoring
+- [`stream-bridge-implementation`](../stream-bridge-implementation/SKILL.md) — runtime
+- [`container-and-delivery`](../container-and-delivery/SKILL.md) — packaging
+- [`notebook-feeder-retrofit`](../notebook-feeder-retrofit/SKILL.md) — Fabric notebook pattern (also the model for new poll-based sources)
+- [`fabric-notebook-deployment`](../fabric-notebook-deployment/SKILL.md) — how the notebook gets deployed
 - JSON Structure Core: https://json-structure.github.io/core/draft-vasters-json-structure-core.html
 - JSON Structure Alternate Names and Descriptions: https://json-structure.github.io/alternate-names/draft-vasters-json-structure-alternate-names.html
 - JSON Structure Symbols, Scientific Units, and Currencies: https://json-structure.github.io/units/draft-vasters-json-structure-units.html

--- a/.github/skills/bootstrap-real-time-source/references/bootstrap-checklist.md
+++ b/.github/skills/bootstrap-real-time-source/references/bootstrap-checklist.md
@@ -20,7 +20,13 @@
 - runtime package like `<source>/<source>.py` or `bridge.py`
 - generated producer output like `<source>_producer/` or `<source>_producer_tmp/`
 - `tests/`
+- `notebook/<source>-feed.ipynb` — **required for poll-based sources**; copied from `pegelonline/notebook/pegelonline-feed.ipynb` with the substitutions from the `notebook-feeder-retrofit` skill. Skipped for streaming bridges (WebSocket / MQTT / raw TCP / SSE).
 - optional `azure-template.json`, `generate-template.ps1`, `kql/`, or `fabric/`
+
+In addition:
+
+- `catalog.json` at the repo root must list the new source. For poll-based sources, set `"notebook": true` after the `kql` field so the gh-pages portal exposes the Fabric Notebook deploy button.
+- The bridge module must support `--once` (preferred) or `ONCE_MODE=true` so the notebook can run a single polling cycle on a Fabric schedule.
 
 ## Repo Conventions
 
@@ -40,6 +46,7 @@
 - The container can be started with repo-standard Kafka configuration.
 - README, CONTAINER, and EVENTS docs match the actual behavior.
 - The Docker E2E test validates both reference and telemetry event types where applicable.
+- **For poll-based sources:** `<source>/notebook/<source>-feed.ipynb` exists, declares the five required placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`), contains no forbidden patterns (`asyncio.run(`, `%pip install`, hardcoded `CONNECTION_STRING=`), and `catalog.json` has `"notebook": true` for the source. The bridge accepts `--once` and exits after one cycle.
 
 ## Common Mistakes
 
@@ -51,3 +58,4 @@
 - **Forgetting that multiple message groups produce multiple generated producer classes.** If the contract splits the source into several message groups, plan for the runtime to import and instantiate all corresponding `*EventProducer` classes. Do not assume one generated producer wrapper owns every `send_*` method.
 - Adding a source folder without container docs or without a generator script.
 - Copying a superficially similar source when the transport pattern is wrong.
+- **Shipping a poll-based source without the notebook artifact and `catalog.json` `notebook: true` flag.** The Fabric Notebook hosting path is a first-class deployment option in this repo; new poll-based sources must expose it from day one rather than being retrofitted later. Forgetting `--once` support in the bridge is the same mistake — the notebook flow requires single-cycle execution.

--- a/canada-aqhi/canada_aqhi/canada_aqhi.py
+++ b/canada-aqhi/canada_aqhi/canada_aqhi.py
@@ -242,13 +242,14 @@ class CanadaAQHIBridge:
         return math.sqrt((lat1 - lat2) ** 2 + (lon1 - lon2) ** 2)
 
     def fetch_json(self, url: str, **kwargs: Any) -> Any:
-        response = self.session.get(url, timeout=60, **kwargs)
+        timeout = kwargs.pop("timeout", 30)
+        response = self.session.get(url, timeout=timeout, **kwargs)
         response.raise_for_status()
         return response.json()
 
-    def fetch_text(self, url: str) -> Optional[str]:
+    def fetch_text(self, url: str, *, timeout: int = 30) -> Optional[str]:
         try:
-            response = self.session.get(url, timeout=60)
+            response = self.session.get(url, timeout=timeout)
             if response.status_code == 404:
                 return None
             response.raise_for_status()
@@ -338,14 +339,46 @@ class CanadaAQHIBridge:
             entry["forecast_url"] = canonicalize_feed_url(properties.get("path_to_current_forecast"))
         return merged
 
-    def load_reference_catalogs(self, selected_provinces: set[str]) -> dict[str, dict[str, Any]]:
-        """Load and enrich AQHI community metadata."""
+    def load_reference_catalogs(
+        self,
+        selected_provinces: set[str],
+        *,
+        max_communities: int = 0,
+    ) -> dict[str, dict[str, Any]]:
+        """Load and enrich AQHI community metadata.
+
+        ``max_communities`` (when > 0) lets the caller cap the result so the
+        method can early-exit once enough entries are filtered, avoiding the
+        expensive per-community geolocator round-trips for the rest of the
+        catalog. Items whose URLs already pin a single selected province are
+        preferred so the cap can be reached without any geolocator call.
+        """
         community_geojson = self.fetch_json(COMMUNITY_GEOJSON_URL)
         station_geojson = self.fetch_json(STATION_GEOJSON_URL)
         communities = self.merge_community_catalogs(community_geojson, station_geojson)
         filtered: dict[str, dict[str, Any]] = {}
 
-        for cgndb_code, entry in communities.items():
+        def _priority(item: tuple[str, dict[str, Any]]) -> tuple[int, str]:
+            cgndb_code, entry = item
+            if cgndb_code in self.province_cache:
+                if self.province_cache[cgndb_code] in selected_provinces:
+                    return (0, cgndb_code)
+                return (3, cgndb_code)
+            candidates = (
+                province_candidates_for_feed(entry.get("observation_url"))
+                or province_candidates_for_feed(entry.get("forecast_url"))
+            )
+            if len(candidates) == 1 and next(iter(candidates)) in selected_provinces:
+                return (0, cgndb_code)
+            if candidates and candidates.isdisjoint(selected_provinces):
+                return (4, cgndb_code)
+            if candidates and not candidates.isdisjoint(selected_provinces):
+                return (1, cgndb_code)
+            return (2, cgndb_code)
+
+        ordered_items = sorted(communities.items(), key=_priority)
+
+        for cgndb_code, entry in ordered_items:
             province = self.province_cache.get(cgndb_code)
             candidate_provinces = (
                 province_candidates_for_feed(entry.get("observation_url"))
@@ -366,6 +399,8 @@ class CanadaAQHIBridge:
                 continue
             entry["province"] = province
             filtered[cgndb_code] = entry
+            if max_communities > 0 and len(filtered) >= max_communities:
+                break
 
         self.communities = filtered
         return filtered
@@ -580,7 +615,9 @@ class CanadaAQHIBridge:
         reference_count = 0
         if needs_reference_refresh:
             try:
-                communities = self.load_reference_catalogs(selected_provinces)
+                communities = self.load_reference_catalogs(
+                    selected_provinces, max_communities=max_communities
+                )
                 communities = self.limit_communities(communities, max_communities=max_communities)
                 self.communities = communities
                 reference_count = self.emit_reference_data(producer, communities)

--- a/canada-aqhi/tests/test_canada_aqhi_unit.py
+++ b/canada-aqhi/tests/test_canada_aqhi_unit.py
@@ -291,6 +291,55 @@ class TestCatalogMerging:
         assert filtered["FAFFD"]["province"] == "ON"
         assert geolocation_calls == []
 
+    def test_load_reference_catalogs_honors_max_communities_early_exit(self, monkeypatch):
+        # Build 30 ON-feed stations; assert load_reference_catalogs stops at the cap
+        # so we don't iterate (and potentially geolocate) the entire catalog.
+        community_features = []
+        station_features = []
+        for i in range(30):
+            cgndb = f"ON{i:03d}"
+            community_features.append({
+                "properties": {
+                    "Latitude": "44.0",
+                    "Longitude": "-79.0",
+                    "cgndb_key": cgndb,
+                    "region_name_en": f"Town{i}",
+                }
+            })
+            station_features.append({
+                "properties": {
+                    "cgndb": cgndb,
+                    "name": {"en": f"Town{i}", "fr": f"Town{i}"},
+                    "path_to_current_observation": f"http://dd.weather.gc.ca/air_quality/aqhi/ont/observation/realtime/xml/AQ_OBS_{cgndb}_CURRENT.xml",
+                    "path_to_current_forecast": f"http://dd.weather.gc.ca/air_quality/aqhi/ont/forecast/realtime/xml/AQ_FCST_{cgndb}_CURRENT.xml",
+                }
+            })
+        communities = {"features": community_features}
+        stations = {"features": station_features}
+
+        bridge = CanadaAQHIBridge()
+
+        def fake_fetch_json(url, **kwargs):
+            if url == COMMUNITY_GEOJSON_URL:
+                return communities
+            if url == STATION_GEOJSON_URL:
+                return stations
+            raise AssertionError(f"unexpected url {url}")
+
+        geolocation_calls: list[str] = []
+
+        def fake_resolve_province_code(cgndb_code, latitude, longitude):
+            geolocation_calls.append(cgndb_code)
+            return "ON"
+
+        monkeypatch.setattr(bridge, "fetch_json", fake_fetch_json)
+        monkeypatch.setattr(bridge, "resolve_province_code", fake_resolve_province_code)
+
+        filtered = bridge.load_reference_catalogs({"ON"}, max_communities=10)
+
+        assert len(filtered) == 10
+        assert geolocation_calls == []  # URL-pinned to a single selected province → no geolocator calls
+
     def test_poll_once_uses_cached_communities_when_refresh_fails(self):
         bridge = CanadaAQHIBridge()
         bridge.communities = {


### PR DESCRIPTION
Makes Fabric notebook hosting a first-class deliverable in the new-source bootstrap skill instead of an optional later retrofit. Streaming sources are explicitly out of scope. Updates skill, checklist, and root copilot-instructions.