### PR TITLE
feat(seattle-street-closures): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -613,7 +613,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "Seattle, WA — permit-driven street closure windows",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "cbp-border-wait",

--- a/seattle-street-closures/README.md
+++ b/seattle-street-closures/README.md
@@ -63,3 +63,7 @@ configured.
 - Dataset page: https://data.seattle.gov/Built-Environment/Street-Closures/ium9-iqtc
 - SODA endpoint: https://data.seattle.gov/resource/ium9-iqtc.json
 - API docs: https://dev.socrata.com/foundry/data.seattle.gov/ium9-iqtc
+
+## Fabric notebook hosting
+
+This bridge can also run as a scheduled Microsoft Fabric notebook (`notebook/seattle-street-closures-feed.ipynb`); deploy it via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).

--- a/seattle-street-closures/kql/create-kql-script.ps1
+++ b/seattle-street-closures/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\seattle_street_closures.xreg.json"
 $kqlFile = Join-Path $scriptDir "seattle_street_closures.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.wa.seattle.streetclosures"

--- a/seattle-street-closures/kql/seattle_street_closures.kql
+++ b/seattle-street-closures/kql/seattle_street_closures.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [StreetClosure] (
+.create-merge table ['us.wa.seattle.streetclosures.StreetClosure'] (
    [closure_id]: string,
    [permit_number]: string,
    [permit_type]: string,
@@ -52,9 +52,9 @@
    [___subject]: string
 );
 
-.alter table [StreetClosure] docstring "{\"description\": \"Street closure row from the Seattle Department of Transportation street closures dataset, describing one closed street segment and its active occurrence window.\"}";
+.alter table ['us.wa.seattle.streetclosures.StreetClosure'] docstring "{\"description\": \"Street closure row from the Seattle Department of Transportation street closures dataset, describing one closed street segment and its active occurrence window.\"}";
 
-.alter table [StreetClosure] column-docstrings (
+.alter table ['us.wa.seattle.streetclosures.StreetClosure'] column-docstrings (
    [closure_id]: "{\"description\": \"Derived stable identity for the closure row, composed from permit number, street segment key, start date, and end date.\"}",
    [permit_number]: "{\"description\": \"Identifier for the permit record granting authorization to close the street.\"}",
    [permit_type]: "{\"description\": \"Type of permit, such as Block Party, Play Street, Farmers Market, or Temporary Activation.\"}",
@@ -81,7 +81,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [StreetClosure] ingestion json mapping "StreetClosure_json_flat"
+.create-or-alter table ['us.wa.seattle.streetclosures.StreetClosure'] ingestion json mapping "us.wa.seattle.streetclosures.StreetClosure_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -111,7 +111,7 @@
 ]
 ```
 
-.create-or-alter table [StreetClosure] ingestion json mapping "StreetClosure_json_ce_structured"
+.create-or-alter table ['us.wa.seattle.streetclosures.StreetClosure'] ingestion json mapping "us.wa.seattle.streetclosures.StreetClosure_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -141,13 +141,13 @@
 ]
 ```
 
-.drop materialized-view StreetClosureLatest ifexists;
+.drop materialized-view ['us.wa.seattle.streetclosures.StreetClosureLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StreetClosureLatest on table StreetClosure {
-    StreetClosure | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.seattle.streetclosures.StreetClosureLatest'] on table ['us.wa.seattle.streetclosures.StreetClosure'] {
+    ['us.wa.seattle.streetclosures.StreetClosure'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [StreetClosure] policy update
+.alter table ['us.wa.seattle.streetclosures.StreetClosure'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/seattle-street-closures/notebook/seattle-street-closures-feed.ipynb
+++ b/seattle-street-closures/notebook/seattle-street-closures-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Seattle Street Closures Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the City of Seattle Open Data street closures dataset (Socrata `ium9-iqtc`) and emits one CloudEvent per permitted closed street segment occurrence window to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `seattle_street_closures` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `seattle-street-closures --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new or changed closure rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"seattle-street-closures-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/seattle-street-closures/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/seattle-street-closures/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing seattle_street_closures package from Fabric Environment...')\n",
+    "    from seattle_street_closures import seattle_street_closures as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['seattle-street-closures', '--once'] if ONCE_MODE else ['seattle-street-closures']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- `seattle-street-closures/notebook/seattle-street-closures-feed.ipynb` — copied from pegelonline template; bridge invoked via `sys.argv = ['seattle-street-closures', '--once']` (no subcommand). Lakehouse state + log paths point at `feeder-state/seattle-street-closures/`.
- `catalog.json` — `notebook: true` added so the gh-pages portal exposes the Fabric Notebook deploy button.
- `seattle-street-closures/kql/create-kql-script.ps1` — passes `-Qualified -Namespace us.wa.seattle.streetclosures` (the xreg schema does not declare a namespace, so an explicit override is required). DWD reference: PR #257 / branch `feat/dwd-qualified-tables`.
- `seattle-street-closures/kql/seattle_street_closures.kql` — regenerated; landing table, JSON mappings, materialized view, and update policy are now `['us.wa.seattle.streetclosures.StreetClosure']` / `['us.wa.seattle.streetclosures.StreetClosureLatest']`. The update-policy `type ==` predicate still matches the upstream CloudEvents type `US.WA.Seattle.StreetClosures.StreetClosure`. `_cloudevents_dispatch` unchanged.
- `seattle-street-closures/README.md` — one-line `Fabric notebook hosting` bullet linking to the deploy script.

## Validation
- Notebook JSON loads cleanly (`json.load`).
- All five required placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present in the parameters cell.
- No forbidden patterns (`asyncio.run(`, `CONNECTION_STRING = "`, `primaryConnectionString =`). The skill's `%pip install` regex matches a markdown sentence that *negates* its presence (`No %pip install is required`) — identical to the pegelonline template.
- Bridge module `seattle_street_closures.py` is unchanged and `py_compile`-clean. Bridge unit tests cannot be run in this worktree because the generated producer sub-packages are not pip-installed (skill forbids `pip install` in retrofit agents); no bridge code path is touched by this PR.
- Regenerated KQL passes the qualified-tables regex check (`create-merge table \['[a-z]`).

## Notes
- This PR depends on the `-Qualified` / `-Namespace` switches on `tools/generate-kql-from-xreg.ps1` landing via PR #257. Regeneration here was done with the generator from branch `feat/dwd-qualified-tables` (commit b6b5b9a); the tool file itself is not modified in this PR. Once #257 merges, `pwsh seattle-street-closures/kql/create-kql-script.ps1` produces identical output.
- The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the notebook-wheels release.