### PR TITLE
feat(king-county-marine): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -91,7 +91,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Washington State / Puget Sound — buoy and mooring telemetry",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "nve-hydro",

--- a/king-county-marine/README.md
+++ b/king-county-marine/README.md
@@ -53,6 +53,13 @@ configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fking-county-marine%2Fazure-template-with-eventhub.json)
 
+## Fabric notebook hosting
+
+You can also host this feeder as a scheduled Microsoft Fabric notebook (no
+container required) using
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+The notebook lives at [`notebook/king-county-marine-feed.ipynb`](notebook/king-county-marine-feed.ipynb).
+
 ## Upstream Links
 
 - King County buoy search surface: https://data.kingcounty.gov/

--- a/king-county-marine/kql/create-kql-script.ps1
+++ b/king-county-marine/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\king_county_marine.xreg.json"
 $kqlFile = Join-Path $scriptDir "king_county_marine.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.wa.kingcounty.marine"

--- a/king-county-marine/kql/king_county_marine.kql
+++ b/king-county-marine/kql/king_county_marine.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['us.wa.kingcounty.marine.Station'] (
    [station_id]: string,
    [station_name]: string,
    [dataset_id]: string,
@@ -41,9 +41,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for one active King County buoy or mooring raw-data dataset.\"}";
+.alter table ['us.wa.kingcounty.marine.Station'] docstring "{\"description\": \"Reference metadata for one active King County buoy or mooring raw-data dataset.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['us.wa.kingcounty.marine.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Stable bridge identifier for the buoy or mooring dataset.\"}",
    [station_name]: "{\"description\": \"Human-readable station name derived from the dataset title.\"}",
    [dataset_id]: "{\"description\": \"Socrata dataset identifier for the source dataset.\"}",
@@ -59,7 +59,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['us.wa.kingcounty.marine.Station'] ingestion json mapping "us.wa.kingcounty.marine.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -78,7 +78,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['us.wa.kingcounty.marine.Station'] ingestion json mapping "us.wa.kingcounty.marine.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -97,13 +97,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['us.wa.kingcounty.marine.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.kingcounty.marine.StationLatest'] on table ['us.wa.kingcounty.marine.Station'] {
+    ['us.wa.kingcounty.marine.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['us.wa.kingcounty.marine.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -114,7 +114,7 @@
 }]
 ```
 
-.create-merge table [WaterQualityReading] (
+.create-merge table ['us.wa.kingcounty.marine.WaterQualityReading'] (
    [station_id]: string,
    [station_name]: string,
    [observation_time]: string,
@@ -147,9 +147,9 @@
    [___subject]: string
 );
 
-.alter table [WaterQualityReading] docstring "{\"description\": \"Normalized King County buoy or mooring reading carrying the documented water-quality and weather measurements published by the current raw-data datasets.\"}";
+.alter table ['us.wa.kingcounty.marine.WaterQualityReading'] docstring "{\"description\": \"Normalized King County buoy or mooring reading carrying the documented water-quality and weather measurements published by the current raw-data datasets.\"}";
 
-.alter table [WaterQualityReading] column-docstrings (
+.alter table ['us.wa.kingcounty.marine.WaterQualityReading'] column-docstrings (
    [station_id]: "{\"description\": \"Stable bridge identifier for the buoy or mooring dataset.\"}",
    [station_name]: "{\"description\": \"Human-readable station name derived from the dataset title.\"}",
    [observation_time]: "{\"description\": \"Observation timestamp normalized to UTC ISO 8601 form.\"}",
@@ -182,7 +182,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WaterQualityReading] ingestion json mapping "WaterQualityReading_json_flat"
+.create-or-alter table ['us.wa.kingcounty.marine.WaterQualityReading'] ingestion json mapping "us.wa.kingcounty.marine.WaterQualityReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -218,7 +218,7 @@
 ]
 ```
 
-.create-or-alter table [WaterQualityReading] ingestion json mapping "WaterQualityReading_json_ce_structured"
+.create-or-alter table ['us.wa.kingcounty.marine.WaterQualityReading'] ingestion json mapping "us.wa.kingcounty.marine.WaterQualityReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -254,13 +254,13 @@
 ]
 ```
 
-.drop materialized-view WaterQualityReadingLatest ifexists;
+.drop materialized-view ['us.wa.kingcounty.marine.WaterQualityReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterQualityReadingLatest on table WaterQualityReading {
-    WaterQualityReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.kingcounty.marine.WaterQualityReadingLatest'] on table ['us.wa.kingcounty.marine.WaterQualityReading'] {
+    ['us.wa.kingcounty.marine.WaterQualityReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterQualityReading] policy update
+.alter table ['us.wa.kingcounty.marine.WaterQualityReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/king-county-marine/notebook/king-county-marine-feed.ipynb
+++ b/king-county-marine/notebook/king-county-marine-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# King County Marine Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the King County (Washington) Socrata marine buoy and mooring raw-data datasets and emits station reference events and normalized water-quality readings as CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `king_county_marine` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No inline pip install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `king-county-marine --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"king-county-marine-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/king-county-marine/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/king-county-marine/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing king_county_marine package from Fabric Environment...')\n",
+    "    from king_county_marine import king_county_marine as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['king-county-marine', '--once'] if ONCE_MODE else ['king-county-marine']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes
- Adds `king-county-marine/notebook/king-county-marine-feed.ipynb` following the canonical `pegelonline` template (4 cells: markdown intro, parameters, CS lookup, run). Bridge is invoked via `sys.argv = ['king-county-marine', '--once']` (no subcommand; matches the bridge's argparse setup).
- Flips `catalog.json` entry for `king-county-marine` to add `"notebook": true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds a one-sentence "Fabric notebook hosting" pointer to `king-county-marine/README.md`.
- Flips `king-county-marine/kql/create-kql-script.ps1` to pass `-Qualified -Namespace us.wa.kingcounty.marine` and regenerates `king-county-marine/kql/king_county_marine.kql`. The xreg schemas don't declare a namespace, so an explicit `-Namespace` override is required for qualified table names (see `docs/plan-qualified-table-names.md`, DWD reference PR #257). Tables, materialized views, ingestion mappings, and update policies now use `['us.wa.kingcounty.marine.Station']` / `['us.wa.kingcounty.marine.WaterQualityReading']`. The update-policy `type ==` predicate values are unchanged (still upstream CloudEvents type strings `'US.WA.KingCounty.Marine.Station'` / `'US.WA.KingCounty.Marine.WaterQualityReading'`).

## Validations performed
- Notebook JSON well-formed (`json.load` round-trip).
- Parameters cell contains all 5 placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns (`asyncio.run(`, `%pip install`, hard-coded `CONNECTION_STRING=`, `primaryConnectionString=`).
- Qualified-tables regex passes (`create-merge table ['[a-z]`).
- Consumer-asset audit (`fabric/`, `dashboard/`, `notebook/`, `README.md`): the new notebook does not reference KQL tables; README mentions of `Station` / `WaterQualityReading` are event-schema names in prose, not table references.

## Notes
- The `--once` flag already existed on the bridge; no bridge code changes required.
- Bridge unit tests were not re-run in this agent because the shared venv does not have the local `king_county_marine_producer_data` / `king_county_marine_producer_kafka_producer` packages installed, and the skill forbids `pip install` from the retrofit agent. No bridge source was modified.
- This PR depends on the `-Qualified` / `-Namespace` parameters added to `tools/generate-kql-from-xreg.ps1` by DWD PR #257. Once that merges, regeneration here will work against `main`.
- No live Fabric deployment performed (per skill).