### PR TITLE
feat(epa-uv): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -389,7 +389,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "United States — city-scoped hourly and daily UV forecasts",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "sensor-community",

--- a/epa-uv/README.md
+++ b/epa-uv/README.md
@@ -64,6 +64,10 @@ configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fepa-uv%2Fazure-template-with-eventhub.json)
 
+## Fabric notebook hosting
+
+- This bridge can also be hosted as a scheduled Microsoft Fabric notebook. See `tools/deploy-fabric/deploy-feeder-notebook.ps1` and `epa-uv/notebook/epa-uv-feed.ipynb`.
+
 ## Upstream Links
 
 - Docs: https://www.epa.gov/enviro/web-services

--- a/epa-uv/kql/create-kql-script.ps1
+++ b/epa-uv/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\epa_uv.xreg.json"
 $kqlFile = Join-Path $scriptDir "epa_uv.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.epa.uvindex"

--- a/epa-uv/kql/epa_uv.kql
+++ b/epa-uv/kql/epa_uv.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [HourlyForecast] (
+.create-merge table ['us.epa.uvindex.HourlyForecast'] (
    [location_id]: string,
    [city]: string,
    [state]: string,
@@ -38,9 +38,9 @@
    [___subject]: string
 );
 
-.alter table [HourlyForecast] docstring "{\"description\": \"Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.\"}";
+.alter table ['us.epa.uvindex.HourlyForecast'] docstring "{\"description\": \"Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.\"}";
 
-.alter table [HourlyForecast] column-docstrings (
+.alter table ['us.epa.uvindex.HourlyForecast'] column-docstrings (
    [location_id]: "{\"description\": \"Stable slug derived from the configured city and state.\"}",
    [city]: "{\"description\": \"City for which the hourly UV forecast was requested.\"}",
    [state]: "{\"description\": \"Two-letter state abbreviation for the requested city.\"}",
@@ -53,7 +53,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [HourlyForecast] ingestion json mapping "HourlyForecast_json_flat"
+.create-or-alter table ['us.epa.uvindex.HourlyForecast'] ingestion json mapping "us.epa.uvindex.HourlyForecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -69,7 +69,7 @@
 ]
 ```
 
-.create-or-alter table [HourlyForecast] ingestion json mapping "HourlyForecast_json_ce_structured"
+.create-or-alter table ['us.epa.uvindex.HourlyForecast'] ingestion json mapping "us.epa.uvindex.HourlyForecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -85,13 +85,13 @@
 ]
 ```
 
-.drop materialized-view HourlyForecastLatest ifexists;
+.drop materialized-view ['us.epa.uvindex.HourlyForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) HourlyForecastLatest on table HourlyForecast {
-    HourlyForecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.epa.uvindex.HourlyForecastLatest'] on table ['us.epa.uvindex.HourlyForecast'] {
+    ['us.epa.uvindex.HourlyForecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [HourlyForecast] policy update
+.alter table ['us.epa.uvindex.HourlyForecast'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -102,7 +102,7 @@
 }]
 ```
 
-.create-merge table [DailyForecast] (
+.create-merge table ['us.epa.uvindex.DailyForecast'] (
    [location_id]: string,
    [city]: string,
    [state]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [DailyForecast] docstring "{\"description\": \"Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.\"}";
+.alter table ['us.epa.uvindex.DailyForecast'] docstring "{\"description\": \"Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.\"}";
 
-.alter table [DailyForecast] column-docstrings (
+.alter table ['us.epa.uvindex.DailyForecast'] column-docstrings (
    [location_id]: "{\"description\": \"Stable slug derived from the configured city and state.\"}",
    [city]: "{\"description\": \"City for which the daily UV forecast was requested.\"}",
    [state]: "{\"description\": \"Two-letter state abbreviation for the requested city.\"}",
@@ -132,7 +132,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [DailyForecast] ingestion json mapping "DailyForecast_json_flat"
+.create-or-alter table ['us.epa.uvindex.DailyForecast'] ingestion json mapping "us.epa.uvindex.DailyForecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -149,7 +149,7 @@
 ]
 ```
 
-.create-or-alter table [DailyForecast] ingestion json mapping "DailyForecast_json_ce_structured"
+.create-or-alter table ['us.epa.uvindex.DailyForecast'] ingestion json mapping "us.epa.uvindex.DailyForecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -166,13 +166,13 @@
 ]
 ```
 
-.drop materialized-view DailyForecastLatest ifexists;
+.drop materialized-view ['us.epa.uvindex.DailyForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DailyForecastLatest on table DailyForecast {
-    DailyForecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.epa.uvindex.DailyForecastLatest'] on table ['us.epa.uvindex.DailyForecast'] {
+    ['us.epa.uvindex.DailyForecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DailyForecast] policy update
+.alter table ['us.epa.uvindex.DailyForecast'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/epa-uv/notebook/epa-uv-feed.ipynb
+++ b/epa-uv/notebook/epa-uv-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EPA UV Index Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the US EPA Envirofacts UV Index web service for the configured `CITY,STATE` locations and emits hourly and daily UV forecast CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `epa_uv` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `epa-uv --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new forecasts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"epa-uv-ingest\"          # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/epa-uv/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/epa-uv/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing epa_uv package from Fabric Environment...')\n",
+    "    from epa_uv import epa_uv as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['epa-uv', '--once'] if ONCE_MODE else ['epa-uv']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent.

## What this PR does

- **Notebook hosting**: Adds `epa-uv/notebook/epa-uv-feed.ipynb` following the canonical `pegelonline` template (no-subcommand variant: bridge invokes `epa-uv --once`). Flips `catalog.json` so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Qualified KQL tables**: Flips `epa-uv/kql/create-kql-script.ps1` to pass `-Qualified -Namespace `us.epa.uvindex`` and regenerates `epa-uv/kql/epa_uv.kql`. Tables are now `['us.epa.uvindex.HourlyForecast']` and `['us.epa.uvindex.DailyForecast']` (the EPA UV xreg schemas do not declare a namespace, so the override is required). `_cloudevents_dispatch` and the `type ==` predicates in update policies are unchanged.
- **Generator switch (cherry-pick)**: Includes `tools/generate-kql-from-xreg.ps1` `-Qualified`/`-Namespace` switch cherry-picked from b6b5b9a (DWD reference PR #257), so the regeneration is reproducible on this branch ahead of #257 merging. If #257 lands first this diff will rebase to zero.

## Local validation

- Notebook JSON well-formed (`json.load` ok).
- Parameters cell contains all required placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- Regenerated KQL has qualified table names matching `\['[a-z]` pattern; `_cloudevents_dispatch` table is preserved.
- Consumer-asset audit: no hand-authored fabric/dashboard/notebook references to the old unqualified table names (no `epa-uv/fabric/` or `epa-uv/dashboard/` directories exist; Python `HourlyForecast`/`DailyForecast` identifiers are dataclass names, not table refs).
- Bridge unit tests could not run in this worktree because the generated `epa_uv_producer_data` package is not pip-installed in the shared venv (orchestrator rule forbids `pip install`). Pre-existing environment limitation, not caused by this PR — no bridge code is modified.

## Out of scope

End-to-end Fabric deployment is performed manually post-merge per the skill (no live deploy from the agent).