### PR TITLE
feat(ireland-opw-waterlevel): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -54,7 +54,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Ireland — ~500 OPW hydrometric stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "nepal-bipad-hydrology",

--- a/ireland-opw-waterlevel/README.md
+++ b/ireland-opw-waterlevel/README.md
@@ -58,3 +58,10 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fireland-opw-waterlevel%2Fazure-template-with-eventhub.json)
+
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Microsoft Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which deploys [`notebook/ireland-opw-waterlevel-feed.ipynb`](notebook/ireland-opw-waterlevel-feed.ipynb)
+into a Fabric workspace alongside an Eventhouse and Event Stream.

--- a/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
+++ b/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
@@ -201,7 +201,7 @@ def emit_readings(
 
 
 def feed(kafka_config: dict, kafka_topic: str, polling_interval: int,
-         state_file: str = '') -> None:
+         state_file: str = '', once: bool = False) -> None:
     """Main polling loop: emit stations then poll readings."""
     seen_keys: Set[str] = set(_load_state(state_file).get("seen_keys", []))
     session = requests.Session()
@@ -251,6 +251,9 @@ def feed(kafka_config: dict, kafka_topic: str, polling_interval: int,
 
             logging.info("Emitted %d readings in %.1fs. Waiting %.0fs.",
                          count, elapsed, effective_interval)
+            if once:
+                logging.info("--once mode: exiting after first polling cycle")
+                break
             if effective_interval > 0:
                 time.sleep(effective_interval)
         except KeyboardInterrupt:
@@ -296,6 +299,9 @@ def main() -> None:
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE',
                                                os.path.expanduser('~/.ireland_opw_waterlevel_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -339,7 +345,7 @@ def main() -> None:
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
 
-        feed(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        feed(kafka_config, kafka_topic, args.polling_interval, args.state_file, args.once)
     else:
         parser.print_help()
 

--- a/ireland-opw-waterlevel/kql/create-kql-script.ps1
+++ b/ireland-opw-waterlevel/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\ireland_opw_waterlevel.xreg.json"
 $kqlFile = Join-Path $scriptDir "ireland_opw_waterlevel.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/ireland-opw-waterlevel/kql/ireland_opw_waterlevel.kql
+++ b/ireland-opw-waterlevel/kql/ireland_opw_waterlevel.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['ie.gov.opw.waterlevel.Station'] (
    [station_ref]: string,
    [station_name]: string,
    [region_id]: int,
@@ -38,9 +38,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for an OPW hydrometric station in Ireland, including location and region.\"}";
+.alter table ['ie.gov.opw.waterlevel.Station'] docstring "{\"description\": \"Reference data for an OPW hydrometric station in Ireland, including location and region.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['ie.gov.opw.waterlevel.Station'] column-docstrings (
    [station_ref]: "{\"description\": \"Zero-padded 10-digit station reference code uniquely identifying the hydrometric station (e.g. '0000001041').\"}",
    [station_name]: "{\"description\": \"Human-readable name of the hydrometric station (e.g. 'Sandy Mills').\"}",
    [region_id]: "{\"description\": \"Integer identifier of the OPW hydrometric region the station belongs to.\"}",
@@ -53,7 +53,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['ie.gov.opw.waterlevel.Station'] ingestion json mapping "ie.gov.opw.waterlevel.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -69,7 +69,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['ie.gov.opw.waterlevel.Station'] ingestion json mapping "ie.gov.opw.waterlevel.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -85,13 +85,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['ie.gov.opw.waterlevel.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ie.gov.opw.waterlevel.StationLatest'] on table ['ie.gov.opw.waterlevel.Station'] {
+    ['ie.gov.opw.waterlevel.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['ie.gov.opw.waterlevel.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -102,7 +102,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelReading] (
+.create-merge table ['ie.gov.opw.waterlevel.WaterLevelReading'] (
    [station_ref]: string,
    [station_name]: string,
    [sensor_ref]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelReading] docstring "{\"description\": \"A sensor reading from an OPW hydrometric station, covering water level, temperature, voltage, or Ordnance Datum.\"}";
+.alter table ['ie.gov.opw.waterlevel.WaterLevelReading'] docstring "{\"description\": \"A sensor reading from an OPW hydrometric station, covering water level, temperature, voltage, or Ordnance Datum.\"}";
 
-.alter table [WaterLevelReading] column-docstrings (
+.alter table ['ie.gov.opw.waterlevel.WaterLevelReading'] column-docstrings (
    [station_ref]: "{\"description\": \"Zero-padded 10-digit station reference code uniquely identifying the hydrometric station (e.g. '0000001041').\"}",
    [station_name]: "{\"description\": \"Human-readable name of the hydrometric station (e.g. 'Sandy Mills').\"}",
    [sensor_ref]: "{\"description\": \"Sensor reference code identifying the measurement type: '0001' for water level (metres), '0002' for temperature (degrees Celsius), '0003' for voltage (volts), 'OD' for Ordnance Datum level (metres).\"}",
@@ -132,7 +132,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_flat"
+.create-or-alter table ['ie.gov.opw.waterlevel.WaterLevelReading'] ingestion json mapping "ie.gov.opw.waterlevel.WaterLevelReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -149,7 +149,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_ce_structured"
+.create-or-alter table ['ie.gov.opw.waterlevel.WaterLevelReading'] ingestion json mapping "ie.gov.opw.waterlevel.WaterLevelReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -166,13 +166,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelReadingLatest ifexists;
+.drop materialized-view ['ie.gov.opw.waterlevel.WaterLevelReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelReadingLatest on table WaterLevelReading {
-    WaterLevelReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ie.gov.opw.waterlevel.WaterLevelReadingLatest'] on table ['ie.gov.opw.waterlevel.WaterLevelReading'] {
+    ['ie.gov.opw.waterlevel.WaterLevelReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelReading] policy update
+.alter table ['ie.gov.opw.waterlevel.WaterLevelReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/ireland-opw-waterlevel/notebook/ireland-opw-waterlevel-feed.ipynb
+++ b/ireland-opw-waterlevel/notebook/ireland-opw-waterlevel-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ireland OPW Water Level Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Ireland OPW waterlevel.ie GeoJSON API for water level, temperature, and voltage measurements from ~500 hydrometric stations and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `ireland_opw_waterlevel` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `ireland-opw-waterlevel feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"ireland-opw-waterlevel-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/ireland-opw-waterlevel/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/ireland-opw-waterlevel/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing ireland_opw_waterlevel package from Fabric Environment...')\n",
+    "    from ireland_opw_waterlevel import ireland_opw_waterlevel as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['ireland-opw-waterlevel', 'feed', '--once'] if ONCE_MODE else ['ireland-opw-waterlevel', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/ireland-opw-waterlevel/tests/test_once_mode.py
+++ b/ireland-opw-waterlevel/tests/test_once_mode.py
@@ -1,0 +1,45 @@
+"""Unit test for --once mode: feed() exits after a single polling cycle."""
+
+from unittest.mock import MagicMock, patch
+
+from ireland_opw_waterlevel import ireland_opw_waterlevel as bridge
+
+
+SAMPLE_FEATURES = [
+    {
+        "type": "Feature",
+        "properties": {
+            "station_ref": "0000001041",
+            "station_name": "Sandy Mills",
+            "sensor_ref": "0001",
+            "region_id": 3,
+            "datetime": "2024-01-15T12:00:00Z",
+            "value": "0.368",
+            "err_code": 99,
+        },
+        "geometry": {"type": "Point", "coordinates": [-7.5, 54.8]},
+    }
+]
+
+
+def test_feed_once_exits_after_one_cycle():
+    """feed(..., once=True) must return after one polling cycle, not loop."""
+    with patch.object(bridge, "fetch_geojson", return_value=SAMPLE_FEATURES) as mock_fetch, \
+         patch.object(bridge, "Producer") as mock_producer_cls, \
+         patch.object(bridge, "IeGovOpwWaterlevelEventProducer") as mock_pc_cls, \
+         patch.object(bridge.time, "sleep") as mock_sleep:
+        mock_producer_cls.return_value = MagicMock()
+        mock_pc_cls.return_value = MagicMock()
+
+        bridge.feed(
+            kafka_config={"bootstrap.servers": "localhost:9092"},
+            kafka_topic="test-topic",
+            polling_interval=0,
+            state_file="",
+            once=True,
+        )
+
+        # One fetch for initial reference data + one fetch in the loop
+        assert mock_fetch.call_count == 2
+        # Must not sleep when --once is set
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes

- **Notebook**: `ireland-opw-waterlevel/notebook/ireland-opw-waterlevel-feed.ipynb` (copied from canonical `pegelonline` template with mechanical substitutions per `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md`).
- **Catalog**: `catalog.json` entry gets `notebook: true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Bridge `--once` flag**: added to `ireland_opw_waterlevel.py` (mirrors `pegelonline`); also honors `ONCE_MODE` env var. Plus `tests/test_once_mode.py` asserting one-cycle exit.
- **Qualified KQL tables**: `kql/create-kql-script.ps1` now passes `-Qualified`; `kql/ireland_opw_waterlevel.kql` regenerated with namespace-prefixed tables (`['ie.gov.opw.waterlevel.Station']`, `['ie.gov.opw.waterlevel.WaterLevelReading']`). No hand-authored consumer assets reference unqualified names. See `docs/plan-qualified-table-names.md`, DWD reference PR #257.
- **README**: one-sentence Fabric notebook hosting bullet added.

## Validation (local)

- ✅ Notebook JSON well-formed.
- ✅ All 5 parameter placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present in params cell.
- ✅ No forbidden runtime patterns (`asyncio.run(`, runtime `%pip install`, hardcoded `CONNECTION_STRING=`, baked `primaryConnectionString`).
- ✅ Bridge tests pass: 61/61 including new `test_once_mode.py`.
- ✅ KQL has `create-merge table ['<namespace>.<Table>']` form.

The `publish-notebook-wheels.yml` workflow will pick up this source on merge and publish wheels to the `notebook-wheels` release. End-to-end Fabric deployment is a separate manual verification step.