### PR TITLE
feat(imgw-hydro): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -49,7 +49,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Poland — IMGW-PIB",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "ireland-opw-waterlevel",

--- a/imgw-hydro/README.md
+++ b/imgw-hydro/README.md
@@ -31,6 +31,10 @@ bridge.
 
 See [CONTAINER.md](CONTAINER.md) for container deployment instructions.
 
+Fabric notebook hosting: this source ships a Fabric notebook
+(`notebook/imgw-hydro-feed.ipynb`) deployable via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Usage
 
 ### List all stations

--- a/imgw-hydro/imgw_hydro/imgw_hydro.py
+++ b/imgw-hydro/imgw_hydro/imgw_hydro.py
@@ -197,6 +197,9 @@ def main():
                         help='Polling interval in seconds (default: 600)')
     parser.add_argument('--state-file', type=str,
                         default=os.environ.get('STATE_FILE', os.path.expanduser('~/.imgw_hydro_state.json')))
+    parser.add_argument('--once', action='store_true',
+                        default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.add_parser('list', help='List all stations')
     level_parser = subparsers.add_parser('level', help='Get water level for a station')
@@ -260,6 +263,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/imgw-hydro/kql/create-kql-script.ps1
+++ b/imgw-hydro/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\imgw_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "imgw_hydro.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace pl.gov.imgw.hydro

--- a/imgw-hydro/kql/imgw_hydro.kql
+++ b/imgw-hydro/kql/imgw_hydro.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['pl.gov.imgw.hydro.Station'] (
    [station_id]: string,
    [station_name]: string,
    [river]: string,
@@ -39,9 +39,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['pl.gov.imgw.hydro.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['pl.gov.imgw.hydro.Station'] ingestion json mapping "pl.gov.imgw.hydro.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -58,7 +58,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['pl.gov.imgw.hydro.Station'] ingestion json mapping "pl.gov.imgw.hydro.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -75,13 +75,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['pl.gov.imgw.hydro.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.imgw.hydro.StationLatest'] on table ['pl.gov.imgw.hydro.Station'] {
+    ['pl.gov.imgw.hydro.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['pl.gov.imgw.hydro.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -92,7 +92,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelObservation] (
+.create-merge table ['pl.gov.imgw.hydro.WaterLevelObservation'] (
    [station_id]: string,
    [station_name]: string,
    [river]: string,
@@ -112,9 +112,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelObservation] docstring "{\"description\": \"WaterLevelObservation\"}";
+.alter table ['pl.gov.imgw.hydro.WaterLevelObservation'] docstring "{\"description\": \"WaterLevelObservation\"}";
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_flat"
+.create-or-alter table ['pl.gov.imgw.hydro.WaterLevelObservation'] ingestion json mapping "pl.gov.imgw.hydro.WaterLevelObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -137,7 +137,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_ce_structured"
+.create-or-alter table ['pl.gov.imgw.hydro.WaterLevelObservation'] ingestion json mapping "pl.gov.imgw.hydro.WaterLevelObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -160,13 +160,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelObservationLatest ifexists;
+.drop materialized-view ['pl.gov.imgw.hydro.WaterLevelObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelObservationLatest on table WaterLevelObservation {
-    WaterLevelObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.imgw.hydro.WaterLevelObservationLatest'] on table ['pl.gov.imgw.hydro.WaterLevelObservation'] {
+    ['pl.gov.imgw.hydro.WaterLevelObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelObservation] policy update
+.alter table ['pl.gov.imgw.hydro.WaterLevelObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/imgw-hydro/notebook/imgw-hydro-feed.ipynb
+++ b/imgw-hydro/notebook/imgw-hydro-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# IMGW Hydro Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Polish Institute of Meteorology and Water Management (IMGW-PIB) public hydrological API for water-level, water-temperature, and discharge measurements across hundreds of stations in Poland, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `imgw_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `imgw-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"imgw-hydro-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/imgw-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/pegelonline/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing pegelonline package from Fabric Environment...')\n",
+    "    from pegelonline import pegelonline as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['pegelonline', 'feed', '--once'] if ONCE_MODE else ['pegelonline', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/imgw-hydro/tests/test_once_mode.py
+++ b/imgw-hydro/tests/test_once_mode.py
@@ -1,0 +1,86 @@
+"""Unit test asserting --once causes main() to return after exactly one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from imgw_hydro import imgw_hydro as bridge
+
+
+SAMPLE_RECORDS = [
+    {
+        "id_stacji": "150180090",
+        "stacja": "Test",
+        "rzeka": "TestRiver",
+        "wojewodztwo": "test",
+        "lon": "18.0",
+        "lat": "50.0",
+        "stan_wody": "100",
+        "stan_wody_data_pomiaru": "2026-03-25 12:00:00",
+        "temperatura_wody": None,
+        "temperatura_wody_data_pomiaru": None,
+        "przeplyw": None,
+        "przeplyw_data": None,
+        "zjawisko_lodowe": None,
+        "zjawisko_zarastania": None,
+    },
+]
+
+
+def test_once_mode_exits_after_single_cycle(monkeypatch):
+    """`feed --once` must return after one polling cycle without sleeping."""
+    fake_producer = MagicMock()
+    fake_producer_cls = MagicMock(return_value=fake_producer)
+
+    fake_event_producer = MagicMock()
+    fake_event_producer.producer = fake_producer
+
+    sleep_calls = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        raise AssertionError("time.sleep must not be called when --once is set")
+
+    monkeypatch.setattr(bridge, "Producer", fake_producer_cls)
+    monkeypatch.setattr(bridge, "PLGovIMGWHydroEventProducer", lambda *a, **kw: fake_event_producer)
+    monkeypatch.setattr(bridge.time, "sleep", fake_sleep)
+    monkeypatch.setattr(bridge.IMGWHydroAPI, "get_all_data", lambda self: list(SAMPLE_RECORDS))
+
+    argv = [
+        "imgw-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "test-imgw-hydro",
+        "--state-file", "",
+        "--once",
+        "feed",
+    ]
+    with patch.object(sys, "argv", argv):
+        bridge.main()
+
+    assert sleep_calls == [], "Expected no sleep calls in --once mode"
+    assert fake_event_producer.producer.flush.call_count >= 1
+
+
+def test_once_mode_via_env_var(monkeypatch):
+    """ONCE_MODE=true env var must also short-circuit the polling loop."""
+    fake_producer = MagicMock()
+    fake_event_producer = MagicMock()
+    fake_event_producer.producer = fake_producer
+
+    monkeypatch.setattr(bridge, "Producer", MagicMock(return_value=fake_producer))
+    monkeypatch.setattr(bridge, "PLGovIMGWHydroEventProducer", lambda *a, **kw: fake_event_producer)
+    monkeypatch.setattr(bridge.time, "sleep", lambda s: (_ for _ in ()).throw(AssertionError("sleep called")))
+    monkeypatch.setattr(bridge.IMGWHydroAPI, "get_all_data", lambda self: list(SAMPLE_RECORDS))
+
+    monkeypatch.setenv("ONCE_MODE", "true")
+
+    argv = [
+        "imgw-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "test-imgw-hydro",
+        "--state-file", "",
+        "feed",
+    ]
+    with patch.object(sys, "argv", argv):
+        bridge.main()


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes

- **Notebook**: `imgw-hydro/notebook/imgw-hydro-feed.ipynb` — copy of the canonical `pegelonline` notebook with the mechanical substitutions from `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md`.
- **Catalog flag**: `catalog.json` — adds `notebook: true` to the `imgw-hydro` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **--once flag** (new): added to the bridge's `feed` subcommand, modeled after `pegelonline`. Honors `ONCE_MODE` env var too. New `tests/test_once_mode.py` asserts the polling loop exits after one cycle (mocks the upstream HTTP and `time.sleep` to fail on call).
- **Qualified KQL tables**: `kql/create-kql-script.ps1` now invokes `tools/generate-kql-from-xreg.ps1` with `-Qualified -Namespace pl.gov.imgw.hydro`. The xreg JsonStructure schemas do not declare a top-level `namespace` so an explicit one is supplied (DWD reference PR #257). Regenerated `kql/imgw_hydro.kql` now uses `['pl.gov.imgw.hydro.Station']` / `['pl.gov.imgw.hydro.WaterLevelObservation']` everywhere (tables, mappings, materialized views, update policies). The `type ==` predicate values are unchanged.
- **README touch**: one-sentence pointer to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validation

- Notebook JSON parses.
- All placeholder parameters present (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns in code cells (`asyncio.run`, `%pip install` as code, baked `CONNECTION_STRING`, `primaryConnectionString` assignment). The phrase `%pip install` appears only in the markdown intro (verbatim from the template).
- Bridge tests pass: `pytest tests/test_imgw_hydro_unit.py tests/test_once_mode.py` → 31 passed.
- New `test_once_mode.py` specifically asserts `--once` and `ONCE_MODE=true` env both short-circuit the polling loop without calling `time.sleep`.
- KQL contains qualified `create-merge table ['pl.gov.imgw.hydro.*']` entries.
- No hand-authored consumer assets (`fabric/`, dashboards, secondary KQL) needed fixing — only the auto-generated KQL was affected.

## Out of scope

Per the skill, no Fabric deployment is performed by this PR. The
wheel-bundle workflow will pick up the source on merge to main.