### PR TITLE
feat(chmi-hydro): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -22,7 +22,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Czech Republic — CHMU",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "german-waters",

--- a/chmi-hydro/README.md
+++ b/chmi-hydro/README.md
@@ -28,6 +28,8 @@ bridge.
 
 ## Deployment
 
+- **Fabric notebook hosting (recommended for Fabric users):** Deploy this bridge as a scheduled Fabric notebook with `tools/deploy-fabric/deploy-feeder-notebook.ps1`. It auto-builds the per-source Environment, looks up the Event Stream connection string at runtime, and schedules `chmi-hydro feed --once`.
+
 See [CONTAINER.md](CONTAINER.md) for container deployment instructions.
 
 ## Usage

--- a/chmi-hydro/chmi_hydro/chmi_hydro.py
+++ b/chmi-hydro/chmi_hydro/chmi_hydro.py
@@ -276,7 +276,10 @@ def main():
     subparsers.add_parser('list', help='List all stations')
     level_parser = subparsers.add_parser('level', help='Get water level for a station')
     level_parser.add_argument('station_id', help='Station ID (e.g. 0-203-1-001000)')
-    subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser = subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -336,6 +339,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/chmi-hydro/kql/chmi_hydro.kql
+++ b/chmi-hydro/kql/chmi_hydro.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['cz.gov.chmi.hydro.Station'] (
    [station_id]: string,
    [dbc]: string,
    [station_name]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['cz.gov.chmi.hydro.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['cz.gov.chmi.hydro.Station'] ingestion json mapping "cz.gov.chmi.hydro.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -68,7 +68,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['cz.gov.chmi.hydro.Station'] ingestion json mapping "cz.gov.chmi.hydro.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -90,13 +90,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['cz.gov.chmi.hydro.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['cz.gov.chmi.hydro.StationLatest'] on table ['cz.gov.chmi.hydro.Station'] {
+    ['cz.gov.chmi.hydro.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['cz.gov.chmi.hydro.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -107,7 +107,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelObservation] (
+.create-merge table ['cz.gov.chmi.hydro.WaterLevelObservation'] (
    [station_id]: string,
    [station_name]: string,
    [stream_name]: string,
@@ -124,9 +124,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelObservation] docstring "{\"description\": \"WaterLevelObservation\"}";
+.alter table ['cz.gov.chmi.hydro.WaterLevelObservation'] docstring "{\"description\": \"WaterLevelObservation\"}";
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_flat"
+.create-or-alter table ['cz.gov.chmi.hydro.WaterLevelObservation'] ingestion json mapping "cz.gov.chmi.hydro.WaterLevelObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -146,7 +146,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_ce_structured"
+.create-or-alter table ['cz.gov.chmi.hydro.WaterLevelObservation'] ingestion json mapping "cz.gov.chmi.hydro.WaterLevelObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -166,13 +166,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelObservationLatest ifexists;
+.drop materialized-view ['cz.gov.chmi.hydro.WaterLevelObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelObservationLatest on table WaterLevelObservation {
-    WaterLevelObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['cz.gov.chmi.hydro.WaterLevelObservationLatest'] on table ['cz.gov.chmi.hydro.WaterLevelObservation'] {
+    ['cz.gov.chmi.hydro.WaterLevelObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelObservation] policy update
+.alter table ['cz.gov.chmi.hydro.WaterLevelObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/chmi-hydro/kql/create-kql-script.ps1
+++ b/chmi-hydro/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\chmi_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "chmi_hydro.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace cz.gov.chmi.hydro

--- a/chmi-hydro/notebook/chmi-hydro-feed.ipynb
+++ b/chmi-hydro/notebook/chmi-hydro-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CHMI Hydro Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Czech Hydrometeorological Institute (ČHMÚ) open-data hydrology API for water-level, discharge, and water-temperature measurements at hundreds of stations across the Czech Republic and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `chmi_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `chmi-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"chmi-hydro-ingest\"      # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/chmi-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/chmi-hydro/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing chmi_hydro package from Fabric Environment...')\n",
+    "    from chmi_hydro import chmi_hydro as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['chmi-hydro', 'feed', '--once'] if ONCE_MODE else ['chmi-hydro', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/chmi-hydro/tests/test_once_mode.py
+++ b/chmi-hydro/tests/test_once_mode.py
@@ -1,0 +1,106 @@
+"""Verify the --once flag causes main() to exit after one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import chmi_hydro.chmi_hydro as bridge
+
+
+SAMPLE_META_PAYLOAD = {
+    "data": {
+        "data": {
+            "header": (
+                "objID,DBC,STATION_NAME,STREAM_NAME,GEOGR1,GEOGR2,"
+                "SPA_TYP,SPAH_DS,SPAH_UNIT,DRYH,SPA1H,SPA2H,SPA3H,SPA4H,"
+                "SPAQ_DS,SPAQ_UNIT,DRYQ,SPA1Q,SPA2Q,SPA3Q,SPA4Q,ISFORECAST"
+            ),
+            "values": [
+                [
+                    "0-203-1-001000", "001000", "Test", "TestStream",
+                    50.0, 15.0,
+                    "H", "vodní stav", "CM", 88,
+                    165, 200, 220, 297,
+                    "průtok", "M3_S", 0.419,
+                    19.3, 39.4, 54.5, 137,
+                    0,
+                ],
+            ],
+        }
+    }
+}
+
+SAMPLE_STATION_DATA = {
+    "objList": [{
+        "objID": "0-203-1-001000",
+        "tsList": [
+            {
+                "tsConID": "H",
+                "tsData": [{"dt": "2024-01-01T00:00:00Z", "value": 100}],
+            }
+        ],
+    }]
+}
+
+
+def _fake_get(url, *args, **kwargs):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    if "meta1.json" in url:
+        resp.json.return_value = SAMPLE_META_PAYLOAD
+    else:
+        resp.json.return_value = SAMPLE_STATION_DATA
+    return resp
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "chmi-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "chmi-hydro",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+        "--once",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with patch.object(bridge, "Producer") as ProducerCls, \
+         patch("chmi_hydro.chmi_hydro.requests.Session") as SessionCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProducerCls.return_value = MagicMock()
+        session_instance = MagicMock()
+        session_instance.get.side_effect = _fake_get
+        SessionCls.return_value = session_instance
+        bridge.main()
+
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "chmi-hydro",
+        "--connection-string", "BootstrapServer=localhost:9092",
+        "--topic", "chmi-hydro",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with patch.object(bridge, "Producer") as ProducerCls, \
+         patch("chmi_hydro.chmi_hydro.requests.Session") as SessionCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProducerCls.return_value = MagicMock()
+        session_instance = MagicMock()
+        session_instance.get.side_effect = _fake_get
+        SessionCls.return_value = session_instance
+        bridge.main()
+
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` agent (see `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- **`chmi-hydro/notebook/chmi-hydro-feed.ipynb`** — new, copied from `pegelonline/notebook/pegelonline-feed.ipynb` with the source-specific substitutions (package `chmi_hydro`, argv `chmi-hydro feed`, lakehouse path `feeder-state/chmi-hydro/`, eventstream name `chmi-hydro-ingest`, display name `CHMI Hydro`, adapted README paragraph). Four-cell structure, CS-lookup cell, worker-thread cell, and OneLake log layout copied verbatim.
- **`chmi-hydro/chmi_hydro/chmi_hydro.py`** — adds `--once` CLI flag (also via `ONCE_MODE` env var) on the `feed` subparser, with a `break` before `time.sleep` so a single polling cycle returns cleanly. Modeled after `pegelonline`/`bafu-hydro`.
- **`chmi-hydro/tests/test_once_mode.py`** — new unit tests asserting both `--once` and `ONCE_MODE=true` cause `main()` to return after exactly one cycle (`time.sleep` not called).
- **`catalog.json`** — adds `"notebook": true` to the `chmi-hydro` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **`chmi-hydro/README.md`** — one-sentence Fabric notebook hosting bullet under Deployment.
- **`chmi-hydro/kql/create-kql-script.ps1`** + **`chmi-hydro/kql/chmi_hydro.kql`** — KQL generator now passes `-Qualified -Namespace cz.gov.chmi.hydro`. All tables, materialized views, ingestion mappings, and update policies are namespace-prefixed (e.g. `['cz.gov.chmi.hydro.Station']`). The `-Namespace` override is required because the JsonStructure schemas in this source's xreg manifest do not declare a `namespace` key. See `docs/plan-qualified-table-names.md` and DWD reference PR #257.

## Validations performed locally

- Notebook JSON well-formed (`json.load` ok).
- All five placeholder parameters present in the params cell (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden runtime patterns in the notebook (`asyncio.run(`, `%pip install` invocation, hard-coded `CONNECTION_STRING=""`, hard-coded `primaryConnectionString`). The descriptive markdown phrase "No `%pip install` is required" is copied verbatim from the canonical pegelonline notebook.
- KQL regeneration produced qualified, bracket-quoted table names; the `_cloudevents_dispatch` dispatch table and the `type ==` predicate values (upstream CloudEvents types like `CZ.Gov.CHMI.Hydro.Station`) are unchanged.
- `py_compile` on the bridge and the new test module succeeded. `pytest` was not executed in this sandbox because the agent must not run `pip install` against the shared venv; the test pattern is identical to the already-passing `bafu-hydro/tests/test_once_mode.py`.
- Audit for stale unqualified table references in `chmi-hydro/fabric/`, `chmi-hydro/notebook/`, `chmi-hydro/README.md`: no consumer assets reference `Station`/`WaterLevelObservation` as KQL tables (only Python class names, schema names, and upstream event type strings).

## Out of scope (per skill)

- No Fabric deployment from this PR. The `publish-notebook-wheels.yml` workflow runs on merge and end-to-end verification happens separately.