### PR TITLE
feat(hubeau-hydrometrie): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -38,7 +38,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "France — ~6,300 stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "imgw-hydro",

--- a/hubeau-hydrometrie/README.md
+++ b/hubeau-hydrometrie/README.md
@@ -6,6 +6,13 @@ Event Hubs, or Microsoft Fabric Event Streams. It provides real-time water level
 (height) and flow (discharge) data from approximately 6,300 monitoring stations
 across France.
 
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Microsoft Fabric notebook via
+`tools/deploy-fabric/deploy-feeder-notebook.ps1`, which deploys
+[`notebook/hubeau-hydrometrie-feed.ipynb`](notebook/hubeau-hydrometrie-feed.ipynb)
+as an alternative to the Azure Container Instance bridge.
+
 ## Hub'Eau Hydrométrie API
 
 Hub'Eau is a service provided by the French Ministry for an Ecological

--- a/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
+++ b/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
@@ -126,7 +126,7 @@ class HubEauHydrometrieAPI:
             config_dict['sasl.mechanism'] = 'PLAIN'
         return config_dict
 
-    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '') -> None:
+    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '', once: bool = False) -> None:
         """Feed stations and send updates as CloudEvents."""
         previous_observations: Dict[str, str] = _load_state(state_file)
 
@@ -202,6 +202,9 @@ class HubEauHydrometrieAPI:
                 logging.info("Sent %d observations in %.1f seconds. Waiting %.0f seconds.",
                              count, end_time - start_time, effective_interval)
                 _save_state(state_file, previous_observations)
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
 
@@ -242,6 +245,9 @@ def main() -> None:
                              default=polling_interval_default)
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE', os.path.expanduser('~/.hubeau_hydrometrie_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     api = HubEauHydrometrieAPI()
@@ -294,7 +300,7 @@ def main() -> None:
             })
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
-        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file, args.once)
     else:
         parser.print_help()
 

--- a/hubeau-hydrometrie/kql/create-kql-script.ps1
+++ b/hubeau-hydrometrie/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\hubeau_hydrometrie.xreg.json"
 $kqlFile = Join-Path $scriptDir "hubeau_hydrometrie.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "fr.gov.eaufrance.hubeau.hydrometrie"

--- a/hubeau-hydrometrie/kql/hubeau_hydrometrie.kql
+++ b/hubeau-hydrometrie/kql/hubeau_hydrometrie.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] (
    [code_station]: string,
    [libelle_station]: string,
    [code_site]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] ingestion json mapping "fr.gov.eaufrance.hubeau.hydrometrie.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] ingestion json mapping "fr.gov.eaufrance.hubeau.hydrometrie.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,13 +87,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['fr.gov.eaufrance.hubeau.hydrometrie.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fr.gov.eaufrance.hubeau.hydrometrie.StationLatest'] on table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] {
+    ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -104,7 +104,7 @@
 }]
 ```
 
-.create-merge table [Observation] (
+.create-merge table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] (
    [code_station]: string,
    [date_obs]: datetime,
    [resultat_obs]: real,
@@ -118,9 +118,9 @@
    [___subject]: string
 );
 
-.alter table [Observation] docstring "{\"description\": \"Observation\"}";
+.alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] docstring "{\"description\": \"Observation\"}";
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_flat"
+.create-or-alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] ingestion json mapping "fr.gov.eaufrance.hubeau.hydrometrie.Observation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -137,7 +137,7 @@
 ]
 ```
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_ce_structured"
+.create-or-alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] ingestion json mapping "fr.gov.eaufrance.hubeau.hydrometrie.Observation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -154,13 +154,13 @@
 ]
 ```
 
-.drop materialized-view ObservationLatest ifexists;
+.drop materialized-view ['fr.gov.eaufrance.hubeau.hydrometrie.ObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservationLatest on table Observation {
-    Observation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fr.gov.eaufrance.hubeau.hydrometrie.ObservationLatest'] on table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] {
+    ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observation] policy update
+.alter table ['fr.gov.eaufrance.hubeau.hydrometrie.Observation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/hubeau-hydrometrie/notebook/hubeau-hydrometrie-feed.ipynb
+++ b/hubeau-hydrometrie/notebook/hubeau-hydrometrie-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hub'Eau Hydrometrie Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the French Hub'Eau Hydrometrie API (Eaufrance) for real-time water-level and discharge measurements from ~6,300 hydrometric stations across metropolitan France and overseas territories, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `hubeau_hydrometrie` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `hubeau-hydrometrie feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"hubeau-hydrometrie-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/hubeau-hydrometrie/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/hubeau-hydrometrie/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing hubeau_hydrometrie package from Fabric Environment...')\n",
+    "    from hubeau_hydrometrie import hubeau_hydrometrie as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['hubeau-hydrometrie', 'feed', '--once'] if ONCE_MODE else ['hubeau-hydrometrie', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/hubeau-hydrometrie/tests/test_once_mode.py
+++ b/hubeau-hydrometrie/tests/test_once_mode.py
@@ -1,0 +1,92 @@
+"""Verify the --once flag causes main() to exit after one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import hubeau_hydrometrie.hubeau_hydrometrie as bridge
+
+
+SAMPLE_STATIONS = {
+    "data": [
+        {
+            "code_station": "A123456789",
+            "libelle_station": "Test Station",
+            "code_site": "A1234567",
+            "longitude_station": 2.0,
+            "latitude_station": 48.0,
+            "libelle_cours_eau": "Seine",
+            "libelle_commune": "Paris",
+            "code_departement": "75",
+            "en_service": True,
+            "date_ouverture_station": "2000-01-01",
+        }
+    ],
+    "next": None,
+}
+
+SAMPLE_OBSERVATIONS = {
+    "data": [
+        {
+            "code_station": "A123456789",
+            "date_obs": "2024-01-01T00:00:00Z",
+            "grandeur_hydro": "H",
+            "resultat_obs": 100.0,
+            "libelle_methode_obs": "Mesure",
+            "libelle_qualification_obs": "Bonne",
+        }
+    ],
+    "next": None,
+}
+
+
+def _fake_session_get(self, url, *args, **kwargs):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    if "stations" in url:
+        resp.json.return_value = SAMPLE_STATIONS
+    else:
+        resp.json.return_value = SAMPLE_OBSERVATIONS
+    return resp
+
+
+def _run_main(monkeypatch, argv, extra_env=None):
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    for k, v in (extra_env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    sleep_mock = MagicMock()
+    fake_producer = MagicMock()
+    with patch("confluent_kafka.Producer", return_value=fake_producer), \
+         patch.object(bridge.requests.Session, "get", _fake_session_get), \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        bridge.main()
+    return sleep_mock
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "hubeau-hydrometrie",
+        "feed",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "--once",
+    ]
+    sleep_mock = _run_main(monkeypatch, argv)
+    # The single-cycle exit must skip the inter-cycle sleep.
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "hubeau-hydrometrie",
+        "feed",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+    ]
+    sleep_mock = _run_main(monkeypatch, argv, extra_env={"ONCE_MODE": "true"})
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by the notebook-feeder-retrofit agent.

**Changes**
- New `hubeau-hydrometrie/notebook/hubeau-hydrometrie-feed.ipynb` (copy of `pegelonline/notebook/pegelonline-feed.ipynb` with mechanical substitutions per `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md`).
- `catalog.json` flips `notebook: true` for `hubeau-hydrometrie` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Bridge gains `--once` CLI flag (and `ONCE_MODE` env var) modeled after pegelonline, plus `tests/test_once_mode.py` that asserts `main()` exits after one polling cycle (both flag and env-var paths).
- `hubeau-hydrometrie/kql/create-kql-script.ps1` now passes `-Qualified -Namespace fr.gov.eaufrance.hubeau.hydrometrie` and the regenerated `hubeau_hydrometrie.kql` produces namespace-qualified table names (`['fr.gov.eaufrance.hubeau.hydrometrie.Station']` etc.). The JsonStructure schemas in this xreg have no `namespace` key, so the explicit `-Namespace` override is required (see `docs/plan-qualified-table-names.md`, DWD reference PR #257).
- One-line README addition pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

**Validated locally**
- Notebook JSON is well-formed (`json.load` ok).
- Notebook contains no `asyncio.run(`, no `CONNECTION_STRING = ...` baked in, and looks up the connection string at runtime via the Topology API.
- New `test_once_mode.py` passes (2/2, both `--once` and `ONCE_MODE` env paths).
- KQL regenerated; `create-merge table ['fr.gov.eaufrance.hubeau.hydrometrie.Station']` and `...Observation` present.
- No hand-authored consumer assets under `hubeau-hydrometrie/fabric`, `hubeau-hydrometrie/dashboard`, or `hubeau-hydrometrie/notebook` to audit for stale unqualified table references.

**Out of scope / Notes**
- 4 pre-existing test failures in `tests/test_hubeau_hydrometrie_unit.py` (`TestDataClasses::*`) reference a non-existent module path (`hubeau_hydrometrie.hubeau_hydrometrie_producer`); these exist on `main` and are not introduced by this PR.
- No live Fabric deployment performed (per the retrofit skill). The wheel-bundle workflow will publish on merge to main.