### PR TITLE
feat(rws-waterwebservices): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -111,7 +111,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Netherlands — ~785 stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "smhi-hydro",

--- a/rws-waterwebservices/README.md
+++ b/rws-waterwebservices/README.md
@@ -58,6 +58,13 @@ See [EVENTS.md](EVENTS.md) for the CloudEvents message definitions.
 
 See [CONTAINER.md](CONTAINER.md) for Docker container deployment info.
 
+## Fabric notebook hosting
+
+This source can also run as a scheduled Microsoft Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which packages the bridge as a Fabric Environment and schedules
+`notebook/rws-waterwebservices-feed.ipynb` to run one polling cycle per tick.
+
 ## API Reference
 
 - **Base URL**: `https://ddapi20-waterwebservices.rijkswaterstaat.nl`

--- a/rws-waterwebservices/kql/create-kql-script.ps1
+++ b/rws-waterwebservices/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\rws_waterwebservices.xreg.json"
 $kqlFile = Join-Path $scriptDir "rws_waterwebservices.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'nl.rws.waterwebservices'

--- a/rws-waterwebservices/kql/rws_waterwebservices.kql
+++ b/rws-waterwebservices/kql/rws_waterwebservices.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['nl.rws.waterwebservices.Station'] (
    [station_code]: string,
    [name]: string,
    [latitude]: real,
@@ -38,9 +38,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['nl.rws.waterwebservices.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['nl.rws.waterwebservices.Station'] ingestion json mapping "nl.rws.waterwebservices.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -56,7 +56,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['nl.rws.waterwebservices.Station'] ingestion json mapping "nl.rws.waterwebservices.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -72,13 +72,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['nl.rws.waterwebservices.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rws.waterwebservices.StationLatest'] on table ['nl.rws.waterwebservices.Station'] {
+    ['nl.rws.waterwebservices.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['nl.rws.waterwebservices.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -89,7 +89,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelObservation] (
+.create-merge table ['nl.rws.waterwebservices.WaterLevelObservation'] (
    [station_code]: string,
    [location_name]: string,
    [timestamp]: datetime,
@@ -106,9 +106,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelObservation] docstring "{\"description\": \"WaterLevelObservation\"}";
+.alter table ['nl.rws.waterwebservices.WaterLevelObservation'] docstring "{\"description\": \"WaterLevelObservation\"}";
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_flat"
+.create-or-alter table ['nl.rws.waterwebservices.WaterLevelObservation'] ingestion json mapping "nl.rws.waterwebservices.WaterLevelObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -128,7 +128,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_ce_structured"
+.create-or-alter table ['nl.rws.waterwebservices.WaterLevelObservation'] ingestion json mapping "nl.rws.waterwebservices.WaterLevelObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -148,13 +148,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelObservationLatest ifexists;
+.drop materialized-view ['nl.rws.waterwebservices.WaterLevelObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelObservationLatest on table WaterLevelObservation {
-    WaterLevelObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rws.waterwebservices.WaterLevelObservationLatest'] on table ['nl.rws.waterwebservices.WaterLevelObservation'] {
+    ['nl.rws.waterwebservices.WaterLevelObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelObservation] policy update
+.alter table ['nl.rws.waterwebservices.WaterLevelObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/rws-waterwebservices/notebook/rws-waterwebservices-feed.ipynb
+++ b/rws-waterwebservices/notebook/rws-waterwebservices-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RWS Waterwebservices Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Dutch Rijkswaterstaat Waterwebservices API for water-level measurements at ~785 surface-water stations across the Netherlands and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `rws_waterwebservices` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `rws-waterwebservices feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"rws-waterwebservices-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/rws-waterwebservices/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/rws-waterwebservices/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing rws_waterwebservices package from Fabric Environment...')\n",
+    "    from rws_waterwebservices import rws_waterwebservices as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['rws-waterwebservices', 'feed', '--once'] if ONCE_MODE else ['rws-waterwebservices', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/rws-waterwebservices/rws_waterwebservices/rws_waterwebservices.py
+++ b/rws-waterwebservices/rws_waterwebservices/rws_waterwebservices.py
@@ -182,7 +182,7 @@ class RWSWaterwebservicesAPI:
             config_dict['sasl.mechanism'] = 'PLAIN'
         return config_dict
 
-    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '') -> None:
+    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '', once: bool = False) -> None:
         """Feed station and water level data as CloudEvents to Kafka."""
         previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -268,6 +268,9 @@ class RWSWaterwebservicesAPI:
                 logging.info("Sent %d observations in %.1f seconds. Waiting %.0f seconds.",
                              count, end_time - start_time, effective_interval)
                 _save_state(state_file, previous_readings)
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
 
@@ -308,6 +311,9 @@ def main() -> None:
                              default=polling_interval_default)
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE', os.path.expanduser('~/.rws_waterwebservices_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     api = RWSWaterwebservicesAPI()
@@ -355,7 +361,7 @@ def main() -> None:
             })
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
-        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file, args.once)
     else:
         parser.print_help()
 

--- a/rws-waterwebservices/tests/test_once_mode.py
+++ b/rws-waterwebservices/tests/test_once_mode.py
@@ -1,0 +1,46 @@
+"""Test that --once flag causes feed_stations() to exit after one polling cycle."""
+
+from unittest.mock import MagicMock, patch
+
+from rws_waterwebservices.rws_waterwebservices import RWSWaterwebservicesAPI
+
+
+def test_once_mode_exits_after_one_cycle():
+    """feed_stations(..., once=True) must return after exactly one cycle."""
+    api = RWSWaterwebservicesAPI()
+
+    api.get_water_level_stations = MagicMock(return_value=[
+        {"Code": "HOlv", "Naam": "Test", "Lat": 52.0, "Lon": 4.0, "Coordinatenstelsel": "25831"},
+    ])
+    api.get_latest_observations = MagicMock(return_value=[
+        {
+            "Locatie": {"Code": "HOlv", "Naam": "Test"},
+            "AquoMetadata": {"Eenheid": {"Code": "cm"}},
+            "MetingenLijst": [
+                {
+                    "Tijdstip": "2025-01-01T00:00:00.000+00:00",
+                    "Meetwaarde": {"Waarde_Numeriek": 12.3},
+                    "WaarnemingMetadata": {"Kwaliteitswaardecode": "00", "Statuswaarde": "Gecontroleerd"},
+                }
+            ],
+        }
+    ])
+
+    with patch("rws_waterwebservices.rws_waterwebservices.time.sleep") as mock_sleep, \
+         patch("confluent_kafka.Producer") as mock_producer_cls, \
+         patch("rws_waterwebservices.rws_waterwebservices.NLRWSWaterwebservicesEventProducer") as mock_rws_producer_cls:
+        mock_producer_cls.return_value = MagicMock()
+        mock_rws_producer_cls.return_value = MagicMock()
+
+        api.feed_stations(
+            kafka_config={"bootstrap.servers": "localhost:9092"},
+            kafka_topic="test-topic",
+            polling_interval=1,
+            state_file="",
+            once=True,
+        )
+
+        # Latest observations fetched exactly once
+        assert api.get_latest_observations.call_count == 1
+        # No sleep call after the cycle (once-mode breaks before sleep)
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` agent (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- **Notebook**: `rws-waterwebservices/notebook/rws-waterwebservices-feed.ipynb` — verbatim copy of the canonical `pegelonline/notebook/pegelonline-feed.ipynb` with the required substitutions (package name, argv0, subcommand, lakehouse paths, display name).
- **Catalog flag**: `catalog.json` — set `notebook: true` on the `rws-waterwebservices` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **--once flag added to bridge**: The bridge's `feed` subcommand previously had no single-cycle exit path. Added a `--once` flag (default from `ONCE_MODE` env var) and a `break` in the polling loop after the first cycle, modeled on `pegelonline`. Added `tests/test_once_mode.py` covering the single-cycle exit.
- **Qualified KQL tables**: `rws-waterwebservices/kql/create-kql-script.ps1` now passes `-Qualified -Namespace 'nl.rws.waterwebservices'` (the xreg JsonStructure schemas have no namespace property of their own, so an explicit `-Namespace` is required per the skill). Regenerated `rws_waterwebservices.kql` — every typed table, materialized view, and update policy now uses the bracketed FQN form. Reference: docs/plan-qualified-table-names.md, DWD PR #257.
- **README**: One-sentence Fabric notebook hosting bullet linking to the deploy script.

## Local validation performed

- Notebook JSON well-formed (`json.load` succeeds).
- All 30 bridge unit tests pass, including the new `test_once_mode.py` (asserts `get_latest_observations` called exactly once and `time.sleep` never called).
- Parameters cell contains all required placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns in code cells (no `asyncio.run(`, no `CONNECTION_STRING = "`, no literal `primaryConnectionString =` assignment). The literal `%pip install` only appears in the markdown describing the runtime model — same as the canonical pegelonline template.
- Qualified-tables check passes (`create-merge table ['nl.rws.waterwebservices.*'` etc.).
- No stale unqualified table references in consumer assets (no `fabric/` or `dashboard/` folder in this source).

## Not done in this PR

- No live Fabric deployment. The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the `notebook-wheels` release.