### PR TITLE
feat(nepal-bipad-hydrology): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -62,7 +62,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Nepal — Himalayan river basins, BIPAD",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "noaa",

--- a/nepal-bipad-hydrology/README.md
+++ b/nepal-bipad-hydrology/README.md
@@ -43,6 +43,10 @@ docker run --rm \
 
 See [CONTAINER.md](CONTAINER.md) for full deployment documentation.
 
+- **Fabric notebook hosting** — schedule single-cycle runs inside a Microsoft
+  Fabric workspace via
+  [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Development
 
 ```shell

--- a/nepal-bipad-hydrology/kql/create-kql-script.ps1
+++ b/nepal-bipad-hydrology/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\nepal_bipad_hydrology.xreg.json"
 $kqlFile = Join-Path $scriptDir "nepal_bipad_hydrology.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/nepal-bipad-hydrology/kql/nepal_bipad_hydrology.kql
+++ b/nepal-bipad-hydrology/kql/nepal_bipad_hydrology.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [RiverStation] (
+.create-merge table ['np.gov.bipad.hydrology.RiverStation'] (
    [station_id]: string,
    [title]: string,
    [basin]: string,
@@ -47,9 +47,9 @@
    [___subject]: string
 );
 
-.alter table [RiverStation] docstring "{\"description\": \"Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.\"}";
+.alter table ['np.gov.bipad.hydrology.RiverStation'] docstring "{\"description\": \"Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.\"}";
 
-.alter table [RiverStation] column-docstrings (
+.alter table ['np.gov.bipad.hydrology.RiverStation'] column-docstrings (
    [station_id]: "{\"description\": \"Unique integer identifier of the river station assigned by the BIPAD portal, transmitted as a string for key compatibility.\"}",
    [title]: "{\"description\": \"Human-readable name of the river station, typically in the format 'River at Location' (e.g. 'Babai at Chepang').\"}",
    [basin]: "{\"description\": \"Name of the river basin the station belongs to (e.g. 'Bagmati', 'Narayani', 'Koshi', 'Karnali', 'Mahakali', 'Babai').\"}",
@@ -71,7 +71,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [RiverStation] ingestion json mapping "RiverStation_json_flat"
+.create-or-alter table ['np.gov.bipad.hydrology.RiverStation'] ingestion json mapping "np.gov.bipad.hydrology.RiverStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -96,7 +96,7 @@
 ]
 ```
 
-.create-or-alter table [RiverStation] ingestion json mapping "RiverStation_json_ce_structured"
+.create-or-alter table ['np.gov.bipad.hydrology.RiverStation'] ingestion json mapping "np.gov.bipad.hydrology.RiverStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -121,13 +121,13 @@
 ]
 ```
 
-.drop materialized-view RiverStationLatest ifexists;
+.drop materialized-view ['np.gov.bipad.hydrology.RiverStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) RiverStationLatest on table RiverStation {
-    RiverStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['np.gov.bipad.hydrology.RiverStationLatest'] on table ['np.gov.bipad.hydrology.RiverStation'] {
+    ['np.gov.bipad.hydrology.RiverStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [RiverStation] policy update
+.alter table ['np.gov.bipad.hydrology.RiverStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -138,7 +138,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelReading] (
+.create-merge table ['np.gov.bipad.hydrology.WaterLevelReading'] (
    [station_id]: string,
    [title]: string,
    [basin]: string,
@@ -155,9 +155,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelReading] docstring "{\"description\": \"Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal, including current water level, alert status, and trend direction.\"}";
+.alter table ['np.gov.bipad.hydrology.WaterLevelReading'] docstring "{\"description\": \"Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal, including current water level, alert status, and trend direction.\"}";
 
-.alter table [WaterLevelReading] column-docstrings (
+.alter table ['np.gov.bipad.hydrology.WaterLevelReading'] column-docstrings (
    [station_id]: "{\"description\": \"Unique integer identifier of the river station assigned by the BIPAD portal, transmitted as a string for key compatibility.\"}",
    [title]: "{\"description\": \"Human-readable name of the river station at the time of the reading.\"}",
    [basin]: "{\"description\": \"Name of the river basin the station belongs to at the time of the reading.\"}",
@@ -174,7 +174,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_flat"
+.create-or-alter table ['np.gov.bipad.hydrology.WaterLevelReading'] ingestion json mapping "np.gov.bipad.hydrology.WaterLevelReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -194,7 +194,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_ce_structured"
+.create-or-alter table ['np.gov.bipad.hydrology.WaterLevelReading'] ingestion json mapping "np.gov.bipad.hydrology.WaterLevelReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -214,13 +214,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelReadingLatest ifexists;
+.drop materialized-view ['np.gov.bipad.hydrology.WaterLevelReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelReadingLatest on table WaterLevelReading {
-    WaterLevelReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['np.gov.bipad.hydrology.WaterLevelReadingLatest'] on table ['np.gov.bipad.hydrology.WaterLevelReading'] {
+    ['np.gov.bipad.hydrology.WaterLevelReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelReading] policy update
+.alter table ['np.gov.bipad.hydrology.WaterLevelReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/nepal-bipad-hydrology/nepal_bipad_hydrology/nepal_bipad_hydrology.py
+++ b/nepal-bipad-hydrology/nepal_bipad_hydrology/nepal_bipad_hydrology.py
@@ -140,7 +140,7 @@ class NepalBipadHydrologyAPI:
 
     def feed_stations(self, kafka_config: dict, kafka_topic: str,
                       polling_interval: int, state_file: str = '',
-                      reference_refresh_hours: int = 6) -> None:
+                      reference_refresh_hours: int = 6, once: bool = False) -> None:
         """Fetch stations, emit reference data and telemetry in a loop."""
         previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -231,6 +231,9 @@ class NepalBipadHydrologyAPI:
                 effective_interval = max(0, polling_interval - (end_time - start_time).total_seconds())
                 logging.info("Sent %d water level readings in %.1fs. Sleeping %.0fs.",
                               count, (end_time - start_time).total_seconds(), effective_interval)
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
             except KeyboardInterrupt:
@@ -277,6 +280,9 @@ def main() -> None:
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE',
                                                os.path.expanduser('~/.nepal_bipad_hydrology_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     api = NepalBipadHydrologyAPI()
@@ -320,7 +326,7 @@ def main() -> None:
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
 
-        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file, once=args.once)
     else:
         parser.print_help()
 

--- a/nepal-bipad-hydrology/notebook/nepal-bipad-hydrology-feed.ipynb
+++ b/nepal-bipad-hydrology/notebook/nepal-bipad-hydrology-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Nepal BIPAD Hydrology Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Nepal BIPAD Portal river-stations API for water-level measurements across Himalayan river basins (Bagmati, Narayani, Koshi, Karnali, Mahakali, Babai, …) and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `nepal_bipad_hydrology` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `nepal-bipad-hydrology feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"nepal-bipad-hydrology-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/nepal-bipad-hydrology/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/nepal-bipad-hydrology/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing nepal_bipad_hydrology package from Fabric Environment...')\n",
+    "    from nepal_bipad_hydrology import nepal_bipad_hydrology as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['nepal-bipad-hydrology', 'feed', '--once'] if ONCE_MODE else ['nepal-bipad-hydrology', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/nepal-bipad-hydrology/tests/test_once_mode.py
+++ b/nepal-bipad-hydrology/tests/test_once_mode.py
@@ -1,0 +1,91 @@
+"""Verify the --once flag causes main() to exit after one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import requests_mock
+
+import nepal_bipad_hydrology.nepal_bipad_hydrology as bridge
+
+
+SAMPLE_STATIONS_PAGE = {
+    "results": [
+        {
+            "id": 1,
+            "title": "Karnali at Chisapani",
+            "basin": "Karnali",
+            "point": {"coordinates": [81.27, 28.64]},
+            "elevation": 191.0,
+            "dangerLevel": 10.8,
+            "warningLevel": 10.0,
+            "description": "Test station",
+            "dataSource": "DHM",
+            "province": 6,
+            "district": 34,
+            "municipality": 76,
+            "ward": 1,
+            "waterLevel": 5.2,
+            "status": "BELOW WARNING LEVEL",
+            "steady": "STEADY",
+            "waterLevelOn": "2024-01-01T00:00:00Z",
+        },
+    ]
+}
+EMPTY_PAGE = {"results": []}
+
+
+def _register_pages(m):
+    base = "https://bipadportal.gov.np/api/v1/river-stations/"
+    # First page returns one station, second page is empty (terminates pagination).
+    m.get(base, [
+        {"json": SAMPLE_STATIONS_PAGE, "status_code": 200},
+        {"json": EMPTY_PAGE, "status_code": 200},
+        {"json": SAMPLE_STATIONS_PAGE, "status_code": 200},
+        {"json": EMPTY_PAGE, "status_code": 200},
+    ])
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "nepal-bipad-hydrology", "feed",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "--once",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with requests_mock.Mocker() as m, \
+         patch.object(bridge, "Producer") as ProducerCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        _register_pages(m)
+        ProducerCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "nepal-bipad-hydrology", "feed",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    with requests_mock.Mocker() as m, \
+         patch.object(bridge, "Producer") as ProducerCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        _register_pages(m)
+        ProducerCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- Adds `nepal-bipad-hydrology/notebook/nepal-bipad-hydrology-feed.ipynb` following the canonical pegelonline pattern (verbatim cell structure, CS-lookup, worker-thread runner, OneLake logging).
- Flips `catalog.json` `notebook: true` for nepal-bipad-hydrology so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` flag and `ONCE_MODE` env-var support to the bridge for single-cycle notebook execution (mirrors pegelonline).
- New `tests/test_once_mode.py` asserts `--once` and `ONCE_MODE=true` each cause `main()` to return after one polling cycle (no `time.sleep` calls).
- Flips `nepal-bipad-hydrology/kql/create-kql-script.ps1` to pass `-Qualified` and regenerates `nepal_bipad_hydrology.kql` — tables now namespaced as `['np.gov.bipad.hydrology.RiverStation']` / `['np.gov.bipad.hydrology.WaterLevelReading']` (see docs/plan-qualified-table-names.md, DWD reference PR #257).
- README adds a one-line Fabric notebook hosting bullet.

## Validation
- `python -m pytest tests/` → **52 passed** (including 2 new once-mode tests).
- Notebook JSON well-formed; all five parameters cell placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present.
- No forbidden code patterns (`asyncio.run(`, `CONNECTION_STRING=`, baked `primaryConnectionString`).
- KQL contains `create-merge table ['np.gov.bipad.hydrology…`.
- No `nepal-bipad-hydrology/fabric/` or `dashboard/` consumer assets to update.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main.