### PR TITLE
feat(snotel): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -127,7 +127,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Western US & Alaska — ~900 snowpack stations, NRCS",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "syke-hydro",

--- a/snotel/README.md
+++ b/snotel/README.md
@@ -64,6 +64,10 @@ Requires `xrcg` 0.10.1.
 - **Coverage**: 900+ stations across western US and Alaska
 - **License**: US Government Public Domain
 
+## Fabric notebook hosting
+
+For scheduled execution as a Microsoft Fabric notebook (instead of a long-running container), deploy with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1). The notebook at `snotel/notebook/snotel-feed.ipynb` runs `snotel feed --once` per scheduled invocation and writes dedupe state to OneLake.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/snotel/kql/create-kql-script.ps1
+++ b/snotel/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\snotel.xreg.json"
 $kqlFile = Join-Path $scriptDir "snotel.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace gov.usda.nrcs.snotel

--- a/snotel/kql/snotel.kql
+++ b/snotel/kql/snotel.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['gov.usda.nrcs.snotel.Station'] (
    [station_triplet]: string,
    [name]: string,
    [state]: string,
@@ -39,9 +39,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for a USDA NRCS SNOTEL (SNOwpack TELemetry) station. SNOTEL is an automated system of over 900 snowpack monitoring sites in the western United States and Alaska operated by the Natural Resources Conservation Service. Each station reports snowpack, precipitation, and temperature data via satellite telemetry. This reference record provides the station identity and geographic context for the hourly telemetry observations.\"}";
+.alter table ['gov.usda.nrcs.snotel.Station'] docstring "{\"description\": \"Reference metadata for a USDA NRCS SNOTEL (SNOwpack TELemetry) station. SNOTEL is an automated system of over 900 snowpack monitoring sites in the western United States and Alaska operated by the Natural Resources Conservation Service. Each station reports snowpack, precipitation, and temperature data via satellite telemetry. This reference record provides the station identity and geographic context for the hourly telemetry observations.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['gov.usda.nrcs.snotel.Station'] column-docstrings (
    [station_triplet]: "{\"description\": \"SNOTEL station triplet identifier in the format '{stationId}:{stateCode}:SNTL'. This is the canonical identifier used by the USDA NRCS Water and Climate Center to uniquely reference each SNOTEL site (e.g. '838:CO:SNTL' for University Camp, Colorado).\"}",
    [name]: "{\"description\": \"Human-readable station name assigned by the USDA NRCS (e.g. 'University Camp', 'Berthoud Summit'). Station names are generally geographic references to the site location.\"}",
    [state]: "{\"description\": \"Two-letter US state or territory code where the station is located (e.g. 'CO', 'AK', 'MT'). Stations are distributed across the western United States and Alaska.\"}",
@@ -55,7 +55,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['gov.usda.nrcs.snotel.Station'] ingestion json mapping "gov.usda.nrcs.snotel.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -72,7 +72,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['gov.usda.nrcs.snotel.Station'] ingestion json mapping "gov.usda.nrcs.snotel.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -89,13 +89,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['gov.usda.nrcs.snotel.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usda.nrcs.snotel.StationLatest'] on table ['gov.usda.nrcs.snotel.Station'] {
+    ['gov.usda.nrcs.snotel.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['gov.usda.nrcs.snotel.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -106,7 +106,7 @@
 }]
 ```
 
-.create-merge table [SnowObservation] (
+.create-merge table ['gov.usda.nrcs.snotel.SnowObservation'] (
    [station_triplet]: string,
    [date_time]: datetime,
    [snow_water_equivalent]: real,
@@ -120,9 +120,9 @@
    [___subject]: string
 );
 
-.alter table [SnowObservation] docstring "{\"description\": \"Hourly snow and weather observation from a USDA NRCS SNOTEL station. Each record represents one hourly reading transmitted via satellite telemetry from an automated high-elevation monitoring site. The observation includes Snow Water Equivalent (the primary hydrologic measurement), snow depth, accumulated precipitation, and air temperature. Missing values are common when sensors are offline, under maintenance, or producing suspect readings \\u2014 the NRCS quality-control process may flag or remove values. Data is sourced from the NRCS Report Generator at https://wcc.sc.egov.usda.gov/reportGenerator/.\"}";
+.alter table ['gov.usda.nrcs.snotel.SnowObservation'] docstring "{\"description\": \"Hourly snow and weather observation from a USDA NRCS SNOTEL station. Each record represents one hourly reading transmitted via satellite telemetry from an automated high-elevation monitoring site. The observation includes Snow Water Equivalent (the primary hydrologic measurement), snow depth, accumulated precipitation, and air temperature. Missing values are common when sensors are offline, under maintenance, or producing suspect readings \\u2014 the NRCS quality-control process may flag or remove values. Data is sourced from the NRCS Report Generator at https://wcc.sc.egov.usda.gov/reportGenerator/.\"}";
 
-.alter table [SnowObservation] column-docstrings (
+.alter table ['gov.usda.nrcs.snotel.SnowObservation'] column-docstrings (
    [station_triplet]: "{\"description\": \"SNOTEL station triplet identifier in the format '{stationId}:{stateCode}:SNTL'. Links this observation to the station that reported it.\"}",
    [date_time]: "{\"description\": \"Observation timestamp reported by the SNOTEL station. Hourly readings are transmitted via satellite telemetry, typically at the top of each hour. The time is in the station's local standard time as reported by the NRCS Report Generator.\"}",
    [snow_water_equivalent]: "{\"description\": \"Snow Water Equivalent (SWE) \\u2014 the depth of water that would theoretically result if the entire snowpack were melted instantaneously. Measured by a snow pillow sensor at the station. This is the primary measurement for water supply forecasting. Reported in inches.\"}",
@@ -136,7 +136,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [SnowObservation] ingestion json mapping "SnowObservation_json_flat"
+.create-or-alter table ['gov.usda.nrcs.snotel.SnowObservation'] ingestion json mapping "gov.usda.nrcs.snotel.SnowObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -153,7 +153,7 @@
 ]
 ```
 
-.create-or-alter table [SnowObservation] ingestion json mapping "SnowObservation_json_ce_structured"
+.create-or-alter table ['gov.usda.nrcs.snotel.SnowObservation'] ingestion json mapping "gov.usda.nrcs.snotel.SnowObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -170,13 +170,13 @@
 ]
 ```
 
-.drop materialized-view SnowObservationLatest ifexists;
+.drop materialized-view ['gov.usda.nrcs.snotel.SnowObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SnowObservationLatest on table SnowObservation {
-    SnowObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usda.nrcs.snotel.SnowObservationLatest'] on table ['gov.usda.nrcs.snotel.SnowObservation'] {
+    ['gov.usda.nrcs.snotel.SnowObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [SnowObservation] policy update
+.alter table ['gov.usda.nrcs.snotel.SnowObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/snotel/notebook/snotel-feed.ipynb
+++ b/snotel/notebook/snotel-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SNOTEL Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the USDA NRCS SNOTEL API for hourly snow and weather observations from SNOTEL stations and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `snotel` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `snotel feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"snotel-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/snotel/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/snotel/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing snotel package from Fabric Environment...')\n",
+    "    from snotel import snotel as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['snotel', 'feed', '--once'] if ONCE_MODE else ['snotel', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/snotel/snotel/snotel.py
+++ b/snotel/snotel/snotel.py
@@ -384,14 +384,19 @@ class SnotelPoller:
                      total, len(station_triplets))
         return total
 
-    def run(self, station_triplets: List[str]) -> None:
+    def run(self, station_triplets: List[str], once: bool = False,
+            polling_interval: int = POLL_INTERVAL_SECONDS) -> None:
         """
-        Main run loop: emit reference data, then poll continuously.
+        Main run loop: emit reference data, then poll.
 
         Args:
             station_triplets: The list of station triplets to monitor.
+            once: If True, exit after a single polling cycle. Useful for
+                  scheduled execution in Fabric notebooks.
+            polling_interval: Seconds to wait between polling cycles.
         """
-        logger.info("Starting SNOTEL bridge with %d stations", len(station_triplets))
+        logger.info("Starting SNOTEL bridge with %d stations (once=%s)",
+                    len(station_triplets), once)
         self.emit_station_reference(station_triplets)
 
         while True:
@@ -399,7 +404,10 @@ class SnotelPoller:
                 self.poll_all(station_triplets)
             except Exception as e:
                 logger.error("Error during poll cycle: %s", e)
-            time.sleep(POLL_INTERVAL_SECONDS)
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
+            time.sleep(polling_interval)
 
 
 def main():
@@ -410,6 +418,10 @@ def main():
     feed_parser = subparsers.add_parser("feed", help="Start polling SNOTEL stations")
     feed_parser.add_argument("--stations", nargs="*",
                              help="Station triplets to poll (default: built-in set)")
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                                  'Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -450,8 +462,16 @@ def main():
     station_triplets = args.stations if args.stations else DEFAULT_STATION_TRIPLETS
     state_file = os.environ.get("STATE_FILE", "snotel_state.json")
 
+    polling_interval = POLL_INTERVAL_SECONDS
+    if os.environ.get("POLLING_INTERVAL"):
+        try:
+            polling_interval = int(os.environ["POLLING_INTERVAL"])
+        except ValueError:
+            logger.warning("Invalid POLLING_INTERVAL env var; using default %d",
+                           POLL_INTERVAL_SECONDS)
+
     log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
     logging.getLogger().setLevel(getattr(logging, log_level, logging.INFO))
 
     poller = SnotelPoller(kafka_config, kafka_topic, state_file)
-    poller.run(station_triplets)
+    poller.run(station_triplets, once=args.once, polling_interval=polling_interval)

--- a/snotel/tests/test_once_mode.py
+++ b/snotel/tests/test_once_mode.py
@@ -1,0 +1,74 @@
+"""
+Tests that the SNOTEL bridge exits after a single polling cycle when
+`--once` (or `ONCE_MODE=true`) is set. This is required by the Fabric
+notebook hosting model where each scheduled invocation runs exactly one
+cycle before returning control to the kernel.
+"""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from snotel.snotel import SnotelPoller, main
+
+
+@patch('snotel.snotel.GovUsdaNrcsSnotelEventProducer')
+@patch('confluent_kafka.Producer')
+@patch('snotel.snotel.time.sleep')
+def test_run_once_exits_after_single_cycle(
+    mock_sleep, mock_producer_class, mock_event_producer, tmp_path,
+):
+    """``run(..., once=True)`` polls once and returns without sleeping."""
+    poller = SnotelPoller(
+        kafka_config={'bootstrap.servers': 'localhost:9092'},
+        kafka_topic='test',
+        last_polled_file=str(tmp_path / 'state.json'),
+    )
+
+    with patch.object(poller, 'poll_all', return_value=0) as mock_poll, \
+         patch.object(poller, 'emit_station_reference', return_value=1) as mock_ref:
+        poller.run(['838:CO:SNTL'], once=True, polling_interval=3600)
+
+    mock_ref.assert_called_once()
+    assert mock_poll.call_count == 1, "poll_all must run exactly once in --once mode"
+    mock_sleep.assert_not_called(), "no sleep between cycles when once=True"
+
+
+@patch('snotel.snotel.SnotelPoller')
+def test_main_once_flag_propagates(mock_poller_class, monkeypatch):
+    """``snotel feed --once`` propagates once=True into SnotelPoller.run."""
+    instance = MagicMock()
+    mock_poller_class.return_value = instance
+
+    monkeypatch.setenv('CONNECTION_STRING', 'BootstrapServer=localhost:9092;EntityPath=snotel')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+
+    test_argv = ['snotel', 'feed', '--once', '--stations', '838:CO:SNTL']
+    with patch.object(sys, 'argv', test_argv):
+        main()
+
+    instance.run.assert_called_once()
+    _, kwargs = instance.run.call_args
+    assert kwargs.get('once') is True
+
+
+@patch('snotel.snotel.SnotelPoller')
+def test_main_once_env_var(mock_poller_class, monkeypatch):
+    """``ONCE_MODE=true`` environment variable also enables once mode."""
+    instance = MagicMock()
+    mock_poller_class.return_value = instance
+
+    monkeypatch.setenv('CONNECTION_STRING', 'BootstrapServer=localhost:9092;EntityPath=snotel')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+
+    test_argv = ['snotel', 'feed', '--stations', '838:CO:SNTL']
+    with patch.object(sys, 'argv', test_argv):
+        main()
+
+    instance.run.assert_called_once()
+    _, kwargs = instance.run.call_args
+    assert kwargs.get('once') is True


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (see `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes
- Adds `snotel/notebook/snotel-feed.ipynb` cloned from the pegelonline canonical template with mechanical substitutions.
- Adds `--once` / `ONCE_MODE` support to the bridge (modeled on pegelonline) plus `tests/test_once_mode.py` covering both single-cycle exit and CLI/env-var propagation.
- Flips `catalog.json` `"notebook": true` for snotel so the gh-pages portal exposes the Fabric Notebook deploy button.
- Flips `snotel/kql/create-kql-script.ps1` to pass `-Qualified -Namespace gov.usda.nrcs.snotel` and regenerates `snotel/kql/snotel.kql` with namespace-prefixed table names (e.g. `['gov.usda.nrcs.snotel.Station']`). The xreg schemas have no `namespace` declared so the namespace is supplied explicitly. Update-policy `type ==` predicates remain the upstream CloudEvents type strings (`'gov.usda.nrcs.snotel.Station'`, etc.).

## Validations performed locally
- Notebook JSON is well-formed (`json.load` ok).
- `pytest snotel/tests` — 64/64 passed (including 3 new `--once` tests in `test_once_mode.py`).
- Notebook parameter cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in code cells (`asyncio.run(`, `%pip install`, baked `CONNECTION_STRING=`, `primaryConnectionString=`).
- Regenerated KQL has qualified table names (`create-merge table ['gov.usda.nrcs.snotel.Station']`, `['gov.usda.nrcs.snotel.SnowObservation']`).

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on merge to main and publish wheels to the `notebook-wheels` release.
