### PR TITLE
feat(uk-ea-flood-monitoring): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -143,7 +143,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "England — ~4,000 stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "usgs-iv",

--- a/uk-ea-flood-monitoring/README.md
+++ b/uk-ea-flood-monitoring/README.md
@@ -17,6 +17,9 @@ minutes.
 - **Parameters**: Water Level, Flow, Rainfall, Wind, Temperature
 - **Update Frequency**: Every 15 minutes
 - **Data Format**: JSON (Linked Data)
+- **Fabric notebook hosting**: deploy as a scheduled Fabric notebook with
+  [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+  (uses `notebook/uk-ea-flood-monitoring-feed.ipynb`).
 
 ## Installation
 

--- a/uk-ea-flood-monitoring/kql/create-kql-script.ps1
+++ b/uk-ea-flood-monitoring/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\uk_ea_flood_monitoring.xreg.json"
 $kqlFile = Join-Path $scriptDir "uk_ea_flood_monitoring.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "uk.gov.environment.ea.floodmonitoring"

--- a/uk-ea-flood-monitoring/kql/uk_ea_flood_monitoring.kql
+++ b/uk-ea-flood-monitoring/kql/uk_ea_flood_monitoring.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['uk.gov.environment.ea.floodmonitoring.Station'] (
    [station_reference]: string,
    [label]: string,
    [river_name]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['uk.gov.environment.ea.floodmonitoring.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['uk.gov.environment.ea.floodmonitoring.Station'] ingestion json mapping "uk.gov.environment.ea.floodmonitoring.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['uk.gov.environment.ea.floodmonitoring.Station'] ingestion json mapping "uk.gov.environment.ea.floodmonitoring.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,13 +87,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['uk.gov.environment.ea.floodmonitoring.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.gov.environment.ea.floodmonitoring.StationLatest'] on table ['uk.gov.environment.ea.floodmonitoring.Station'] {
+    ['uk.gov.environment.ea.floodmonitoring.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['uk.gov.environment.ea.floodmonitoring.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -104,7 +104,7 @@
 }]
 ```
 
-.create-merge table [Reading] (
+.create-merge table ['uk.gov.environment.ea.floodmonitoring.Reading'] (
    [station_reference]: string,
    [date_time]: datetime,
    [measure]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [Reading] docstring "{\"description\": \"Reading\"}";
+.alter table ['uk.gov.environment.ea.floodmonitoring.Reading'] docstring "{\"description\": \"Reading\"}";
 
-.create-or-alter table [Reading] ingestion json mapping "Reading_json_flat"
+.create-or-alter table ['uk.gov.environment.ea.floodmonitoring.Reading'] ingestion json mapping "uk.gov.environment.ea.floodmonitoring.Reading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -133,7 +133,7 @@
 ]
 ```
 
-.create-or-alter table [Reading] ingestion json mapping "Reading_json_ce_structured"
+.create-or-alter table ['uk.gov.environment.ea.floodmonitoring.Reading'] ingestion json mapping "uk.gov.environment.ea.floodmonitoring.Reading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -148,13 +148,13 @@
 ]
 ```
 
-.drop materialized-view ReadingLatest ifexists;
+.drop materialized-view ['uk.gov.environment.ea.floodmonitoring.ReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ReadingLatest on table Reading {
-    Reading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.gov.environment.ea.floodmonitoring.ReadingLatest'] on table ['uk.gov.environment.ea.floodmonitoring.Reading'] {
+    ['uk.gov.environment.ea.floodmonitoring.Reading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Reading] policy update
+.alter table ['uk.gov.environment.ea.floodmonitoring.Reading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/uk-ea-flood-monitoring/notebook/uk-ea-flood-monitoring-feed.ipynb
+++ b/uk-ea-flood-monitoring/notebook/uk-ea-flood-monitoring-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# UK EA Flood Monitoring Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the UK Environment Agency Flood Monitoring API for water level, flow, and rainfall readings from ~4,000 stations across England and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `uk_ea_flood_monitoring` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `uk-ea-flood-monitoring feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"uk-ea-flood-monitoring-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/uk-ea-flood-monitoring/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/uk-ea-flood-monitoring/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing uk_ea_flood_monitoring package from Fabric Environment...')\n",
+    "    from uk_ea_flood_monitoring import uk_ea_flood_monitoring as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['uk-ea-flood-monitoring', 'feed', '--once'] if ONCE_MODE else ['uk-ea-flood-monitoring', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/uk-ea-flood-monitoring/tests/test_once_mode.py
+++ b/uk-ea-flood-monitoring/tests/test_once_mode.py
@@ -1,0 +1,98 @@
+"""Verify the --once flag causes main() to exit after one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import uk_ea_flood_monitoring.uk_ea_flood_monitoring as bridge
+
+
+SAMPLE_STATIONS = [
+    {
+        "@id": "http://environment.data.gov.uk/flood-monitoring/id/stations/1029TH",
+        "stationReference": "1029TH",
+        "notation": "1029TH",
+        "label": "Kingston",
+        "riverName": "Thames",
+        "catchmentName": "Thames",
+        "town": "Kingston",
+        "lat": 51.41,
+        "long": -0.30,
+        "status": "Active",
+        "dateOpened": "1900-01-01",
+        "measures": [
+            {"@id": "http://environment.data.gov.uk/flood-monitoring/id/measures/1029TH-level-stage-i-15_min-mASD"}
+        ],
+    }
+]
+
+SAMPLE_READINGS = [
+    {
+        "measure": "http://environment.data.gov.uk/flood-monitoring/id/measures/1029TH-level-stage-i-15_min-mASD",
+        "dateTime": "2025-01-01T00:00:00Z",
+        "value": 1.23,
+    }
+]
+
+
+def _fake_get(url, *args, **kwargs):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    if "stations" in url:
+        resp.json.return_value = {"items": SAMPLE_STATIONS}
+    else:
+        resp.json.return_value = {"items": SAMPLE_READINGS}
+    return resp
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "uk-ea-flood-monitoring",
+        "feed",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "uk-ea-flood-monitoring",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "--once",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    fake_producer_module = MagicMock()
+    fake_producer_module.Producer = MagicMock(return_value=MagicMock())
+    with patch.dict(sys.modules, {"confluent_kafka": fake_producer_module}), \
+         patch.object(bridge.requests.Session, "get", side_effect=_fake_get), \
+         patch.object(bridge, "UKGovEnvironmentEAFloodMonitoringEventProducer") as ProdCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProdCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "uk-ea-flood-monitoring",
+        "feed",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "uk-ea-flood-monitoring",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    sleep_mock = MagicMock()
+    fake_producer_module = MagicMock()
+    fake_producer_module.Producer = MagicMock(return_value=MagicMock())
+    with patch.dict(sys.modules, {"confluent_kafka": fake_producer_module}), \
+         patch.object(bridge.requests.Session, "get", side_effect=_fake_get), \
+         patch.object(bridge, "UKGovEnvironmentEAFloodMonitoringEventProducer") as ProdCls, \
+         patch.object(bridge.time, "sleep", sleep_mock):
+        ProdCls.return_value = MagicMock()
+        bridge.main()
+
+    sleep_mock.assert_not_called()

--- a/uk-ea-flood-monitoring/uk_ea_flood_monitoring/uk_ea_flood_monitoring.py
+++ b/uk-ea-flood-monitoring/uk_ea_flood_monitoring/uk_ea_flood_monitoring.py
@@ -130,7 +130,7 @@ class EAFloodMonitoringAPI:
             config_dict['sasl.mechanism'] = 'PLAIN'
         return config_dict
 
-    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '') -> None:
+    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '', once: bool = False) -> None:
         """Feed stations and send updates as CloudEvents."""
         previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -224,6 +224,9 @@ class EAFloodMonitoringAPI:
                 logging.info("Sent %d readings in %.1f seconds. Waiting %.0f seconds.",
                              count, end_time - start_time, effective_interval)
                 _save_state(state_file, previous_readings)
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
 
@@ -279,6 +282,9 @@ def main() -> None:
                              default=polling_interval_default)
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE', os.path.expanduser('~/.uk_ea_flood_monitoring_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -333,7 +339,7 @@ def main() -> None:
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
 
-        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file, once=args.once)
     else:
         parser.print_help()
 


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes
- **Notebook**: `uk-ea-flood-monitoring/notebook/uk-ea-flood-monitoring-feed.ipynb` — copied verbatim from the pegelonline template with the exact substitution table applied (display name, package import, sys.argv, STATE_FILE / LOG_PATH paths, EVENTSTREAM_NAME).
- **Catalog**: `catalog.json` `uk-ea-flood-monitoring` entry now has `\"notebook\": true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Bridge `--once`**: Added `--once` CLI flag and `ONCE_MODE` env-var fallback to `uk_ea_flood_monitoring.py` modeled on pegelonline. Added `tests/test_once_mode.py` with two passing tests (CLI flag + env var) asserting `main()` exits after one polling cycle with `time.sleep` never called.
- **Qualified KQL tables**: `kql/create-kql-script.ps1` now passes `-Qualified -Namespace uk.gov.environment.ea.floodmonitoring`. Regenerated `kql/uk_ea_flood_monitoring.kql` so all tables, mappings, and update policies are namespace-prefixed (e.g. `['uk.gov.environment.ea.floodmonitoring.Station']`). The `_cloudevents_dispatch` table and the update-policy type predicate values are unchanged. The xreg schemas declare no namespace at the schema level, so an explicit `-Namespace` is required.
- **README**: One-bullet `Fabric notebook hosting` entry added pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

No `fabric/` or `dashboard/` assets exist for this source, so no consumer-asset audit fixes were needed.

## Validations performed locally
- Notebook JSON parses (`json.load`).
- All required placeholders present in parameters cell (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No `asyncio.run()`, no `CONNECTION_STRING = \"...\"` literal, no `primaryConnectionString` bake-in. (The literal `%pip install` only appears in the same documentary mention as in the canonical pegelonline template.)
- Qualified-tables regex check passes (`create-merge table ['[a-z]`).
- 20 bridge unit tests pass including the 2 new `test_once_mode` tests.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to `main` and publish wheels to the `notebook-wheels` release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>