### PR TITLE
feat(noaa-ndbc): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -83,7 +83,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "United States — buoy observations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "king-county-marine",

--- a/noaa-ndbc/README.md
+++ b/noaa-ndbc/README.md
@@ -12,6 +12,7 @@
 - **Family-Aware Deduplication**: Tracks last seen observation timestamps per station and feed family in a state file to avoid reprocessing.
 - **Kafka Integration**: Send buoy observations to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: A Fabric notebook variant lives under `notebook/noaa-ndbc-feed.ipynb` and is deployable via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) for serverless, scheduled execution.
 
 ## Installation
 

--- a/noaa-ndbc/kql/create-kql-script.ps1
+++ b/noaa-ndbc/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\noaa_ndbc.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa_ndbc.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'microsoft.opendata.us.noaa.ndbc'

--- a/noaa-ndbc/kql/noaa_ndbc.kql
+++ b/noaa-ndbc/kql/noaa_ndbc.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [BuoyObservation] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] (
    [station_id]: string,
    [latitude]: real,
    [longitude]: real,
@@ -51,9 +51,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyObservation] docstring "{\"description\": \"Real-time standard meteorological and oceanographic observation from an NDBC buoy, C-MAN station, or partner platform. Sourced from the NDBC latest_obs.txt composite file which is updated every five minutes. Fields cover wind, waves, pressure, temperature, dewpoint, pressure tendency, visibility, and tide.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] docstring "{\"description\": \"Real-time standard meteorological and oceanographic observation from an NDBC buoy, C-MAN station, or partner platform. Sourced from the NDBC latest_obs.txt composite file which is updated every five minutes. Fields cover wind, waves, pressure, temperature, dewpoint, pressure tendency, visibility, and tide.\"}";
 
-.alter table [BuoyObservation] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier. Five-character alphanumeric code assigned by NDBC (e.g. '41001' for deep-ocean buoys, 'BURL1' for C-MAN stations).\"}",
    [latitude]: "{\"description\": \"Latitude of the observing platform in decimal degrees north. Negative values indicate southern hemisphere.\"}",
    [longitude]: "{\"description\": \"Longitude of the observing platform in decimal degrees east. Negative values indicate western hemisphere.\"}",
@@ -79,7 +79,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyObservation] ingestion json mapping "BuoyObservation_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -108,7 +108,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyObservation] ingestion json mapping "BuoyObservation_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -137,13 +137,13 @@
 ]
 ```
 
-.drop materialized-view BuoyObservationLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyObservationLatest on table BuoyObservation {
-    BuoyObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyObservationLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyObservation] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyObservation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -154,7 +154,7 @@
 }]
 ```
 
-.create-merge table [BuoyStation] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] (
    [station_id]: string,
    [owner]: string,
    [station_type]: string,
@@ -170,9 +170,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyStation] docstring "{\"description\": \"Reference record from the NDBC station table describing the owning agency, platform type, hull class, canonical station name, parsed location, and time-zone code for an observing platform.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] docstring "{\"description\": \"Reference record from the NDBC station table describing the owning agency, platform type, hull class, canonical station name, parsed location, and time-zone code for an observing platform.\"}";
 
-.alter table [BuoyStation] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier. Five-character alphanumeric code assigned by NDBC and reused across the station table, latest observations, and realtime2 products.\"}",
    [owner]: "{\"description\": \"Owning organization as listed in the NDBC station table, such as NDBC, NOS, or another partner agency.\"}",
    [station_type]: "{\"description\": \"Platform type from the station table, such as Weather Buoy or C-MAN Station.\"}",
@@ -188,7 +188,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyStation] ingestion json mapping "BuoyStation_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -207,7 +207,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyStation] ingestion json mapping "BuoyStation_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -226,13 +226,13 @@
 ]
 ```
 
-.drop materialized-view BuoyStationLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyStationLatest on table BuoyStation {
-    BuoyStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyStationLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyStation] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -243,7 +243,7 @@
 }]
 ```
 
-.create-merge table [BuoySolarRadiationObservation] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] (
    [station_id]: string,
    [timestamp]: datetime,
    [shortwave_radiation_licor]: real,
@@ -256,9 +256,9 @@
    [___subject]: string
 );
 
-.alter table [BuoySolarRadiationObservation] docstring "{\"description\": \"Hourly solar radiation observation from the NDBC .srad realtime2 product. The file reports LI-COR shortwave radiation, Eppley shortwave radiation, and downwelling longwave radiation when those sensors are installed on a station.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] docstring "{\"description\": \"Hourly solar radiation observation from the NDBC .srad realtime2 product. The file reports LI-COR shortwave radiation, Eppley shortwave radiation, and downwelling longwave radiation when those sensors are installed on a station.\"}";
 
-.alter table [BuoySolarRadiationObservation] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier. The .srad realtime2 file is published per station and keyed by this identifier.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .srad realtime2 file.\"}",
    [shortwave_radiation_licor]: "{\"description\": \"Average shortwave radiation over the preceding hour from a LI-COR LI-200 pyranometer when the SRAD1 column is present. Unit: watts per square meter.\"}",
@@ -271,7 +271,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoySolarRadiationObservation] ingestion json mapping "BuoySolarRadiationObservation_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -287,7 +287,7 @@
 ]
 ```
 
-.create-or-alter table [BuoySolarRadiationObservation] ingestion json mapping "BuoySolarRadiationObservation_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -303,13 +303,13 @@
 ]
 ```
 
-.drop materialized-view BuoySolarRadiationObservationLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoySolarRadiationObservationLatest on table BuoySolarRadiationObservation {
-    BuoySolarRadiationObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservationLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoySolarRadiationObservation] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySolarRadiationObservation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -320,7 +320,7 @@
 }]
 ```
 
-.create-merge table [BuoyOceanographicObservation] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] (
    [station_id]: string,
    [timestamp]: datetime,
    [depth]: real,
@@ -340,9 +340,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyOceanographicObservation] docstring "{\"description\": \"Oceanographic observation from the NDBC .ocean realtime2 product. Each record reports the measurement depth together with direct ocean temperature, conductivity, salinity, dissolved oxygen, chlorophyll, turbidity, pH, and redox potential for one station and timestamp.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] docstring "{\"description\": \"Oceanographic observation from the NDBC .ocean realtime2 product. Each record reports the measurement depth together with direct ocean temperature, conductivity, salinity, dissolved oxygen, chlorophyll, turbidity, pH, and redox potential for one station and timestamp.\"}";
 
-.alter table [BuoyOceanographicObservation] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier. The .ocean realtime2 file is published per station and keyed by this identifier.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .ocean realtime2 file.\"}",
    [depth]: "{\"description\": \"Depth in meters at which the oceanographic measurements in this record were taken.\"}",
@@ -362,7 +362,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyOceanographicObservation] ingestion json mapping "BuoyOceanographicObservation_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -385,7 +385,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyOceanographicObservation] ingestion json mapping "BuoyOceanographicObservation_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -408,13 +408,13 @@
 ]
 ```
 
-.drop materialized-view BuoyOceanographicObservationLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyOceanographicObservationLatest on table BuoyOceanographicObservation {
-    BuoyOceanographicObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservationLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyOceanographicObservation] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyOceanographicObservation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -425,7 +425,7 @@
 }]
 ```
 
-.create-merge table [BuoyDartMeasurement] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] (
    [station_id]: string,
    [timestamp]: datetime,
    [measurement_type_code]: int,
@@ -437,9 +437,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyDartMeasurement] docstring "{\"description\": \"Realtime DART tsunameter measurement from the NDBC .dart product. Each record contains a second-resolution timestamp, the documented NDBC measurement type code, and the measured water-column height for a DART station.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] docstring "{\"description\": \"Realtime DART tsunameter measurement from the NDBC .dart product. Each record contains a second-resolution timestamp, the documented NDBC measurement type code, and the measured water-column height for a DART station.\"}";
 
-.alter table [BuoyDartMeasurement] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier for the DART tsunameter site publishing the .dart realtime2 file.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm ss columns in the NDBC .dart realtime2 file.\"}",
    [measurement_type_code]: "{\"description\": \"Measurement type code from the T column in the DART file. NDBC documents 1 as a 15-minute measurement, 2 as a 1-minute measurement, and 3 as a 15-second measurement.\"}",
@@ -451,7 +451,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyDartMeasurement] ingestion json mapping "BuoyDartMeasurement_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -466,7 +466,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyDartMeasurement] ingestion json mapping "BuoyDartMeasurement_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -481,13 +481,13 @@
 ]
 ```
 
-.drop materialized-view BuoyDartMeasurementLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyDartMeasurementLatest on table BuoyDartMeasurement {
-    BuoyDartMeasurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurementLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyDartMeasurement] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDartMeasurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -498,7 +498,7 @@
 }]
 ```
 
-.create-merge table [BuoyContinuousWindObservation] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] (
    [station_id]: string,
    [timestamp]: datetime,
    [wind_direction]: real,
@@ -513,9 +513,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyContinuousWindObservation] docstring "{\"description\": \"Continuous-wind measurement from the NDBC .cwind realtime2 product. Each record reports the latest ten-minute wind average together with the strongest gust observed during the surrounding hourly window and the HHMM code describing when that gust occurred.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] docstring "{\"description\": \"Continuous-wind measurement from the NDBC .cwind realtime2 product. Each record reports the latest ten-minute wind average together with the strongest gust observed during the surrounding hourly window and the HHMM code describing when that gust occurred.\"}";
 
-.alter table [BuoyContinuousWindObservation] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier for the station publishing the .cwind realtime2 file.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .cwind realtime2 file.\"}",
    [wind_direction]: "{\"description\": \"Ten-minute average wind direction from the WDIR column, measured clockwise from true north. Unit: degrees true.\"}",
@@ -530,7 +530,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyContinuousWindObservation] ingestion json mapping "BuoyContinuousWindObservation_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -548,7 +548,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyContinuousWindObservation] ingestion json mapping "BuoyContinuousWindObservation_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -566,13 +566,13 @@
 ]
 ```
 
-.drop materialized-view BuoyContinuousWindObservationLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyContinuousWindObservationLatest on table BuoyContinuousWindObservation {
-    BuoyContinuousWindObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservationLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyContinuousWindObservation] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyContinuousWindObservation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -583,7 +583,7 @@
 }]
 ```
 
-.create-merge table [BuoySupplementalMeasurement] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] (
    [station_id]: string,
    [timestamp]: datetime,
    [lowest_pressure]: real,
@@ -598,9 +598,9 @@
    [___subject]: string
 );
 
-.alter table [BuoySupplementalMeasurement] docstring "{\"description\": \"Supplemental hourly extrema from the NDBC .supl realtime2 product. Each record reports the lowest one-minute pressure recorded during the hour and the highest one-minute wind speed with its direction and HHMM occurrence times.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] docstring "{\"description\": \"Supplemental hourly extrema from the NDBC .supl realtime2 product. Each record reports the lowest one-minute pressure recorded during the hour and the highest one-minute wind speed with its direction and HHMM occurrence times.\"}";
 
-.alter table [BuoySupplementalMeasurement] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier for the station publishing the .supl realtime2 file.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .supl realtime2 file.\"}",
    [lowest_pressure]: "{\"description\": \"Lowest one-minute atmospheric pressure recorded during the hour from the PRES column. Unit: hectopascals.\"}",
@@ -615,7 +615,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoySupplementalMeasurement] ingestion json mapping "BuoySupplementalMeasurement_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -633,7 +633,7 @@
 ]
 ```
 
-.create-or-alter table [BuoySupplementalMeasurement] ingestion json mapping "BuoySupplementalMeasurement_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -651,13 +651,13 @@
 ]
 ```
 
-.drop materialized-view BuoySupplementalMeasurementLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoySupplementalMeasurementLatest on table BuoySupplementalMeasurement {
-    BuoySupplementalMeasurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurementLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoySupplementalMeasurement] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoySupplementalMeasurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -668,7 +668,7 @@
 }]
 ```
 
-.create-merge table [BuoyDetailedWaveSummary] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] (
    [station_id]: string,
    [timestamp]: datetime,
    [significant_wave_height]: real,
@@ -688,9 +688,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyDetailedWaveSummary] docstring "{\"description\": \"Detailed wave-summary record from the NDBC .spec realtime2 product. Each record summarizes significant wave height together with swell and wind-wave components, qualitative steepness, and mean wave direction for one station timestamp.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] docstring "{\"description\": \"Detailed wave-summary record from the NDBC .spec realtime2 product. Each record summarizes significant wave height together with swell and wind-wave components, qualitative steepness, and mean wave direction for one station timestamp.\"}";
 
-.alter table [BuoyDetailedWaveSummary] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier for the station publishing the .spec realtime2 file.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .spec realtime2 file.\"}",
    [significant_wave_height]: "{\"description\": \"Significant wave height from the WVHT column, representing the average height of the highest one-third of waves during the sampling period. Unit: meters.\"}",
@@ -710,7 +710,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyDetailedWaveSummary] ingestion json mapping "BuoyDetailedWaveSummary_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -733,7 +733,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyDetailedWaveSummary] ingestion json mapping "BuoyDetailedWaveSummary_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -756,13 +756,13 @@
 ]
 ```
 
-.drop materialized-view BuoyDetailedWaveSummaryLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummaryLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyDetailedWaveSummaryLatest on table BuoyDetailedWaveSummary {
-    BuoyDetailedWaveSummary | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummaryLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyDetailedWaveSummary] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyDetailedWaveSummary'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -773,7 +773,7 @@
 }]
 ```
 
-.create-merge table [BuoyHourlyRainMeasurement] (
+.create-merge table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] (
    [station_id]: string,
    [timestamp]: datetime,
    [accumulation]: real,
@@ -784,9 +784,9 @@
    [___subject]: string
 );
 
-.alter table [BuoyHourlyRainMeasurement] docstring "{\"description\": \"Hourly precipitation total from the NDBC .rain realtime2 product. Each record reports the one-hour rain accumulation for a station timestamp.\"}";
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] docstring "{\"description\": \"Hourly precipitation total from the NDBC .rain realtime2 product. Each record reports the one-hour rain accumulation for a station timestamp.\"}";
 
-.alter table [BuoyHourlyRainMeasurement] column-docstrings (
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] column-docstrings (
    [station_id]: "{\"description\": \"NDBC station identifier for the station publishing the .rain realtime2 file.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in UTC, constructed from the YYYY MM DD hh mm columns in the NDBC .rain realtime2 file.\"}",
    [accumulation]: "{\"description\": \"Hourly rain accumulation from the ACCUM column. This is the total precipitation accumulated during the 60-minute period ending at the reported timestamp. Unit: millimeters.\"}",
@@ -797,7 +797,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BuoyHourlyRainMeasurement] ingestion json mapping "BuoyHourlyRainMeasurement_json_flat"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -811,7 +811,7 @@
 ]
 ```
 
-.create-or-alter table [BuoyHourlyRainMeasurement] ingestion json mapping "BuoyHourlyRainMeasurement_json_ce_structured"
+.create-or-alter table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] ingestion json mapping "microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -825,13 +825,13 @@
 ]
 ```
 
-.drop materialized-view BuoyHourlyRainMeasurementLatest ifexists;
+.drop materialized-view ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BuoyHourlyRainMeasurementLatest on table BuoyHourlyRainMeasurement {
-    BuoyHourlyRainMeasurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurementLatest'] on table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] {
+    ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BuoyHourlyRainMeasurement] policy update
+.alter table ['microsoft.opendata.us.noaa.ndbc.BuoyHourlyRainMeasurement'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
+++ b/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
@@ -1031,6 +1031,9 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -1039,7 +1042,7 @@ def main():
     if not args.last_polled_file:
         args.last_polled_file = os.getenv('NDBC_LAST_POLLED_FILE')
         if not args.last_polled_file:
-            args.last_polled_file = os.path.expanduser('~/.ndbc_last_polled.json')
+            args.last_polled_file = os.getenv('STATE_FILE') or os.path.expanduser('~/.ndbc_last_polled.json')
 
     if args.connection_string:
         config_params = parse_connection_string(args.connection_string)
@@ -1078,7 +1081,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/noaa-ndbc/notebook/noaa-ndbc-feed.ipynb
+++ b/noaa-ndbc/notebook/noaa-ndbc-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NOAA NDBC Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the NOAA National Data Buoy Center (NDBC) station table, the composite `latest_obs.txt` feed, and selected `realtime2` family files (srad, ocean, dart, cwind, supl, spec, rain), then emits CloudEvents to the bound Fabric Event Stream. Station reference data is emitted first; per-station/per-family timestamps are deduped via a state file.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `noaa_ndbc` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `noaa-ndbc --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"noaa-ndbc-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/noaa-ndbc/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/noaa-ndbc/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing noaa_ndbc package from Fabric Environment...')\n",
+    "    from noaa_ndbc import noaa_ndbc as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['noaa-ndbc', '--once'] if ONCE_MODE else ['noaa-ndbc']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/noaa-ndbc/tests/test_once_mode.py
+++ b/noaa-ndbc/tests/test_once_mode.py
@@ -1,0 +1,89 @@
+"""Tests for --once single-cycle exit, used by the Fabric notebook hosting path."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import noaa_ndbc.noaa_ndbc as bridge  # noqa: F401  (ensure submodule import for patch())
+
+
+@pytest.fixture
+def fake_producer():
+    producer = MagicMock()
+    producer.producer = MagicMock()
+    return producer
+
+
+def _run_main_with_once(monkeypatch, fake_producer, argv):
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with patch(
+        "noaa_ndbc.noaa_ndbc.MicrosoftOpenDataUSNOAANDBCEventProducer",
+        return_value=fake_producer,
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.fetch_stations", return_value=[]
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_observations", return_value=[]
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.fetch_realtime2_file_index",
+        return_value={},
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_solar_radiation_observations",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_oceanographic_observations",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_dart_measurements", return_value=[]
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_continuous_wind_observations",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_supplemental_measurements",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_detailed_wave_summaries",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.poll_hourly_rain_measurements",
+        return_value=[],
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.load_state", return_value={}
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.NDBCBuoyPoller.save_state"
+    ), patch(
+        "noaa_ndbc.noaa_ndbc.time.sleep"
+    ) as sleep_mock:
+        from noaa_ndbc.noaa_ndbc import main
+        main()
+    return sleep_mock
+
+
+def test_once_flag_exits_after_one_cycle(monkeypatch, fake_producer):
+    sleep_mock = _run_main_with_once(
+        monkeypatch,
+        fake_producer,
+        [
+            "noaa-ndbc",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=test-topic",
+            "--once",
+        ],
+    )
+    # Single-cycle exit must NOT sleep at the end of the loop.
+    sleep_mock.assert_not_called()
+
+
+def test_once_env_var_exits_after_one_cycle(monkeypatch, fake_producer):
+    monkeypatch.setenv("ONCE_MODE", "true")
+    sleep_mock = _run_main_with_once(
+        monkeypatch,
+        fake_producer,
+        [
+            "noaa-ndbc",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        ],
+    )
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent. See `.github/skills/notebook-feeder-retrofit/SKILL.md`.

## What

- `noaa-ndbc/notebook/noaa-ndbc-feed.ipynb` — Fabric notebook copy of the pegelonline canonical template (4 cells, params/CS-lookup/run, log to OneLake).
- `catalog.json` — `notebook: true` flipped for `noaa-ndbc` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Bridge `--once` / `ONCE_MODE` support: added the missing argparse plumbing (`poll_and_send` already accepted `once=` internally) and a unit test asserting `main()` exits after exactly one polling cycle. `STATE_FILE` env var is also honored as a fallback for `--last-polled-file` so the notebook's parameter wires through.
- `noaa-ndbc/kql/create-kql-script.ps1` — appended `-Qualified -Namespace 'microsoft.opendata.us.noaa.ndbc'` (the xreg schemas declare no namespace) and regenerated `noaa_ndbc.kql`. All typed tables, materialized views, ingestion mappings, and update policies are now bracket-quoted with their FQN; the `_cloudevents_dispatch` table and the CloudEvents `type ==` predicates (`Microsoft.OpenData.US.NOAA.NDBC.*`) are unchanged. See `docs/plan-qualified-table-names.md` and DWD reference PR #257.
- `noaa-ndbc/README.md` — one-bullet Fabric-notebook-hosting note linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations

- Notebook JSON well-formed.
- Parameters cell contains all five placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns in code cells (no `asyncio.run(`, no `%pip install`, no baked `CONNECTION_STRING` or `primaryConnectionString`).
- KQL regenerated; qualified tables present (e.g. `['microsoft.opendata.us.noaa.ndbc.BuoyObservation']`); CloudEvents type predicates preserved.
- No consumer-asset drift to fix (source has no `fabric/` or `dashboard/` assets referencing landing tables).
- Bridge syntax check passed. `pip install`-dependent tests were not run locally per skill rules; the wheel-bundle workflow + Docker E2E gate the contract.

## Out of scope

No live Fabric deployment from the agent. The `publish-notebook-wheels.yml` workflow runs on merge and the portal exposes the button once `update-ghpages-catalog.yml` syncs the flag.