### PR TITLE
feat(smhi-hydro): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -126,7 +126,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Sweden — SMHI",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "snotel",

--- a/smhi-hydro/README.md
+++ b/smhi-hydro/README.md
@@ -30,6 +30,12 @@ bridge.
 
 See [CONTAINER.md](CONTAINER.md) for container deployment instructions.
 
+### Fabric notebook hosting
+
+This source can also be deployed as a scheduled Microsoft Fabric notebook
+feeder via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+using `notebook/smhi-hydro-feed.ipynb`.
+
 ## Usage
 
 ### List all stations

--- a/smhi-hydro/kql/create-kql-script.ps1
+++ b/smhi-hydro/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\smhi_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "smhi_hydro.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'se.gov.smhi.hydro'

--- a/smhi-hydro/kql/smhi_hydro.kql
+++ b/smhi-hydro/kql/smhi_hydro.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['se.gov.smhi.hydro.Station'] (
    [station_id]: string,
    [name]: string,
    [owner]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['se.gov.smhi.hydro.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['se.gov.smhi.hydro.Station'] ingestion json mapping "se.gov.smhi.hydro.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['se.gov.smhi.hydro.Station'] ingestion json mapping "se.gov.smhi.hydro.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,13 +87,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['se.gov.smhi.hydro.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['se.gov.smhi.hydro.StationLatest'] on table ['se.gov.smhi.hydro.Station'] {
+    ['se.gov.smhi.hydro.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['se.gov.smhi.hydro.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -104,7 +104,7 @@
 }]
 ```
 
-.create-merge table [DischargeObservation] (
+.create-merge table ['se.gov.smhi.hydro.DischargeObservation'] (
    [station_id]: string,
    [station_name]: string,
    [catchment_name]: string,
@@ -118,9 +118,9 @@
    [___subject]: string
 );
 
-.alter table [DischargeObservation] docstring "{\"description\": \"DischargeObservation\"}";
+.alter table ['se.gov.smhi.hydro.DischargeObservation'] docstring "{\"description\": \"DischargeObservation\"}";
 
-.create-or-alter table [DischargeObservation] ingestion json mapping "DischargeObservation_json_flat"
+.create-or-alter table ['se.gov.smhi.hydro.DischargeObservation'] ingestion json mapping "se.gov.smhi.hydro.DischargeObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -137,7 +137,7 @@
 ]
 ```
 
-.create-or-alter table [DischargeObservation] ingestion json mapping "DischargeObservation_json_ce_structured"
+.create-or-alter table ['se.gov.smhi.hydro.DischargeObservation'] ingestion json mapping "se.gov.smhi.hydro.DischargeObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -154,13 +154,13 @@
 ]
 ```
 
-.drop materialized-view DischargeObservationLatest ifexists;
+.drop materialized-view ['se.gov.smhi.hydro.DischargeObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DischargeObservationLatest on table DischargeObservation {
-    DischargeObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['se.gov.smhi.hydro.DischargeObservationLatest'] on table ['se.gov.smhi.hydro.DischargeObservation'] {
+    ['se.gov.smhi.hydro.DischargeObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DischargeObservation] policy update
+.alter table ['se.gov.smhi.hydro.DischargeObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/smhi-hydro/notebook/smhi-hydro-feed.ipynb
+++ b/smhi-hydro/notebook/smhi-hydro-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SMHI Hydro Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Swedish Meteorological and Hydrological Institute (SMHI) open-data hydrological API for 15-minute river discharge measurements across hundreds of Swedish stations and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `smhi_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `smhi-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"smhi-hydro-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/smhi-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/smhi-hydro/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing smhi_hydro package from Fabric Environment...')\n",
+    "    from smhi_hydro import smhi_hydro as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['smhi-hydro', 'feed', '--once'] if ONCE_MODE else ['smhi-hydro', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/smhi-hydro/smhi_hydro/smhi_hydro.py
+++ b/smhi-hydro/smhi_hydro/smhi_hydro.py
@@ -188,6 +188,9 @@ def main():
                         help='Polling interval in seconds (default: 900)')
     parser.add_argument('--state-file', type=str,
                         default=os.environ.get('STATE_FILE', os.path.expanduser('~/.smhi_hydro_state.json')))
+    parser.add_argument('--once', action='store_true',
+                        default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.add_parser('list', help='List all stations')
     obs_parser = subparsers.add_parser('observation', help='Get latest discharge for a station')
@@ -249,6 +252,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/smhi-hydro/tests/test_once_mode.py
+++ b/smhi-hydro/tests/test_once_mode.py
@@ -1,0 +1,65 @@
+"""Unit tests for --once / ONCE_MODE single-cycle execution in the SMHI Hydro bridge."""
+
+import sys
+import time as time_module
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smhi_hydro import smhi_hydro as bridge
+
+
+SAMPLE_BULK = {
+    "station": [
+        {
+            "key": "1583",
+            "name": "VÄSTERSEL",
+            "owner": "SMHI",
+            "measuringStations": "CORE",
+            "region": 36,
+            "catchmentName": "MOÄLVEN",
+            "catchmentNumber": 36000,
+            "catchmentSize": 1465.2,
+            "latitude": 63.4332,
+            "longitude": 18.3034,
+            "value": [{"date": 1774454400000, "value": 16.0, "quality": "O"}],
+        }
+    ]
+}
+
+
+def _run_main_with_once(monkeypatch, once_argv=True, once_env=False):
+    """Invoke bridge.main() in feed mode with --once and assert single-cycle exit."""
+    monkeypatch.setenv("KAFKA_BROKER", "localhost:9092")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    if once_env:
+        monkeypatch.setenv("ONCE_MODE", "true")
+    else:
+        monkeypatch.delenv("ONCE_MODE", raising=False)
+
+    argv = ["smhi-hydro", "--state-file", "", "feed"]
+    if once_argv:
+        argv.append("--once")
+    monkeypatch.setattr(sys, "argv", argv)
+
+    sleep_calls = []
+    monkeypatch.setattr(time_module, "sleep", lambda s: sleep_calls.append(s))
+
+    with patch.object(bridge.SMHIHydroAPI, "get_bulk_discharge_data", return_value=SAMPLE_BULK) as mock_get, \
+         patch.object(bridge, "Producer", return_value=MagicMock()):
+        bridge.main()
+
+    return mock_get, sleep_calls
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch):
+    mock_get, sleep_calls = _run_main_with_once(monkeypatch, once_argv=True)
+    # send_stations + feed_observations = 2 calls to the bulk endpoint, then exit.
+    assert mock_get.call_count == 2
+    assert sleep_calls == [], "--once must not sleep for the next polling cycle"
+
+
+def test_once_env_var_exits_after_single_cycle(monkeypatch):
+    mock_get, sleep_calls = _run_main_with_once(monkeypatch, once_argv=False, once_env=True)
+    assert mock_get.call_count == 2
+    assert sleep_calls == []


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (see `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- **Notebook hosting**: adds `smhi-hydro/notebook/smhi-hydro-feed.ipynb` following the canonical pegelonline pattern (4-cell structure, Topology-API connection-string lookup, worker-thread invocation, OneLake log file).
- **`--once` flag**: SMHI Hydro bridge previously had no single-cycle exit. Added `--once` CLI flag (and `ONCE_MODE` env var) modeled after pegelonline. Includes `tests/test_once_mode.py` asserting one-cycle exit with no `time.sleep`.
- **catalog.json**: `"notebook": true` flag added so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Qualified KQL tables**: `kql/create-kql-script.ps1` now calls the generator with `-Qualified -Namespace 'se.gov.smhi.hydro'` (the JsonStructure schemas in this source have no namespace key, so the explicit override is required). Regenerated `kql/smhi_hydro.kql` now emits `['se.gov.smhi.hydro.Station']` and `['se.gov.smhi.hydro.DischargeObservation']`. See `docs/plan-qualified-table-names.md` and DWD reference PR #257.
- **README**: one-line Fabric notebook hosting bullet pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validation

- Notebook JSON parses (`json.load`).
- All five parameter placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present in the parameters cell.
- No forbidden patterns: no `asyncio.run(`, no `%pip install`, no baked `CONNECTION_STRING=`, no `primaryConnectionString =`.
- Regenerated KQL has bracketed FQN tables (`create-merge table ['se.gov…'`).
- Bridge + once-mode tests are syntax-clean; full pytest cannot run in this worktree without the local producer subpackages being pip-installed (skill forbids `pip install`); pre-existing tests have the same constraint.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick this source up on merge to main.

No Fabric deployment performed by this agent (per skill: manual verification step post-merge).