### PR TITLE
feat(syke-hydro): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -135,7 +135,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Finland — SYKE",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "uk-ea-flood-monitoring",

--- a/syke-hydro/README.md
+++ b/syke-hydro/README.md
@@ -61,6 +61,12 @@ pip install .
 For a packaged install, consider using the [CONTAINER.md](CONTAINER.md)
 instructions.
 
+## Fabric notebook hosting
+
+This source can also run as a scheduled Microsoft Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+using the notebook at [`notebook/syke-hydro-feed.ipynb`](notebook/syke-hydro-feed.ipynb).
+
 ## How to Use
 
 After installation, the tool can be run using `python -m syke_hydro`. It

--- a/syke-hydro/kql/create-kql-script.ps1
+++ b/syke-hydro/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\syke_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "syke_hydro.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace fi.syke.hydrology

--- a/syke-hydro/kql/syke_hydro.kql
+++ b/syke-hydro/kql/syke_hydro.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['fi.syke.hydrology.Station'] (
    [station_id]: string,
    [name]: string,
    [river_name]: string,
@@ -40,9 +40,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['fi.syke.hydrology.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['fi.syke.hydrology.Station'] ingestion json mapping "fi.syke.hydrology.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -60,7 +60,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['fi.syke.hydrology.Station'] ingestion json mapping "fi.syke.hydrology.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -78,13 +78,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['fi.syke.hydrology.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fi.syke.hydrology.StationLatest'] on table ['fi.syke.hydrology.Station'] {
+    ['fi.syke.hydrology.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['fi.syke.hydrology.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -95,7 +95,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelObservation] (
+.create-merge table ['fi.syke.hydrology.WaterLevelObservation'] (
    [station_id]: string,
    [water_level]: real,
    [water_level_unit]: string,
@@ -110,9 +110,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelObservation] docstring "{\"description\": \"WaterLevelObservation\"}";
+.alter table ['fi.syke.hydrology.WaterLevelObservation'] docstring "{\"description\": \"WaterLevelObservation\"}";
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_flat"
+.create-or-alter table ['fi.syke.hydrology.WaterLevelObservation'] ingestion json mapping "fi.syke.hydrology.WaterLevelObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -130,7 +130,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_ce_structured"
+.create-or-alter table ['fi.syke.hydrology.WaterLevelObservation'] ingestion json mapping "fi.syke.hydrology.WaterLevelObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -148,13 +148,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelObservationLatest ifexists;
+.drop materialized-view ['fi.syke.hydrology.WaterLevelObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelObservationLatest on table WaterLevelObservation {
-    WaterLevelObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fi.syke.hydrology.WaterLevelObservationLatest'] on table ['fi.syke.hydrology.WaterLevelObservation'] {
+    ['fi.syke.hydrology.WaterLevelObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelObservation] policy update
+.alter table ['fi.syke.hydrology.WaterLevelObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/syke-hydro/notebook/syke-hydro-feed.ipynb
+++ b/syke-hydro/notebook/syke-hydro-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SYKE Hydro Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Finnish Environment Institute (SYKE) Hydrology OData API for water level and discharge observations across Finland's national network of river and lake gauging stations, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `syke_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `syke-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"syke-hydro-ingest\"      # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/syke-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 3600                      # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/syke-hydro/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing syke_hydro package from Fabric Environment...')\n",
+    "    from syke_hydro import syke_hydro as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['syke-hydro', 'feed', '--once'] if ONCE_MODE else ['syke-hydro', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/syke-hydro/syke_hydro/syke_hydro.py
+++ b/syke-hydro/syke_hydro/syke_hydro.py
@@ -240,6 +240,9 @@ def main():
                         default=int(os.environ.get('POLLING_INTERVAL', '3600')))
     parser.add_argument('--state-file', type=str,
                         default=os.environ.get('STATE_FILE', os.path.expanduser('~/.syke_hydro_state.json')))
+    parser.add_argument('--once', action='store_true',
+                        default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.add_parser('feed', help='Feed data to Kafka')
     subparsers.add_parser('list', help='List all stations')
@@ -287,6 +290,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/syke-hydro/tests/test_once_mode.py
+++ b/syke-hydro/tests/test_once_mode.py
@@ -1,0 +1,64 @@
+"""Test that --once causes the feed loop to exit after a single cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from syke_hydro import syke_hydro as bridge
+
+
+def test_once_flag_exits_after_one_cycle(monkeypatch):
+    """With --once set, main() must return after a single polling cycle."""
+    monkeypatch.setattr(sys, 'argv', [
+        'syke-hydro',
+        '--connection-string', 'BootstrapServer=localhost:9092;EntityPath=test',
+        '--once',
+        'feed',
+    ])
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+
+    feed_calls = {'n': 0}
+
+    def _fake_feed(api, producer, stations_by_id, previous_readings):
+        feed_calls['n'] += 1
+        return 0
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("time.sleep must not be called in --once mode")
+
+    with patch.object(bridge, 'send_stations', return_value={}) as send_stations_mock, \
+         patch.object(bridge, 'feed_observations', side_effect=_fake_feed), \
+         patch.object(bridge, 'Producer', return_value=MagicMock()), \
+         patch.object(bridge, 'FISYKEHydrologyEventProducer', return_value=MagicMock()), \
+         patch.object(bridge.time, 'sleep', side_effect=_boom):
+        bridge.main()
+
+    assert feed_calls['n'] == 1
+    send_stations_mock.assert_called_once()
+
+
+def test_once_env_var_enables_once_mode(monkeypatch):
+    """ONCE_MODE=true env var must set args.once even without the CLI flag."""
+    monkeypatch.setattr(sys, 'argv', [
+        'syke-hydro',
+        '--connection-string', 'BootstrapServer=localhost:9092;EntityPath=test',
+        'feed',
+    ])
+    monkeypatch.setenv('ONCE_MODE', 'true')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+
+    feed_calls = {'n': 0}
+
+    def _fake_feed(*_a, **_kw):
+        feed_calls['n'] += 1
+        return 0
+
+    with patch.object(bridge, 'send_stations', return_value={}), \
+         patch.object(bridge, 'feed_observations', side_effect=_fake_feed), \
+         patch.object(bridge, 'Producer', return_value=MagicMock()), \
+         patch.object(bridge, 'FISYKEHydrologyEventProducer', return_value=MagicMock()), \
+         patch.object(bridge.time, 'sleep', side_effect=AssertionError("sleep must not be called")):
+        bridge.main()
+
+    assert feed_calls['n'] == 1


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

Changes:
- Adds `syke-hydro/notebook/syke-hydro-feed.ipynb` following the pegelonline template (verbatim cell structure, substitutions per references/notebook-substitution-table.md).
- Flips `catalog.json` `notebook: true` for syke-hydro so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` flag (and `ONCE_MODE` env var) to the bridge polling loop in `syke-hydro/syke_hydro/syke_hydro.py`, modeled on `pegelonline/pegelonline/pegelonline.py`. Required because the notebook scheduler expects single-cycle exits.
- Adds `syke-hydro/tests/test_once_mode.py` with two tests asserting `main()` returns after exactly one cycle when `--once` (or `ONCE_MODE=true`) is set, with `time.sleep` mocked to fail.
- Flips `syke-hydro/kql/create-kql-script.ps1` to pass `-Qualified -Namespace fi.syke.hydrology` (the JsonStructure schemas don't declare a top-level namespace) and regenerates `syke-hydro/kql/syke_hydro.kql` with bracket-quoted FQN tables (`['fi.syke.hydrology.Station']` etc.). See docs/plan-qualified-table-names.md and DWD reference PR #257.
- Adds a one-line Fabric notebook hosting bullet to `syke-hydro/README.md`.

Validated locally:
- Notebook JSON parses cleanly.
- All 46 bridge tests pass (44 existing + 2 new `--once` tests).
- Parameters cell contains EVENTSTREAM_NAME, STATE_FILE, POLLING_INTERVAL, ONCE_MODE, WORKSPACE_ID placeholders.
- No forbidden runtime patterns (`asyncio.run(`, real `%pip install` cell, hardcoded `CONNECTION_STRING=`, baked `primaryConnectionString`). The `%pip install` string appears only in markdown prose documenting that it is *not* required, identical to the pegelonline template.
- Regenerated KQL contains `create-merge table ['fi.syke.hydrology.*']` qualified forms; no stale unqualified consumer-side table references in the source's tree.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the notebook-wheels release.

Skill: `.github/skills/notebook-feeder-retrofit/SKILL.md`.