### PR TITLE
feat(nve-hydro): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -94,7 +94,8 @@
     "cat": "Hydrology",
     "key": true,
     "desc": "Norway — NVE (requires free API key)",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "pegelonline",

--- a/nve-hydro/README.md
+++ b/nve-hydro/README.md
@@ -26,6 +26,9 @@ and emits only new or changed readings.
 - **Configurable polling interval**: Default 600 seconds (10 minutes)
 - **Kafka integration**: SASL PLAIN authentication for Event Hubs / Fabric Event
   Streams
+- **Fabric notebook hosting**: deployable as a scheduled Fabric notebook via
+  [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+  (uses the `--once` flag for single-cycle execution).
 
 ## Data Source
 

--- a/nve-hydro/kql/create-kql-script.ps1
+++ b/nve-hydro/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\nve_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "nve_hydro.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "no.nve.hydrology"

--- a/nve-hydro/kql/nve_hydro.kql
+++ b/nve-hydro/kql/nve_hydro.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['no.nve.hydrology.Station'] (
    [station_id]: string,
    [station_name]: string,
    [river_name]: string,
@@ -42,9 +42,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['no.nve.hydrology.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['no.nve.hydrology.Station'] ingestion json mapping "no.nve.hydrology.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -64,7 +64,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['no.nve.hydrology.Station'] ingestion json mapping "no.nve.hydrology.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -84,13 +84,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['no.nve.hydrology.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['no.nve.hydrology.StationLatest'] on table ['no.nve.hydrology.Station'] {
+    ['no.nve.hydrology.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['no.nve.hydrology.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -101,7 +101,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelObservation] (
+.create-merge table ['no.nve.hydrology.WaterLevelObservation'] (
    [station_id]: string,
    [water_level]: real,
    [water_level_unit]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelObservation] docstring "{\"description\": \"WaterLevelObservation\"}";
+.alter table ['no.nve.hydrology.WaterLevelObservation'] docstring "{\"description\": \"WaterLevelObservation\"}";
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_flat"
+.create-or-alter table ['no.nve.hydrology.WaterLevelObservation'] ingestion json mapping "no.nve.hydrology.WaterLevelObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -136,7 +136,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelObservation] ingestion json mapping "WaterLevelObservation_json_ce_structured"
+.create-or-alter table ['no.nve.hydrology.WaterLevelObservation'] ingestion json mapping "no.nve.hydrology.WaterLevelObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -154,13 +154,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelObservationLatest ifexists;
+.drop materialized-view ['no.nve.hydrology.WaterLevelObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelObservationLatest on table WaterLevelObservation {
-    WaterLevelObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['no.nve.hydrology.WaterLevelObservationLatest'] on table ['no.nve.hydrology.WaterLevelObservation'] {
+    ['no.nve.hydrology.WaterLevelObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelObservation] policy update
+.alter table ['no.nve.hydrology.WaterLevelObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/nve-hydro/notebook/nve-hydro-feed.ipynb
+++ b/nve-hydro/notebook/nve-hydro-feed.ipynb
@@ -1,0 +1,231 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NVE Hydrology Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Norwegian Water Resources and Energy Directorate (NVE) HydAPI for water-level and discharge measurements across Norway's river and lake gauging stations, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `nve_hydro` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `nve-hydro feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements.\n",
+    "- `NVE_API_KEY` must be supplied (HydAPI requires a free API key). Set it in the parameters cell below or in the attached Fabric Environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"nve-hydro-ingest\"        # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/nve-hydro/state.json\"\n",
+    "POLLING_INTERVAL = 600                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)\n",
+    "NVE_API_KEY      = \"\"                        # required: HydAPI key from https://hydapi.nve.no — set here or via Environment variable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/nve-hydro/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    if NVE_API_KEY:\n",
+    "        os.environ['NVE_API_KEY'] = NVE_API_KEY\n",
+    "    if not os.environ.get('NVE_API_KEY'):\n",
+    "        raise RuntimeError('NVE_API_KEY is required (set in the parameters cell or in the attached Fabric Environment).')\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "    _log(f'NVE_API_KEY present: {bool(os.environ.get(\"NVE_API_KEY\"))}')\n",
+    "\n",
+    "    _log('Importing nve_hydro package from Fabric Environment...')\n",
+    "    from nve_hydro import nve_hydro as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['nve-hydro', 'feed', '--once'] if ONCE_MODE else ['nve-hydro', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/nve-hydro/nve_hydro/nve_hydro.py
+++ b/nve-hydro/nve_hydro/nve_hydro.py
@@ -236,6 +236,9 @@ def main():
                         default=os.environ.get('STATE_FILE', os.path.expanduser('~/.nve_hydro_state.json')))
     parser.add_argument('--api-key', type=str,
                         default=os.environ.get('NVE_API_KEY'))
+    parser.add_argument('--once', action='store_true',
+                        default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.add_parser('feed', help='Feed data to Kafka')
     subparsers.add_parser('list', help='List all stations')
@@ -287,6 +290,9 @@ def main():
                 logger.info("Sent %d events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/nve-hydro/tests/test_once_mode.py
+++ b/nve-hydro/tests/test_once_mode.py
@@ -1,0 +1,65 @@
+"""Test that --once causes main() to exit after exactly one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_api_and_producer():
+    """Patch external dependencies so main() can run without network or Kafka."""
+    with patch('nve_hydro.nve_hydro.NVEHydroAPI') as api_cls, \
+         patch('nve_hydro.nve_hydro.Producer') as producer_cls, \
+         patch('nve_hydro.nve_hydro.NONVEHydrologyEventProducer') as nve_prod_cls, \
+         patch('nve_hydro.nve_hydro.send_stations', return_value={}) as send_st, \
+         patch('nve_hydro.nve_hydro.feed_observations', return_value=0) as feed_obs, \
+         patch('nve_hydro.nve_hydro._load_state', return_value={}), \
+         patch('nve_hydro.nve_hydro._save_state'), \
+         patch('nve_hydro.nve_hydro.time.sleep') as sleep_mock:
+        api_cls.return_value = MagicMock()
+        producer_cls.return_value = MagicMock()
+        nve_prod_cls.return_value = MagicMock()
+        yield {
+            'sleep': sleep_mock,
+            'feed_observations': feed_obs,
+            'send_stations': send_st,
+        }
+
+
+def test_once_flag_exits_after_one_cycle(fake_api_and_producer, monkeypatch):
+    """--once must cause main() to return without ever calling time.sleep."""
+    monkeypatch.setenv('NVE_API_KEY', 'test-key')
+    monkeypatch.setenv('KAFKA_BROKER', 'localhost:9092')
+    monkeypatch.setenv('KAFKA_TOPIC', 'test-nve-hydro')
+    monkeypatch.delenv('CONNECTION_STRING', raising=False)
+    monkeypatch.delenv('KAFKA_CONNECTION_STRING', raising=False)
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+
+    from nve_hydro.nve_hydro import main
+
+    with patch.object(sys, 'argv', ['nve-hydro', '--once', 'feed']):
+        main()
+
+    assert fake_api_and_producer['send_stations'].call_count == 1
+    assert fake_api_and_producer['feed_observations'].call_count == 1
+    # --once must skip the sleep that gates the next polling cycle
+    assert fake_api_and_producer['sleep'].call_count == 0
+
+
+def test_once_mode_env_var_exits_after_one_cycle(fake_api_and_producer, monkeypatch):
+    """ONCE_MODE env var must also cause main() to exit after one cycle."""
+    monkeypatch.setenv('NVE_API_KEY', 'test-key')
+    monkeypatch.setenv('KAFKA_BROKER', 'localhost:9092')
+    monkeypatch.setenv('KAFKA_TOPIC', 'test-nve-hydro')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+    monkeypatch.delenv('CONNECTION_STRING', raising=False)
+    monkeypatch.delenv('KAFKA_CONNECTION_STRING', raising=False)
+
+    from nve_hydro.nve_hydro import main
+
+    with patch.object(sys, 'argv', ['nve-hydro', 'feed']):
+        main()
+
+    assert fake_api_and_producer['feed_observations'].call_count == 1
+    assert fake_api_and_producer['sleep'].call_count == 0


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes

- **Notebook**: `nve-hydro/notebook/nve-hydro-feed.ipynb` — copy of the canonical pegelonline notebook with mechanical substitutions (package = `nve_hydro`, argv = `['nve-hydro', 'feed', '--once']`, state path, title). Adds an extra `NVE_API_KEY` parameter because HydAPI requires a free API key; the cell raises if neither the parameter nor the env var is set.
- **Catalog**: `catalog.json` — `"notebook": true` added for `nve-hydro`.
- **Bridge `--once` flag**: `nve-hydro/nve_hydro/nve_hydro.py` — adds the `--once` argparse flag (defaults from `ONCE_MODE` env var) and breaks the polling loop after one cycle, modeled on pegelonline. Two unit tests in `nve-hydro/tests/test_once_mode.py` assert one-cycle exit for both the flag and env-var paths.
- **Qualified KQL**: `nve-hydro/kql/create-kql-script.ps1` now passes `-Qualified -Namespace no.nve.hydrology`; the regenerated `nve_hydro.kql` has bracket-quoted FQN tables (`['no.nve.hydrology.Station']`, `['no.nve.hydrology.WaterLevelObservation']`). The xreg's JsonStructure schemas do not declare `namespace` inline, so `-Namespace` is required. The Avro mirror in the same xreg declares `NO.NVE.Hydrology`; we use the lowercase form to match the DWD reference (`de.dwd.cdc`).
- **README**: one-sentence bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- **No consumer assets** under `nve-hydro/fabric/` or `nve-hydro/dashboard/` to fix up.

## Validation

- Notebook JSON parses.
- `python -m pytest nve-hydro/tests/` — **40 passed** (38 existing + 2 new `--once` tests).
- Parameters cell contains all 5 required placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) plus `NVE_API_KEY`.
- No `asyncio.run()`, `%pip install` in code cells, baked `CONNECTION_STRING`, or `primaryConnectionString` assignment in any code cell.
- KQL contains qualified `create-merge table ['no.nve.hydrology....']` entries.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the `notebook-wheels` release. Live Fabric deployment is intentionally out of scope for this PR.