### PR TITLE
feat(geosphere-austria): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -223,7 +223,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Austria — ~280 TAWES stations, 10-min obs",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "hko-hong-kong",

--- a/geosphere-austria/README.md
+++ b/geosphere-austria/README.md
@@ -49,6 +49,8 @@ docker run --rm \
 
 See [CONTAINER.md](CONTAINER.md) for full deployment instructions.
 
+- **Fabric notebook hosting:** alternatively, deploy this bridge as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) (see [`notebook/geosphere-austria-feed.ipynb`](notebook/geosphere-austria-feed.ipynb)).
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/geosphere-austria/geosphere_austria/geosphere_austria.py
+++ b/geosphere-austria/geosphere_austria/geosphere_austria.py
@@ -298,6 +298,13 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="GeoSphere Austria TAWES bridge")
     parser.add_argument("command", choices=["feed", "list"], default="feed", nargs="?")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). "
+             "Useful for scheduled execution in Fabric notebooks.",
+    )
     args = parser.parse_args()
 
     if args.command == "list":
@@ -353,6 +360,9 @@ def main() -> None:
             logger.exception("Unexpected error during feed cycle")
 
         logger.info("Sleeping %d seconds until next poll", polling_interval)
+        if args.once:
+            logger.info("--once mode: exiting after first polling cycle")
+            break
         time.sleep(polling_interval)
 
 

--- a/geosphere-austria/kql/create-kql-script.ps1
+++ b/geosphere-austria/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\geosphere-austria.xreg.json"
 $kqlFile = Join-Path $scriptDir "geosphere-austria.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/geosphere-austria/kql/geosphere-austria.kql
+++ b/geosphere-austria/kql/geosphere-austria.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [WeatherStation] (
+.create-merge table ['at.geosphere.tawes.WeatherStation'] (
    [station_id]: string,
    [station_name]: string,
    [latitude]: real,
@@ -39,9 +39,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherStation] docstring "{\"description\": \"Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID. Metadata is sourced from the TAWES v1 10-minute current dataset metadata endpoint.\"}";
+.alter table ['at.geosphere.tawes.WeatherStation'] docstring "{\"description\": \"Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID. Metadata is sourced from the TAWES v1 10-minute current dataset metadata endpoint.\"}";
 
-.alter table [WeatherStation] column-docstrings (
+.alter table ['at.geosphere.tawes.WeatherStation'] column-docstrings (
    [station_id]: "{\"description\": \"Stable GeoSphere Austria numeric station identifier used as the Kafka key and CloudEvents subject. Mapped from the upstream 'id' field in the station metadata.\"}",
    [station_name]: "{\"description\": \"Station name from the GeoSphere metadata, for example 'WIEN HOHE WARTE' or 'INNSBRUCK FLUGHAFEN'. Mapped from the upstream 'name' field.\"}",
    [latitude]: "{\"description\": \"WGS84 latitude of the station in decimal degrees, sourced from the GeoSphere metadata 'lat' field.\"}",
@@ -55,7 +55,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherStation] ingestion json mapping "WeatherStation_json_flat"
+.create-or-alter table ['at.geosphere.tawes.WeatherStation'] ingestion json mapping "at.geosphere.tawes.WeatherStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -72,7 +72,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherStation] ingestion json mapping "WeatherStation_json_ce_structured"
+.create-or-alter table ['at.geosphere.tawes.WeatherStation'] ingestion json mapping "at.geosphere.tawes.WeatherStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -89,13 +89,13 @@
 ]
 ```
 
-.drop materialized-view WeatherStationLatest ifexists;
+.drop materialized-view ['at.geosphere.tawes.WeatherStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherStationLatest on table WeatherStation {
-    WeatherStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['at.geosphere.tawes.WeatherStationLatest'] on table ['at.geosphere.tawes.WeatherStation'] {
+    ['at.geosphere.tawes.WeatherStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherStation] policy update
+.alter table ['at.geosphere.tawes.WeatherStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -106,7 +106,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['at.geosphere.tawes.WeatherObservation'] (
    [station_id]: string,
    [observation_time]: string,
    [temperature]: real,
@@ -124,9 +124,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters. Values are null when the station does not report a parameter or the measurement is missing for the current interval.\"}";
+.alter table ['at.geosphere.tawes.WeatherObservation'] docstring "{\"description\": \"10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters. Values are null when the station does not report a parameter or the measurement is missing for the current interval.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['at.geosphere.tawes.WeatherObservation'] column-docstrings (
    [station_id]: "{\"description\": \"GeoSphere Austria numeric station identifier for the observing station. Mapped from the upstream 'station' property in the GeoJSON features.\"}",
    [observation_time]: "{\"description\": \"Observation timestamp in UTC from the GeoSphere API 'timestamps' array, formatted as an ISO-8601 instant such as '2024-01-15T13:00:00+00:00'.\"}",
    [temperature]: "{\"description\": \"Air temperature (Lufttemperatur) in degrees Celsius over the 10-minute interval, from the GeoSphere TL parameter. Null when the station does not report this parameter.\"}",
@@ -144,7 +144,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['at.geosphere.tawes.WeatherObservation'] ingestion json mapping "at.geosphere.tawes.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -165,7 +165,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['at.geosphere.tawes.WeatherObservation'] ingestion json mapping "at.geosphere.tawes.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -186,13 +186,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['at.geosphere.tawes.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['at.geosphere.tawes.WeatherObservationLatest'] on table ['at.geosphere.tawes.WeatherObservation'] {
+    ['at.geosphere.tawes.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['at.geosphere.tawes.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/geosphere-austria/notebook/geosphere-austria-feed.ipynb
+++ b/geosphere-austria/notebook/geosphere-austria-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GeoSphere Austria Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the GeoSphere Austria TAWES (Teilautomatische Wetterstationen) REST API for 10-minute weather observations from ~270 automatic stations across Austria and emits station reference data and observation CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `geosphere_austria` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `geosphere-austria feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"geosphere-austria-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/geosphere-austria/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/geosphere-austria/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing geosphere_austria package from Fabric Environment...')\n",
+    "    from geosphere_austria import geosphere_austria as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['geosphere-austria', 'feed', '--once'] if ONCE_MODE else ['geosphere-austria', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/geosphere-austria/tests/test_once_mode.py
+++ b/geosphere-austria/tests/test_once_mode.py
@@ -1,0 +1,47 @@
+"""Test that --once flag (and ONCE_MODE env var) causes main() to exit after one cycle."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from geosphere_austria import geosphere_austria as bridge
+
+pytestmark = pytest.mark.unit
+
+
+def _run_main_with_argv(argv, monkeypatch):
+    monkeypatch.setenv("CONNECTION_STRING", "BootstrapServer=localhost:9092;EntityPath=t")
+    monkeypatch.setenv("POLLING_INTERVAL", "9999")
+    monkeypatch.setenv("STATION_REFRESH_INTERVAL", "9999")
+    monkeypatch.setenv("STATE_FILE", "")
+    monkeypatch.setattr(sys, "argv", argv)
+
+    cycle = MagicMock(return_value=(0, 0, []))
+    sleep = MagicMock(side_effect=AssertionError("time.sleep called in --once mode"))
+
+    with patch.object(bridge, "Producer", MagicMock()), \
+         patch.object(bridge, "AtGeosphereTawesEventProducer", MagicMock()), \
+         patch.object(bridge, "create_retrying_session", MagicMock()), \
+         patch.object(bridge, "load_state", MagicMock(return_value={})), \
+         patch.object(bridge, "save_state", MagicMock()), \
+         patch.object(bridge, "run_feed_cycle", cycle), \
+         patch.object(bridge.time, "sleep", sleep):
+        bridge.main()
+
+    return cycle, sleep
+
+
+def test_once_flag_exits_after_one_cycle(monkeypatch):
+    cycle, sleep = _run_main_with_argv(["geosphere-austria", "feed", "--once"], monkeypatch)
+    assert cycle.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_once_mode_env_var_exits_after_one_cycle(monkeypatch):
+    monkeypatch.setenv("ONCE_MODE", "true")
+    cycle, sleep = _run_main_with_argv(["geosphere-austria", "feed"], monkeypatch)
+    assert cycle.call_count == 1
+    sleep.assert_not_called()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (see `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes
- Adds `geosphere-austria/notebook/geosphere-austria-feed.ipynb` following the canonical `pegelonline` template with the source-specific substitutions (package, module, argv-0, subcommand, state paths, display title, description).
- Flips `catalog.json` `notebook: true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` flag (and `ONCE_MODE` env var) to the bridge `geosphere_austria.py` modeled after `pegelonline/pegelonline/pegelonline.py`. New unit tests in `tests/test_once_mode.py` assert that `main()` exits after exactly one polling cycle in both modes.
- Flips `geosphere-austria/kql/create-kql-script.ps1` to pass `-Qualified` and regenerates `geosphere-austria.kql` with namespace-prefixed table names (`['at.geosphere.tawes.WeatherStation']`, `['at.geosphere.tawes.WeatherObservation']`). See `docs/plan-qualified-table-names.md` and DWD reference PR #257. No hand-authored consumer assets (fabric/, dashboard/) exist in this source, so no consumer-side fixes were needed.
- README: adds a one-sentence Fabric notebook hosting bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations performed locally
- Notebook JSON parses (`json.load` ok, 6 cells).
- Bridge test suite passes (48 passed).
- New `--once` unit tests pass (2 passed).
- Notebook parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden runtime patterns (`asyncio.run(`, real `%pip install`, hard-coded `CONNECTION_STRING`, `primaryConnectionString` baked in). The string `%pip install` appears only inside a markdown sentence saying it is NOT required — identical to the canonical pegelonline template.
- Qualified KQL tables present (`create-merge table ['at.geosphere.tawes.*']`).

Fabric end-to-end verification is intentionally out of scope for this agent and is handled separately after merge.