### PR TITLE
feat(hko-hong-kong): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -231,7 +231,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Hong Kong — 27 temp stations, 18 rainfall districts",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "jma-japan",

--- a/hko-hong-kong/README.md
+++ b/hko-hong-kong/README.md
@@ -54,3 +54,9 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fhko-hong-kong%2Fazure-template-with-eventhub.json)
+
+### Option 3: Fabric notebook hosting
+
+Run this feeder as a scheduled Microsoft Fabric notebook (no container required) via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which uploads [`notebook/hko-hong-kong-feed.ipynb`](notebook/hko-hong-kong-feed.ipynb) and binds it to a Lakehouse, KQL database, and Event Stream in your Fabric workspace.

--- a/hko-hong-kong/hko_hong_kong/hko_hong_kong.py
+++ b/hko-hong-kong/hko_hong_kong/hko_hong_kong.py
@@ -231,7 +231,9 @@ def main():
                         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.hko_hong_kong_state.json")))
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List places from current weather")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             help="Run a single polling cycle and exit (for scheduled hosts).")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
     api = HKOWeatherAPI(polling_interval=args.polling_interval)
@@ -264,6 +266,7 @@ def main():
         logger.info("Starting HKO Hong Kong Weather bridge, polling every %d seconds", args.polling_interval)
         previous_readings = _load_state(args.state_file)
         send_stations(api, event_producer)
+        once = bool(getattr(args, "once", False))
         while True:
             try:
                 count = feed_observations(api, event_producer, previous_readings)
@@ -271,6 +274,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/hko-hong-kong/kql/create-kql-script.ps1
+++ b/hko-hong-kong/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\hko_hong_kong.xreg.json"
 $kqlFile = Join-Path $scriptDir "hko_hong_kong.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace hk.gov.hko.weather

--- a/hko-hong-kong/kql/hko_hong_kong.kql
+++ b/hko-hong-kong/kql/hko_hong_kong.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['hk.gov.hko.weather.Station'] (
    [place_id]: string,
    [name]: string,
    [data_types]: string,
@@ -36,9 +36,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for a HKO weather observation place. Places include automatic weather stations (temperature), rainfall reporting districts, and special measurement locations (humidity at HKO headquarters, UV index at King's Park).\"}";
+.alter table ['hk.gov.hko.weather.Station'] docstring "{\"description\": \"Reference data for a HKO weather observation place. Places include automatic weather stations (temperature), rainfall reporting districts, and special measurement locations (humidity at HKO headquarters, UV index at King's Park).\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['hk.gov.hko.weather.Station'] column-docstrings (
    [place_id]: "{\"description\": \"URL-safe slug identifier derived from the English place name, e.g. 'kings-park', 'central-western-district'. Used as Kafka key and CloudEvents subject.\"}",
    [name]: "{\"description\": \"Original English place name from the HKO rhrread API, e.g. 'King's Park', 'Central & Western District'.\"}",
    [data_types]: "{\"description\": \"Comma-separated list of data types reported by this place. Values: 'temperature', 'rainfall', 'humidity', 'uvindex'.\"}",
@@ -49,7 +49,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['hk.gov.hko.weather.Station'] ingestion json mapping "hk.gov.hko.weather.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -63,7 +63,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['hk.gov.hko.weather.Station'] ingestion json mapping "hk.gov.hko.weather.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -77,13 +77,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['hk.gov.hko.weather.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['hk.gov.hko.weather.StationLatest'] on table ['hk.gov.hko.weather.Station'] {
+    ['hk.gov.hko.weather.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['hk.gov.hko.weather.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -94,7 +94,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['hk.gov.hko.weather.WeatherObservation'] (
    [place_id]: string,
    [place_name]: string,
    [observation_time]: datetime,
@@ -110,9 +110,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"Current weather observation for a HKO place from the rhrread endpoint. Temperature from automatic weather stations, rainfall from district-level rain gauges, humidity from HKO headquarters, UV index from King's Park. Fields are null when the place does not report that data type.\"}";
+.alter table ['hk.gov.hko.weather.WeatherObservation'] docstring "{\"description\": \"Current weather observation for a HKO place from the rhrread endpoint. Temperature from automatic weather stations, rainfall from district-level rain gauges, humidity from HKO headquarters, UV index from King's Park. Fields are null when the place does not report that data type.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['hk.gov.hko.weather.WeatherObservation'] column-docstrings (
    [place_id]: "{\"description\": \"URL-safe slug identifier for the place, matching the Kafka key.\"}",
    [place_name]: "{\"description\": \"Original English place name from the HKO API.\"}",
    [observation_time]: "{\"description\": \"ISO 8601 timestamp of the observation including Hong Kong timezone offset (+08:00), from the updateTime field.\"}",
@@ -128,7 +128,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['hk.gov.hko.weather.WeatherObservation'] ingestion json mapping "hk.gov.hko.weather.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -147,7 +147,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['hk.gov.hko.weather.WeatherObservation'] ingestion json mapping "hk.gov.hko.weather.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -166,13 +166,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['hk.gov.hko.weather.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['hk.gov.hko.weather.WeatherObservationLatest'] on table ['hk.gov.hko.weather.WeatherObservation'] {
+    ['hk.gov.hko.weather.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['hk.gov.hko.weather.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/hko-hong-kong/notebook/hko-hong-kong-feed.ipynb
+++ b/hko-hong-kong/notebook/hko-hong-kong-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HKO Hong Kong Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Hong Kong Observatory (HKO) `rhrread` regional weather API for temperature, rainfall, humidity, and UV-index observations and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `hko_hong_kong` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `hko-hong-kong feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"hko-hong-kong-ingest\"   # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/hko-hong-kong/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/hko-hong-kong/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing hko_hong_kong package from Fabric Environment...')\n",
+    "    from hko_hong_kong import hko_hong_kong as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['hko-hong-kong', 'feed', '--once'] if ONCE_MODE else ['hko-hong-kong', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/hko-hong-kong/tests/test_once_mode.py
+++ b/hko-hong-kong/tests/test_once_mode.py
@@ -1,0 +1,46 @@
+"""Verify that `feed --once` causes main() to exit after one polling cycle."""
+
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hko_hong_kong import hko_hong_kong as bridge
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch.object(bridge.time, "sleep", side_effect=AssertionError(
+            "time.sleep must not be called when --once is set"
+    )):
+        yield
+
+
+def test_once_mode_exits_after_one_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(sys, "argv", [
+        "hko-hong-kong",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-hko",
+        "--polling-interval", "1",
+        "--state-file", str(state_file),
+        "feed",
+        "--once",
+    ])
+
+    feed_calls = {"n": 0}
+
+    def fake_feed(api, producer, previous):
+        feed_calls["n"] += 1
+        return 0
+
+    with patch.object(bridge, "Producer", return_value=MagicMock()), \
+         patch.object(bridge, "HKGovHKOWeatherEventProducer", return_value=MagicMock()), \
+         patch.object(bridge, "send_stations", return_value=0), \
+         patch.object(bridge, "feed_observations", side_effect=fake_feed):
+        start = time.monotonic()
+        bridge.main()
+        elapsed = time.monotonic() - start
+
+    assert feed_calls["n"] == 1, "feed_observations should run exactly once in --once mode"
+    assert elapsed < 5, "main() should return promptly in --once mode without sleeping"


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- Adds `hko-hong-kong/notebook/hko-hong-kong-feed.ipynb` following the canonical pegelonline pattern (cell structure, CS-lookup, worker-thread, OneLake log layout preserved verbatim).
- Flips `catalog.json` `notebook: true` for `hko-hong-kong` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` flag to the `feed` subcommand (modeled on pegelonline) + unit test (`tests/test_once_mode.py`) asserting `main()` exits after exactly one cycle and never sleeps.
- Regenerates `hko-hong-kong/kql/hko_hong_kong.kql` with namespace-qualified table names via `-Qualified -Namespace hk.gov.hko.weather` (xreg schemas have no namespace declared). Tables are now `['hk.gov.hko.weather.Station']` and `['hk.gov.hko.weather.WeatherObservation']`. See `docs/plan-qualified-table-names.md` and DWD reference PR #257.
- Adds Option 3 (Fabric notebook hosting) bullet to `hko-hong-kong/README.md`.

## Validated locally
- Notebook JSON well-formed.
- All 28 existing + 1 new bridge tests pass (`pytest tests/`).
- Parameters cell contains all 5 placeholders the deploy script patches (EVENTSTREAM_NAME, STATE_FILE, POLLING_INTERVAL, ONCE_MODE, WORKSPACE_ID).
- No forbidden runtime patterns (no `asyncio.run(` in cells, no `%pip install` in code cells, no baked-in CONNECTION_STRING).
- KQL regenerated and now uses qualified table names (`create-merge table ['hk.gov.ho.weather.*']`).
- No hand-authored `fabric/` or `dashboard/` consumer assets in this source — no stale unqualified references to fix.

The wheel-bundle workflow (.github/workflows/publish-notebook-wheels.yml) will pick up this source on next push to main and publish wheels to the notebook-wheels release. Live Fabric deployment is out of scope for this agent.