### PR TITLE
feat(waterinfo-vmm): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -177,7 +177,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "Belgium / Flanders — ~1,785 stations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "aviationweather",

--- a/waterinfo-vmm/README.md
+++ b/waterinfo-vmm/README.md
@@ -56,6 +56,13 @@ See [EVENTS.md](EVENTS.md) for the CloudEvents message definitions.
 
 See [CONTAINER.md](CONTAINER.md) for Docker container deployment info.
 
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Fabric notebook (per-cycle
+single execution against a bound Lakehouse + Event Stream). See
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+and the bundled notebook at [`notebook/waterinfo-vmm-feed.ipynb`](notebook/waterinfo-vmm-feed.ipynb).
+
 ## API Reference
 
 - **Base URL**: `https://download.waterinfo.be/tsmdownload/KiWIS/KiWIS`

--- a/waterinfo-vmm/kql/create-kql-script.ps1
+++ b/waterinfo-vmm/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\waterinfo_vmm.xreg.json"
 $kqlFile = Join-Path $scriptDir "waterinfo_vmm.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "be.vlaanderen.waterinfo.vmm"

--- a/waterinfo-vmm/kql/waterinfo_vmm.kql
+++ b/waterinfo-vmm/kql/waterinfo_vmm.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['be.vlaanderen.waterinfo.vmm.Station'] (
    [station_no]: string,
    [station_name]: string,
    [station_id]: string,
@@ -42,9 +42,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Station\"}";
+.alter table ['be.vlaanderen.waterinfo.vmm.Station'] docstring "{\"description\": \"Station\"}";
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['be.vlaanderen.waterinfo.vmm.Station'] ingestion json mapping "be.vlaanderen.waterinfo.vmm.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -64,7 +64,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['be.vlaanderen.waterinfo.vmm.Station'] ingestion json mapping "be.vlaanderen.waterinfo.vmm.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -84,13 +84,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['be.vlaanderen.waterinfo.vmm.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['be.vlaanderen.waterinfo.vmm.StationLatest'] on table ['be.vlaanderen.waterinfo.vmm.Station'] {
+    ['be.vlaanderen.waterinfo.vmm.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['be.vlaanderen.waterinfo.vmm.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -101,7 +101,7 @@
 }]
 ```
 
-.create-merge table [WaterLevelReading] (
+.create-merge table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] (
    [ts_id]: string,
    [station_no]: string,
    [station_name]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [WaterLevelReading] docstring "{\"description\": \"WaterLevelReading\"}";
+.alter table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] docstring "{\"description\": \"WaterLevelReading\"}";
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_flat"
+.create-or-alter table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] ingestion json mapping "be.vlaanderen.waterinfo.vmm.WaterLevelReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -136,7 +136,7 @@
 ]
 ```
 
-.create-or-alter table [WaterLevelReading] ingestion json mapping "WaterLevelReading_json_ce_structured"
+.create-or-alter table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] ingestion json mapping "be.vlaanderen.waterinfo.vmm.WaterLevelReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -154,13 +154,13 @@
 ]
 ```
 
-.drop materialized-view WaterLevelReadingLatest ifexists;
+.drop materialized-view ['be.vlaanderen.waterinfo.vmm.WaterLevelReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterLevelReadingLatest on table WaterLevelReading {
-    WaterLevelReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['be.vlaanderen.waterinfo.vmm.WaterLevelReadingLatest'] on table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] {
+    ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterLevelReading] policy update
+.alter table ['be.vlaanderen.waterinfo.vmm.WaterLevelReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/waterinfo-vmm/notebook/waterinfo-vmm-feed.ipynb
+++ b/waterinfo-vmm/notebook/waterinfo-vmm-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Waterinfo VMM Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Belgian Waterinfo.be KIWIS API (VMM provider) for ~1,785 Flemish monitoring stations and ~1,109 15-minute water-level time series, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `waterinfo_vmm` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `waterinfo-vmm feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"waterinfo-vmm-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/waterinfo-vmm/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/waterinfo-vmm/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing waterinfo_vmm package from Fabric Environment...')\n",
+    "    from waterinfo_vmm import waterinfo_vmm as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['waterinfo-vmm', 'feed', '--once'] if ONCE_MODE else ['waterinfo-vmm', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/waterinfo-vmm/tests/test_once_mode.py
+++ b/waterinfo-vmm/tests/test_once_mode.py
@@ -1,0 +1,46 @@
+"""Test that --once mode causes a single polling cycle then exits."""
+
+from unittest.mock import patch, MagicMock
+
+from waterinfo_vmm.waterinfo_vmm import WaterinfoVMMAPI
+
+
+def test_once_mode_exits_after_one_cycle():
+    api = WaterinfoVMMAPI()
+
+    stations_payload = [
+        ["station_no", "station_name", "station_id", "station_latitude",
+         "station_longitude", "river_name"],
+        ["L04_007", "Test Station", "1", 51.0, 4.0, "Test River"],
+    ]
+    readings_payload = [
+        {
+            "ts_id": "1001",
+            "station_no": "L04_007",
+            "station_name": "Test Station",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "ts_value": 1.23,
+            "ts_unitname": "m",
+            "stationparameter_name": "H",
+        }
+    ]
+
+    fake_producer = MagicMock()
+
+    with patch.object(api, "list_stations", return_value=stations_payload) as ls, \
+            patch.object(api, "get_latest_water_levels", return_value=readings_payload) as gw, \
+            patch("confluent_kafka.Producer", return_value=fake_producer), \
+            patch("time.sleep") as sleep_mock:
+        api.feed_stations(
+            kafka_config={"bootstrap.servers": "localhost:9092"},
+            kafka_topic="test-topic",
+            polling_interval=1,
+            state_file="",
+            once=True,
+        )
+
+    # Reference + telemetry queried exactly once.
+    assert ls.call_count == 1
+    assert gw.call_count == 1
+    # In --once mode no inter-cycle sleep should occur.
+    assert sleep_mock.call_count == 0

--- a/waterinfo-vmm/waterinfo_vmm/waterinfo_vmm.py
+++ b/waterinfo-vmm/waterinfo_vmm/waterinfo_vmm.py
@@ -116,7 +116,7 @@ class WaterinfoVMMAPI:
             config_dict['sasl.mechanism'] = 'PLAIN'
         return config_dict
 
-    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '') -> None:
+    def feed_stations(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '', once: bool = False) -> None:
         """Feed station and water level data as CloudEvents to Kafka."""
         previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -196,6 +196,9 @@ class WaterinfoVMMAPI:
                 logging.info("Sent %d readings in %.1f seconds. Waiting %.0f seconds.",
                              count, end_time - start_time, effective_interval)
                 _save_state(state_file, previous_readings)
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
 
@@ -236,6 +239,9 @@ def main() -> None:
                              default=polling_interval_default)
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE', os.path.expanduser('~/.waterinfo_vmm_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     api = WaterinfoVMMAPI()
@@ -286,7 +292,7 @@ def main() -> None:
             })
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
-        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        api.feed_stations(kafka_config, kafka_topic, args.polling_interval, args.state_file, args.once)
     else:
         parser.print_help()
 


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- **Notebook**: `waterinfo-vmm/notebook/waterinfo-vmm-feed.ipynb` — copy of the canonical `pegelonline-feed.ipynb` with the source-id, package, module, argv, lakehouse paths, and event-stream name substituted per the skill's substitution table.
- **catalog.json**: flips `notebook: true` for `waterinfo-vmm` so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Bridge `--once`**: `waterinfo_vmm/waterinfo_vmm.py` gains a `--once` flag (honored via `ONCE_MODE` env var as well), modeled on `pegelonline/pegelonline/pegelonline.py`. Required because the existing bridge had no single-cycle exit path.
- **New unit test**: `tests/test_once_mode.py` asserts `feed_stations(once=True)` calls the upstream APIs exactly once and never sleeps between cycles.
- **Qualified KQL tables** (per `docs/plan-qualified-table-names.md`, DWD reference PR #257): `kql/create-kql-script.ps1` now passes `-Qualified -Namespace be.vlaanderen.waterinfo.vmm` (xreg JsonStructure schemas don't declare a namespace, so an override is supplied). Regenerated `kql/waterinfo_vmm.kql` now emits `['be.vlaanderen.waterinfo.vmm.Station']` and `['be.vlaanderen.waterinfo.vmm.WaterLevelReading']` instead of `[Station]` / `[WaterLevelReading]`.
- **README**: one-sentence Fabric notebook hosting bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validation performed

- Notebook JSON well-formed (`json.load` round-trip).
- All parameters cell placeholders present (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns in notebook code cells (`asyncio.run`, `%pip install` code, hard-coded `CONNECTION_STRING`, `primaryConnectionString` assignment). `%pip install` only appears in the markdown paragraph that documents 'No %pip install is required' (same as pegelonline template).
- Qualified-tables check (`create-merge table ['[a-z]`) passes.
- Bridge and new test files syntax-validated via `ast.parse`. (The local environment has no path-installed producer wheels so pytest collection cannot import the bridge here; CI installs the producer sub-packages and will exercise both the existing suite and `test_once_mode.py`.)
- No hand-authored consumer assets in `waterinfo-vmm/fabric/` or `waterinfo-vmm/dashboard/` (neither dir exists) reference the unqualified table names.

## Out of scope

- Live Fabric deployment is not performed by this agent. The `publish-notebook-wheels.yml` workflow will pick up this source on merge to `main` and publish `waterinfo-vmm-notebook-wheels.zip` to the `notebook-wheels` release; manual end-to-end Fabric verification follows separately.