### PR TITLE
feat(aviationweather): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/aviationweather/README.md
+++ b/aviationweather/README.md
@@ -12,6 +12,7 @@
 - **Deduplication**: Tracks last seen METAR observation time per station and SIGMET identity to avoid reprocessing.
 - **Kafka Integration**: Send events to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: deploy the feeder as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) (uses [`notebook/aviationweather-feed.ipynb`](notebook/aviationweather-feed.ipynb)).
 
 ## Installation
 

--- a/aviationweather/aviationweather/aviationweather.py
+++ b/aviationweather/aviationweather/aviationweather.py
@@ -610,6 +610,9 @@ def main():
                         help=f"METAR poll interval in seconds (default: {METAR_POLL_INTERVAL})")
     parser.add_argument('--sigmet-poll-interval', type=int, default=SIGMET_POLL_INTERVAL,
                         help=f"SIGMET poll interval in seconds (default: {SIGMET_POLL_INTERVAL})")
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -663,7 +666,7 @@ def main():
         metar_poll_interval=args.metar_poll_interval,
         sigmet_poll_interval=args.sigmet_poll_interval,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/aviationweather/kql/aviationweather.kql
+++ b/aviationweather/kql/aviationweather.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['gov.noaa.aviationweather.Station'] (
    [icao_id]: string,
    [iata_id]: string,
    [faa_id]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference record for an aviation weather reporting station. Sourced from the AviationWeather.gov station information endpoint. Fields cover ICAO, IATA, FAA, and WMO identifiers, location, elevation, and available data products.\"}";
+.alter table ['gov.noaa.aviationweather.Station'] docstring "{\"description\": \"Reference record for an aviation weather reporting station. Sourced from the AviationWeather.gov station information endpoint. Fields cover ICAO, IATA, FAA, and WMO identifiers, location, elevation, and available data products.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['gov.noaa.aviationweather.Station'] column-docstrings (
    [icao_id]: "{\"description\": \"ICAO station identifier. Four-character alphanumeric code assigned by ICAO (e.g. 'KJFK' for John F. Kennedy International Airport).\"}",
    [iata_id]: "{\"description\": \"IATA airport code, a three-character code used by the airline industry (e.g. 'JFK'). May be null for non-airport stations.\"}",
    [faa_id]: "{\"description\": \"FAA location identifier. Three or four character code assigned by the FAA. May be null for non-US stations.\"}",
@@ -65,7 +65,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['gov.noaa.aviationweather.Station'] ingestion json mapping "gov.noaa.aviationweather.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,7 +87,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['gov.noaa.aviationweather.Station'] ingestion json mapping "gov.noaa.aviationweather.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -109,13 +109,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['gov.noaa.aviationweather.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.noaa.aviationweather.StationLatest'] on table ['gov.noaa.aviationweather.Station'] {
+    ['gov.noaa.aviationweather.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['gov.noaa.aviationweather.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -126,7 +126,7 @@
 }]
 ```
 
-.create-merge table [Metar] (
+.create-merge table ['gov.noaa.aviationweather.Metar'] (
    [icao_id]: string,
    [obs_time]: datetime,
    [report_time]: datetime,
@@ -155,9 +155,9 @@
    [___subject]: string
 );
 
-.alter table [Metar] docstring "{\"description\": \"METAR aviation weather observation from the AviationWeather.gov API. Reports surface conditions including temperature, dewpoint, wind, visibility, pressure, clouds, and flight category for an ICAO reporting station.\"}";
+.alter table ['gov.noaa.aviationweather.Metar'] docstring "{\"description\": \"METAR aviation weather observation from the AviationWeather.gov API. Reports surface conditions including temperature, dewpoint, wind, visibility, pressure, clouds, and flight category for an ICAO reporting station.\"}";
 
-.alter table [Metar] column-docstrings (
+.alter table ['gov.noaa.aviationweather.Metar'] column-docstrings (
    [icao_id]: "{\"description\": \"ICAO station identifier for the reporting station (e.g. 'KJFK').\"}",
    [obs_time]: "{\"description\": \"Observation time as a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z) from the obsTime field in the API response.\"}",
    [report_time]: "{\"description\": \"Report time as an ISO 8601 UTC string from the reportTime field. This is the time the observation was officially reported.\"}",
@@ -186,7 +186,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Metar] ingestion json mapping "Metar_json_flat"
+.create-or-alter table ['gov.noaa.aviationweather.Metar'] ingestion json mapping "gov.noaa.aviationweather.Metar_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -218,7 +218,7 @@
 ]
 ```
 
-.create-or-alter table [Metar] ingestion json mapping "Metar_json_ce_structured"
+.create-or-alter table ['gov.noaa.aviationweather.Metar'] ingestion json mapping "gov.noaa.aviationweather.Metar_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -250,13 +250,13 @@
 ]
 ```
 
-.drop materialized-view MetarLatest ifexists;
+.drop materialized-view ['gov.noaa.aviationweather.MetarLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MetarLatest on table Metar {
-    Metar | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.noaa.aviationweather.MetarLatest'] on table ['gov.noaa.aviationweather.Metar'] {
+    ['gov.noaa.aviationweather.Metar'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Metar] policy update
+.alter table ['gov.noaa.aviationweather.Metar'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -267,7 +267,7 @@
 }]
 ```
 
-.create-merge table [Sigmet] (
+.create-merge table ['gov.noaa.aviationweather.Sigmet'] (
    [icao_id]: string,
    [series_id]: string,
    [valid_time_from]: datetime,
@@ -289,9 +289,9 @@
    [___subject]: string
 );
 
-.alter table [Sigmet] docstring "{\"description\": \"SIGMET (Significant Meteorological Information) advisory from the AviationWeather.gov API. Covers both US domestic convective/non-convective SIGMETs and international SIGMETs. Reports hazardous weather conditions for aviation including thunderstorms, turbulence, icing, and volcanic ash.\"}";
+.alter table ['gov.noaa.aviationweather.Sigmet'] docstring "{\"description\": \"SIGMET (Significant Meteorological Information) advisory from the AviationWeather.gov API. Covers both US domestic convective/non-convective SIGMETs and international SIGMETs. Reports hazardous weather conditions for aviation including thunderstorms, turbulence, icing, and volcanic ash.\"}";
 
-.alter table [Sigmet] column-docstrings (
+.alter table ['gov.noaa.aviationweather.Sigmet'] column-docstrings (
    [icao_id]: "{\"description\": \"ICAO identifier for the issuing office (e.g. 'KKCI' for the Kansas City Aviation Weather Center) or FIR identifier for international SIGMETs.\"}",
    [series_id]: "{\"description\": \"SIGMET series identifier combining alphanumeric sequence (e.g. '6W' for domestic, '8' for international).\"}",
    [valid_time_from]: "{\"description\": \"Start of the SIGMET validity period as a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z).\"}",
@@ -313,7 +313,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Sigmet] ingestion json mapping "Sigmet_json_flat"
+.create-or-alter table ['gov.noaa.aviationweather.Sigmet'] ingestion json mapping "gov.noaa.aviationweather.Sigmet_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -338,7 +338,7 @@
 ]
 ```
 
-.create-or-alter table [Sigmet] ingestion json mapping "Sigmet_json_ce_structured"
+.create-or-alter table ['gov.noaa.aviationweather.Sigmet'] ingestion json mapping "gov.noaa.aviationweather.Sigmet_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -363,13 +363,13 @@
 ]
 ```
 
-.drop materialized-view SigmetLatest ifexists;
+.drop materialized-view ['gov.noaa.aviationweather.SigmetLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SigmetLatest on table Sigmet {
-    Sigmet | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.noaa.aviationweather.SigmetLatest'] on table ['gov.noaa.aviationweather.Sigmet'] {
+    ['gov.noaa.aviationweather.Sigmet'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Sigmet] policy update
+.alter table ['gov.noaa.aviationweather.Sigmet'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/aviationweather/kql/create-kql-script.ps1
+++ b/aviationweather/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\aviationweather.xreg.json"
 $kqlFile = Join-Path $scriptDir "aviationweather.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace gov.noaa.aviationweather

--- a/aviationweather/notebook/aviationweather-feed.ipynb
+++ b/aviationweather/notebook/aviationweather-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AviationWeather.gov Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the NOAA Aviation Weather Center API for METAR observations, SIGMET advisories, and station reference data, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `aviationweather` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `aviationweather --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new METARs and SIGMETs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"aviationweather-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/aviationweather/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/aviationweather/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing aviationweather package from Fabric Environment...')\n",
+    "    from aviationweather import aviationweather as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['aviationweather', '--once'] if ONCE_MODE else ['aviationweather']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/aviationweather/tests/test_once_mode.py
+++ b/aviationweather/tests/test_once_mode.py
@@ -1,0 +1,84 @@
+"""
+Test that --once causes poll_and_send() to return after exactly one cycle.
+"""
+
+import os
+from unittest.mock import patch, MagicMock
+
+from aviationweather.aviationweather import AviationWeatherPoller
+
+
+def _make_poller(tmp_path):
+    state_file = tmp_path / "state.json"
+    with patch("confluent_kafka.Producer") as mock_kp, \
+         patch("aviationweather.aviationweather.GovNoaaAviationweatherEventProducer") as mock_evt:
+        mock_evt.return_value = MagicMock(producer=MagicMock())
+        poller = AviationWeatherPoller(
+            kafka_config={"bootstrap.servers": "localhost:9092"},
+            kafka_topic="test-topic",
+            last_polled_file=str(state_file),
+            station_ids="KJFK",
+            metar_poll_interval=900,
+            sigmet_poll_interval=900,
+        )
+    return poller
+
+
+def test_poll_and_send_once_exits_after_single_cycle(tmp_path):
+    poller = _make_poller(tmp_path)
+
+    with patch.object(poller, "emit_stations", return_value=1) as m_st, \
+         patch.object(poller, "emit_metars", return_value=(0, {})) as m_metar, \
+         patch.object(poller, "emit_sigmets", return_value=(0, set())) as m_sigmet, \
+         patch("aviationweather.aviationweather.time.sleep") as m_sleep:
+        poller.poll_and_send(once=True)
+
+    assert m_metar.call_count == 1, "METAR poll must run exactly once"
+    assert m_sigmet.call_count == 1, "SIGMET poll must run exactly once"
+    assert m_sleep.call_count == 0, "Must not sleep when --once is set"
+    assert m_st.call_count >= 1, "Station reference data must be emitted at startup"
+
+
+def test_main_parses_once_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("CONNECTION_STRING",
+                       "BootstrapServer=localhost:9092;EntityPath=test-topic")
+    monkeypatch.setenv("AVIATIONWEATHER_LAST_POLLED_FILE", str(tmp_path / "s.json"))
+    monkeypatch.setattr("sys.argv", ["aviationweather", "--once"])
+
+    captured = {}
+
+    def fake_init(self, **kwargs):
+        captured["init"] = kwargs
+
+    def fake_poll(self, once=False):
+        captured["once"] = once
+
+    with patch.object(AviationWeatherPoller, "__init__", fake_init), \
+         patch.object(AviationWeatherPoller, "poll_and_send", fake_poll):
+        from aviationweather.aviationweather import main
+        main()
+
+    assert captured.get("once") is True
+
+
+def test_main_once_via_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CONNECTION_STRING",
+                       "BootstrapServer=localhost:9092;EntityPath=test-topic")
+    monkeypatch.setenv("AVIATIONWEATHER_LAST_POLLED_FILE", str(tmp_path / "s.json"))
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr("sys.argv", ["aviationweather"])
+
+    captured = {}
+
+    def fake_init(self, **kwargs):
+        pass
+
+    def fake_poll(self, once=False):
+        captured["once"] = once
+
+    with patch.object(AviationWeatherPoller, "__init__", fake_init), \
+         patch.object(AviationWeatherPoller, "poll_and_send", fake_poll):
+        from aviationweather.aviationweather import main
+        main()
+
+    assert captured.get("once") is True

--- a/catalog.json
+++ b/catalog.json
@@ -175,7 +175,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Global — METAR, SIGMET advisories",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "blitzortung",


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- Adds viationweather/notebook/aviationweather-feed.ipynb following the pegelonline template (4-cell structure, runtime CS lookup via Topology API, worker-thread run, OneLake log).
- Flips `catalog.json` `notebook: true` for `aviationweather` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` CLI flag and `ONCE_MODE` env-var support to the bridge (modeled on `pegelonline/pegelonline/pegelonline.py`) so the notebook can run a single polling cycle and exit. Wired through to `poll_and_send(once=...)`.
- New `aviationweather/tests/test_once_mode.py` with 3 tests asserting one-cycle exit, `--once` flag parsing, and `ONCE_MODE` env-var parsing.
- Flips `aviationweather/kql/create-kql-script.ps1` to pass `-Qualified -Namespace gov.noaa.aviationweather` (schemas have no inline namespace), regenerates `aviationweather/kql/aviationweather.kql` with FQN-bracketed table names (`['gov.noaa.aviationweather.Station']`, etc.). See `docs/plan-qualified-table-names.md` and DWD reference PR #257.

## Validated locally
- Notebook JSON parses.
- All 67 bridge tests pass (including 3 new `test_once_mode.py`).
- Required parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No `asyncio.run()`, no `CONNECTION_STRING =` assignment, no `primaryConnectionString` write. (The phrase `%pip install` appears only in the markdown sentence stating it is NOT used at runtime — verbatim from the pegelonline template.)
- KQL regenerated with qualified table names; `['gov.noaa.aviationweather.Station|Metar|Sigmet]` all present. `_cloudevents_dispatch` unchanged. No hand-authored consumer KQL/fabric/dashboard assets to audit.

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on merge to main and publish wheels to the notebook-wheels release. End-to-end Fabric deployment is intentionally **not** performed by this agent.