### PR TITLE
feat(jma-japan): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -239,7 +239,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Japan — weather bulletins, warnings, forecasts",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "kmi-belgium",

--- a/jma-japan/README.md
+++ b/jma-japan/README.md
@@ -20,6 +20,9 @@ tracks previously seen bulletin IDs to avoid sending duplicates.
   authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in
   [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: This source ships a Fabric notebook feeder
+  at [`notebook/jma-japan-feed.ipynb`](notebook/jma-japan-feed.ipynb),
+  deployable via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
 
 ## Data Sources
 

--- a/jma-japan/jma_japan/jma_japan.py
+++ b/jma-japan/jma_japan/jma_japan.py
@@ -171,10 +171,14 @@ class JMABulletinPoller:
                 all_bulletins.extend(bulletins)
         return all_bulletins
 
-    def poll_and_send(self):
+    def poll_and_send(self, once: bool = False):
         """
         Main polling loop. Fetches bulletins, deduplicates, and sends new ones
         to Kafka as CloudEvents. Polls every POLL_INTERVAL_SECONDS.
+
+        Args:
+            once: When True, exit after a single polling cycle (used by the
+                Fabric notebook scheduler).
         """
         print(f"Starting JMA Weather Bulletin poller, polling every {self.POLL_INTERVAL_SECONDS}s")
         print(f"  Regular feed: {self.REGULAR_FEED_URL}")
@@ -210,6 +214,10 @@ class JMABulletinPoller:
 
             except Exception as e:
                 print(f"Error in polling loop: {e}")
+
+            if once:
+                print("--once mode: exiting after first polling cycle")
+                break
 
             time.sleep(self.POLL_INTERVAL_SECONDS)
 
@@ -263,6 +271,9 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Used by the Fabric notebook scheduler.')
 
     args = parser.parse_args()
 
@@ -310,7 +321,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/jma-japan/kql/create-kql-script.ps1
+++ b/jma-japan/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\jma_japan.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma_japan.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace jp.go.jma

--- a/jma-japan/kql/jma_japan.kql
+++ b/jma-japan/kql/jma_japan.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [WeatherBulletin] (
+.create-merge table ['jp.go.jma.WeatherBulletin'] (
    [bulletin_id]: string,
    [title]: string,
    [author]: string,
@@ -40,9 +40,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherBulletin] docstring "{\"description\": \"Weather bulletin entry from the JMA XML Atom feed. Covers forecasts, warnings, advisories, and risk notifications published by the Japan Meteorological Agency and its regional observatories.\"}";
+.alter table ['jp.go.jma.WeatherBulletin'] docstring "{\"description\": \"Weather bulletin entry from the JMA XML Atom feed. Covers forecasts, warnings, advisories, and risk notifications published by the Japan Meteorological Agency and its regional observatories.\"}";
 
-.alter table [WeatherBulletin] column-docstrings (
+.alter table ['jp.go.jma.WeatherBulletin'] column-docstrings (
    [bulletin_id]: "{\"description\": \"Unique identifier for the bulletin, derived from the Atom entry ID (typically a URL to the full XML document).\"}",
    [title]: "{\"description\": \"Title of the weather bulletin in Japanese, e.g. '\\u6c17\\u8c61\\u7279\\u5225\\u8b66\\u5831\\u30fb\\u8b66\\u5831\\u30fb\\u6ce8\\u610f\\u5831' (Special weather warnings/advisories).\"}",
    [author]: "{\"description\": \"Issuing authority name in Japanese, e.g. '\\u6c17\\u8c61\\u5e81' (JMA) or a regional observatory name like '\\u677e\\u6c5f\\u5730\\u65b9\\u6c17\\u8c61\\u53f0'.\"}",
@@ -57,7 +57,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherBulletin] ingestion json mapping "WeatherBulletin_json_flat"
+.create-or-alter table ['jp.go.jma.WeatherBulletin'] ingestion json mapping "jp.go.jma.WeatherBulletin_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -75,7 +75,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherBulletin] ingestion json mapping "WeatherBulletin_json_ce_structured"
+.create-or-alter table ['jp.go.jma.WeatherBulletin'] ingestion json mapping "jp.go.jma.WeatherBulletin_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -93,13 +93,13 @@
 ]
 ```
 
-.drop materialized-view WeatherBulletinLatest ifexists;
+.drop materialized-view ['jp.go.jma.WeatherBulletinLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherBulletinLatest on table WeatherBulletin {
-    WeatherBulletin | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['jp.go.jma.WeatherBulletinLatest'] on table ['jp.go.jma.WeatherBulletin'] {
+    ['jp.go.jma.WeatherBulletin'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherBulletin] policy update
+.alter table ['jp.go.jma.WeatherBulletin'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/jma-japan/notebook/jma-japan-feed.ipynb
+++ b/jma-japan/notebook/jma-japan-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JMA Japan Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Japan Meteorological Agency (JMA) Atom XML feeds (regular and extra) for weather bulletins — forecasts, warnings, advisories, and risk notifications — and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `jma_japan` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `jma-japan --once`, exits after one polling cycle, and persists dedupe state (seen bulletin IDs) to a Lakehouse Files path so the next scheduled run only emits new bulletins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"jma-japan-ingest\"       # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/jma-japan/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/jma-japan/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing jma_japan package from Fabric Environment...')\n",
+    "    from jma_japan import jma_japan as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['jma-japan', '--once'] if ONCE_MODE else ['jma-japan']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/jma-japan/tests/test_once_mode.py
+++ b/jma-japan/tests/test_once_mode.py
@@ -1,0 +1,44 @@
+"""Verify --once causes the poller to exit after one cycle."""
+
+from unittest.mock import MagicMock, patch
+
+from jma_japan.jma_japan import JMABulletinPoller
+
+
+def _make_poller(tmp_path):
+    poller = JMABulletinPoller.__new__(JMABulletinPoller)
+    poller.kafka_topic = 'test-topic'
+    poller.last_polled_file = str(tmp_path / 'state.json')
+    poller.kafka_producer = MagicMock()
+    poller.bulletins_producer = MagicMock()
+    return poller
+
+
+def test_once_mode_exits_after_one_cycle(tmp_path):
+    poller = _make_poller(tmp_path)
+    with patch.object(poller, 'poll_feeds', return_value=[]) as poll_feeds, \
+         patch('jma_japan.jma_japan.time.sleep') as sleep_mock:
+        poller.poll_and_send(once=True)
+    assert poll_feeds.call_count == 1
+    sleep_mock.assert_not_called()
+
+
+def test_default_mode_loops(tmp_path):
+    poller = _make_poller(tmp_path)
+    call_count = {'n': 0}
+
+    def fake_poll():
+        call_count['n'] += 1
+        return []
+
+    def fake_sleep(_):
+        if call_count['n'] >= 2:
+            raise KeyboardInterrupt
+
+    with patch.object(poller, 'poll_feeds', side_effect=fake_poll), \
+         patch('jma_japan.jma_japan.time.sleep', side_effect=fake_sleep):
+        try:
+            poller.poll_and_send(once=False)
+        except KeyboardInterrupt:
+            pass
+    assert call_count['n'] >= 2


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## What
- Adds `jma-japan/notebook/jma-japan-feed.ipynb` following the canonical `pegelonline` pattern (4-cell structure, runtime CS lookup, worker-thread invocation, OneLake logging).
- Flips `catalog.json` `notebook: true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` CLI flag (and `ONCE_MODE` env var) to the JMA bridge so the Fabric notebook scheduler can run single-cycle polls. The bridge previously only supported the infinite `while True` polling loop.
- Adds `tests/test_once_mode.py` asserting that `--once` exits after exactly one cycle and that default mode still loops.
- Flips `jma-japan/kql/create-kql-script.ps1` to pass `-Qualified -Namespace jp.go.jma` and regenerates `jma-japan/kql/jma_japan.kql`. The xreg schema has no declared namespace, so `-Namespace jp.go.jma` supplies one. See `docs/plan-qualified-table-names.md` and DWD reference PR #257.

## Validation
- ✅ Notebook JSON parses.
- ✅ All 56 bridge unit tests pass (`python -m pytest tests/` in `jma-japan/`).
- ✅ New `test_once_mode.py` passes (2/2).
- ✅ Notebook params cell contains EVENTSTREAM_NAME / STATE_FILE / POLLING_INTERVAL / ONCE_MODE / WORKSPACE_ID.
- ✅ No forbidden patterns (`asyncio.run(`, `%pip install`, baked CONNECTION_STRING, baked primaryConnectionString).
- ✅ Regenerated KQL uses qualified table names (`['jp.go.jma.WeatherBulletin']`, `['jp.go.jma.WeatherBulletinLatest']`).
- ✅ No stale unqualified consumer-asset references (no fabric/dashboard directories in this source).

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the `notebook-wheels` release. Live Fabric deployment is out of scope for this PR per the retrofit skill.