### PR TITLE
feat(environment-canada): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -226,7 +226,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Canada — ~963 SWOB stations, hourly obs",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "geosphere-austria",

--- a/environment-canada/README.md
+++ b/environment-canada/README.md
@@ -56,3 +56,10 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fenvironment-canada%2Fazure-template-with-eventhub.json)
+
+## Fabric notebook hosting
+
+The bridge can also run as a scheduled Microsoft Fabric notebook (see
+[`notebook/environment-canada-feed.ipynb`](notebook/environment-canada-feed.ipynb))
+deployed via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).

--- a/environment-canada/environment_canada/environment_canada.py
+++ b/environment-canada/environment_canada/environment_canada.py
@@ -271,6 +271,9 @@ def main():
                         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.environment_canada_state.json")))
     parser.add_argument("--station-limit", type=int, default=int(os.environ.get("STATION_LIMIT", "500")))
     parser.add_argument("--obs-limit", type=int, default=int(os.environ.get("OBS_LIMIT", "500")))
+    parser.add_argument("--once", action="store_true",
+                        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+                        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List SWOB stations")
     subparsers.add_parser("feed", help="Feed data to Kafka")
@@ -314,6 +317,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/environment-canada/kql/create-kql-script.ps1
+++ b/environment-canada/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\environment_canada.xreg.json"
 $kqlFile = Join-Path $scriptDir "environment_canada.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace ca.gov.eccc.weather

--- a/environment-canada/kql/environment_canada.kql
+++ b/environment-canada/kql/environment_canada.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['ca.gov.eccc.weather.Station'] (
    [msc_id]: string,
    [name]: string,
    [iata_id]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for an Environment Canada SWOB weather station. Stations are identified by their MSC ID (Meteorological Service of Canada identifier) and include WMO synoptic IDs where available.\"}";
+.alter table ['ca.gov.eccc.weather.Station'] docstring "{\"description\": \"Reference data for an Environment Canada SWOB weather station. Stations are identified by their MSC ID (Meteorological Service of Canada identifier) and include WMO synoptic IDs where available.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['ca.gov.eccc.weather.Station'] column-docstrings (
    [msc_id]: "{\"description\": \"MSC station identifier (Meteorological Service of Canada ID), also known as Climate ID. Used as Kafka key.\"}",
    [name]: "{\"description\": \"Station name as listed in the SWOB station registry, e.g. 'TORONTO PEARSON INTL A', 'VANCOUVER INTL A'.\"}",
    [iata_id]: "{\"description\": \"IATA station code, e.g. 'CYYZ' for Toronto Pearson.\"}",
@@ -65,7 +65,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['ca.gov.eccc.weather.Station'] ingestion json mapping "ca.gov.eccc.weather.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,7 +87,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['ca.gov.eccc.weather.Station'] ingestion json mapping "ca.gov.eccc.weather.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -109,13 +109,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['ca.gov.eccc.weather.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ca.gov.eccc.weather.StationLatest'] on table ['ca.gov.eccc.weather.Station'] {
+    ['ca.gov.eccc.weather.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['ca.gov.eccc.weather.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -126,7 +126,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['ca.gov.eccc.weather.WeatherObservation'] (
    [msc_id]: string,
    [station_name]: string,
    [observation_time]: datetime,
@@ -156,9 +156,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"Weather observation from an Environment Canada SWOB station. Fields are extracted from the verbose SWOB-ML record (200+ raw fields). The core meteorological parameters retained include temperature, humidity, dew point, pressure (station and sea-level), wind, precipitation, visibility, snow depth, cloud cover, pressure tendency, and 24-hour temperature extremes.\"}";
+.alter table ['ca.gov.eccc.weather.WeatherObservation'] docstring "{\"description\": \"Weather observation from an Environment Canada SWOB station. Fields are extracted from the verbose SWOB-ML record (200+ raw fields). The core meteorological parameters retained include temperature, humidity, dew point, pressure (station and sea-level), wind, precipitation, visibility, snow depth, cloud cover, pressure tendency, and 24-hour temperature extremes.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['ca.gov.eccc.weather.WeatherObservation'] column-docstrings (
    [msc_id]: "{\"description\": \"MSC station identifier.\"}",
    [station_name]: "{\"description\": \"Station name from the SWOB record.\"}",
    [observation_time]: "{\"description\": \"Observation timestamp in UTC from the obs_date_tm field.\"}",
@@ -188,7 +188,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['ca.gov.eccc.weather.WeatherObservation'] ingestion json mapping "ca.gov.eccc.weather.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -221,7 +221,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['ca.gov.eccc.weather.WeatherObservation'] ingestion json mapping "ca.gov.eccc.weather.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -254,13 +254,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['ca.gov.eccc.weather.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ca.gov.eccc.weather.WeatherObservationLatest'] on table ['ca.gov.eccc.weather.WeatherObservation'] {
+    ['ca.gov.eccc.weather.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['ca.gov.eccc.weather.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/environment-canada/notebook/environment-canada-feed.ipynb
+++ b/environment-canada/notebook/environment-canada-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Environment Canada Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Environment and Climate Change Canada (ECCC) Surface Weather Observations (SWOB) OGC API (`api.weather.gc.ca`) for SWOB station metadata and hourly observations across ~963 Canadian stations, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `environment_canada` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `environment-canada feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"environment-canada-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/environment-canada/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/environment-canada/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing environment_canada package from Fabric Environment...')\n",
+    "    from environment_canada import environment_canada as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['environment-canada', 'feed', '--once'] if ONCE_MODE else ['environment-canada', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/environment-canada/tests/test_once_mode.py
+++ b/environment-canada/tests/test_once_mode.py
@@ -1,0 +1,82 @@
+"""Test that the bridge supports --once single-cycle execution.
+
+Regression guard for the Fabric notebook hosting path, which schedules
+the bridge as a single-cycle command and depends on the polling loop
+exiting cleanly after one iteration.
+"""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import environment_canada.environment_canada as bridge
+
+
+def test_once_flag_exits_after_one_cycle(monkeypatch):
+    """With --once, main() must return after exactly one feed cycle, no sleep."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "environment-canada",
+            "--connection-string",
+            "Endpoint=sb://fake/;EntityPath=topic",
+            "--topic",
+            "test-topic",
+            "--state-file",
+            "",
+            "--once",
+            "feed",
+        ],
+    )
+
+    sleep_mock = MagicMock()
+    send_stations_mock = MagicMock()
+    feed_observations_mock = MagicMock(return_value=3)
+    producer_mock = MagicMock()
+    event_producer_mock = MagicMock()
+
+    with patch.object(bridge, "time", MagicMock(sleep=sleep_mock)), \
+         patch.object(bridge, "Producer", return_value=producer_mock), \
+         patch.object(bridge, "CAGovECCCWeatherEventProducer", return_value=event_producer_mock), \
+         patch.object(bridge, "send_stations", send_stations_mock), \
+         patch.object(bridge, "feed_observations", feed_observations_mock), \
+         patch.object(bridge, "_load_state", return_value={}), \
+         patch.object(bridge, "_save_state"):
+        bridge.main()
+
+    assert feed_observations_mock.call_count == 1, "feed_observations should run exactly once"
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var(monkeypatch):
+    """Setting ONCE_MODE=true via environment must also cause single-cycle exit."""
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "environment-canada",
+            "--connection-string",
+            "Endpoint=sb://fake/;EntityPath=topic",
+            "--topic",
+            "test-topic",
+            "--state-file",
+            "",
+            "feed",
+        ],
+    )
+
+    sleep_mock = MagicMock()
+    feed_observations_mock = MagicMock(return_value=0)
+
+    with patch.object(bridge, "time", MagicMock(sleep=sleep_mock)), \
+         patch.object(bridge, "Producer", return_value=MagicMock()), \
+         patch.object(bridge, "CAGovECCCWeatherEventProducer", return_value=MagicMock()), \
+         patch.object(bridge, "send_stations"), \
+         patch.object(bridge, "feed_observations", feed_observations_mock), \
+         patch.object(bridge, "_load_state", return_value={}), \
+         patch.object(bridge, "_save_state"):
+        bridge.main()
+
+    assert feed_observations_mock.call_count == 1
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (see `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes
- **Notebook**: `environment-canada/notebook/environment-canada-feed.ipynb` — verbatim copy of the canonical `pegelonline/notebook/pegelonline-feed.ipynb` with the mechanical substitutions from the skill's substitution table (package import, sys.argv, state/log paths, EVENTSTREAM_NAME, markdown copy adapted from the README).
- **catalog.json**: `notebook: true` added to the `environment-canada` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Bridge `--once` flag**: added to `environment_canada/environment_canada.py` (modeled on `pegelonline`); also honors `ONCE_MODE` env var. Required because the previous bridge had no single-cycle exit.
- **Unit test**: `tests/test_once_mode.py` asserts `--once` and `ONCE_MODE=true` both cause exactly one `feed_observations` call and zero `time.sleep` calls.
- **Qualified KQL tables** (per PR #257 / `docs/plan-qualified-table-names.md`): `kql/create-kql-script.ps1` now calls the generator with `-Qualified -Namespace ca.gov.eccc.weather` (xreg has no embedded namespace). `kql/environment_canada.kql` regenerated — landing tables now `['ca.gov.eccc.weather.Station']` and `['ca.gov.eccc.weather.WeatherObservation']`. No hand-authored consumer assets (no fabric/, no dashboard/, no secondary kql overlays) required updates.
- **README**: one-sentence Fabric notebook hosting bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validation (local)
- Notebook JSON parses ✓
- All 24 bridge tests pass (22 existing + 2 new `test_once_mode` cases) ✓
- All notebook parameter placeholders present (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) ✓
- No forbidden patterns (`asyncio.run(`, `%pip install`, hardcoded `CONNECTION_STRING=`, `primaryConnectionString=`) ✓
- No stale `pegelonline` references in the notebook ✓
- Qualified KQL tables present (`create-merge table ['ca.gov.eccc.weather.…']`) ✓

The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the `notebook-wheels` release. End-to-end Fabric verification is out of scope for this PR.