### PR TITLE
feat(bom-australia): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/bom-australia/README.md
+++ b/bom-australia/README.md
@@ -45,6 +45,13 @@ Additional stations can be configured via the `BOM_STATIONS` environment variabl
 - [BOM Data Feeds](http://www.bom.gov.au/catalogue/data-feeds.shtml)
 - [72-hour Observation Products User Guide](https://www.bom.gov.au/catalogue/72_hr_historical_obs.pdf)
 
+## Fabric notebook hosting
+
+This source can also run as a scheduled Fabric notebook feeder (single polling
+cycle per run, no always-on container). Deploy via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1);
+the notebook lives at [`notebook/bom-australia-feed.ipynb`](notebook/bom-australia-feed.ipynb).
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/bom-australia/bom_australia/bom_australia.py
+++ b/bom-australia/bom_australia/bom_australia.py
@@ -482,6 +482,9 @@ def main():
                         help="Comma-separated state abbreviations to filter (e.g. NSW,VIC)")
     parser.add_argument("--warning-feeds", type=str, default=os.environ.get("BOM_WARNING_FEEDS", ""),
                         help="Comma-separated BOM warning RSS feed URLs or /fwo/... feed paths")
+    parser.add_argument("--once", action="store_true",
+                        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+                        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List configured stations")
     subparsers.add_parser("feed", help="Feed data to Kafka")
@@ -539,6 +542,9 @@ def main():
                 logger.info("Sent %d observation events and %d warning events", observation_count, warning_count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/bom-australia/kql/bom_australia.kql
+++ b/bom-australia/kql/bom_australia.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['au.gov.bom.Station'] (
    [station_wmo]: int,
    [name]: string,
    [product_id]: string,
@@ -40,9 +40,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for a BOM weather observation station identified by its WMO station number. Stations report half-hourly surface observations covering temperature, wind, pressure, rainfall, humidity, cloud, and visibility.\"}";
+.alter table ['au.gov.bom.Station'] docstring "{\"description\": \"Reference metadata for a BOM weather observation station identified by its WMO station number. Stations report half-hourly surface observations covering temperature, wind, pressure, rainfall, humidity, cloud, and visibility.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['au.gov.bom.Station'] column-docstrings (
    [station_wmo]: "{\"description\": \"WMO station number assigned by the World Meteorological Organization, used as the stable identity for this station across all BOM products.\"}",
    [name]: "{\"description\": \"Human-readable station name as assigned by the Bureau of Meteorology, e.g. 'Sydney Airport' or 'Melbourne Airport'.\"}",
    [product_id]: "{\"description\": \"BOM product code identifying the observation product this station belongs to, e.g. 'IDN60901' for NSW capital city observations.\"}",
@@ -57,7 +57,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['au.gov.bom.Station'] ingestion json mapping "au.gov.bom.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -75,7 +75,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['au.gov.bom.Station'] ingestion json mapping "au.gov.bom.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -93,13 +93,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['au.gov.bom.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['au.gov.bom.StationLatest'] on table ['au.gov.bom.Station'] {
+    ['au.gov.bom.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['au.gov.bom.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -110,7 +110,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['au.gov.bom.WeatherObservation'] (
    [station_wmo]: int,
    [station_name]: string,
    [observation_time_utc]: datetime,
@@ -149,9 +149,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"Half-hourly surface weather observation from a BOM automatic weather station. Each record contains temperature, wind, pressure, humidity, rainfall, cloud, and visibility measurements as reported in the station's 72-hour observation product.\"}";
+.alter table ['au.gov.bom.WeatherObservation'] docstring "{\"description\": \"Half-hourly surface weather observation from a BOM automatic weather station. Each record contains temperature, wind, pressure, humidity, rainfall, cloud, and visibility measurements as reported in the station's 72-hour observation product.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['au.gov.bom.WeatherObservation'] column-docstrings (
    [station_wmo]: "{\"description\": \"WMO station number identifying the reporting station.\"}",
    [station_name]: "{\"description\": \"Human-readable name of the reporting station.\"}",
    [observation_time_utc]: "{\"description\": \"Timestamp of the observation in UTC, derived from the BOM 'aifstime_utc' field in YYYYMMDDHHmmss format.\"}",
@@ -190,7 +190,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['au.gov.bom.WeatherObservation'] ingestion json mapping "au.gov.bom.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -232,7 +232,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['au.gov.bom.WeatherObservation'] ingestion json mapping "au.gov.bom.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -274,13 +274,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['au.gov.bom.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['au.gov.bom.WeatherObservationLatest'] on table ['au.gov.bom.WeatherObservation'] {
+    ['au.gov.bom.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['au.gov.bom.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -291,7 +291,7 @@
 }]
 ```
 
-.create-merge table [WarningBulletin] (
+.create-merge table ['au.gov.bom.WarningBulletin'] (
    [warning_id]: string,
    [warning_url]: string,
    [feed_url]: string,
@@ -308,9 +308,9 @@
    [___subject]: string
 );
 
-.alter table [WarningBulletin] docstring "{\"description\": \"Current weather warning bulletin item from a Bureau of Meteorology RSS warnings feed. Each item points to the published warning product page and carries the update timestamp and headline text from the feed.\"}";
+.alter table ['au.gov.bom.WarningBulletin'] docstring "{\"description\": \"Current weather warning bulletin item from a Bureau of Meteorology RSS warnings feed. Each item points to the published warning product page and carries the update timestamp and headline text from the feed.\"}";
 
-.alter table [WarningBulletin] column-docstrings (
+.alter table ['au.gov.bom.WarningBulletin'] column-docstrings (
    [warning_id]: "{\"description\": \"Stable BOM warning product identifier derived from the linked product page path, for example 'IDN21037'.\"}",
    [warning_url]: "{\"description\": \"Absolute BOM URL of the warning product page linked from the RSS item.\"}",
    [feed_url]: "{\"description\": \"Absolute BOM RSS feed URL that published this warning item.\"}",
@@ -327,7 +327,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WarningBulletin] ingestion json mapping "WarningBulletin_json_flat"
+.create-or-alter table ['au.gov.bom.WarningBulletin'] ingestion json mapping "au.gov.bom.WarningBulletin_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -347,7 +347,7 @@
 ]
 ```
 
-.create-or-alter table [WarningBulletin] ingestion json mapping "WarningBulletin_json_ce_structured"
+.create-or-alter table ['au.gov.bom.WarningBulletin'] ingestion json mapping "au.gov.bom.WarningBulletin_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -367,13 +367,13 @@
 ]
 ```
 
-.drop materialized-view WarningBulletinLatest ifexists;
+.drop materialized-view ['au.gov.bom.WarningBulletinLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WarningBulletinLatest on table WarningBulletin {
-    WarningBulletin | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['au.gov.bom.WarningBulletinLatest'] on table ['au.gov.bom.WarningBulletin'] {
+    ['au.gov.bom.WarningBulletin'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WarningBulletin] policy update
+.alter table ['au.gov.bom.WarningBulletin'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/bom-australia/kql/create-kql-script.ps1
+++ b/bom-australia/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\bom_australia.xreg.json"
 $kqlFile = Join-Path $scriptDir "bom_australia.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace au.gov.bom

--- a/bom-australia/notebook/bom-australia-feed.ipynb
+++ b/bom-australia/notebook/bom-australia-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BOM Australia Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Australian Bureau of Meteorology (BOM) public observation products and warning RSS feeds and emits CloudEvents (Station / WeatherObservation / WarningBulletin) to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `bom_australia` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `bom-australia --once feed`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations and warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"bom-australia-ingest\"   # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/bom-australia/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/bom-australia/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing bom_australia package from Fabric Environment...')\n",
+    "    from bom_australia import bom_australia as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['bom-australia', '--once', 'feed'] if ONCE_MODE else ['bom-australia', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/bom-australia/tests/test_once_mode.py
+++ b/bom-australia/tests/test_once_mode.py
@@ -1,0 +1,58 @@
+"""Unit test for the ``--once`` single-cycle execution mode added to support
+Fabric notebook hosting (see notebook-feeder-retrofit skill)."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+def _stub_producer_modules():
+    """Insert lightweight stubs for the generated producer packages.
+
+    This keeps the test runnable in environments where the path-installed
+    ``bom_australia_producer_*`` sub-packages are not yet pip-installed.
+    """
+    for mod in (
+        "bom_australia_producer_kafka_producer",
+        "bom_australia_producer_kafka_producer.producer",
+        "bom_australia_producer_data",
+    ):
+        sys.modules.setdefault(mod, types.ModuleType(mod))
+    sys.modules["bom_australia_producer_kafka_producer.producer"].AUGovBOMWarningEventProducer = MagicMock()
+    sys.modules["bom_australia_producer_kafka_producer.producer"].AUGovBOMWeatherEventProducer = MagicMock()
+    sys.modules["bom_australia_producer_data"].Station = MagicMock()
+    sys.modules["bom_australia_producer_data"].WarningBulletin = MagicMock()
+    sys.modules["bom_australia_producer_data"].WeatherObservation = MagicMock()
+
+
+def test_once_mode_exits_after_single_cycle():
+    """``--once`` must cause main() to return after exactly one cycle without sleeping."""
+    _stub_producer_modules()
+    from bom_australia import bom_australia as bridge
+
+    with patch.object(bridge, "time") as mock_time, \
+         patch.object(bridge, "feed_warnings", return_value=0) as mock_feed_warnings, \
+         patch.object(bridge, "feed_observations", return_value=0) as mock_feed_observations, \
+         patch.object(bridge, "send_stations"), \
+         patch.object(bridge, "_save_state"), \
+         patch.object(bridge, "_load_state", return_value={"observations": {}, "warnings": {}}), \
+         patch.object(bridge, "AUGovBOMWarningEventProducer"), \
+         patch.object(bridge, "AUGovBOMWeatherEventProducer"), \
+         patch.object(bridge, "Producer"), \
+         patch.object(bridge, "BOMAustraliaAPI") as mock_api_cls:
+        mock_api_cls.return_value.discover_stations.return_value = [("IDN60901", 94767)]
+
+        argv = [
+            "bom-australia",
+            "--connection-string", "PLAINTEXT://localhost:9092",
+            "--topic", "bom-australia",
+            "--stations", "IDN60901:94767",
+            "--once",
+            "feed",
+        ]
+        with patch.object(sys, "argv", argv):
+            bridge.main()
+
+        assert mock_feed_observations.call_count == 1, "feed_observations should run exactly once"
+        assert mock_feed_warnings.call_count == 1, "feed_warnings should run exactly once"
+        mock_time.sleep.assert_not_called()

--- a/catalog.json
+++ b/catalog.json
@@ -202,7 +202,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Australia — ~8 capital city airports, half-hourly obs",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "dwd",


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (one source, one PR).

## Changes

- **Notebook**: `bom-australia/notebook/bom-australia-feed.ipynb` — verbatim copy of the canonical `pegelonline-feed.ipynb` with the substitutions from `references/notebook-substitution-table.md` (display name, package/module imports, `sys.argv` shape, state-file & log paths, eventstream name).
- **Catalog flag**: `catalog.json` `bom-australia.notebook = true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- **`--once` mode**: added `--once` / `ONCE_MODE` single-cycle exit to `bom_australia/bom_australia.py` (modeled on `pegelonline/pegelonline/pegelonline.py`). New unit test `tests/test_once_mode.py` asserts `main()` returns after exactly one cycle and never sleeps.
- **Qualified KQL tables**: `kql/create-kql-script.ps1` now invokes `tools/generate-kql-from-xreg.ps1` with `-Qualified -Namespace au.gov.bom` (xreg schemas have no `namespace` declared, so the `-Namespace` fallback is used per the SKILL). Regenerated `kql/bom_australia.kql` — tables are now `['au.gov.bom.Station']`, `['au.gov.bom.WeatherObservation']`, `['au.gov.bom.WarningBulletin']`. `_cloudevents_dispatch` and the update-policy `type ==` predicates are unchanged. No hand-authored Fabric / dashboard / notebook consumer assets ship for this source, so no other rewrites were needed.
- **README**: one-line "Fabric notebook hosting" bullet linking to the deploy script.

## Local validation

- `python -c "import json; json.load(...)"` — notebook JSON well-formed.
- `pytest tests/test_once_mode.py -v` — **PASSED** (1 test).
- Placeholder check — all 5 (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present.
- Qualified-tables check — regenerated KQL contains lowercased namespace-qualified `create-merge table ['au.gov.bom.…']`.
- Forbidden-pattern regex hits a false positive on the markdown literal `\`%pip install\\` *describing* the runtime model (the canonical `pegelonline` template has the same wording) — no code cell executes `%pip install`.

## Out of scope

- No live Fabric deployment (per SKILL §7). The `publish-notebook-wheels.yml` workflow will publish wheels on merge.
- The full bridge test suite cannot run in this worktree because the path-installed `bom_australia_producer_*` sub-packages are not pip-installed (and the SKILL forbids `pip install`). The new `test_once_mode.py` stubs the producer modules to remain self-contained.