### PR TITLE
feat(usgs-nwis-wq): Fabric notebook hosting + qualified KQL tables

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -169,7 +169,8 @@
     "cat": "Hydrology",
     "key": false,
     "desc": "United States — ~3,000 continuous WQ sites",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "waterinfo-vmm",

--- a/usgs-nwis-wq/README.md
+++ b/usgs-nwis-wq/README.md
@@ -32,7 +32,7 @@ cd real-time-sources/usgs-nwis-wq
 pip install .
 ```
 
-For container deployment, see [CONTAINER.md](CONTAINER.md).
+For container deployment, see [CONTAINER.md](CONTAINER.md). For Fabric notebook hosting (scheduled single-cycle runs in a Microsoft Fabric workspace), see [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
 
 ## Usage
 

--- a/usgs-nwis-wq/kql/create-kql-script.ps1
+++ b/usgs-nwis-wq/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\usgs_nwis_wq.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs_nwis_wq.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'gov.usgs.waterservices.wq'

--- a/usgs-nwis-wq/kql/usgs_nwis_wq.kql
+++ b/usgs-nwis-wq/kql/usgs_nwis_wq.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [MonitoringSite] (
+.create-merge table ['gov.usgs.waterservices.wq.MonitoringSite'] (
    [site_number]: string,
    [site_name]: string,
    [agency_code]: string,
@@ -42,7 +42,7 @@
    [___subject]: string
 );
 
-.create-or-alter table [MonitoringSite] ingestion json mapping "MonitoringSite_json_flat"
+.create-or-alter table ['gov.usgs.waterservices.wq.MonitoringSite'] ingestion json mapping "gov.usgs.waterservices.wq.MonitoringSite_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -62,7 +62,7 @@
 ]
 ```
 
-.create-or-alter table [MonitoringSite] ingestion json mapping "MonitoringSite_json_ce_structured"
+.create-or-alter table ['gov.usgs.waterservices.wq.MonitoringSite'] ingestion json mapping "gov.usgs.waterservices.wq.MonitoringSite_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -82,13 +82,13 @@
 ]
 ```
 
-.drop materialized-view MonitoringSiteLatest ifexists;
+.drop materialized-view ['gov.usgs.waterservices.wq.MonitoringSiteLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MonitoringSiteLatest on table MonitoringSite {
-    MonitoringSite | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usgs.waterservices.wq.MonitoringSiteLatest'] on table ['gov.usgs.waterservices.wq.MonitoringSite'] {
+    ['gov.usgs.waterservices.wq.MonitoringSite'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [MonitoringSite] policy update
+.alter table ['gov.usgs.waterservices.wq.MonitoringSite'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -99,7 +99,7 @@
 }]
 ```
 
-.create-merge table [WaterQualityReading] (
+.create-merge table ['gov.usgs.waterservices.wq.WaterQualityReading'] (
    [site_number]: string,
    [site_name]: string,
    [parameter_code]: string,
@@ -115,7 +115,7 @@
    [___subject]: string
 );
 
-.create-or-alter table [WaterQualityReading] ingestion json mapping "WaterQualityReading_json_flat"
+.create-or-alter table ['gov.usgs.waterservices.wq.WaterQualityReading'] ingestion json mapping "gov.usgs.waterservices.wq.WaterQualityReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -134,7 +134,7 @@
 ]
 ```
 
-.create-or-alter table [WaterQualityReading] ingestion json mapping "WaterQualityReading_json_ce_structured"
+.create-or-alter table ['gov.usgs.waterservices.wq.WaterQualityReading'] ingestion json mapping "gov.usgs.waterservices.wq.WaterQualityReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -153,13 +153,13 @@
 ]
 ```
 
-.drop materialized-view WaterQualityReadingLatest ifexists;
+.drop materialized-view ['gov.usgs.waterservices.wq.WaterQualityReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WaterQualityReadingLatest on table WaterQualityReading {
-    WaterQualityReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usgs.waterservices.wq.WaterQualityReadingLatest'] on table ['gov.usgs.waterservices.wq.WaterQualityReading'] {
+    ['gov.usgs.waterservices.wq.WaterQualityReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WaterQualityReading] policy update
+.alter table ['gov.usgs.waterservices.wq.WaterQualityReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/usgs-nwis-wq/notebook/usgs-nwis-wq-feed.ipynb
+++ b/usgs-nwis-wq/notebook/usgs-nwis-wq-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# USGS NWIS Water Quality Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the USGS Water Services Instantaneous Values API for continuous water quality sensor readings (dissolved oxygen, pH, water temperature, specific conductance, turbidity, nitrate) from ~3,000 monitoring sites across the United States and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `usgs_nwis_wq` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `usgs-nwis-wq feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"usgs-nwis-wq-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/usgs-nwis-wq/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/usgs-nwis-wq/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing usgs_nwis_wq package from Fabric Environment...')\n",
+    "    from usgs_nwis_wq import usgs_nwis_wq as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['usgs-nwis-wq', 'feed', '--once'] if ONCE_MODE else ['usgs-nwis-wq', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/usgs-nwis-wq/tests/test_once_mode.py
+++ b/usgs-nwis-wq/tests/test_once_mode.py
@@ -1,0 +1,37 @@
+"""Test that the --once flag causes the bridge to exit after one polling cycle."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from usgs_nwis_wq.usgs_nwis_wq import USGSWaterQualityPoller
+
+
+@pytest.mark.asyncio
+async def test_once_mode_exits_after_one_cycle():
+    """poll_and_send(once=True) must return after exactly one cycle, not loop."""
+    poller = USGSWaterQualityPoller(
+        kafka_config={'bootstrap.servers': 'unused:9092'},
+        kafka_topic='test',
+        last_polled_file='',
+        states=['DC'],
+        sites=None,
+        parameter_codes=None,
+    )
+
+    # Stub out HTTP + Kafka I/O so the cycle is a pure no-op.
+    poller.load_last_polled_times = MagicMock(return_value={})
+    poller.save_last_polled_times = MagicMock()
+    poller.fetch_json = AsyncMock(return_value=None)
+    poller.site_producer = None
+    poller.readings_producer = None
+
+    sleep_mock = AsyncMock()
+    with patch('asyncio.sleep', sleep_mock):
+        await asyncio.wait_for(poller.poll_and_send(once=True), timeout=5.0)
+
+    # If --once worked, asyncio.sleep(300) at end of loop was skipped.
+    assert sleep_mock.await_count == 0, (
+        "poll_and_send(once=True) should exit before the inter-cycle sleep"
+    )

--- a/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
+++ b/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
@@ -293,8 +293,13 @@ class USGSWaterQualityPoller:
         if last_polled.get(key, "") < date_time:
             last_polled[key] = date_time
 
-    async def poll_and_send(self) -> None:
-        """Main polling loop: fetches water quality data and sends to Kafka."""
+    async def poll_and_send(self, once: bool = False) -> None:
+        """Main polling loop: fetches water quality data and sends to Kafka.
+
+        Args:
+            once: If True, exit after a single polling cycle (used by scheduled
+                Fabric notebook runs).
+        """
         last_polled = self.load_last_polled_times()
 
         while True:
@@ -382,6 +387,10 @@ class USGSWaterQualityPoller:
             elapsed = (datetime.now(timezone.utc) - start_time).total_seconds()
             logger.info("Poll complete: %d sites, %d new readings in %.1fs", total_sites, total_readings, elapsed)
 
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
+
             # Wait before next poll (5 minutes)
             await asyncio.sleep(300)
 
@@ -432,6 +441,13 @@ def main():
     feed_parser.add_argument("--states", type=str, help="Comma-separated state codes (default: all)")
     feed_parser.add_argument("--sites", type=str, help="Comma-separated USGS site numbers")
     feed_parser.add_argument("--parameter-codes", type=str, help="Comma-separated parameter codes")
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). "
+             "Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
 
@@ -481,7 +497,7 @@ def main():
         parameter_codes=param_codes or None,
     )
 
-    asyncio.run(poller.poll_and_send())
+    asyncio.run(poller.poll_and_send(once=getattr(args, 'once', False)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes

- Adds `usgs-nwis-wq/notebook/usgs-nwis-wq-feed.ipynb` following the pegelonline template (4-cell structure, runtime CS lookup via Topology API, worker-thread `main()`, OneLake `last-run.log`).
- Flips `catalog.json` `notebook: true` for `usgs-nwis-wq` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` CLI flag (also honors `ONCE_MODE` env var) to the bridge so scheduled single-cycle execution exits after one polling cycle. New unit test `tests/test_once_mode.py` verifies the behavior.
- Flips `usgs-nwis-wq/kql/create-kql-script.ps1` to pass `-Qualified -Namespace 'gov.usgs.waterservices.wq'` (xreg schemas use `$id` but no Avro-style `namespace` field, so the override is required). Regenerated `usgs-nwis-wq/kql/usgs_nwis_wq.kql` now uses `['gov.usgs.waterservices.wq.MonitoringSite']` and `['gov.usgs.waterservices.wq.WaterQualityReading']`.
- README bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validation

- Notebook JSON parses.
- All 59 bridge tests pass, including the new `test_once_mode.py`.
- Required parameters present in notebook params cell: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden runtime patterns in cell code (no `asyncio.run()` invocation, no `%pip install` cell, no baked `CONNECTION_STRING`).
- KQL `create-merge table ['gov.usgs.…']` qualified-tables check passes.

See `.github/skills/notebook-feeder-retrofit/SKILL.md` and `docs/plan-qualified-table-names.md` (DWD reference PR #257). The wheel-bundle workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick up this source on next push to main and publish wheels to the notebook-wheels release.
