### PR TITLE
feat(hongkong-epd): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -357,7 +357,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Hong Kong — 18 AQHI stations, hourly health index",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "irceline-belgium",

--- a/hongkong-epd/README.md
+++ b/hongkong-epd/README.md
@@ -40,6 +40,7 @@ view.
 | [xreg/hongkong_epd.xreg.json](xreg/hongkong_epd.xreg.json) | xRegistry manifest |
 | [hongkong_epd/hongkong_epd.py](hongkong_epd/hongkong_epd.py) | Runtime bridge |
 | [hongkong_epd_producer/](hongkong_epd_producer/) | Generated producer (xrcg 0.10.1) |
+| [notebook/hongkong-epd-feed.ipynb](notebook/hongkong-epd-feed.ipynb) | Fabric notebook hosting (deployed via [tools/deploy-fabric/deploy-feeder-notebook.ps1](../tools/deploy-fabric/deploy-feeder-notebook.ps1)) |
 | [tests/](tests/) | Unit tests |
 | [Dockerfile](Dockerfile) | Container image |
 | [CONTAINER.md](CONTAINER.md) | Deployment contract |

--- a/hongkong-epd/hongkong_epd/hongkong_epd.py
+++ b/hongkong-epd/hongkong_epd/hongkong_epd.py
@@ -265,6 +265,12 @@ def main():
         type=str,
         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.hongkong_epd_state.json")),
     )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List AQHI stations")
     subparsers.add_parser("feed", help="Feed data to Kafka")
@@ -299,6 +305,9 @@ def main():
             logger.info("Sent %d AQHI reading events", count)
         except Exception as exc:  # pragma: no cover - runtime safety
             logger.error("Error fetching/sending AQHI data: %s", exc)
+        if args.once:
+            logger.info("--once mode: exiting after first polling cycle")
+            break
         time.sleep(args.polling_interval)
 
 

--- a/hongkong-epd/kql/create-kql-script.ps1
+++ b/hongkong-epd/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\hongkong_epd.xreg.json"
 $kqlFile = Join-Path $scriptDir "hongkong_epd.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace hk.gov.epd.aqhi

--- a/hongkong-epd/kql/hongkong_epd.kql
+++ b/hongkong-epd/kql/hongkong_epd.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['hk.gov.epd.aqhi.Station'] (
    [station_id]: string,
    [station_name]: string,
    [station_type]: string,
@@ -38,9 +38,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for a Hong Kong EPD AQHI monitoring station. The EPD operates a network of General Stations and Roadside Stations across Hong Kong. Station coordinates are derived from the EPD station map.\"}";
+.alter table ['hk.gov.epd.aqhi.Station'] docstring "{\"description\": \"Reference data for a Hong Kong EPD AQHI monitoring station. The EPD operates a network of General Stations and Roadside Stations across Hong Kong. Station coordinates are derived from the EPD station map.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['hk.gov.epd.aqhi.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Stable station identifier derived from the station name in snake_case, for example central_western or mong_kok.\"}",
    [station_name]: "{\"description\": \"Station name as published in the EPD AQHI feed, for example 'Central/Western' or 'Mong Kok'.\"}",
    [station_type]: "{\"description\": \"Station classification. General Stations measure ambient background air quality and Roadside Stations are positioned near roads to capture traffic-related pollution.\"}",
@@ -53,7 +53,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['hk.gov.epd.aqhi.Station'] ingestion json mapping "hk.gov.epd.aqhi.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -69,7 +69,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['hk.gov.epd.aqhi.Station'] ingestion json mapping "hk.gov.epd.aqhi.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -85,13 +85,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['hk.gov.epd.aqhi.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['hk.gov.epd.aqhi.StationLatest'] on table ['hk.gov.epd.aqhi.Station'] {
+    ['hk.gov.epd.aqhi.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['hk.gov.epd.aqhi.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -102,7 +102,7 @@
 }]
 ```
 
-.create-merge table [AQHIReading] (
+.create-merge table ['hk.gov.epd.aqhi.AQHIReading'] (
    [station_id]: string,
    [station_name]: string,
    [station_type]: string,
@@ -116,9 +116,9 @@
    [___subject]: string
 );
 
-.alter table [AQHIReading] docstring "{\"description\": \"Air Quality Health Index (AQHI) reading for a Hong Kong EPD monitoring station. AQHI quantifies health risk from air pollution on a scale of 1 to 10+ and is calculated from concentrations of nitrogen dioxide, sulphur dioxide, ozone, and PM2.5. Published hourly by the EPD.\"}";
+.alter table ['hk.gov.epd.aqhi.AQHIReading'] docstring "{\"description\": \"Air Quality Health Index (AQHI) reading for a Hong Kong EPD monitoring station. AQHI quantifies health risk from air pollution on a scale of 1 to 10+ and is calculated from concentrations of nitrogen dioxide, sulphur dioxide, ozone, and PM2.5. Published hourly by the EPD.\"}";
 
-.alter table [AQHIReading] column-docstrings (
+.alter table ['hk.gov.epd.aqhi.AQHIReading'] column-docstrings (
    [station_id]: "{\"description\": \"Stable station identifier in snake_case.\"}",
    [station_name]: "{\"description\": \"Station name as published in the EPD AQHI feed.\"}",
    [station_type]: "{\"description\": \"Station classification: General Stations or Roadside Stations.\"}",
@@ -132,7 +132,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [AQHIReading] ingestion json mapping "AQHIReading_json_flat"
+.create-or-alter table ['hk.gov.epd.aqhi.AQHIReading'] ingestion json mapping "hk.gov.epd.aqhi.AQHIReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -149,7 +149,7 @@
 ]
 ```
 
-.create-or-alter table [AQHIReading] ingestion json mapping "AQHIReading_json_ce_structured"
+.create-or-alter table ['hk.gov.epd.aqhi.AQHIReading'] ingestion json mapping "hk.gov.epd.aqhi.AQHIReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -166,13 +166,13 @@
 ]
 ```
 
-.drop materialized-view AQHIReadingLatest ifexists;
+.drop materialized-view ['hk.gov.epd.aqhi.AQHIReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) AQHIReadingLatest on table AQHIReading {
-    AQHIReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['hk.gov.epd.aqhi.AQHIReadingLatest'] on table ['hk.gov.epd.aqhi.AQHIReading'] {
+    ['hk.gov.epd.aqhi.AQHIReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [AQHIReading] policy update
+.alter table ['hk.gov.epd.aqhi.AQHIReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/hongkong-epd/notebook/hongkong-epd-feed.ipynb
+++ b/hongkong-epd/notebook/hongkong-epd-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hong Kong EPD AQHI Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Hong Kong Environmental Protection Department [Air Quality Health Index (AQHI)](https://www.aqhi.gov.hk/) 24-hour XML feed and emits CloudEvents to the bound Fabric Event Stream. Two event families are produced into the `hongkong-epd-aqhi` topic, keyed by `{station_id}`: `HK.Gov.EPD.AQHI.Station` reference data for the 18 monitoring stations, and `HK.Gov.EPD.AQHI.AQHIReading` for the latest reading per station.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `hongkong_epd` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `hongkong-epd feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new readings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"hongkong-epd-ingest\"    # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/hongkong-epd/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/hongkong-epd/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing hongkong_epd package from Fabric Environment...')\n",
+    "    from hongkong_epd import hongkong_epd as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['hongkong-epd', 'feed', '--once'] if ONCE_MODE else ['hongkong-epd', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/hongkong-epd/tests/test_once_mode.py
+++ b/hongkong-epd/tests/test_once_mode.py
@@ -1,0 +1,75 @@
+"""Verify the --once flag causes main() to exit after a single polling cycle."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hongkong_epd import hongkong_epd as bridge
+
+
+@pytest.fixture
+def fake_kafka_producer(monkeypatch):
+    """Replace confluent_kafka.Producer and the generated event producer."""
+    fake_producer = MagicMock()
+    monkeypatch.setattr(bridge, "Producer", MagicMock(return_value=fake_producer))
+
+    fake_event_producer = MagicMock()
+    fake_event_producer.producer = fake_producer
+    monkeypatch.setattr(
+        bridge,
+        "HKGovEPDAQHIEventProducer",
+        MagicMock(return_value=fake_event_producer),
+    )
+    return fake_event_producer
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path, fake_kafka_producer, monkeypatch):
+    """With --once the polling loop must not sleep and must exit after one cycle."""
+    state_file = tmp_path / "state.json"
+    sleep_mock = MagicMock()
+    send_stations_mock = MagicMock(return_value=18)
+    feed_readings_mock = MagicMock(return_value=3)
+
+    monkeypatch.setattr(bridge.time, "sleep", sleep_mock)
+    monkeypatch.setattr(bridge, "send_stations", send_stations_mock)
+    monkeypatch.setattr(bridge, "feed_readings", feed_readings_mock)
+
+    argv = [
+        "hongkong-epd",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test",
+        "--topic", "test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "--once",
+        "feed",
+    ]
+    with patch.object(sys, "argv", argv):
+        bridge.main()
+
+    assert send_stations_mock.call_count == 1
+    assert feed_readings_mock.call_count == 1
+    sleep_mock.assert_not_called()
+
+
+def test_once_via_env_var(tmp_path, fake_kafka_producer, monkeypatch):
+    """ONCE_MODE=true should be honored the same as --once."""
+    state_file = tmp_path / "state.json"
+    sleep_mock = MagicMock()
+    monkeypatch.setattr(bridge.time, "sleep", sleep_mock)
+    monkeypatch.setattr(bridge, "send_stations", MagicMock(return_value=0))
+    monkeypatch.setattr(bridge, "feed_readings", MagicMock(return_value=0))
+    monkeypatch.setenv("ONCE_MODE", "true")
+
+    argv = [
+        "hongkong-epd",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test",
+        "--topic", "test-topic",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+    ]
+    with patch.object(sys, "argv", argv):
+        bridge.main()
+
+    sleep_mock.assert_not_called()


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes

- `hongkong-epd/notebook/hongkong-epd-feed.ipynb` — copy of the canonical pegelonline notebook with the mechanical substitutions from the skill's substitution table (display title, package import, `sys.argv`, state/log paths, Event Stream name).
- `catalog.json` — flips `notebook: true` on the hongkong-epd entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `hongkong-epd/hongkong_epd/hongkong_epd.py` — adds `--once` CLI flag (also honors the `ONCE_MODE` env var) so the polling loop exits after a single cycle, suitable for Fabric scheduled notebook execution. Modeled on `pegelonline/pegelonline/pegelonline.py`.
- `hongkong-epd/tests/test_once_mode.py` — new unit tests asserting `--once` and `ONCE_MODE=true` each cause `main()` to return after exactly one cycle (mocks upstream + Kafka).
- `hongkong-epd/kql/create-kql-script.ps1` — passes `-Qualified -Namespace hk.gov.epd.aqhi` so the generator emits namespace-prefixed table names (see docs/plan-qualified-table-names.md, DWD reference PR #257).
- `hongkong-epd/kql/hongkong_epd.kql` — regenerated; `Station` and `AQHIReading` are now `['hk.gov.epd.aqhi.Station']` and `['hk.gov.epd.aqhi.AQHIReading']`. The `_cloudevents_dispatch` landing table and `type ==` update-policy predicates are unchanged.
- `hongkong-epd/README.md` — one-line bullet linking to the Fabric notebook hosting deploy script.

No hand-authored consumer assets exist under `hongkong-epd/fabric/` or `hongkong-epd/dashboard/`, so no consumer-side rewrites were needed.

## Local validation (all passing)

- `python -c "import json; json.load(open(...))"` — notebook JSON well-formed.
- `python -m pytest tests/ -x --no-header -q` — **9 passed** including the two new `--once` tests.
- Placeholder check — notebook params cell declares `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden-pattern check — no `asyncio.run(`, no `%pip install`, no hardcoded `CONNECTION_STRING=` or `primaryConnectionString=`.
- Qualified-tables check — `hongkong-epd/kql/hongkong_epd.kql` matches `create-merge table ['[a-z]`.
- KQL regenerated via `pwsh -File hongkong-epd/kql/create-kql-script.ps1` (avrotize 3.5.3).

## Out of scope

The wheel-publish workflow (`.github/workflows/publish-notebook-wheels.yml`) will pick this source up on merge to `main` and publish wheels to the `notebook-wheels` release. No live Fabric deployment performed by this agent.