### PR TITLE
feat(irceline-belgium): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -365,7 +365,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Belgium — station, timeseries, and hourly observations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "laqn-london",

--- a/irceline-belgium/README.md
+++ b/irceline-belgium/README.md
@@ -61,6 +61,12 @@ python -m irceline_belgium feed --kafka-bootstrap-servers localhost:9092 --kafka
 - Timeseries: `https://geo.irceline.be/sos/api/v1/timeseries`
 - Phenomena: `https://geo.irceline.be/sos/api/v1/phenomena`
 
+## Fabric notebook hosting
+
+This source can also run as a scheduled Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+using `notebook/irceline-belgium-feed.ipynb`.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/irceline-belgium/irceline_belgium/irceline_belgium.py
+++ b/irceline-belgium/irceline_belgium/irceline_belgium.py
@@ -369,6 +369,7 @@ class IrcelineBelgiumAPI:
         kafka_topic: str,
         polling_interval: int,
         state_file: str,
+        once: bool = False,
     ) -> None:
         """Run the long-lived reference-data and observation polling loop."""
         producer = Producer(kafka_config)
@@ -408,6 +409,9 @@ class IrcelineBelgiumAPI:
                     elapsed,
                     sleep_seconds,
                 )
+                if once:
+                    LOGGER.info("--once mode: exiting after first polling cycle")
+                    break
                 if sleep_seconds:
                     time.sleep(sleep_seconds)
         except KeyboardInterrupt:
@@ -434,6 +438,12 @@ def main() -> None:
         default=os.getenv("STATE_FILE", os.path.expanduser("~/.irceline_belgium_state.json")),
     )
     feed_parser.add_argument("--kafka-enable-tls", type=str, default=os.getenv("KAFKA_ENABLE_TLS", "true"))
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command != "feed":
@@ -447,6 +457,7 @@ def main() -> None:
         kafka_topic=kafka_topic,
         polling_interval=args.polling_interval,
         state_file=args.state_file,
+        once=args.once,
     )
 
 

--- a/irceline-belgium/kql/create-kql-script.ps1
+++ b/irceline-belgium/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\irceline_belgium.xreg.json"
 $kqlFile = Join-Path $scriptDir "irceline_belgium.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "be.irceline"

--- a/irceline-belgium/kql/irceline_belgium.kql
+++ b/irceline-belgium/kql/irceline_belgium.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['be.irceline.Station'] (
    [station_id]: string,
    [label]: string,
    [latitude]: real,
@@ -37,9 +37,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data describing one IRCELINE monitoring station from the GET /stations collection. The bridge maps the upstream GeoJSON feature to stable English field names and ignores the third coordinate element, which is the literal string 'NaN' in the live payloads.\"}";
+.alter table ['be.irceline.Station'] docstring "{\"description\": \"Reference data describing one IRCELINE monitoring station from the GET /stations collection. The bridge maps the upstream GeoJSON feature to stable English field names and ignores the third coordinate element, which is the literal string 'NaN' in the live payloads.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['be.irceline.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Stable numeric station identifier from station.properties.id in the IRCELINE stations GeoJSON feed. The bridge converts the upstream integer identifier to a string because this value is also used as the CloudEvents subject and Kafka key.\"}",
    [label]: "{\"description\": \"Human-readable station label from station.properties.label, typically formatted as '{station code} - {municipality}' such as '40AL02 - Beveren'. This is the display name published by IRCELINE for the monitoring site.\"}",
    [latitude]: "{\"description\": \"Station latitude in decimal degrees north, derived from the second element of station.geometry.coordinates in the upstream GeoJSON Point geometry. The upstream array follows GeoJSON order [longitude, latitude, elevation].\"}",
@@ -51,7 +51,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['be.irceline.Station'] ingestion json mapping "be.irceline.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['be.irceline.Station'] ingestion json mapping "be.irceline.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -81,13 +81,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['be.irceline.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['be.irceline.StationLatest'] on table ['be.irceline.Station'] {
+    ['be.irceline.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['be.irceline.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -98,7 +98,7 @@
 }]
 ```
 
-.create-merge table [Timeseries] (
+.create-merge table ['be.irceline.Timeseries'] (
    [timeseries_id]: string,
    [label]: string,
    [uom]: string,
@@ -118,9 +118,9 @@
    [___subject]: string
 );
 
-.alter table [Timeseries] docstring "{\"description\": \"Reference data for a single IRCELINE timeseries from GET /timeseries or GET /timeseries/{id}?expanded=true. Each timeseries combines a stable numeric timeseries identifier with a station, a phenomenon/category pair, the published unit of measurement, and optional statusIntervals that describe threshold bands used by IRCELINE for display and air-quality interpretation.\"}";
+.alter table ['be.irceline.Timeseries'] docstring "{\"description\": \"Reference data for a single IRCELINE timeseries from GET /timeseries or GET /timeseries/{id}?expanded=true. Each timeseries combines a stable numeric timeseries identifier with a station, a phenomenon/category pair, the published unit of measurement, and optional statusIntervals that describe threshold bands used by IRCELINE for display and air-quality interpretation.\"}";
 
-.alter table [Timeseries] column-docstrings (
+.alter table ['be.irceline.Timeseries'] column-docstrings (
    [timeseries_id]: "{\"description\": \"Stable numeric identifier of the IRCELINE timeseries from the root id property on GET /timeseries results. The bridge converts the upstream value to a string because this identifier is the Kafka key and CloudEvents subject for both reference and observation events.\"}",
    [label]: "{\"description\": \"Descriptive timeseries label from the upstream label property, combining phenomenon name, timeseries identifier, procedure label, and station label. Example: 'Particulate Matter < 10 \\u00b5m 6152 - DAILY CORRECTION TEOM - procedure, 40AL01 - Linkeroever'.\"}",
    [uom]: "{\"description\": \"Published unit of measurement from the upstream uom property, such as '\\u00b5g/m\\u00b3'. IRCELINE returns this literal display unit on both collection and expanded timeseries responses.\"}",
@@ -140,7 +140,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Timeseries] ingestion json mapping "Timeseries_json_flat"
+.create-or-alter table ['be.irceline.Timeseries'] ingestion json mapping "be.irceline.Timeseries_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -163,7 +163,7 @@
 ]
 ```
 
-.create-or-alter table [Timeseries] ingestion json mapping "Timeseries_json_ce_structured"
+.create-or-alter table ['be.irceline.Timeseries'] ingestion json mapping "be.irceline.Timeseries_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -186,13 +186,13 @@
 ]
 ```
 
-.drop materialized-view TimeseriesLatest ifexists;
+.drop materialized-view ['be.irceline.TimeseriesLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TimeseriesLatest on table Timeseries {
-    Timeseries | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['be.irceline.TimeseriesLatest'] on table ['be.irceline.Timeseries'] {
+    ['be.irceline.Timeseries'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Timeseries] policy update
+.alter table ['be.irceline.Timeseries'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -203,7 +203,7 @@
 }]
 ```
 
-.create-merge table [Observation] (
+.create-merge table ['be.irceline.Observation'] (
    [timeseries_id]: string,
    [timestamp]: string,
    [value]: real,
@@ -215,9 +215,9 @@
    [___subject]: string
 );
 
-.alter table [Observation] docstring "{\"description\": \"Telemetry measurement for a single IRCELINE timeseries from GET /timeseries/{id}/getData. The upstream payload returns Unix timestamps in milliseconds and numeric values that may be null; the bridge converts the timestamp to an ISO 8601 UTC string and carries the unit from the timeseries metadata.\"}";
+.alter table ['be.irceline.Observation'] docstring "{\"description\": \"Telemetry measurement for a single IRCELINE timeseries from GET /timeseries/{id}/getData. The upstream payload returns Unix timestamps in milliseconds and numeric values that may be null; the bridge converts the timestamp to an ISO 8601 UTC string and carries the unit from the timeseries metadata.\"}";
 
-.alter table [Observation] column-docstrings (
+.alter table ['be.irceline.Observation'] column-docstrings (
    [timeseries_id]: "{\"description\": \"Stable numeric timeseries identifier of the measurement source. This is copied from the parent timeseries metadata and matches the CloudEvents subject and Kafka key.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp in ISO 8601 UTC form produced by converting the upstream Unix millisecond timestamp from values[].timestamp, for example '2025-04-08T09:00:00Z'.\"}",
    [value]: "{\"description\": \"Measured numeric value from values[].value. IRCELINE can publish null when a data point exists without a numeric value, so the schema explicitly allows null.\"}",
@@ -229,7 +229,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_flat"
+.create-or-alter table ['be.irceline.Observation'] ingestion json mapping "be.irceline.Observation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -244,7 +244,7 @@
 ]
 ```
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_ce_structured"
+.create-or-alter table ['be.irceline.Observation'] ingestion json mapping "be.irceline.Observation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -259,13 +259,13 @@
 ]
 ```
 
-.drop materialized-view ObservationLatest ifexists;
+.drop materialized-view ['be.irceline.ObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservationLatest on table Observation {
-    Observation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['be.irceline.ObservationLatest'] on table ['be.irceline.Observation'] {
+    ['be.irceline.Observation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observation] policy update
+.alter table ['be.irceline.Observation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/irceline-belgium/notebook/irceline-belgium-feed.ipynb
+++ b/irceline-belgium/notebook/irceline-belgium-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# IRCELINE Belgium Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the IRCELINE Belgium 52\u00b0North SOS Timeseries API for station metadata, timeseries definitions, and hourly air-quality observations covering Belgium's interregional monitoring network, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `irceline_belgium` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `irceline-belgium feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"irceline-belgium-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/irceline-belgium/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/irceline-belgium/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing irceline_belgium package from Fabric Environment...')\n",
+    "    from irceline_belgium import irceline_belgium as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['irceline-belgium', 'feed', '--once'] if ONCE_MODE else ['irceline-belgium', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/irceline-belgium/tests/test_once_mode.py
+++ b/irceline-belgium/tests/test_once_mode.py
@@ -1,0 +1,87 @@
+"""Test that --once exits after one polling cycle."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from irceline_belgium import irceline_belgium as bridge
+
+
+@pytest.mark.unit
+def test_once_mode_exits_after_single_cycle(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+
+    call_count = {"emit_reference": 0, "poll": 0}
+
+    def fake_emit_reference(self, station_producer, timeseries_producer):
+        call_count["emit_reference"] += 1
+        return {}
+
+    def fake_poll(self, *, timeseries_by_id, producer, state):
+        call_count["poll"] += 1
+        return 0
+
+    class FakeProducer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def produce(self, *args, **kwargs):
+            pass
+
+        def flush(self, *args, **kwargs):
+            pass
+
+        def poll(self, *args, **kwargs):
+            return 0
+
+    class FakeEventProducer:
+        def __init__(self, producer, topic):
+            self.producer = producer
+
+    monkeypatch.setattr(bridge.IrcelineBelgiumAPI, "emit_reference_data", fake_emit_reference)
+    monkeypatch.setattr(bridge.IrcelineBelgiumAPI, "poll_observations", fake_poll)
+    monkeypatch.setattr(bridge, "Producer", FakeProducer)
+    monkeypatch.setattr(bridge, "BeIrcelineStationsEventProducer", FakeEventProducer)
+    monkeypatch.setattr(bridge, "BeIrcelineTimeseriesEventProducer", FakeEventProducer)
+
+    # Ensure time.sleep is never called (would hang) and raises if it is.
+    def _no_sleep(_):
+        raise AssertionError("time.sleep should not be invoked in --once mode")
+
+    monkeypatch.setattr(bridge.time, "sleep", _no_sleep)
+
+    api = bridge.IrcelineBelgiumAPI()
+    api.run_feed(
+        kafka_config={"bootstrap.servers": "localhost:9092"},
+        kafka_topic="irceline-belgium",
+        polling_interval=900,
+        state_file=str(state_file),
+        once=True,
+    )
+
+    assert call_count["emit_reference"] == 1
+    assert call_count["poll"] == 1
+
+
+@pytest.mark.unit
+def test_once_flag_parses_from_argv(monkeypatch):
+    captured = {}
+
+    def fake_run_feed(self, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(bridge.IrcelineBelgiumAPI, "run_feed", fake_run_feed)
+    monkeypatch.setattr(
+        bridge.IrcelineBelgiumAPI,
+        "build_kafka_config",
+        classmethod(lambda cls, args: ({"bootstrap.servers": "localhost:9092"}, "irceline-belgium")),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["irceline-belgium", "feed", "--kafka-bootstrap-servers", "localhost:9092", "--once"],
+    )
+
+    bridge.main()
+    assert captured.get("once") is True


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent. Adds `irceline-belgium/notebook/irceline-belgium-feed.ipynb` following the pegelonline pattern and flips the `catalog.json` notebook flag so the gh-pages portal exposes the Fabric Notebook deploy button.

Bridge changes:
- Added `--once` flag (also via `ONCE_MODE` env var) modeled on `pegelonline/pegelonline/pegelonline.py`. The polling loop now exits after one cycle when set, which is what the scheduled Fabric notebook expects.
- New `tests/test_once_mode.py` asserts `--once` causes `run_feed()` to emit reference data once, poll observations once, and exit without calling `time.sleep`.

KQL changes (mandatory step 5b):
- `kql/create-kql-script.ps1` now passes `-Qualified -Namespace be.irceline`.
- Regenerated `kql/irceline_belgium.kql`; typed tables, materialized views, ingestion mappings, and update policies are now `['be.irceline.Station']` / `['be.irceline.Timeseries']` / `['be.irceline.Observation']`. The `_cloudevents_dispatch` landing table and the CloudEvents `type` predicate values are unchanged.
- Consumer-asset audit: no hand-authored `fabric/`, `dashboard/`, or `notebook/` references to the unqualified `[Station]`/`[Timeseries]`/`[Observation]` names exist in this source, so no further fixes were needed.

Validated locally:
- Notebook JSON parses.
- `python -m pytest tests/ -x` passes (10/10), including the new `test_once_mode.py`.
- Parameters cell declares all five placeholders the deploy script overwrites (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- No forbidden patterns in code cells (`asyncio.run(`, `%pip install`, hardcoded `CONNECTION_STRING=`, `primaryConnectionString=`). The markdown-cell mention of `%pip install` in the canonical template is informational copy, not a runtime install.
- Qualified-tables check (`create-merge table \['[a-z]`) passes against the regenerated KQL.

Skill: `.github/skills/notebook-feeder-retrofit/SKILL.md`. Not deployed to Fabric by the agent; the wheel-publish workflow runs on merge and the portal exposes the button once `update-ghpages-catalog.yml` syncs the flag.