### PR TITLE
feat(canada-aqhi): Fabric notebook hosting

### DIFF
--- a/canada-aqhi/README.md
+++ b/canada-aqhi/README.md
@@ -58,6 +58,10 @@ the payload carries both that public community identity and the upstream
 - Deduplicates forecasts by community, publication time, and forecast period
 - Refreshes reference data every 24 hours by default
 
+## Fabric notebook hosting
+
+- A scheduled Fabric notebook variant is available at [`notebook/canada-aqhi-feed.ipynb`](notebook/canada-aqhi-feed.ipynb) and can be deployed via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Installation
 
 ```powershell

--- a/canada-aqhi/canada_aqhi/canada_aqhi.py
+++ b/canada-aqhi/canada_aqhi/canada_aqhi.py
@@ -742,6 +742,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         default=os.getenv("PROVINCES", ",".join(PROVINCES)),
         help="Comma-separated province/territory codes to emit",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     list_parser = subparsers.add_parser("list", help="List AQHI communities known to the bridge")
     list_parser.add_argument(
@@ -806,6 +812,9 @@ def main() -> None:
             break
         except Exception as exc:  # pylint: disable=broad-except
             LOGGER.error("Error during AQHI poll cycle: %s", exc)
+        if args.once:
+            LOGGER.info("--once mode: exiting after first polling cycle")
+            break
         time.sleep(args.polling_interval)
 
     producer.flush()

--- a/canada-aqhi/kql/canada-aqhi.kql
+++ b/canada-aqhi/kql/canada-aqhi.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Community] (
+.create-merge table ['ca.gc.weather.aqhi.Community'] (
    [province]: string,
    [community_name]: string,
    [cgndb_code]: string,
@@ -40,9 +40,9 @@
    [___subject]: string
 );
 
-.alter table [Community] docstring "{\"description\": \"Reference record for an AQHI community from the official ECCC AQHI city lists. It links the public community name and province code to the CGNDB key and current XML feeds used by the bridge.\"}";
+.alter table ['ca.gc.weather.aqhi.Community'] docstring "{\"description\": \"Reference record for an AQHI community from the official ECCC AQHI city lists. It links the public community name and province code to the CGNDB key and current XML feeds used by the bridge.\"}";
 
-.alter table [Community] column-docstrings (
+.alter table ['ca.gc.weather.aqhi.Community'] column-docstrings (
    [province]: "{\"description\": \"Two-letter Canadian province or territory abbreviation resolved for the AQHI community.\"}",
    [community_name]: "{\"description\": \"English AQHI community name as published by Environment and Climate Change Canada.\"}",
    [cgndb_code]: "{\"description\": \"Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.\"}",
@@ -57,7 +57,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Community] ingestion json mapping "Community_json_flat"
+.create-or-alter table ['ca.gc.weather.aqhi.Community'] ingestion json mapping "ca.gc.weather.aqhi.Community_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -75,7 +75,7 @@
 ]
 ```
 
-.create-or-alter table [Community] ingestion json mapping "Community_json_ce_structured"
+.create-or-alter table ['ca.gc.weather.aqhi.Community'] ingestion json mapping "ca.gc.weather.aqhi.Community_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -93,13 +93,13 @@
 ]
 ```
 
-.drop materialized-view CommunityLatest ifexists;
+.drop materialized-view ['ca.gc.weather.aqhi.CommunityLatest'] ifexists;
 
-.create materialized-view with (backfill=true) CommunityLatest on table Community {
-    Community | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ca.gc.weather.aqhi.CommunityLatest'] on table ['ca.gc.weather.aqhi.Community'] {
+    ['ca.gc.weather.aqhi.Community'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Community] policy update
+.alter table ['ca.gc.weather.aqhi.Community'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -110,7 +110,7 @@
 }]
 ```
 
-.create-merge table [Observation] (
+.create-merge table ['ca.gc.weather.aqhi.Observation'] (
    [province]: string,
    [community_name]: string,
    [cgndb_code]: string,
@@ -124,9 +124,9 @@
    [___subject]: string
 );
 
-.alter table [Observation] docstring "{\"description\": \"Latest AQHI observation for a reporting community. The value reflects short-term health risk from air pollution and may be null when the upstream feed has not published a value yet.\"}";
+.alter table ['ca.gc.weather.aqhi.Observation'] docstring "{\"description\": \"Latest AQHI observation for a reporting community. The value reflects short-term health risk from air pollution and may be null when the upstream feed has not published a value yet.\"}";
 
-.alter table [Observation] column-docstrings (
+.alter table ['ca.gc.weather.aqhi.Observation'] column-docstrings (
    [province]: "{\"description\": \"Two-letter Canadian province or territory abbreviation resolved for the AQHI community.\"}",
    [community_name]: "{\"description\": \"English AQHI community name as published by Environment and Climate Change Canada.\"}",
    [cgndb_code]: "{\"description\": \"Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.\"}",
@@ -140,7 +140,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_flat"
+.create-or-alter table ['ca.gc.weather.aqhi.Observation'] ingestion json mapping "ca.gc.weather.aqhi.Observation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -157,7 +157,7 @@
 ]
 ```
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_ce_structured"
+.create-or-alter table ['ca.gc.weather.aqhi.Observation'] ingestion json mapping "ca.gc.weather.aqhi.Observation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -174,13 +174,13 @@
 ]
 ```
 
-.drop materialized-view ObservationLatest ifexists;
+.drop materialized-view ['ca.gc.weather.aqhi.ObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservationLatest on table Observation {
-    Observation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ca.gc.weather.aqhi.ObservationLatest'] on table ['ca.gc.weather.aqhi.Observation'] {
+    ['ca.gc.weather.aqhi.Observation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observation] policy update
+.alter table ['ca.gc.weather.aqhi.Observation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -191,7 +191,7 @@
 }]
 ```
 
-.create-merge table [Forecast] (
+.create-merge table ['ca.gc.weather.aqhi.Forecast'] (
    [province]: string,
    [community_name]: string,
    [cgndb_code]: string,
@@ -208,9 +208,9 @@
    [___subject]: string
 );
 
-.alter table [Forecast] docstring "{\"description\": \"Public AQHI forecast for a community and one of the four standard forecast periods published by ECCC.\"}";
+.alter table ['ca.gc.weather.aqhi.Forecast'] docstring "{\"description\": \"Public AQHI forecast for a community and one of the four standard forecast periods published by ECCC.\"}";
 
-.alter table [Forecast] column-docstrings (
+.alter table ['ca.gc.weather.aqhi.Forecast'] column-docstrings (
    [province]: "{\"description\": \"Two-letter Canadian province or territory abbreviation resolved for the AQHI community.\"}",
    [community_name]: "{\"description\": \"English AQHI community name as published by Environment and Climate Change Canada.\"}",
    [cgndb_code]: "{\"description\": \"Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.\"}",
@@ -227,7 +227,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Forecast] ingestion json mapping "Forecast_json_flat"
+.create-or-alter table ['ca.gc.weather.aqhi.Forecast'] ingestion json mapping "ca.gc.weather.aqhi.Forecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -247,7 +247,7 @@
 ]
 ```
 
-.create-or-alter table [Forecast] ingestion json mapping "Forecast_json_ce_structured"
+.create-or-alter table ['ca.gc.weather.aqhi.Forecast'] ingestion json mapping "ca.gc.weather.aqhi.Forecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -267,13 +267,13 @@
 ]
 ```
 
-.drop materialized-view ForecastLatest ifexists;
+.drop materialized-view ['ca.gc.weather.aqhi.ForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ForecastLatest on table Forecast {
-    Forecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['ca.gc.weather.aqhi.ForecastLatest'] on table ['ca.gc.weather.aqhi.Forecast'] {
+    ['ca.gc.weather.aqhi.Forecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Forecast] policy update
+.alter table ['ca.gc.weather.aqhi.Forecast'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/canada-aqhi/kql/create-kql-script.ps1
+++ b/canada-aqhi/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\canada-aqhi.xreg.json"
 $kqlFile = Join-Path $scriptDir "canada-aqhi.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace ca.gc.weather.aqhi

--- a/canada-aqhi/notebook/canada-aqhi-feed.ipynb
+++ b/canada-aqhi/notebook/canada-aqhi-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Canada AQHI Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls Environment and Climate Change Canada's Air Quality Health Index (AQHI) realtime XML feeds for community-level observations and public forecasts, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `canada_aqhi` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `canada-aqhi feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations and forecasts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"canada-aqhi-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/canada-aqhi/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/canada-aqhi/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing canada_aqhi package from Fabric Environment...')\n",
+    "    from canada_aqhi import canada_aqhi as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['canada-aqhi', 'feed', '--once'] if ONCE_MODE else ['canada-aqhi', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/canada-aqhi/tests/test_once_mode.py
+++ b/canada-aqhi/tests/test_once_mode.py
@@ -1,0 +1,40 @@
+"""Tests for the --once flag added for Fabric notebook hosting."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from canada_aqhi import canada_aqhi as bridge
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch):
+    """`main()` must return after a single poll cycle when --once is set."""
+
+    # Avoid any real Kafka or network behaviour.
+    monkeypatch.setattr(bridge, "Producer", lambda config: MagicMock())
+    monkeypatch.setattr(bridge, "CaGcWeatherAqhiEventProducer", lambda producer, topic: MagicMock())
+    monkeypatch.setattr(bridge, "build_kafka_config", lambda args: ({}, "test-topic"))
+
+    call_count = {"value": 0}
+
+    def fake_poll_once(self, *args, **kwargs):
+        call_count["value"] += 1
+        return {"communities": 0, "observations": 0, "forecasts": 0}
+
+    monkeypatch.setattr(bridge.CanadaAQHIBridge, "poll_once", fake_poll_once)
+
+    # If --once is not honored, time.sleep would be called and the loop would
+    # iterate again — fail loudly if that happens.
+    def fail_sleep(_seconds):
+        raise AssertionError("time.sleep should not be called when --once is set")
+
+    monkeypatch.setattr(bridge.time, "sleep", fail_sleep)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["canada-aqhi", "feed", "--connection-string", "BootstrapServer=h:9092;EntityPath=t", "--once"],
+    )
+
+    bridge.main()
+
+    assert call_count["value"] == 1

--- a/catalog.json
+++ b/catalog.json
@@ -325,7 +325,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Canada — community AQHI observations and forecasts",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "defra-aurn",


### PR DESCRIPTION
Retrofit by the notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md) for source `canada-aqhi`.

## Changes

- `canada-aqhi/notebook/canada-aqhi-feed.ipynb` — copied verbatim from the canonical `pegelonline/notebook/pegelonline-feed.ipynb` template, with the mechanical substitutions from `references/notebook-substitution-table.md` (package `canada_aqhi`, module `canada_aqhi`, argv0 `canada-aqhi`, subcommand `feed`, state path `/lakehouse/default/Files/feeder-state/canada-aqhi/`).
- `catalog.json` — added `"notebook": true` to the `canada-aqhi` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `canada-aqhi/canada_aqhi/canada_aqhi.py` — added `--once` flag (also honored via `ONCE_MODE` env var) on the `feed` subcommand, modeled on pegelonline. The polling loop breaks after one cycle when set.
- `canada-aqhi/tests/test_once_mode.py` — new unit test asserting `main()` returns after exactly one `poll_once` call when `--once` is supplied.
- `canada-aqhi/kql/create-kql-script.ps1` — appended `-Qualified -Namespace ca.gc.weather.aqhi` (per step 5b of the skill, docs/plan-qualified-table-names.md, DWD reference PR #257).
- `canada-aqhi/kql/canada-aqhi.kql` — regenerated. Every typed table, materialized view, ingestion mapping, and update policy is now bracket-quoted with its FQN (`['ca.gc.weather.aqhi.Community']`, etc.). The `_cloudevents_dispatch` table and the `type ==` predicate values are unchanged.
- `canada-aqhi/README.md` — one-sentence `Fabric notebook hosting` bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Consumer-asset audit

No `canada-aqhi/fabric/`, `canada-aqhi/dashboard/`, or hand-authored secondary KQL overlay exists. The producer `README.md`, `EVENTS.md`, and source `README.md` mentions of `Community` / `Observation` / `Forecast` are Python identifiers and CloudEvents type names — not KQL table references — so they are correctly left alone per the skill.

## Local validation

- `python -c \"import json; json.load(open('canada-aqhi/notebook/canada-aqhi-feed.ipynb'))\"` — well-formed.
- `python -m pytest tests/ -x --no-header -q` from `canada-aqhi/` — **26 passed** (including the new `test_once_mode`).
- Notebook params cell contains all five placeholders the deploy script patches (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- Notebook contains no `asyncio.run(`, no hard-coded `CONNECTION_STRING = "…"`, no `primaryConnectionString = …`. The skill's `%pip install` forbidden-pattern check matches the markdown commentary (`"No \%pip install\ is required at runtime"`) in the canonical template — verified per-cell, no actual `%pip install` directive in any code cell, treated as a false positive.
- Regenerated KQL contains `create-merge table ['ca.gc.weather.aqhi.…']` blocks — qualified-tables check passes.

## Out of scope (per skill)

No Fabric deployment was performed. The `publish-notebook-wheels.yml` workflow will pick up this source on next push to `main` and publish `canada-aqhi-notebook-wheels.zip` to the `notebook-wheels` release; end-to-end Fabric verification is a separate, serial step.