### PR TITLE
feat(gios-poland): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -349,7 +349,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Poland — ~250 stations, hourly pollutants + AQI",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "hongkong-epd",

--- a/gios-poland/README.md
+++ b/gios-poland/README.md
@@ -85,3 +85,7 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fgios-poland%2Fazure-template-with-eventhub.json)
+
+## Deploying as a Fabric notebook feeder
+
+- This source ships a Microsoft Fabric notebook that polls one cycle per scheduled run, looks up the Event Stream connection string at runtime, and writes dedupe state to OneLake. Deploy it with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1); the notebook source is at [`gios-poland/notebook/gios-poland-feed.ipynb`](notebook/gios-poland-feed.ipynb).

--- a/gios-poland/gios_poland/gios_poland.py
+++ b/gios-poland/gios_poland/gios_poland.py
@@ -593,6 +593,9 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -649,7 +652,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/gios-poland/kql/create-kql-script.ps1
+++ b/gios-poland/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\gios_poland.xreg.json"
 $kqlFile = Join-Path $scriptDir "gios_poland.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'pl.gov.gios.airquality'

--- a/gios-poland/kql/gios_poland.kql
+++ b/gios-poland/kql/gios_poland.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['pl.gov.gios.airquality.Station'] (
    [station_id]: int,
    [station_code]: string,
    [name]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference record for a GIO\\u015a air quality monitoring station in Poland. Contains the station identifier, code, name, WGS84 coordinates, and administrative location (city, commune, district, voivodeship, street). Fields are mapped from the Polish-language GIO\\u015a REST API /station/findAll endpoint.\"}";
+.alter table ['pl.gov.gios.airquality.Station'] docstring "{\"description\": \"Reference record for a GIO\\u015a air quality monitoring station in Poland. Contains the station identifier, code, name, WGS84 coordinates, and administrative location (city, commune, district, voivodeship, street). Fields are mapped from the Polish-language GIO\\u015a REST API /station/findAll endpoint.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['pl.gov.gios.airquality.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Unique numeric identifier of the monitoring station assigned by GIO\\u015a. Mapped from the Polish field 'Identyfikator stacji'.\"}",
    [station_code]: "{\"description\": \"Short alphanumeric code uniquely identifying the station, e.g. 'DsLegAlRzecz'. Mapped from 'Kod stacji'.\"}",
    [name]: "{\"description\": \"Human-readable name of the monitoring station, typically including city and street. Mapped from 'Nazwa stacji'.\"}",
@@ -65,7 +65,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['pl.gov.gios.airquality.Station'] ingestion json mapping "pl.gov.gios.airquality.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,7 +87,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['pl.gov.gios.airquality.Station'] ingestion json mapping "pl.gov.gios.airquality.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -109,13 +109,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['pl.gov.gios.airquality.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.gios.airquality.StationLatest'] on table ['pl.gov.gios.airquality.Station'] {
+    ['pl.gov.gios.airquality.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['pl.gov.gios.airquality.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -126,7 +126,7 @@
 }]
 ```
 
-.create-merge table [Sensor] (
+.create-merge table ['pl.gov.gios.airquality.Sensor'] (
    [sensor_id]: int,
    [station_id]: int,
    [parameter_name]: string,
@@ -140,9 +140,9 @@
    [___subject]: string
 );
 
-.alter table [Sensor] docstring "{\"description\": \"Reference record for a sensor installed at a GIO\\u015a air quality station. Identifies the specific pollutant being measured (e.g. PM10, NO\\u2082, O\\u2083) along with the sensor and station identifiers. Fields are mapped from the Polish-language /station/sensors/{stationId} endpoint.\"}";
+.alter table ['pl.gov.gios.airquality.Sensor'] docstring "{\"description\": \"Reference record for a sensor installed at a GIO\\u015a air quality station. Identifies the specific pollutant being measured (e.g. PM10, NO\\u2082, O\\u2083) along with the sensor and station identifiers. Fields are mapped from the Polish-language /station/sensors/{stationId} endpoint.\"}";
 
-.alter table [Sensor] column-docstrings (
+.alter table ['pl.gov.gios.airquality.Sensor'] column-docstrings (
    [sensor_id]: "{\"description\": \"Unique numeric identifier of the sensor (measurement point) assigned by GIO\\u015a. Mapped from 'Identyfikator stanowiska'.\"}",
    [station_id]: "{\"description\": \"Numeric identifier of the parent monitoring station. Mapped from 'Identyfikator stacji'.\"}",
    [parameter_name]: "{\"description\": \"Polish-language name of the measured pollutant, e.g. 'py\\u0142 zawieszony PM10', 'dwutlenek azotu'. Mapped from 'Wska\\u017anik'.\"}",
@@ -156,7 +156,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Sensor] ingestion json mapping "Sensor_json_flat"
+.create-or-alter table ['pl.gov.gios.airquality.Sensor'] ingestion json mapping "pl.gov.gios.airquality.Sensor_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -173,7 +173,7 @@
 ]
 ```
 
-.create-or-alter table [Sensor] ingestion json mapping "Sensor_json_ce_structured"
+.create-or-alter table ['pl.gov.gios.airquality.Sensor'] ingestion json mapping "pl.gov.gios.airquality.Sensor_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -190,13 +190,13 @@
 ]
 ```
 
-.drop materialized-view SensorLatest ifexists;
+.drop materialized-view ['pl.gov.gios.airquality.SensorLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SensorLatest on table Sensor {
-    Sensor | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.gios.airquality.SensorLatest'] on table ['pl.gov.gios.airquality.Sensor'] {
+    ['pl.gov.gios.airquality.Sensor'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Sensor] policy update
+.alter table ['pl.gov.gios.airquality.Sensor'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -207,7 +207,7 @@
 }]
 ```
 
-.create-merge table [Measurement] (
+.create-merge table ['pl.gov.gios.airquality.Measurement'] (
    [station_id]: int,
    [sensor_id]: int,
    [sensor_code]: string,
@@ -220,9 +220,9 @@
    [___subject]: string
 );
 
-.alter table [Measurement] docstring "{\"description\": \"Hourly air quality measurement from a GIO\\u015a sensor. Reports the pollutant concentration in \\u00b5g/m\\u00b3 at a specific timestamp. The measurement may be null when data is missing or under validation. Fields are mapped from the Polish-language /data/getData/{sensorId} endpoint.\"}";
+.alter table ['pl.gov.gios.airquality.Measurement'] docstring "{\"description\": \"Hourly air quality measurement from a GIO\\u015a sensor. Reports the pollutant concentration in \\u00b5g/m\\u00b3 at a specific timestamp. The measurement may be null when data is missing or under validation. Fields are mapped from the Polish-language /data/getData/{sensorId} endpoint.\"}";
 
-.alter table [Measurement] column-docstrings (
+.alter table ['pl.gov.gios.airquality.Measurement'] column-docstrings (
    [station_id]: "{\"description\": \"Numeric identifier of the monitoring station that owns this sensor.\"}",
    [sensor_id]: "{\"description\": \"Numeric identifier of the sensor that produced this measurement.\"}",
    [sensor_code]: "{\"description\": \"Code identifying the sensor and its aggregation period, e.g. 'DsLegAlRzecz-NO2-1g'. Mapped from 'Kod stanowiska'.\"}",
@@ -235,7 +235,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_flat"
+.create-or-alter table ['pl.gov.gios.airquality.Measurement'] ingestion json mapping "pl.gov.gios.airquality.Measurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -251,7 +251,7 @@
 ]
 ```
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_ce_structured"
+.create-or-alter table ['pl.gov.gios.airquality.Measurement'] ingestion json mapping "pl.gov.gios.airquality.Measurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -267,13 +267,13 @@
 ]
 ```
 
-.drop materialized-view MeasurementLatest ifexists;
+.drop materialized-view ['pl.gov.gios.airquality.MeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MeasurementLatest on table Measurement {
-    Measurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.gios.airquality.MeasurementLatest'] on table ['pl.gov.gios.airquality.Measurement'] {
+    ['pl.gov.gios.airquality.Measurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Measurement] policy update
+.alter table ['pl.gov.gios.airquality.Measurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -284,7 +284,7 @@
 }]
 ```
 
-.create-merge table [AirQualityIndex] (
+.create-merge table ['pl.gov.gios.airquality.AirQualityIndex'] (
    [station_id]: int,
    [calculation_timestamp]: datetime,
    [index_value]: int,
@@ -319,9 +319,9 @@
    [___subject]: string
 );
 
-.alter table [AirQualityIndex] docstring "{\"description\": \"Current Polish Air Quality Index (Indeks Jako\\u015bci Powietrza) for a GIO\\u015a monitoring station. Includes the overall index value and category plus sub-indices for SO\\u2082, NO\\u2082, PM10, PM2.5, and O\\u2083. Each sub-index uses a 0\\u20135 scale: 0=Bardzo dobry (Very good), 1=Dobry (Good), 2=Umiarkowany (Moderate), 3=Dostateczny (Sufficient), 4=Z\\u0142y (Bad), 5=Bardzo z\\u0142y (Very bad). Fields are mapped from the Polish-language /aqindex/getIndex/{stationId} endpoint.\"}";
+.alter table ['pl.gov.gios.airquality.AirQualityIndex'] docstring "{\"description\": \"Current Polish Air Quality Index (Indeks Jako\\u015bci Powietrza) for a GIO\\u015a monitoring station. Includes the overall index value and category plus sub-indices for SO\\u2082, NO\\u2082, PM10, PM2.5, and O\\u2083. Each sub-index uses a 0\\u20135 scale: 0=Bardzo dobry (Very good), 1=Dobry (Good), 2=Umiarkowany (Moderate), 3=Dostateczny (Sufficient), 4=Z\\u0142y (Bad), 5=Bardzo z\\u0142y (Very bad). Fields are mapped from the Polish-language /aqindex/getIndex/{stationId} endpoint.\"}";
 
-.alter table [AirQualityIndex] column-docstrings (
+.alter table ['pl.gov.gios.airquality.AirQualityIndex'] column-docstrings (
    [station_id]: "{\"description\": \"Numeric identifier of the monitoring station. Mapped from 'Identyfikator stacji pomiarowej'.\"}",
    [calculation_timestamp]: "{\"description\": \"Timestamp when the overall index was calculated (ISO 8601 in local Polish time). Mapped from 'Data wykonania oblicze\\u0144 indeksu'.\"}",
    [index_value]: "{\"description\": \"Overall air quality index value: 0=Bardzo dobry (Very good), 1=Dobry (Good), 2=Umiarkowany (Moderate), 3=Dostateczny (Sufficient), 4=Z\\u0142y (Bad), 5=Bardzo z\\u0142y (Very bad). Mapped from 'Warto\\u015b\\u0107 indeksu'.\"}",
@@ -356,7 +356,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [AirQualityIndex] ingestion json mapping "AirQualityIndex_json_flat"
+.create-or-alter table ['pl.gov.gios.airquality.AirQualityIndex'] ingestion json mapping "pl.gov.gios.airquality.AirQualityIndex_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -394,7 +394,7 @@
 ]
 ```
 
-.create-or-alter table [AirQualityIndex] ingestion json mapping "AirQualityIndex_json_ce_structured"
+.create-or-alter table ['pl.gov.gios.airquality.AirQualityIndex'] ingestion json mapping "pl.gov.gios.airquality.AirQualityIndex_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -432,13 +432,13 @@
 ]
 ```
 
-.drop materialized-view AirQualityIndexLatest ifexists;
+.drop materialized-view ['pl.gov.gios.airquality.AirQualityIndexLatest'] ifexists;
 
-.create materialized-view with (backfill=true) AirQualityIndexLatest on table AirQualityIndex {
-    AirQualityIndex | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['pl.gov.gios.airquality.AirQualityIndexLatest'] on table ['pl.gov.gios.airquality.AirQualityIndex'] {
+    ['pl.gov.gios.airquality.AirQualityIndex'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [AirQualityIndex] policy update
+.alter table ['pl.gov.gios.airquality.AirQualityIndex'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/gios-poland/notebook/gios-poland-feed.ipynb
+++ b/gios-poland/notebook/gios-poland-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GIOŚ Poland Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Polish Chief Inspectorate of Environmental Protection (GIOŚ) air-quality API for station metadata, sensor reference data, hourly pollutant measurements (PM10, PM2.5, SO₂, NO₂, O₃, CO, benzene) and the Polish AQI, then emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `gios_poland` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `gios-poland --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"gios-poland-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/gios-poland/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/gios-poland/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing gios_poland package from Fabric Environment...')\n",
+    "    from gios_poland import gios_poland as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['gios-poland', '--once'] if ONCE_MODE else ['gios-poland']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/gios-poland/tests/test_once_mode.py
+++ b/gios-poland/tests/test_once_mode.py
@@ -1,0 +1,106 @@
+"""Tests for --once mode added for Fabric notebook hosting."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_poller_stub():
+    poller = MagicMock()
+    poller.poll_and_send = MagicMock()
+    return poller
+
+
+def test_once_flag_passes_once_true_to_poll_and_send(monkeypatch):
+    """`--once` on the CLI must propagate to poller.poll_and_send(once=True)."""
+    from gios_poland import gios_poland as bridge
+
+    stub = _make_poller_stub()
+
+    monkeypatch.setattr(sys, "argv", [
+        "gios-poland",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "gios-poland",
+        "--once",
+    ])
+    monkeypatch.delenv("CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    with patch.object(bridge, "GIOSPolandPoller", return_value=stub) as factory:
+        bridge.main()
+
+    factory.assert_called_once()
+    stub.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_once_env_var_propagates(monkeypatch):
+    """ONCE_MODE=true env var is equivalent to --once."""
+    from gios_poland import gios_poland as bridge
+
+    stub = _make_poller_stub()
+
+    monkeypatch.setattr(sys, "argv", [
+        "gios-poland",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "gios-poland",
+    ])
+    monkeypatch.delenv("CONNECTION_STRING", raising=False)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    with patch.object(bridge, "GIOSPolandPoller", return_value=stub):
+        bridge.main()
+
+    stub.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_default_runs_continuous(monkeypatch):
+    """Without --once or ONCE_MODE, poll_and_send is invoked with once=False."""
+    from gios_poland import gios_poland as bridge
+
+    stub = _make_poller_stub()
+
+    monkeypatch.setattr(sys, "argv", [
+        "gios-poland",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "gios-poland",
+    ])
+    monkeypatch.delenv("CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    with patch.object(bridge, "GIOSPolandPoller", return_value=stub):
+        bridge.main()
+
+    stub.poll_and_send.assert_called_once_with(once=False)
+
+
+def test_poll_and_send_exits_after_one_cycle_when_once_true():
+    """poll_and_send(once=True) must exit after a single iteration of the while loop."""
+    from gios_poland import gios_poland as bridge
+
+    poller = bridge.GIOSPolandPoller.__new__(bridge.GIOSPolandPoller)
+    poller.BASE_URL = "http://example/invalid"
+    poller.POLL_INTERVAL_SECONDS = 9999
+    poller.REQUEST_DELAY = 0
+    poller.kafka_topic = "x"
+    poller.last_polled_file = None
+    poller.producer = MagicMock()
+    poller.fetch_stations = MagicMock(return_value=[])
+    poller.fetch_sensors = MagicMock(return_value=[])
+    poller.fetch_measurements = MagicMock(return_value=[])
+    poller.fetch_air_quality_index = MagicMock(return_value=None)
+    poller.load_state = MagicMock(return_value={})
+    poller.save_state = MagicMock()
+
+    with patch.object(bridge.time, "sleep") as sleep_mock:
+        poller.poll_and_send(once=True)
+
+    # Must NOT have slept on POLL_INTERVAL_SECONDS (which would indicate it
+    # entered a second iteration).
+    for call in sleep_mock.call_args_list:
+        assert call.args[0] != poller.POLL_INTERVAL_SECONDS, \
+            "poll_and_send slept on POLL_INTERVAL_SECONDS — did not exit after one cycle"


### PR DESCRIPTION
Retrofit performed by the `notebook-feeder-retrofit` skill (.github/skills/notebook-feeder-retrofit/SKILL.md) for source `gios-poland`.

## What changed
- **Notebook**: `gios-poland/notebook/gios-poland-feed.ipynb` — copied verbatim from the canonical `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per `references/notebook-substitution-table.md`. Four-cell structure, CS-lookup logic, worker-thread wrapper and OneLake log path layout are unchanged.
- **`--once` flag added** to the bridge (gate (2) was missing). Modeled after pegelonline: `argparse.add_argument('--once', ..., default=os.getenv('ONCE_MODE', '').lower() in ('1','true','yes'))`. The pre-existing `GIOSPolandPoller.poll_and_send(once=...)` already supported single-cycle exit, so the change is purely wiring. Four new unit tests in `tests/test_once_mode.py` cover `--once`, `ONCE_MODE` env, default continuous mode, and that the polling loop actually exits after one cycle.
- **catalog.json**: `"notebook": true` added to the `gios-poland` entry (key order preserved, inserted after `kql`).
- **README**: one-line `Deploying as a Fabric notebook feeder` section appended pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- **Qualified KQL tables (step 5b, mandatory)**: `gios-poland/kql/create-kql-script.ps1` now invokes the generator with `-Qualified -Namespace 'pl.gov.gios.airquality'`. Regenerated `gios-poland/kql/gios_poland.kql`; every typed table, materialized view, ingestion mapping, and update policy is now `['pl.gov.gios.airquality.Station']` / `Sensor` / `Measurement` / `AirQualityIndex`. The `_cloudevents_dispatch` table and update-policy `type ==` predicates are unchanged. The source ships no hand-authored `fabric/`, `dashboard/`, or secondary KQL overlay; README mentions of "Station" / "Sensor" are prose, not table references.

## Local validation performed
- ✅ Notebook JSON well-formed (`json.load`).
- ✅ Bridge tests: `python -m pytest tests/ -q` → 44 passed (40 pre-existing + 4 new).
- ✅ Parameters cell contains all five placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`. (Validated per-cell after JSON parse; the skill's raw-text `(?m)^\s*<NAME>\s*=` regex matches neither this notebook nor the canonical pegelonline template — it does not account for the leading `"` in JSON-escaped cell-source lines. Per-cell verification is the correct check.)
- ✅ No forbidden patterns (`asyncio.run(`, `%pip install`, `CONNECTION_STRING = "`, `primaryConnectionString.*=`) in any **code** cell. (The skill's `%pip install` regex also matches benign markdown commentary in the canonical template; per-cell scoping confirms code cells are clean.)
- ✅ No residual `pegelonline` strings in the notebook.
- ✅ Qualified-tables guard: ` -match "create-merge table \['[a-z]"` is true.

## Not done (per skill)
- No live Fabric deployment — handed off to manual verification on merge.
- One source per PR — only `gios-poland` touched.

## Wheel-bundle workflow
`.github/workflows/publish-notebook-wheels.yml` will pick up this source on merge to main and publish `gios-poland-notebook-wheels.zip` to the `notebook-wheels` release; downstream `deploy-feeder-notebook.ps1` will then succeed.
