### PR TITLE
feat(fmi-finland): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -341,7 +341,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Finland — hourly air quality observations via FMI WFS",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "gios-poland",

--- a/fmi-finland/README.md
+++ b/fmi-finland/README.md
@@ -45,6 +45,10 @@ segments as a fallback.
 
 See [EVENTS.md](EVENTS.md) for the CloudEvents contract.
 
+## Fabric notebook hosting
+
+This source can also run as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1); the notebook lives at [`notebook/fmi-finland-feed.ipynb`](notebook/fmi-finland-feed.ipynb) and invokes `fmi-finland feed --once` per scheduled run.
+
 ## Usage
 
 List known stations:

--- a/fmi-finland/fmi_finland/fmi_finland.py
+++ b/fmi-finland/fmi_finland/fmi_finland.py
@@ -558,6 +558,12 @@ def main() -> None:
         default=os.getenv("STATE_FILE", os.path.expanduser("~/.fmi_finland_state.json")),
         help="JSON file used for deduplication state.",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     _configure_logging()
@@ -613,6 +619,10 @@ def main() -> None:
             break
         except Exception as exc:  # pragma: no cover - runtime resiliency
             logger.exception("Feed cycle failed: %s", exc)
+
+        if args.once:
+            logger.info("--once mode: exiting after first polling cycle")
+            break
 
         sleep_seconds = max(
             0,

--- a/fmi-finland/kql/create-kql-script.ps1
+++ b/fmi-finland/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\fmi-finland.xreg.json"
 $kqlFile = Join-Path $scriptDir "fmi-finland.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace fi.fmi.opendata.airquality

--- a/fmi-finland/kql/fmi-finland.kql
+++ b/fmi-finland/kql/fmi-finland.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['fi.fmi.opendata.airquality.Station'] (
    [fmisid]: string,
    [station_name]: string,
    [latitude]: real,
@@ -38,9 +38,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for an FMI air quality monitoring station. The station identifier is the FMI station identifier (fmisid). Municipality is taken from the WFS station metadata region name, and coordinates are the representative point published by FMI.\"}";
+.alter table ['fi.fmi.opendata.airquality.Station'] docstring "{\"description\": \"Reference data for an FMI air quality monitoring station. The station identifier is the FMI station identifier (fmisid). Municipality is taken from the WFS station metadata region name, and coordinates are the representative point published by FMI.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['fi.fmi.opendata.airquality.Station'] column-docstrings (
    [fmisid]: "{\"description\": \"Stable FMI station identifier (fmisid) used as the Kafka key and CloudEvents subject.\"}",
    [station_name]: "{\"description\": \"Air quality station name from the FMI station metadata, for example 'Helsinki Kallio 2'.\"}",
    [latitude]: "{\"description\": \"WGS84 latitude of the station representative point in decimal degrees.\"}",
@@ -53,7 +53,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['fi.fmi.opendata.airquality.Station'] ingestion json mapping "fi.fmi.opendata.airquality.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -69,7 +69,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['fi.fmi.opendata.airquality.Station'] ingestion json mapping "fi.fmi.opendata.airquality.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -85,13 +85,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['fi.fmi.opendata.airquality.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fi.fmi.opendata.airquality.StationLatest'] on table ['fi.fmi.opendata.airquality.Station'] {
+    ['fi.fmi.opendata.airquality.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['fi.fmi.opendata.airquality.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -102,7 +102,7 @@
 }]
 ```
 
-.create-merge table [Observation] (
+.create-merge table ['fi.fmi.opendata.airquality.Observation'] (
    [fmisid]: string,
    [station_name]: string,
    [observation_time]: string,
@@ -120,9 +120,9 @@
    [___subject]: string
 );
 
-.alter table [Observation] docstring "{\"description\": \"Hourly FMI air quality observation aggregated per station and observation timestamp from the urban::observations::airquality::hourly::simple stored query. Each event combines all supported pollutant and index parameters published for the station and hour.\"}";
+.alter table ['fi.fmi.opendata.airquality.Observation'] docstring "{\"description\": \"Hourly FMI air quality observation aggregated per station and observation timestamp from the urban::observations::airquality::hourly::simple stored query. Each event combines all supported pollutant and index parameters published for the station and hour.\"}";
 
-.alter table [Observation] column-docstrings (
+.alter table ['fi.fmi.opendata.airquality.Observation'] column-docstrings (
    [fmisid]: "{\"description\": \"Stable FMI station identifier (fmisid) for the observing station.\"}",
    [station_name]: "{\"description\": \"Station name resolved from station metadata or, if metadata lookup fails, the station identifier string.\"}",
    [observation_time]: "{\"description\": \"Observation timestamp in UTC, formatted as an ISO-8601 instant such as 2024-01-15T13:00:00Z.\"}",
@@ -140,7 +140,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_flat"
+.create-or-alter table ['fi.fmi.opendata.airquality.Observation'] ingestion json mapping "fi.fmi.opendata.airquality.Observation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -161,7 +161,7 @@
 ]
 ```
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_ce_structured"
+.create-or-alter table ['fi.fmi.opendata.airquality.Observation'] ingestion json mapping "fi.fmi.opendata.airquality.Observation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -182,13 +182,13 @@
 ]
 ```
 
-.drop materialized-view ObservationLatest ifexists;
+.drop materialized-view ['fi.fmi.opendata.airquality.ObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservationLatest on table Observation {
-    Observation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fi.fmi.opendata.airquality.ObservationLatest'] on table ['fi.fmi.opendata.airquality.Observation'] {
+    ['fi.fmi.opendata.airquality.Observation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observation] policy update
+.alter table ['fi.fmi.opendata.airquality.Observation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/fmi-finland/notebook/fmi-finland-feed.ipynb
+++ b/fmi-finland/notebook/fmi-finland-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FMI Finland Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Finnish Meteorological Institute (FMI) open OGC WFS service for hourly air quality observations (PM10, PM2.5, NO2, O3, SO2, CO, AQI) from Finnish urban monitoring stations and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `fmi_finland` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `fmi-finland feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"fmi-finland-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/fmi-finland/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/fmi-finland/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing fmi_finland package from Fabric Environment...')\n",
+    "    from fmi_finland import fmi_finland as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['fmi-finland', 'feed', '--once'] if ONCE_MODE else ['fmi-finland', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/fmi-finland/tests/test_once_mode.py
+++ b/fmi-finland/tests/test_once_mode.py
@@ -1,0 +1,86 @@
+"""Verify the bridge's --once flag exits after a single polling cycle."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fmi_finland import fmi_finland as bridge
+
+pytestmark = pytest.mark.unit
+
+
+def test_once_flag_runs_single_cycle_then_returns(monkeypatch, tmp_path):
+    """`fmi-finland feed --once` must invoke run_feed_cycle exactly once and return."""
+
+    state_file = tmp_path / "state.json"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fmi-finland",
+            "feed",
+            "--kafka-bootstrap-servers",
+            "localhost:9092",
+            "--state-file",
+            str(state_file),
+            "--once",
+        ],
+    )
+
+    fake_producer = MagicMock()
+    cycle_calls = {"count": 0}
+
+    def fake_cycle(*_args, **_kwargs):
+        cycle_calls["count"] += 1
+        return {"stations": 1, "observations": 2}
+
+    sleep_mock = MagicMock()
+
+    with patch.object(bridge, "FMIAirQualityAPI"), patch.object(
+        bridge, "FiFmiOpendataAirqualityEventProducer", return_value=fake_producer
+    ), patch.object(bridge, "Producer"), patch.object(
+        bridge, "run_feed_cycle", side_effect=fake_cycle
+    ), patch.object(bridge.time, "sleep", sleep_mock):
+        bridge.main()
+
+    assert cycle_calls["count"] == 1, "run_feed_cycle should run exactly once with --once"
+    sleep_mock.assert_not_called()
+
+
+def test_once_flag_via_env(monkeypatch, tmp_path):
+    """Setting ONCE_MODE=true should also trigger a single-cycle exit."""
+
+    state_file = tmp_path / "state.json"
+
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fmi-finland",
+            "feed",
+            "--kafka-bootstrap-servers",
+            "localhost:9092",
+            "--state-file",
+            str(state_file),
+        ],
+    )
+
+    cycle_calls = {"count": 0}
+
+    def fake_cycle(*_args, **_kwargs):
+        cycle_calls["count"] += 1
+        return {"stations": 0, "observations": 0}
+
+    with patch.object(bridge, "FMIAirQualityAPI"), patch.object(
+        bridge, "FiFmiOpendataAirqualityEventProducer"
+    ), patch.object(bridge, "Producer"), patch.object(
+        bridge, "run_feed_cycle", side_effect=fake_cycle
+    ), patch.object(bridge.time, "sleep", MagicMock()):
+        bridge.main()
+
+    assert cycle_calls["count"] == 1


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- Add `fmi-finland/notebook/fmi-finland-feed.ipynb` following the canonical pegelonline pattern (4 cells: markdown intro, parameters, Event Stream CS lookup, worker-thread run cell).
- Flip `catalog.json` `notebook: true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Add `--once` CLI flag to the `fmi-finland feed` bridge (also honored via `ONCE_MODE` env var), modeled on pegelonline. Covered by `tests/test_once_mode.py` (2 new tests).
- Flip `fmi-finland/kql/create-kql-script.ps1` to pass `-Qualified -Namespace fi.fmi.opendata.airquality` and regenerate `fmi-finland.kql`. Tables, mappings, materialized views, and update policies now use `['fi.fmi.opendata.airquality.Station']` / `['fi.fmi.opendata.airquality.Observation']` FQNs (see `docs/plan-qualified-table-names.md`, DWD reference PR #257).
- One-line Fabric notebook bullet added to `fmi-finland/README.md`.

## Consumer-asset audit
This source has no `fabric/`, `notebook/` (pre-existing), or `dashboard/` hand-authored assets, and no secondary KQL overlays — nothing else needed renaming.

## Local validation
- Notebook JSON parses.
- Bridge tests pass: 15/15 (`test_once_mode.py` 2, `test_fmi_finland_unit.py` 11, `test_fmi_finland_integration.py` 2).
- Parameters cell contains all of: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Per-cell forbidden-pattern scan clean (the `%pip install` token only appears in the markdown intro as a 'no install required' note — false positive per the skill).
- KQL contains qualified `create-merge table ['fi.fmi…']` entries.

No live Fabric deployment performed; the wheel-publish workflow will pick this up on merge.