### PR TITLE
feat(sensor-community): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -397,7 +397,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Global — citizen air sensors, PM and climate readings",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "uba-airdata",

--- a/sensor-community/README.md
+++ b/sensor-community/README.md
@@ -57,6 +57,10 @@ python -m sensor_community feed --connection-string "BootstrapServer=localhost:9
 - `STATE_FILE` — persisted dedup and metadata state file
 - `KAFKA_ENABLE_TLS` — set to `false` for plain Kafka when you want an explicit `PLAINTEXT` security protocol
 
+## Fabric notebook hosting
+
+- This source ships a Fabric notebook feeder at `notebook/sensor-community-feed.ipynb` that runs a single polling cycle on a Fabric schedule. Deploy it with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Upstream links
 
 - Sensor.Community project: https://sensor.community/

--- a/sensor-community/kql/create-kql-script.ps1
+++ b/sensor-community/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\sensor-community.xreg.json"
 $kqlFile = Join-Path $scriptDir "sensor-community.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/sensor-community/kql/sensor-community.kql
+++ b/sensor-community/kql/sensor-community.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [SensorInfo] (
+.create-merge table ['io.sensor.community.SensorInfo'] (
    [sensor_id]: int,
    [sensor_type_id]: int,
    [sensor_type_name]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [SensorInfo] docstring "{\"description\": \"Schema for Sensor.Community sensor reference data, capturing the stable sensor identifier, hardware type, and latest known location metadata published in the Airrohr API payload.\"}";
+.alter table ['io.sensor.community.SensorInfo'] docstring "{\"description\": \"Schema for Sensor.Community sensor reference data, capturing the stable sensor identifier, hardware type, and latest known location metadata published in the Airrohr API payload.\"}";
 
-.alter table [SensorInfo] column-docstrings (
+.alter table ['io.sensor.community.SensorInfo'] column-docstrings (
    [sensor_id]: "{\"description\": \"Stable integer identifier of the Sensor.Community sensor device. This value is used as the CloudEvents subject and Kafka key.\"}",
    [sensor_type_id]: "{\"description\": \"Numeric upstream identifier for the sensor hardware type, such as the Sensor.Community type id for SDS011 or BME280.\"}",
    [sensor_type_name]: "{\"description\": \"Upstream sensor hardware type name published under sensor.sensor_type.name, for example SDS011, SPS30, BME280, or DHT22.\"}",
@@ -65,7 +65,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [SensorInfo] ingestion json mapping "SensorInfo_json_flat"
+.create-or-alter table ['io.sensor.community.SensorInfo'] ingestion json mapping "io.sensor.community.SensorInfo_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,7 +87,7 @@
 ]
 ```
 
-.create-or-alter table [SensorInfo] ingestion json mapping "SensorInfo_json_ce_structured"
+.create-or-alter table ['io.sensor.community.SensorInfo'] ingestion json mapping "io.sensor.community.SensorInfo_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -109,13 +109,13 @@
 ]
 ```
 
-.drop materialized-view SensorInfoLatest ifexists;
+.drop materialized-view ['io.sensor.community.SensorInfoLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SensorInfoLatest on table SensorInfo {
-    SensorInfo | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['io.sensor.community.SensorInfoLatest'] on table ['io.sensor.community.SensorInfo'] {
+    ['io.sensor.community.SensorInfo'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [SensorInfo] policy update
+.alter table ['io.sensor.community.SensorInfo'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -126,7 +126,7 @@
 }]
 ```
 
-.create-merge table [SensorReading] (
+.create-merge table ['io.sensor.community.SensorReading'] (
    [sensor_id]: int,
    [timestamp]: string,
    [sensor_type_name]: string,
@@ -148,9 +148,9 @@
    [___subject]: string
 );
 
-.alter table [SensorReading] docstring "{\"description\": \"Schema for the latest normalized Sensor.Community telemetry reading for a single sensor and timestamp, covering particulate matter, temperature, humidity, pressure, and supported noise measurements.\"}";
+.alter table ['io.sensor.community.SensorReading'] docstring "{\"description\": \"Schema for the latest normalized Sensor.Community telemetry reading for a single sensor and timestamp, covering particulate matter, temperature, humidity, pressure, and supported noise measurements.\"}";
 
-.alter table [SensorReading] column-docstrings (
+.alter table ['io.sensor.community.SensorReading'] column-docstrings (
    [sensor_id]: "{\"description\": \"Stable integer identifier of the Sensor.Community sensor device. This value is used as the CloudEvents subject and Kafka key.\"}",
    [timestamp]: "{\"description\": \"UTC timestamp published by Sensor.Community for the reading in the format YYYY-MM-DD HH:mm:ss.\"}",
    [sensor_type_name]: "{\"description\": \"Upstream sensor hardware type name published under sensor.sensor_type.name for the device that emitted the reading.\"}",
@@ -172,7 +172,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [SensorReading] ingestion json mapping "SensorReading_json_flat"
+.create-or-alter table ['io.sensor.community.SensorReading'] ingestion json mapping "io.sensor.community.SensorReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -197,7 +197,7 @@
 ]
 ```
 
-.create-or-alter table [SensorReading] ingestion json mapping "SensorReading_json_ce_structured"
+.create-or-alter table ['io.sensor.community.SensorReading'] ingestion json mapping "io.sensor.community.SensorReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -222,13 +222,13 @@
 ]
 ```
 
-.drop materialized-view SensorReadingLatest ifexists;
+.drop materialized-view ['io.sensor.community.SensorReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SensorReadingLatest on table SensorReading {
-    SensorReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['io.sensor.community.SensorReadingLatest'] on table ['io.sensor.community.SensorReading'] {
+    ['io.sensor.community.SensorReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [SensorReading] policy update
+.alter table ['io.sensor.community.SensorReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/sensor-community/notebook/sensor-community-feed.ipynb
+++ b/sensor-community/notebook/sensor-community-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sensor.Community Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Sensor.Community (formerly Luftdaten.info) public Airrohr API for citizen-science air quality and environmental telemetry and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `sensor_community` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `sensor-community feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"sensor-community-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/sensor-community/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/sensor-community/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing sensor_community package from Fabric Environment...')\n",
+    "    from sensor_community import sensor_community as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['sensor-community', 'feed', '--once'] if ONCE_MODE else ['sensor-community', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/sensor-community/sensor_community/sensor_community.py
+++ b/sensor-community/sensor_community/sensor_community.py
@@ -383,6 +383,7 @@ class SensorCommunityAPI:
         sasl_password: str | None = None,
         polling_interval: int = 300,
         kafka_enable_tls: bool | None = None,
+        once: bool = False,
     ) -> None:
         """Start the continuous polling loop."""
         kafka_config = self.build_kafka_config(
@@ -417,6 +418,9 @@ class SensorCommunityAPI:
                     result.sensor_reading_count,
                     elapsed,
                 )
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if wait_time > 0:
                     time.sleep(wait_time)
             except KeyboardInterrupt:
@@ -424,6 +428,9 @@ class SensorCommunityAPI:
                 break
             except Exception as exc:  # pylint: disable=broad-except
                 logging.error("Polling cycle failed: %s", exc)
+                if once:
+                    logging.info("--once mode: exiting after failed first cycle")
+                    break
                 time.sleep(polling_interval)
         producer.flush()
 
@@ -504,6 +511,12 @@ def main() -> None:
         default=os.getenv("KAFKA_ENABLE_TLS"),
         help="Set to false to force PLAINTEXT for plain Kafka bootstrap servers",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").strip().lower() in {"1", "true", "yes", "on"},
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
 
@@ -530,4 +543,5 @@ def main() -> None:
         sasl_password=args.sasl_password,
         polling_interval=args.polling_interval,
         kafka_enable_tls=kafka_enable_tls,
+        once=args.once,
     )

--- a/sensor-community/tests/test_once_mode.py
+++ b/sensor-community/tests/test_once_mode.py
@@ -1,0 +1,108 @@
+"""Verify the bridge exits after one polling cycle when --once is supplied."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from sensor_community import sensor_community as bridge
+
+
+@pytest.mark.unit
+def test_once_flag_exits_after_single_cycle(monkeypatch):
+    """`sensor-community feed --once` should invoke poll_once exactly once."""
+
+    monkeypatch.setenv("CONNECTION_STRING", "BootstrapServer=localhost:9092;EntityPath=test-topic")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+
+    call_count = {"poll_once": 0}
+
+    class _Result:
+        sensor_info_count = 0
+        sensor_reading_count = 0
+
+    def _fake_poll_once(self, event_producer):
+        call_count["poll_once"] += 1
+        return _Result()
+
+    class _FakeProducer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def flush(self, *_args, **_kwargs):
+            return 0
+
+        def produce(self, *_args, **_kwargs):
+            return None
+
+        def poll(self, *_args, **_kwargs):
+            return 0
+
+    class _FakeEventProducer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    saved_argv = sys.argv
+    sys.argv = [
+        "sensor-community",
+        "feed",
+        "--polling-interval",
+        "1",
+        "--once",
+    ]
+    try:
+        with patch.object(bridge.SensorCommunityAPI, "poll_once", _fake_poll_once), \
+             patch.object(bridge, "Producer", _FakeProducer), \
+             patch.object(bridge, "IoSensorCommunityEventProducer", _FakeEventProducer), \
+             patch.object(bridge.time, "sleep", lambda *_a, **_kw: None):
+            bridge.main()
+    finally:
+        sys.argv = saved_argv
+
+    assert call_count["poll_once"] == 1
+
+
+@pytest.mark.unit
+def test_once_mode_env_var_enables_single_cycle(monkeypatch):
+    """`ONCE_MODE=true` should default `--once` to True."""
+
+    monkeypatch.setenv("CONNECTION_STRING", "BootstrapServer=localhost:9092;EntityPath=test-topic")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setenv("ONCE_MODE", "true")
+
+    call_count = {"poll_once": 0}
+
+    class _Result:
+        sensor_info_count = 0
+        sensor_reading_count = 0
+
+    def _fake_poll_once(self, event_producer):
+        call_count["poll_once"] += 1
+        return _Result()
+
+    class _FakeProducer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def flush(self, *_args, **_kwargs):
+            return 0
+
+    class _FakeEventProducer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    saved_argv = sys.argv
+    sys.argv = ["sensor-community", "feed", "--polling-interval", "1"]
+    try:
+        with patch.object(bridge.SensorCommunityAPI, "poll_once", _fake_poll_once), \
+             patch.object(bridge, "Producer", _FakeProducer), \
+             patch.object(bridge, "IoSensorCommunityEventProducer", _FakeEventProducer), \
+             patch.object(bridge.time, "sleep", lambda *_a, **_kw: None):
+            bridge.main()
+    finally:
+        sys.argv = saved_argv
+
+    assert call_count["poll_once"] == 1


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` skill (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- `sensor-community/notebook/sensor-community-feed.ipynb` — Fabric notebook feeder, copied verbatim from the canonical `pegelonline` template with the exact substitutions from `references/notebook-substitution-table.md` (package = `sensor_community`, module = `sensor_community`, argv-0 = `sensor-community`, subcommand = `feed`, state path = `/lakehouse/default/Files/feeder-state/sensor-community/`, eventstream default = `sensor-community-ingest`, markdown adapted from the source README).
- `sensor_community/sensor_community.py` — added `--once` CLI flag (defaults from `ONCE_MODE` env var) and plumbed it through `feed()` so the polling loop exits after a single cycle. Modeled on `pegelonline/pegelonline/pegelonline.py`.
- `tests/test_once_mode.py` — unit tests covering both `--once` activation paths (CLI flag and `ONCE_MODE=true` env var); `poll_once` is asserted to run exactly once. Full suite: **17 passed**.
- `catalog.json` — flipped `notebook: true` on the `sensor-community` entry.
- `sensor-community/README.md` — one-line bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Qualified KQL tables (mandatory step 5b)

- `kql/create-kql-script.ps1` now passes `-Qualified` to `tools/generate-kql-from-xreg.ps1`.
- Regenerated `kql/sensor-community.kql`: `SensorInfo` → `['io.sensor.community.SensorInfo']` and `SensorReading` → `['io.sensor.community.SensorReading']` across all create-merge, materialized-view, ingestion-mapping, and update-policy statements. `_cloudevents_dispatch` and update-policy `type ==` predicates unchanged.
- Consumer-asset audit: no `fabric/` or `dashboard/` directories in this source. `README.md` already references the fully qualified `io.sensor.community.*` type names. Nothing else to update.

## Local validation performed

- Notebook JSON parses cleanly.
- Parameters cell contains all five placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- Forbidden-pattern check: only hit is the documented false positive — the markdown commentary in cell 0 (`No %pip install is required at runtime.`). No `asyncio.run(`, no hard-coded `CONNECTION_STRING =`, no `primaryConnectionString = ...` assignment.
- Bridge tests: 17 passed (in a local venv; no global installs).
- Qualified-tables regex (`create-merge table ['[a-z]`) matches.

## Out of scope

No live Fabric deployment performed (per skill step 7). The wheel-publish workflow will pick this source up on next push to `main`.