### PR TITLE
feat(defra-aurn): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -333,7 +333,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "United Kingdom — 300+ monitoring locations, hourly pollutants",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "fmi-finland",

--- a/defra-aurn/README.md
+++ b/defra-aurn/README.md
@@ -111,6 +111,17 @@ The upstream station GeoJSON uses `geometry.coordinates[0]` as latitude and
 ordering, and the bridge preserves the actual upstream semantics rather than the
 convention.
 
+## Fabric notebook hosting
+
+This source ships a Fabric notebook feeder at
+`notebook/defra-aurn-feed.ipynb` that runs the bridge in `--once` mode on a
+Fabric schedule. Deploy it with
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1);
+the script builds a per-source Fabric Environment with the producer and
+bridge wheels, binds the Lakehouse, KQL database, and Environment to the
+notebook, looks up the Event Stream connection string at runtime via the
+Topology API, and schedules the notebook.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/defra-aurn/defra_aurn/defra_aurn.py
+++ b/defra-aurn/defra_aurn/defra_aurn.py
@@ -431,6 +431,10 @@ def run_feed(args: argparse.Namespace) -> None:
             emitted = api.emit_observations(timeseries_producer, timeseries_catalog, state)
             _save_state(state_file, state)
             LOGGER.info("Emitted %d observation events", emitted)
+            if getattr(args, "once", False):
+                LOGGER.info("--once mode: exiting after first polling cycle")
+                producer.flush()
+                return
             time.sleep(args.polling_interval)
         except KeyboardInterrupt:
             LOGGER.info("Stopping Defra AURN bridge")
@@ -487,6 +491,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--kafka-enable-tls",
         default=os.getenv("KAFKA_ENABLE_TLS", "true"),
         help="Whether TLS is enabled for Kafka connections",
+    )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help=(
+            "Exit after one polling cycle (also via ONCE_MODE env var). "
+            "Useful for scheduled execution in Fabric notebooks."
+        ),
     )
 
     return parser

--- a/defra-aurn/kql/create-kql-script.ps1
+++ b/defra-aurn/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\defra_aurn.xreg.json"
 $kqlFile = Join-Path $scriptDir "defra_aurn.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "uk.gov.defra.aurn"

--- a/defra-aurn/kql/defra_aurn.kql
+++ b/defra-aurn/kql/defra_aurn.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['uk.gov.defra.aurn.Station'] (
    [station_id]: string,
    [label]: string,
    [latitude]: real,
@@ -37,9 +37,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Metadata for a Defra AURN monitoring station as returned by GET /stations. The bridge flattens the GeoJSON feature into a payload with the station identifier, the upstream display label, and WGS84 latitude and longitude values taken from geometry.coordinates[0] and geometry.coordinates[1], because this API returns coordinates in latitude, longitude order.\"}";
+.alter table ['uk.gov.defra.aurn.Station'] docstring "{\"description\": \"Metadata for a Defra AURN monitoring station as returned by GET /stations. The bridge flattens the GeoJSON feature into a payload with the station identifier, the upstream display label, and WGS84 latitude and longitude values taken from geometry.coordinates[0] and geometry.coordinates[1], because this API returns coordinates in latitude, longitude order.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['uk.gov.defra.aurn.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Stable numeric monitoring station identifier from the GeoJSON feature properties.id field returned by GET /stations. The bridge converts the numeric API value to a string so it can be used consistently as the Kafka key and CloudEvents subject.\"}",
    [label]: "{\"description\": \"Upstream station label from properties.label in GET /stations. In this API the label includes both the site name and the monitored pollutant description, for example 'Camden Kerbside-Particulate matter less than 10 micro m (aerosol)'.\"}",
    [latitude]: "{\"description\": \"WGS84 latitude in decimal degrees taken from geometry.coordinates[0] in the Defra SOS GeoJSON feature. The upstream API uses latitude-first coordinate ordering rather than GeoJSON's usual longitude-first convention.\"}",
@@ -51,7 +51,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['uk.gov.defra.aurn.Station'] ingestion json mapping "uk.gov.defra.aurn.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['uk.gov.defra.aurn.Station'] ingestion json mapping "uk.gov.defra.aurn.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -81,13 +81,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['uk.gov.defra.aurn.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.gov.defra.aurn.StationLatest'] on table ['uk.gov.defra.aurn.Station'] {
+    ['uk.gov.defra.aurn.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['uk.gov.defra.aurn.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -98,7 +98,7 @@
 }]
 ```
 
-.create-merge table [Timeseries] (
+.create-merge table ['uk.gov.defra.aurn.Timeseries'] (
    [timeseries_id]: string,
    [label]: string,
    [uom]: string,
@@ -117,9 +117,9 @@
    [___subject]: string
 );
 
-.alter table [Timeseries] docstring "{\"description\": \"Reference metadata for a Defra AURN station and pollutant timeseries combination, assembled from GET /timeseries/{id}?expanded=true. The payload preserves the stable timeseries identifier, linked station metadata, unit of measurement, and pollutant taxonomy references published in parameters.phenomenon and parameters.category.\"}";
+.alter table ['uk.gov.defra.aurn.Timeseries'] docstring "{\"description\": \"Reference metadata for a Defra AURN station and pollutant timeseries combination, assembled from GET /timeseries/{id}?expanded=true. The payload preserves the stable timeseries identifier, linked station metadata, unit of measurement, and pollutant taxonomy references published in parameters.phenomenon and parameters.category.\"}";
 
-.alter table [Timeseries] column-docstrings (
+.alter table ['uk.gov.defra.aurn.Timeseries'] column-docstrings (
    [timeseries_id]: "{\"description\": \"Stable numeric timeseries identifier from the id field returned by GET /timeseries and GET /timeseries/{id}?expanded=true. Each timeseries represents one station and one pollutant combination.\"}",
    [label]: "{\"description\": \"Descriptive label from the timeseries label field. In the live API this string combines the EIONet pollutant URI, the station identifier, and the station display label.\"}",
    [uom]: "{\"description\": \"Unit of measurement string from the timeseries uom field, for example 'ug.m-3'. The bridge republishes the upstream unit token unchanged so consumers can interpret observation values correctly.\"}",
@@ -138,7 +138,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Timeseries] ingestion json mapping "Timeseries_json_flat"
+.create-or-alter table ['uk.gov.defra.aurn.Timeseries'] ingestion json mapping "uk.gov.defra.aurn.Timeseries_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -160,7 +160,7 @@
 ]
 ```
 
-.create-or-alter table [Timeseries] ingestion json mapping "Timeseries_json_ce_structured"
+.create-or-alter table ['uk.gov.defra.aurn.Timeseries'] ingestion json mapping "uk.gov.defra.aurn.Timeseries_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -182,13 +182,13 @@
 ]
 ```
 
-.drop materialized-view TimeseriesLatest ifexists;
+.drop materialized-view ['uk.gov.defra.aurn.TimeseriesLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TimeseriesLatest on table Timeseries {
-    Timeseries | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.gov.defra.aurn.TimeseriesLatest'] on table ['uk.gov.defra.aurn.Timeseries'] {
+    ['uk.gov.defra.aurn.Timeseries'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Timeseries] policy update
+.alter table ['uk.gov.defra.aurn.Timeseries'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -199,7 +199,7 @@
 }]
 ```
 
-.create-merge table [Observation] (
+.create-merge table ['uk.gov.defra.aurn.Observation'] (
    [timeseries_id]: string,
    [timestamp]: datetime,
    [value]: real,
@@ -211,9 +211,9 @@
    [___subject]: string
 );
 
-.alter table [Observation] docstring "{\"description\": \"Observation value from GET /timeseries/{id}/getData. The bridge converts the upstream Unix millisecond timestamp to an ISO 8601 UTC timestamp string and republishes the measurement value together with the timeseries identifier and unit of measurement from the reference metadata.\"}";
+.alter table ['uk.gov.defra.aurn.Observation'] docstring "{\"description\": \"Observation value from GET /timeseries/{id}/getData. The bridge converts the upstream Unix millisecond timestamp to an ISO 8601 UTC timestamp string and republishes the measurement value together with the timeseries identifier and unit of measurement from the reference metadata.\"}";
 
-.alter table [Observation] column-docstrings (
+.alter table ['uk.gov.defra.aurn.Observation'] column-docstrings (
    [timeseries_id]: "{\"description\": \"Stable numeric timeseries identifier for the series that produced this observation. This field is the Kafka key and CloudEvents subject for both the reference timeseries event and the observation event.\"}",
    [timestamp]: "{\"description\": \"Observation timestamp encoded as an ISO 8601 UTC string. The bridge converts the upstream GET /timeseries/{id}/getData values[].timestamp Unix millisecond value with datetime.fromtimestamp(timestamp/1000, tz=timezone.utc).isoformat().\"}",
    [value]: "{\"description\": \"Measured pollutant concentration or other reported numeric reading from values[].value in GET /timeseries/{id}/getData. The field is nullable because the API can represent missing or flagged values with null.\"}",
@@ -225,7 +225,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_flat"
+.create-or-alter table ['uk.gov.defra.aurn.Observation'] ingestion json mapping "uk.gov.defra.aurn.Observation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -240,7 +240,7 @@
 ]
 ```
 
-.create-or-alter table [Observation] ingestion json mapping "Observation_json_ce_structured"
+.create-or-alter table ['uk.gov.defra.aurn.Observation'] ingestion json mapping "uk.gov.defra.aurn.Observation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -255,13 +255,13 @@
 ]
 ```
 
-.drop materialized-view ObservationLatest ifexists;
+.drop materialized-view ['uk.gov.defra.aurn.ObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservationLatest on table Observation {
-    Observation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.gov.defra.aurn.ObservationLatest'] on table ['uk.gov.defra.aurn.Observation'] {
+    ['uk.gov.defra.aurn.Observation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observation] policy update
+.alter table ['uk.gov.defra.aurn.Observation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/defra-aurn/notebook/defra-aurn-feed.ipynb
+++ b/defra-aurn/notebook/defra-aurn-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Defra AURN Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the UK Defra Automatic Urban and Rural Network (AURN) SOS Timeseries API for hourly air-quality observations from the 300+ UK monitoring stations and emits station, timeseries, and observation CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `defra_aurn` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `defra-aurn feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"defra-aurn-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/defra-aurn/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/defra-aurn/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing defra_aurn package from Fabric Environment...')\n",
+    "    from defra_aurn import defra_aurn as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['defra-aurn', 'feed', '--once'] if ONCE_MODE else ['defra-aurn', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/defra-aurn/tests/test_once_mode.py
+++ b/defra-aurn/tests/test_once_mode.py
@@ -1,0 +1,96 @@
+"""Tests for the --once flag added for Fabric notebook hosting."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from defra_aurn.defra_aurn import build_parser, run_feed
+
+
+@pytest.mark.unit
+def test_once_flag_parses_true():
+    parser = build_parser()
+    args = parser.parse_args(["feed", "--once"])
+    assert args.once is True
+
+
+@pytest.mark.unit
+def test_once_flag_default_false(monkeypatch):
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+    parser = build_parser()
+    args = parser.parse_args(["feed"])
+    assert args.once is False
+
+
+@pytest.mark.unit
+def test_once_mode_env_var_enables_once(monkeypatch):
+    monkeypatch.setenv("ONCE_MODE", "true")
+    parser = build_parser()
+    args = parser.parse_args(["feed"])
+    assert args.once is True
+
+
+@pytest.mark.unit
+def test_run_feed_once_returns_after_single_cycle(monkeypatch):
+    """`run_feed` with args.once=True must exit after one polling cycle."""
+
+    fake_catalog = {"ts-1": object()}
+
+    class FakeAPI:
+        def __init__(self, *_, **__):
+            self.emit_observations_calls = 0
+
+        def emit_observations(self, *_args, **_kwargs):
+            self.emit_observations_calls += 1
+            return 0
+
+    monkeypatch.setattr("defra_aurn.defra_aurn.DefraAURNAPI", FakeAPI)
+    monkeypatch.setattr(
+        "defra_aurn.defra_aurn.refresh_reference_data",
+        lambda *_a, **_kw: (fake_catalog, True),
+    )
+    monkeypatch.setattr(
+        "defra_aurn.defra_aurn.UkGovDefraAurnStationsEventProducer",
+        lambda *_a, **_kw: object(),
+    )
+    monkeypatch.setattr(
+        "defra_aurn.defra_aurn.UkGovDefraAurnTimeseriesEventProducer",
+        lambda *_a, **_kw: object(),
+    )
+
+    flushed = {"count": 0}
+
+    class FakeProducer:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def flush(self):
+            flushed["count"] += 1
+
+    monkeypatch.setattr("defra_aurn.defra_aurn.Producer", FakeProducer)
+    monkeypatch.setattr("defra_aurn.defra_aurn._load_state", lambda *_: {})
+    monkeypatch.setattr("defra_aurn.defra_aurn._save_state", lambda *_: None)
+
+    def _fail_sleep(_seconds):  # pragma: no cover - guard against retry loops
+        raise AssertionError("time.sleep must not be called when --once is set")
+
+    monkeypatch.setattr("defra_aurn.defra_aurn.time.sleep", _fail_sleep)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "feed",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=defra-aurn",
+            "--kafka-enable-tls",
+            "false",
+            "--once",
+        ]
+    )
+
+    run_feed(args)
+
+    assert flushed["count"] == 1


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- `defra-aurn/notebook/defra-aurn-feed.ipynb` — copied from the canonical `pegelonline` template with exact substitutions per `references/notebook-substitution-table.md` (PKG=`defra_aurn`, MODULE=`defra_aurn`, ARGV0=`defra-aurn`, SUBCOMMAND=`feed`, STATE/log paths under `/lakehouse/default/Files/feeder-state/defra-aurn/`).
- `catalog.json` — flipped `defra-aurn` entry to `"notebook": true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- `defra-aurn/defra_aurn/defra_aurn.py` — added `--once` / `ONCE_MODE` flag (modeled on `pegelonline/pegelonline/pegelonline.py`) so the bridge can exit after one polling cycle for scheduled Fabric notebook runs.
- `defra-aurn/tests/test_once_mode.py` — 4 new unit tests covering the new flag and single-cycle exit (mocks upstream + Kafka producer).
- `defra-aurn/kql/create-kql-script.ps1` — appended `-Qualified -Namespace uk.gov.defra.aurn` so generated tables, materialized views, ingestion mappings, and update policies are namespace-prefixed (see `docs/plan-qualified-table-names.md`, DWD reference PR #257).
- `defra-aurn/kql/defra_aurn.kql` — regenerated. `['uk.gov.defra.aurn.Station']`, `['uk.gov.defra.aurn.Timeseries']`, `['uk.gov.defra.aurn.Observation']` and matching `*Latest` materialized views. `_cloudevents_dispatch` and update-policy `type ==` predicate values unchanged.
- `defra-aurn/README.md` — added one-paragraph "Fabric notebook hosting" section linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validations performed

- Notebook JSON parses (`python -c "import json; json.load(open(...))"`).
- All 16 bridge unit tests pass, including the 4 new `tests/test_once_mode.py` tests (run inside a per-source venv with both generated producer sub-packages installed).
- Parameters cell declares `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in code cells: no `asyncio.run(`, no `%pip install`, no baked `CONNECTION_STRING=`, no `primaryConnectionString =`. (The skill's regex-based `%pip install` check also matches markdown commentary in the canonical template — verified per cell that no **code** cell contains it.)
- KQL regeneration produced `create-merge table ['uk.gov.defra.aurn.*]` for every typed table; qualified-tables guard passes.
- Consumer-asset audit: no `defra-aurn/fabric/` or `defra-aurn/dashboard/`; `notebook/` and `README.md` contain no stale unqualified table references.

## Not in scope

- No live Fabric deployment from this agent. The wheel-bundle workflow `.github/workflows/publish-notebook-wheels.yml` will pick up this source on next push to `main` and publish wheels to the `notebook-wheels` release; end-to-end Fabric verification is performed manually by the maintainer.