### PR TITLE
feat(uba-airdata): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -405,7 +405,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Germany — stations, pollutant components, hourly measures",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "wallonia-issep",

--- a/uba-airdata/README.md
+++ b/uba-airdata/README.md
@@ -76,6 +76,13 @@ uba_airdata feed --kafka-bootstrap-servers "<host:port>" --kafka-topic "uba-aird
 
 For container usage, see [CONTAINER.md](CONTAINER.md).
 
+## Fabric notebook hosting
+
+This source can also be deployed as a scheduled Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which runs `uba_airdata feed --once` on a Fabric schedule using
+`notebook/uba-airdata-feed.ipynb`.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/uba-airdata/kql/create-kql-script.ps1
+++ b/uba-airdata/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\uba_airdata.xreg.json"
 $kqlFile = Join-Path $scriptDir "uba_airdata.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/uba-airdata/kql/uba_airdata.kql
+++ b/uba-airdata/kql/uba_airdata.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['de.uba.airdata.Station'] (
    [station_id]: int,
    [station_code]: string,
    [station_name]: string,
@@ -51,9 +51,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference data for a station in the Umweltbundesamt air_data/v3 station catalog. The station payload describes the UBA station identifier, official station code, station naming, active period, WGS84 coordinates, the denormalized federal state monitoring network, and the station environment classification.\"}";
+.alter table ['de.uba.airdata.Station'] docstring "{\"description\": \"Reference data for a station in the Umweltbundesamt air_data/v3 station catalog. The station payload describes the UBA station identifier, official station code, station naming, active period, WGS84 coordinates, the denormalized federal state monitoring network, and the station environment classification.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['de.uba.airdata.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Stable numeric UBA station identifier from the 'station id' column. This is the station key used for CloudEvents subject and Kafka key.\"}",
    [station_code]: "{\"description\": \"Official station code from the 'station code' column, typically the European Environment Agency style identifier such as 'DEBE021' or 'DEBB003'.\"}",
    [station_name]: "{\"description\": \"Human-readable station name from the 'station name' column as published by UBA.\"}",
@@ -79,7 +79,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['de.uba.airdata.Station'] ingestion json mapping "de.uba.airdata.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -108,7 +108,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['de.uba.airdata.Station'] ingestion json mapping "de.uba.airdata.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -137,13 +137,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['de.uba.airdata.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['de.uba.airdata.StationLatest'] on table ['de.uba.airdata.Station'] {
+    ['de.uba.airdata.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['de.uba.airdata.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -154,7 +154,7 @@
 }]
 ```
 
-.create-merge table [Measure] (
+.create-merge table ['de.uba.airdata.Measure'] (
    [station_id]: int,
    [component_id]: int,
    [scope_id]: int,
@@ -169,9 +169,9 @@
    [___subject]: string
 );
 
-.alter table [Measure] docstring "{\"description\": \"Hourly air quality measurement record from the UBA air_data/v3 measures endpoint. The upstream API returns measurements grouped by station and measurement start time for a requested component and averaging scope.\"}";
+.alter table ['de.uba.airdata.Measure'] docstring "{\"description\": \"Hourly air quality measurement record from the UBA air_data/v3 measures endpoint. The upstream API returns measurements grouped by station and measurement start time for a requested component and averaging scope.\"}";
 
-.alter table [Measure] column-docstrings (
+.alter table ['de.uba.airdata.Measure'] column-docstrings (
    [station_id]: "{\"description\": \"Stable numeric UBA station identifier for the station that reported the measurement.\"}",
    [component_id]: "{\"description\": \"Stable numeric UBA pollutant component identifier from the first element of the measure value array, for example 5 for NO\\u2082.\"}",
    [scope_id]: "{\"description\": \"Stable numeric UBA averaging scope identifier from the second element of the measure value array. Scope 2 represents the one-hour average used by this bridge.\"}",
@@ -186,7 +186,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Measure] ingestion json mapping "Measure_json_flat"
+.create-or-alter table ['de.uba.airdata.Measure'] ingestion json mapping "de.uba.airdata.Measure_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -204,7 +204,7 @@
 ]
 ```
 
-.create-or-alter table [Measure] ingestion json mapping "Measure_json_ce_structured"
+.create-or-alter table ['de.uba.airdata.Measure'] ingestion json mapping "de.uba.airdata.Measure_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -222,13 +222,13 @@
 ]
 ```
 
-.drop materialized-view MeasureLatest ifexists;
+.drop materialized-view ['de.uba.airdata.MeasureLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MeasureLatest on table Measure {
-    Measure | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['de.uba.airdata.MeasureLatest'] on table ['de.uba.airdata.Measure'] {
+    ['de.uba.airdata.Measure'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Measure] policy update
+.alter table ['de.uba.airdata.Measure'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -239,7 +239,7 @@
 }]
 ```
 
-.create-merge table [Component] (
+.create-merge table ['de.uba.airdata.components.Component'] (
    [component_id]: int,
    [component_code]: string,
    [symbol]: string,
@@ -252,9 +252,9 @@
    [___subject]: string
 );
 
-.alter table [Component] docstring "{\"description\": \"Reference data for a pollutant component from the UBA air_data/v3 components catalog. Each component defines the stable numeric component identifier, short code, published symbol, published unit string, and English display name.\"}";
+.alter table ['de.uba.airdata.components.Component'] docstring "{\"description\": \"Reference data for a pollutant component from the UBA air_data/v3 components catalog. Each component defines the stable numeric component identifier, short code, published symbol, published unit string, and English display name.\"}";
 
-.alter table [Component] column-docstrings (
+.alter table ['de.uba.airdata.components.Component'] column-docstrings (
    [component_id]: "{\"description\": \"Stable numeric UBA component identifier from the 'component id' column. This is the CloudEvents subject and Kafka key for component events.\"}",
    [component_code]: "{\"description\": \"Short UBA component code from the 'component code' column, such as 'PM10', 'NO2', 'O3', or 'PM2'.\"}",
    [symbol]: "{\"description\": \"Published component symbol from the 'component symbol' column. This may include Unicode subscripts, for example 'PM\\u2081\\u2080' or 'NO\\u2082'.\"}",
@@ -267,7 +267,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Component] ingestion json mapping "Component_json_flat"
+.create-or-alter table ['de.uba.airdata.components.Component'] ingestion json mapping "de.uba.airdata.components.Component_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -283,7 +283,7 @@
 ]
 ```
 
-.create-or-alter table [Component] ingestion json mapping "Component_json_ce_structured"
+.create-or-alter table ['de.uba.airdata.components.Component'] ingestion json mapping "de.uba.airdata.components.Component_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -299,13 +299,13 @@
 ]
 ```
 
-.drop materialized-view ComponentLatest ifexists;
+.drop materialized-view ['de.uba.airdata.components.ComponentLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ComponentLatest on table Component {
-    Component | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['de.uba.airdata.components.ComponentLatest'] on table ['de.uba.airdata.components.Component'] {
+    ['de.uba.airdata.components.Component'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Component] policy update
+.alter table ['de.uba.airdata.components.Component'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/uba-airdata/notebook/uba-airdata-feed.ipynb
+++ b/uba-airdata/notebook/uba-airdata-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# UBA AirData Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the German Umweltbundesamt (UBA) air_data/v3 API for air-quality station catalogs, pollutant component metadata, and hourly measurements, then emits structured JSON CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `uba_airdata` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `uba_airdata feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"uba-airdata-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/uba-airdata/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/uba-airdata/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing uba_airdata package from Fabric Environment...')\n",
+    "    from uba_airdata import uba_airdata as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['uba_airdata', 'feed', '--once'] if ONCE_MODE else ['uba_airdata', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/uba-airdata/tests/test_once_mode.py
+++ b/uba-airdata/tests/test_once_mode.py
@@ -1,0 +1,116 @@
+"""Verify --once causes main() to return after a single polling cycle."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import requests_mock
+
+from uba_airdata import uba_airdata as bridge
+from tests.test_uba_airdata_unit import COMPONENTS_PAYLOAD, MEASURES_PAYLOAD, STATIONS_PAYLOAD
+
+
+def test_once_mode_runs_single_cycle(monkeypatch, tmp_path):
+    """With --once, main() must return after one cycle and call time.sleep zero times for inter-cycle pacing."""
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    monkeypatch.setenv("KAFKA_TOPIC", "uba-airdata-test")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "uba_airdata",
+            "feed",
+            "--state-file",
+            str(state_file),
+            "--polling-interval",
+            "1",
+            "--once",
+        ],
+    )
+
+    class FakeProducer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def produce(self, *args, **kwargs):
+            pass
+
+        def flush(self, *args, **kwargs):
+            pass
+
+        def poll(self, *args, **kwargs):
+            pass
+
+    sleep_calls: list[float] = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(float(seconds))
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/stations/json",
+            json=STATIONS_PAYLOAD,
+        )
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/components/json",
+            json=COMPONENTS_PAYLOAD,
+        )
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/measures/json",
+            json=MEASURES_PAYLOAD,
+        )
+
+        with patch.object(bridge, "Producer", FakeProducer), patch.object(
+            bridge.time, "sleep", side_effect=fake_sleep
+        ):
+            bridge.main()
+
+    assert sleep_calls == [], "Bridge must not sleep between cycles when --once is set"
+    assert state_file.exists(), "State file should be written during the single cycle"
+
+
+def test_once_mode_env_var(monkeypatch, tmp_path):
+    """ONCE_MODE=true env var should be equivalent to --once."""
+
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    monkeypatch.setenv("KAFKA_TOPIC", "uba-airdata-test")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setenv("STATE_FILE", str(state_file))
+    monkeypatch.setattr("sys.argv", ["uba_airdata", "feed", "--polling-interval", "1"])
+
+    class FakeProducer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def produce(self, *args, **kwargs):
+            pass
+
+        def flush(self, *args, **kwargs):
+            pass
+
+        def poll(self, *args, **kwargs):
+            pass
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/stations/json",
+            json=STATIONS_PAYLOAD,
+        )
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/components/json",
+            json=COMPONENTS_PAYLOAD,
+        )
+        mocker.get(
+            "https://www.umweltbundesamt.de/api/air_data/v3/measures/json",
+            json=MEASURES_PAYLOAD,
+        )
+
+        with patch.object(bridge, "Producer", FakeProducer), patch.object(
+            bridge.time, "sleep", lambda *_: None
+        ):
+            bridge.main()

--- a/uba-airdata/uba_airdata/uba_airdata.py
+++ b/uba-airdata/uba_airdata/uba_airdata.py
@@ -399,6 +399,12 @@ def main() -> None:
         default=int(os.getenv("REFERENCE_REFRESH_POLLS", "24")),
         help="Number of telemetry polls between reference refreshes",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command != "feed":
@@ -433,6 +439,9 @@ def main() -> None:
             elapsed = time.monotonic() - cycle_started
             sleep_seconds = max(0.0, float(args.polling_interval) - elapsed)
             logger.info("Sent %d measure events in %.2f seconds; sleeping %.2f seconds", sent, elapsed, sleep_seconds)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             if sleep_seconds > 0:
                 time.sleep(sleep_seconds)
         except KeyboardInterrupt:


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- Add `uba-airdata/notebook/uba-airdata-feed.ipynb` — verbatim copy of the canonical `pegelonline` notebook with the documented substitution table applied (package/module imports, `sys.argv`, EVENTSTREAM_NAME, STATE_FILE, LOG_PATH, title and intro paragraph). Cell structure, parameters tag, CS-lookup cell, and worker-thread run cell are unchanged.
- Add `--once` CLI flag (also honoured via the `ONCE_MODE` env var) to `uba_airdata.uba_airdata.main` so the polling loop exits after the first cycle when the Fabric scheduler triggers it.
- Add `uba-airdata/tests/test_once_mode.py` with two tests covering the `--once` flag and the `ONCE_MODE` env var path, both asserting no inter-cycle sleep occurs.
- Flip `catalog.json` `uba-airdata` entry to `"notebook": true` (inserted after `"kql"`).
- Add a one-sentence "Fabric notebook hosting" bullet to `uba-airdata/README.md` linking `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Qualified KQL tables (step 5b)

- `uba-airdata/kql/create-kql-script.ps1` now passes `-Qualified` to `tools/generate-kql-from-xreg.ps1`.
- Regenerated `uba-airdata/kql/uba_airdata.kql`: every typed table, materialized view, ingestion mapping, and update policy is now bracket-quoted with its schema namespace, e.g. `['de.uba.airdata.Station']`, `['de.uba.airdata.Measure']`, `['de.uba.airdata.components.Component']`. `_cloudevents_dispatch` and the update-policy `type ==` predicates are unchanged.
- No `-Namespace` override is passed: the two distinct schema namespaces (`de.uba.airdata` for `Station`/`Measure` and `de.uba.airdata.components` for `Component`) come from the JsonStructure schemas themselves and must be preserved.
- Consumer-asset audit: this source ships no `fabric/`, `dashboard/`, or hand-authored secondary `kql/*.kql` overlays, and `README.md` references to `Station`/`Measure`/`Component` are event-type prose, not table identifiers. Nothing else to update.

## Validated locally

- Notebook JSON parses with `json.load`.
- All bridge unit + integration tests pass (15/15), including the new `test_once_mode.py`.
- Parameters cell contains all five placeholders `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in **code cells** (`asyncio.run(`, `%pip install`, `CONNECTION_STRING =`, `primaryConnectionString = ...`). The skill's regex matches the canonical markdown commentary string `%pip install` once — verified per-cell that it appears only in markdown, never in executable code.
- Qualified-tables check passes: `create-merge table ['de.uba.airdata...` is present.

## Out of scope

No live Fabric deployment is performed; the wheel-bundle workflow will pick this source up on merge to `main`.