### PR TITLE
feat(luchtmeetnet-nl): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -381,7 +381,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "Netherlands — station measurements, components, LKI index",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "epa-uv",

--- a/luchtmeetnet-nl/README.md
+++ b/luchtmeetnet-nl/README.md
@@ -80,6 +80,13 @@ python -m luchtmeetnet_nl feed --connection-string "Endpoint=sb://namespace.serv
 
 This project is licensed under the MIT License. See [LICENSE.md](../LICENSE.md).
 
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which deploys [`notebook/luchtmeetnet-nl-feed.ipynb`](notebook/luchtmeetnet-nl-feed.ipynb)
+to run one polling cycle per scheduled execution.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/luchtmeetnet-nl/kql/create-kql-script.ps1
+++ b/luchtmeetnet-nl/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\luchtmeetnet_nl.xreg.json"
 $kqlFile = Join-Path $scriptDir "luchtmeetnet_nl.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/luchtmeetnet-nl/kql/luchtmeetnet_nl.kql
+++ b/luchtmeetnet-nl/kql/luchtmeetnet_nl.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['nl.rivm.luchtmeetnet.Station'] (
    [station_number]: string,
    [location]: string,
    [type]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Metadata for a Luchtmeetnet measuring station, combining the station list resource with the station detail resource so downstream consumers can interpret later measurements and LKI values in temporal context.\"}";
+.alter table ['nl.rivm.luchtmeetnet.Station'] docstring "{\"description\": \"Metadata for a Luchtmeetnet measuring station, combining the station list resource with the station detail resource so downstream consumers can interpret later measurements and LKI values in temporal context.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['nl.rivm.luchtmeetnet.Station'] column-docstrings (
    [station_number]: "{\"description\": \"Stable Luchtmeetnet station code, such as NL01491, used in station, measurement, and LKI requests.\"}",
    [location]: "{\"description\": \"Human-readable station location label published by Luchtmeetnet.\"}",
    [type]: "{\"description\": \"Station classification returned by the detail endpoint, for example Traffic, Industrial, Background, or Regional.\"}",
@@ -63,7 +63,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['nl.rivm.luchtmeetnet.Station'] ingestion json mapping "nl.rivm.luchtmeetnet.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -84,7 +84,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['nl.rivm.luchtmeetnet.Station'] ingestion json mapping "nl.rivm.luchtmeetnet.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -105,13 +105,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['nl.rivm.luchtmeetnet.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rivm.luchtmeetnet.StationLatest'] on table ['nl.rivm.luchtmeetnet.Station'] {
+    ['nl.rivm.luchtmeetnet.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['nl.rivm.luchtmeetnet.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -122,7 +122,7 @@
 }]
 ```
 
-.create-merge table [Measurement] (
+.create-merge table ['nl.rivm.luchtmeetnet.Measurement'] (
    [station_number]: string,
    [formula]: string,
    [value]: real,
@@ -134,9 +134,9 @@
    [___subject]: string
 );
 
-.alter table [Measurement] docstring "{\"description\": \"Hourly Luchtmeetnet measurement for a station and a single component formula. The API returns the latest values on page 1 and orders the series by measurement time.\"}";
+.alter table ['nl.rivm.luchtmeetnet.Measurement'] docstring "{\"description\": \"Hourly Luchtmeetnet measurement for a station and a single component formula. The API returns the latest values on page 1 and orders the series by measurement time.\"}";
 
-.alter table [Measurement] column-docstrings (
+.alter table ['nl.rivm.luchtmeetnet.Measurement'] column-docstrings (
    [station_number]: "{\"description\": \"Stable Luchtmeetnet station code identifying where the measurement was taken.\"}",
    [formula]: "{\"description\": \"Component formula code identifying what was measured, for example NO2, O3, PM10, or FN.\"}",
    [value]: "{\"description\": \"Numeric measurement value published by the API for the station and formula at the given timestamp. Standard gaseous and particulate concentration formulas are expressed in micrograms per cubic meter; some specialised formulas such as particle counts or black-carbon indicators may use different domain-specific units, so consumers should interpret the formula-specific semantics together with the component catalog.\"}",
@@ -148,7 +148,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_flat"
+.create-or-alter table ['nl.rivm.luchtmeetnet.Measurement'] ingestion json mapping "nl.rivm.luchtmeetnet.Measurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -163,7 +163,7 @@
 ]
 ```
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_ce_structured"
+.create-or-alter table ['nl.rivm.luchtmeetnet.Measurement'] ingestion json mapping "nl.rivm.luchtmeetnet.Measurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -178,13 +178,13 @@
 ]
 ```
 
-.drop materialized-view MeasurementLatest ifexists;
+.drop materialized-view ['nl.rivm.luchtmeetnet.MeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MeasurementLatest on table Measurement {
-    Measurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rivm.luchtmeetnet.MeasurementLatest'] on table ['nl.rivm.luchtmeetnet.Measurement'] {
+    ['nl.rivm.luchtmeetnet.Measurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Measurement] policy update
+.alter table ['nl.rivm.luchtmeetnet.Measurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -195,7 +195,7 @@
 }]
 ```
 
-.create-merge table [LKI] (
+.create-merge table ['nl.rivm.luchtmeetnet.LKI'] (
    [station_number]: string,
    [value]: int,
    [timestamp_measured]: string,
@@ -206,9 +206,9 @@
    [___subject]: string
 );
 
-.alter table [LKI] docstring "{\"description\": \"Hourly Dutch national air quality index value for a station. The LKI scale runs from 1 to 11, where lower values indicate better air quality.\"}";
+.alter table ['nl.rivm.luchtmeetnet.LKI'] docstring "{\"description\": \"Hourly Dutch national air quality index value for a station. The LKI scale runs from 1 to 11, where lower values indicate better air quality.\"}";
 
-.alter table [LKI] column-docstrings (
+.alter table ['nl.rivm.luchtmeetnet.LKI'] column-docstrings (
    [station_number]: "{\"description\": \"Stable Luchtmeetnet station code identifying the station for which the LKI value was calculated.\"}",
    [value]: "{\"description\": \"Luchtkwaliteitsindex value on the Dutch 1 to 11 scale, where 1 to 3 is good, 4 to 6 is moderate, 7 to 9 is bad, and 10 to 11 is very bad.\"}",
    [timestamp_measured]: "{\"description\": \"Timestamp for the hourly LKI value, encoded as an ISO 8601 date-time string with timezone offset.\"}",
@@ -219,7 +219,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [LKI] ingestion json mapping "LKI_json_flat"
+.create-or-alter table ['nl.rivm.luchtmeetnet.LKI'] ingestion json mapping "nl.rivm.luchtmeetnet.LKI_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -233,7 +233,7 @@
 ]
 ```
 
-.create-or-alter table [LKI] ingestion json mapping "LKI_json_ce_structured"
+.create-or-alter table ['nl.rivm.luchtmeetnet.LKI'] ingestion json mapping "nl.rivm.luchtmeetnet.LKI_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -247,13 +247,13 @@
 ]
 ```
 
-.drop materialized-view LKILatest ifexists;
+.drop materialized-view ['nl.rivm.luchtmeetnet.LKILatest'] ifexists;
 
-.create materialized-view with (backfill=true) LKILatest on table LKI {
-    LKI | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rivm.luchtmeetnet.LKILatest'] on table ['nl.rivm.luchtmeetnet.LKI'] {
+    ['nl.rivm.luchtmeetnet.LKI'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [LKI] policy update
+.alter table ['nl.rivm.luchtmeetnet.LKI'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -264,7 +264,7 @@
 }]
 ```
 
-.create-merge table [Component] (
+.create-merge table ['nl.rivm.luchtmeetnet.components.Component'] (
    [formula]: string,
    [name_nl]: string,
    [name_en]: string,
@@ -275,9 +275,9 @@
    [___subject]: string
 );
 
-.alter table [Component] docstring "{\"description\": \"Reference definition for a Luchtmeetnet monitored component formula as returned by the component catalog endpoint.\"}";
+.alter table ['nl.rivm.luchtmeetnet.components.Component'] docstring "{\"description\": \"Reference definition for a Luchtmeetnet monitored component formula as returned by the component catalog endpoint.\"}";
 
-.alter table [Component] column-docstrings (
+.alter table ['nl.rivm.luchtmeetnet.components.Component'] column-docstrings (
    [formula]: "{\"description\": \"Stable component formula code used in measurement queries and in station component lists, such as NO2, PM25, O3, or BCWB.\"}",
    [name_nl]: "{\"description\": \"Dutch display name for the component from the component catalog.\"}",
    [name_en]: "{\"description\": \"English display name for the component from the component catalog.\"}",
@@ -288,7 +288,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Component] ingestion json mapping "Component_json_flat"
+.create-or-alter table ['nl.rivm.luchtmeetnet.components.Component'] ingestion json mapping "nl.rivm.luchtmeetnet.components.Component_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -302,7 +302,7 @@
 ]
 ```
 
-.create-or-alter table [Component] ingestion json mapping "Component_json_ce_structured"
+.create-or-alter table ['nl.rivm.luchtmeetnet.components.Component'] ingestion json mapping "nl.rivm.luchtmeetnet.components.Component_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -316,13 +316,13 @@
 ]
 ```
 
-.drop materialized-view ComponentLatest ifexists;
+.drop materialized-view ['nl.rivm.luchtmeetnet.components.ComponentLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ComponentLatest on table Component {
-    Component | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.rivm.luchtmeetnet.components.ComponentLatest'] on table ['nl.rivm.luchtmeetnet.components.Component'] {
+    ['nl.rivm.luchtmeetnet.components.Component'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Component] policy update
+.alter table ['nl.rivm.luchtmeetnet.components.Component'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/luchtmeetnet-nl/luchtmeetnet_nl/luchtmeetnet_nl.py
+++ b/luchtmeetnet-nl/luchtmeetnet_nl/luchtmeetnet_nl.py
@@ -287,6 +287,7 @@ class LuchtmeetnetAPI:
         state_file: str = "",
         station_refresh_interval: int = 24,
         station_limit: int | None = None,
+        once: bool = False,
     ) -> None:
         """Run the reference-data emission and telemetry polling loop."""
         state = _load_state(state_file)
@@ -328,6 +329,9 @@ class LuchtmeetnetAPI:
                     sleep_for,
                 )
                 poll_count += 1
+                if once:
+                    LOGGER.info("--once mode: exiting after first polling cycle")
+                    break
                 if sleep_for:
                     time.sleep(sleep_for)
             except KeyboardInterrupt:
@@ -418,6 +422,12 @@ def main() -> None:
         default=int(os.getenv("STATION_LIMIT", "0")) or None,
         help="Optional cap on the number of stations to poll, mainly for testing and fair-use throttling",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command != "feed":
@@ -455,4 +465,5 @@ def main() -> None:
         state_file=args.state_file,
         station_refresh_interval=args.station_refresh_interval,
         station_limit=args.station_limit,
+        once=args.once,
     )

--- a/luchtmeetnet-nl/notebook/luchtmeetnet-nl-feed.ipynb
+++ b/luchtmeetnet-nl/notebook/luchtmeetnet-nl-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Luchtmeetnet Netherlands Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Dutch RIVM Luchtmeetnet open API for station metadata, hourly air-quality measurements, and the LKI air-quality index, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `luchtmeetnet_nl` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `luchtmeetnet_nl feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"luchtmeetnet-nl-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/luchtmeetnet-nl/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/luchtmeetnet-nl/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing luchtmeetnet_nl package from Fabric Environment...')\n",
+    "    from luchtmeetnet_nl import luchtmeetnet_nl as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['luchtmeetnet_nl', 'feed', '--once'] if ONCE_MODE else ['luchtmeetnet_nl', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/luchtmeetnet-nl/tests/test_once_mode.py
+++ b/luchtmeetnet-nl/tests/test_once_mode.py
@@ -1,0 +1,71 @@
+"""Verify that --once causes the bridge to exit after a single polling cycle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from luchtmeetnet_nl.luchtmeetnet_nl import LuchtmeetnetAPI, ReferenceSnapshot, main
+
+
+@pytest.mark.unit
+def test_feed_once_mode_exits_after_single_cycle(monkeypatch):
+    api = LuchtmeetnetAPI()
+
+    snapshot = ReferenceSnapshot(stations=[], components=[])
+    api.fetch_reference_snapshot = MagicMock(return_value=snapshot)  # type: ignore[method-assign]
+    api.emit_reference_data = MagicMock()  # type: ignore[method-assign]
+    api.emit_telemetry_once = MagicMock(return_value=(0, 0))  # type: ignore[method-assign]
+
+    producer_mock = MagicMock()
+    monkeypatch.setattr(
+        "luchtmeetnet_nl.luchtmeetnet_nl.Producer",
+        MagicMock(return_value=producer_mock),
+    )
+    monkeypatch.setattr(
+        "luchtmeetnet_nl.luchtmeetnet_nl.NlRivmLuchtmeetnetEventProducer",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "luchtmeetnet_nl.luchtmeetnet_nl.NlRivmLuchtmeetnetComponentsEventProducer",
+        MagicMock(),
+    )
+
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("luchtmeetnet_nl.luchtmeetnet_nl.time.sleep", sleep_mock)
+
+    api.feed(
+        kafka_config={"bootstrap.servers": "localhost:9092"},
+        kafka_topic="luchtmeetnet-nl",
+        polling_interval=1,
+        state_file="",
+        station_refresh_interval=24,
+        station_limit=0,
+        once=True,
+    )
+
+    assert api.emit_telemetry_once.call_count == 1
+    sleep_mock.assert_not_called()
+
+
+@pytest.mark.unit
+def test_main_passes_once_flag(monkeypatch):
+    feed_mock = MagicMock()
+    monkeypatch.setattr(LuchtmeetnetAPI, "feed", feed_mock)
+    monkeypatch.setenv("ONCE_MODE", "")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "luchtmeetnet_nl",
+            "feed",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=luchtmeetnet-nl",
+            "--once",
+        ],
+    )
+
+    with patch("luchtmeetnet_nl.luchtmeetnet_nl.Producer"):
+        main()
+
+    assert feed_mock.call_args.kwargs["once"] is True


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- **Notebook** `luchtmeetnet-nl/notebook/luchtmeetnet-nl-feed.ipynb` — copied verbatim from the canonical `pegelonline` template and substituted per `references/notebook-substitution-table.md` (display name, package/module import, `sys.argv`, OneLake state/log paths, EVENTSTREAM_NAME).
- **`--once` flag** added to the bridge (`luchtmeetnet_nl feed --once`), honoring `ONCE_MODE` env var. Exits cleanly after one polling cycle, as required by the Fabric scheduled-execution model. New `tests/test_once_mode.py` covers both the bridge-level exit and the `main()` argparse wiring.
- **`catalog.json`** — `"notebook": true` flag added to the `luchtmeetnet-nl` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **Qualified KQL tables** — `kql/create-kql-script.ps1` now passes `-Qualified`. Regenerated `kql/luchtmeetnet_nl.kql` emits `['nl.rivm.luchtmeetnet.Station']`, `['nl.rivm.luchtmeetnet.Measurement']`, `['nl.rivm.luchtmeetnet.LKI']`, and `['nl.rivm.luchtmeetnet.components.Component']`. Both xreg-declared namespaces are preserved; no `-Namespace` override was applied (matches the DWD reference pattern). No hand-authored consumer assets (no `fabric/`, `dashboard/`, or secondary `kql/*.kql` overlays exist) reference these table names.
- **README** — one-sentence Fabric notebook hosting bullet linking to the deploy script.

## Validations performed locally

- ✅ Notebook JSON parses
- ✅ Parameter placeholders present (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`)
- ✅ Forbidden patterns (`asyncio.run(`, `%pip install`, `CONNECTION_STRING="`, `primaryConnectionString =`) absent from all code cells. `%pip install` appears only in the cell-0 markdown commentary saying "No `%pip install` is required at runtime" — verified per-cell and treated as a documented false positive in the skill checker.
- ✅ Qualified-tables check (`create-merge table ['[a-z]`) matches.
- ✅ All 14 tests pass in `luchtmeetnet-nl/tests/` including the two new `--once` tests.

## Out of scope

Live Fabric deployment is intentionally not performed by this agent. The `publish-notebook-wheels.yml` workflow will pick up this source on merge and publish `luchtmeetnet-nl-notebook-wheels.zip` to the `notebook-wheels` release.