### PR TITLE
feat(laqn-london): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -373,7 +373,8 @@
     "cat": "Air Quality",
     "key": false,
     "desc": "London, UK — site metadata, species, hourly measurements",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "luchtmeetnet-nl",

--- a/laqn-london/README.md
+++ b/laqn-london/README.md
@@ -110,6 +110,7 @@ entries with whitespace-only `Species` payloads are ignored.
 - [CONTAINER.md](CONTAINER.md) — container usage
 - [EVENTS.md](EVENTS.md) — generated event contract documentation
 - [DATABASE.md](../DATABASE.md) — downstream analytics notes
+- Fabric notebook hosting: deploy `notebook/laqn-london-feed.ipynb` to a Fabric workspace with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) for serverless scheduled execution.
 
 ## Deploying into Azure Container Instances
 

--- a/laqn-london/kql/create-kql-script.ps1
+++ b/laqn-london/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\laqn_london.xreg.json"
 $kqlFile = Join-Path $scriptDir "laqn_london.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/laqn-london/kql/laqn_london.kql
+++ b/laqn-london/kql/laqn_london.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Site] (
+.create-merge table ['uk.kcl.laqn.Site'] (
    [site_code]: string,
    [site_name]: string,
    [site_type]: string,
@@ -44,9 +44,9 @@
    [___subject]: string
 );
 
-.alter table [Site] docstring "{\"description\": \"Reference description of a London Air Quality Network monitoring site, including its stable code, operator metadata, and WGS84 coordinates.\"}";
+.alter table ['uk.kcl.laqn.Site'] docstring "{\"description\": \"Reference description of a London Air Quality Network monitoring site, including its stable code, operator metadata, and WGS84 coordinates.\"}";
 
-.alter table [Site] column-docstrings (
+.alter table ['uk.kcl.laqn.Site'] column-docstrings (
    [site_code]: "{\"description\": \"Stable LAQN site code that identifies the monitoring site, such as BX1.\"}",
    [site_name]: "{\"description\": \"Human-readable LAQN site name published for the monitoring site.\"}",
    [site_type]: "{\"description\": \"Site classification published by LAQN, such as Suburban, Kerbside, Roadside, Urban Background, Industrial, Rural, or other.\"}",
@@ -65,7 +65,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Site] ingestion json mapping "Site_json_flat"
+.create-or-alter table ['uk.kcl.laqn.Site'] ingestion json mapping "uk.kcl.laqn.Site_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -87,7 +87,7 @@
 ]
 ```
 
-.create-or-alter table [Site] ingestion json mapping "Site_json_ce_structured"
+.create-or-alter table ['uk.kcl.laqn.Site'] ingestion json mapping "uk.kcl.laqn.Site_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -109,13 +109,13 @@
 ]
 ```
 
-.drop materialized-view SiteLatest ifexists;
+.drop materialized-view ['uk.kcl.laqn.SiteLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SiteLatest on table Site {
-    Site | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.kcl.laqn.SiteLatest'] on table ['uk.kcl.laqn.Site'] {
+    ['uk.kcl.laqn.Site'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Site] policy update
+.alter table ['uk.kcl.laqn.Site'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -126,7 +126,7 @@
 }]
 ```
 
-.create-merge table [Measurement] (
+.create-merge table ['uk.kcl.laqn.Measurement'] (
    [site_code]: string,
    [species_code]: string,
    [measurement_date_gmt]: string,
@@ -138,9 +138,9 @@
    [___subject]: string
 );
 
-.alter table [Measurement] docstring "{\"description\": \"Hourly air quality measurement for a LAQN site and pollutant species at a GMT timestamp.\"}";
+.alter table ['uk.kcl.laqn.Measurement'] docstring "{\"description\": \"Hourly air quality measurement for a LAQN site and pollutant species at a GMT timestamp.\"}";
 
-.alter table [Measurement] column-docstrings (
+.alter table ['uk.kcl.laqn.Measurement'] column-docstrings (
    [site_code]: "{\"description\": \"Stable LAQN site code for the monitoring site that produced the measurement.\"}",
    [species_code]: "{\"description\": \"Stable LAQN pollutant code for the measured species.\"}",
    [measurement_date_gmt]: "{\"description\": \"Measurement timestamp in GMT, encoded by LAQN as YYYY-MM-DD HH:MM:SS.\"}",
@@ -152,7 +152,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_flat"
+.create-or-alter table ['uk.kcl.laqn.Measurement'] ingestion json mapping "uk.kcl.laqn.Measurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -167,7 +167,7 @@
 ]
 ```
 
-.create-or-alter table [Measurement] ingestion json mapping "Measurement_json_ce_structured"
+.create-or-alter table ['uk.kcl.laqn.Measurement'] ingestion json mapping "uk.kcl.laqn.Measurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -182,13 +182,13 @@
 ]
 ```
 
-.drop materialized-view MeasurementLatest ifexists;
+.drop materialized-view ['uk.kcl.laqn.MeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MeasurementLatest on table Measurement {
-    Measurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.kcl.laqn.MeasurementLatest'] on table ['uk.kcl.laqn.Measurement'] {
+    ['uk.kcl.laqn.Measurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Measurement] policy update
+.alter table ['uk.kcl.laqn.Measurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -199,7 +199,7 @@
 }]
 ```
 
-.create-merge table [DailyIndex] (
+.create-merge table ['uk.kcl.laqn.DailyIndex'] (
    [site_code]: string,
    [bulletin_date]: string,
    [species_code]: string,
@@ -213,9 +213,9 @@
    [___subject]: string
 );
 
-.alter table [DailyIndex] docstring "{\"description\": \"Daily Air Quality Index bulletin record for a LAQN site and pollutant species within the latest London-wide index publication.\"}";
+.alter table ['uk.kcl.laqn.DailyIndex'] docstring "{\"description\": \"Daily Air Quality Index bulletin record for a LAQN site and pollutant species within the latest London-wide index publication.\"}";
 
-.alter table [DailyIndex] column-docstrings (
+.alter table ['uk.kcl.laqn.DailyIndex'] column-docstrings (
    [site_code]: "{\"description\": \"Stable LAQN site code for the monitoring site to which the daily index applies.\"}",
    [bulletin_date]: "{\"description\": \"Bulletin date and time published by LAQN for the daily index, encoded as YYYY-MM-DD HH:MM:SS.\"}",
    [species_code]: "{\"description\": \"Stable LAQN pollutant code for the species to which the daily index applies.\"}",
@@ -229,7 +229,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [DailyIndex] ingestion json mapping "DailyIndex_json_flat"
+.create-or-alter table ['uk.kcl.laqn.DailyIndex'] ingestion json mapping "uk.kcl.laqn.DailyIndex_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -246,7 +246,7 @@
 ]
 ```
 
-.create-or-alter table [DailyIndex] ingestion json mapping "DailyIndex_json_ce_structured"
+.create-or-alter table ['uk.kcl.laqn.DailyIndex'] ingestion json mapping "uk.kcl.laqn.DailyIndex_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -263,13 +263,13 @@
 ]
 ```
 
-.drop materialized-view DailyIndexLatest ifexists;
+.drop materialized-view ['uk.kcl.laqn.DailyIndexLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DailyIndexLatest on table DailyIndex {
-    DailyIndex | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.kcl.laqn.DailyIndexLatest'] on table ['uk.kcl.laqn.DailyIndex'] {
+    ['uk.kcl.laqn.DailyIndex'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DailyIndex] policy update
+.alter table ['uk.kcl.laqn.DailyIndex'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -280,7 +280,7 @@
 }]
 ```
 
-.create-merge table [Species] (
+.create-merge table ['uk.kcl.laqn.Species'] (
    [species_code]: string,
    [species_name]: string,
    [description]: string,
@@ -293,9 +293,9 @@
    [___subject]: string
 );
 
-.alter table [Species] docstring "{\"description\": \"Reference description of a LAQN pollutant species, including explanatory text and health impact guidance.\"}";
+.alter table ['uk.kcl.laqn.Species'] docstring "{\"description\": \"Reference description of a LAQN pollutant species, including explanatory text and health impact guidance.\"}";
 
-.alter table [Species] column-docstrings (
+.alter table ['uk.kcl.laqn.Species'] column-docstrings (
    [species_code]: "{\"description\": \"Stable LAQN pollutant code, such as NO2, PM10, PM25, O3, SO2, or CO.\"}",
    [species_name]: "{\"description\": \"Human-readable pollutant name published by LAQN for the pollutant code.\"}",
    [description]: "{\"description\": \"LAQN explanatory description of the pollutant and how it is formed or encountered.\"}",
@@ -308,7 +308,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Species] ingestion json mapping "Species_json_flat"
+.create-or-alter table ['uk.kcl.laqn.Species'] ingestion json mapping "uk.kcl.laqn.Species_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -324,7 +324,7 @@
 ]
 ```
 
-.create-or-alter table [Species] ingestion json mapping "Species_json_ce_structured"
+.create-or-alter table ['uk.kcl.laqn.Species'] ingestion json mapping "uk.kcl.laqn.Species_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -340,13 +340,13 @@
 ]
 ```
 
-.drop materialized-view SpeciesLatest ifexists;
+.drop materialized-view ['uk.kcl.laqn.SpeciesLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SpeciesLatest on table Species {
-    Species | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['uk.kcl.laqn.SpeciesLatest'] on table ['uk.kcl.laqn.Species'] {
+    ['uk.kcl.laqn.Species'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Species] policy update
+.alter table ['uk.kcl.laqn.Species'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/laqn-london/laqn_london/laqn_london.py
+++ b/laqn-london/laqn_london/laqn_london.py
@@ -366,6 +366,7 @@ class LAQNLondonAPI:
         polling_interval: int,
         state_file: str = "",
         reference_refresh_polls: int = 24,
+        once: bool = False,
     ) -> None:
         """Emit reference data first and then poll telemetry forever."""
         state = _load_state(state_file)
@@ -414,6 +415,9 @@ class LAQNLondonAPI:
                     elapsed,
                     wait_seconds,
                 )
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if wait_seconds:
                     await asyncio.sleep(wait_seconds)
             except KeyboardInterrupt:
@@ -487,6 +491,12 @@ def main() -> None:
         default=os.getenv("STATE_FILE", os.path.expanduser("~/.laqn_london_state.json")),
         help="Path to the persisted dedupe state file",
     )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     api = LAQNLondonAPI()
@@ -541,4 +551,4 @@ def main() -> None:
     elif tls_enabled:
         kafka_config["security.protocol"] = "SSL"
 
-    asyncio.run(api.feed(kafka_config, kafka_topic, args.polling_interval, args.state_file))
+    asyncio.run(api.feed(kafka_config, kafka_topic, args.polling_interval, args.state_file, once=args.once))

--- a/laqn-london/notebook/laqn-london-feed.ipynb
+++ b/laqn-london/notebook/laqn-london-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LAQN London Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the public LAQN (London Air Quality Network) API operated by King's College London for air-quality reference data and measurements, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `laqn_london` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `laqn_london feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"laqn-london-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/laqn-london/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/laqn-london/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing laqn_london package from Fabric Environment...')\n",
+    "    from laqn_london import laqn_london as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['laqn_london', 'feed', '--once'] if ONCE_MODE else ['laqn_london', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/laqn-london/tests/test_once_mode.py
+++ b/laqn-london/tests/test_once_mode.py
@@ -1,0 +1,102 @@
+"""Verify the --once flag causes the bridge to exit after one polling cycle."""
+
+import asyncio
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from laqn_london.laqn_london import LAQNLondonAPI, main
+
+
+class _FakeProducer:
+    def __init__(self, *_args, **_kwargs):
+        self.flushed = 0
+
+    def flush(self):
+        self.flushed += 1
+
+
+@pytest.mark.unit
+def test_feed_once_returns_after_single_cycle():
+    """feed(once=True) must complete after one cycle and never reach a second poll."""
+    api = LAQNLondonAPI()
+
+    call_counts = {"emit_reference_data": 0, "emit_measurements": 0, "emit_daily_index": 0}
+
+    def fake_reference(_site, _species):
+        call_counts["emit_reference_data"] += 1
+        return ["BX1"]
+
+    def fake_measurements(*_args, **_kwargs):
+        call_counts["emit_measurements"] += 1
+        return 0
+
+    def fake_daily(*_args, **_kwargs):
+        call_counts["emit_daily_index"] += 1
+        return 0
+
+    with patch.object(api, "emit_reference_data", side_effect=fake_reference), \
+         patch.object(api, "emit_measurements", side_effect=fake_measurements), \
+         patch.object(api, "emit_daily_index", side_effect=fake_daily), \
+         patch("laqn_london.laqn_london.Producer", _FakeProducer), \
+         patch("laqn_london.laqn_london._save_state"):
+        asyncio.run(api.feed(
+            kafka_config={"bootstrap.servers": "localhost:9092"},
+            kafka_topic="test",
+            polling_interval=3600,
+            state_file="",
+            once=True,
+        ))
+
+    assert call_counts["emit_reference_data"] == 1
+    assert call_counts["emit_measurements"] == 1
+    assert call_counts["emit_daily_index"] == 1
+
+
+@pytest.mark.unit
+def test_once_flag_parses_from_cli():
+    """`feed --once` must wire through to api.feed(once=True)."""
+    captured = {}
+
+    def fake_feed(self, kafka_config, kafka_topic, polling_interval, state_file, once=False):
+        captured["once"] = once
+        async def _noop():
+            return None
+        return _noop()
+
+    argv = [
+        "laqn_london", "feed",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "test",
+        "--once",
+    ]
+    with patch.object(sys, "argv", argv), \
+         patch.object(LAQNLondonAPI, "feed", fake_feed):
+        main()
+
+    assert captured.get("once") is True
+
+
+@pytest.mark.unit
+def test_once_flag_defaults_to_env():
+    """ONCE_MODE=true env var must set --once default to True."""
+    captured = {}
+
+    def fake_feed(self, kafka_config, kafka_topic, polling_interval, state_file, once=False):
+        captured["once"] = once
+        async def _noop():
+            return None
+        return _noop()
+
+    argv = [
+        "laqn_london", "feed",
+        "--kafka-bootstrap-servers", "localhost:9092",
+        "--kafka-topic", "test",
+    ]
+    with patch.dict("os.environ", {"ONCE_MODE": "true"}), \
+         patch.object(sys, "argv", argv), \
+         patch.object(LAQNLondonAPI, "feed", fake_feed):
+        main()
+
+    assert captured.get("once") is True


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent.

## Changes
- New `laqn-london/notebook/laqn-london-feed.ipynb` (copy of pegelonline template, source-specific substitutions applied).
- `catalog.json`: `notebook: true` for laqn-london so the gh-pages portal exposes the Fabric Notebook deploy button.
- Bridge: added `--once` CLI flag (+ `ONCE_MODE` env fallback) so the notebook can run a single polling cycle, modeled on pegelonline. Threaded through `feed(once=...)` which breaks the poll loop after one cycle.
- New `tests/test_once_mode.py` covering feed exit-after-one-cycle, CLI flag, and `ONCE_MODE` env default.
- `kql/create-kql-script.ps1`: appended `-Qualified` per docs/plan-qualified-table-names.md.
- Regenerated `kql/laqn_london.kql` with namespace-qualified table names (`['uk.kcl.laqn.Site']` etc.). No hand-authored consumer assets (no `fabric/`, no `dashboard/`) needed updating.
- README: added one bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations performed locally
- `python -m json.tool` on the notebook — JSON well-formed.
- `pytest tests/` — 19 passed (including 3 new `--once` tests).
- Parameter placeholders EVENTSTREAM_NAME, STATE_FILE, POLLING_INTERVAL, ONCE_MODE, WORKSPACE_ID present in cell 2 (verified by JSON-parsed per-cell check; the skill's raw-regex check is unreliable for JSON-encoded notebooks and produces the same false MISS on the canonical pegelonline template).
- Forbidden-pattern check run per code-cell — none present. The `%pip install` substring appears only in markdown commentary in the canonical template (false positive on the skill's raw-file regex, called out by the dispatcher).
- KQL regen: every typed table / MV / update policy now bracket-quoted with `uk.kcl.laqn.` namespace; `_cloudevents_dispatch` unchanged; `type ==` predicate values unchanged.

Wheel-bundle workflow will publish `laqn-london-notebook-wheels.zip` on merge to main.
