### PR TITLE
feat(australia-wildfires): Fabric notebook hosting

### DIFF
--- a/australia-wildfires/README.md
+++ b/australia-wildfires/README.md
@@ -29,6 +29,10 @@ All three endpoints are public GeoJSON feeds requiring no authentication.
 
 See [EVENTS.md](EVENTS.md) for the full event catalog.
 
+## Fabric notebook hosting
+
+This source ships a Fabric notebook (`notebook/australia-wildfires-feed.ipynb`) deployable via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) for serverless polling inside a Fabric workspace.
+
 ## Running
 
 ```bash

--- a/australia-wildfires/australia_wildfires/australia_wildfires.py
+++ b/australia-wildfires/australia_wildfires/australia_wildfires.py
@@ -446,6 +446,9 @@ def main():
     parser.add_argument("--state-file", type=str,
                         default=os.environ.get("STATE_FILE",
                                                os.path.expanduser("~/.australia_wildfires_state.json")))
+    parser.add_argument("--once", action="store_true",
+                        default=os.environ.get("ONCE_MODE", "false").lower() in ("true", "1", "yes"),
+                        help="Run a single polling cycle and exit (used by Fabric notebook hosting)")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List current incidents")
     subparsers.add_parser("feed", help="Feed data to Kafka")
@@ -491,6 +494,9 @@ def main():
                 logger.info("Sent %d fire incident events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once specified; exiting after single cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/australia-wildfires/kql/australia_wildfires.kql
+++ b/australia-wildfires/kql/australia_wildfires.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [FireIncident] (
+.create-merge table ['AU.Gov.Emergency.Wildfires.FireIncident'] (
    [incident_id]: string,
    [state]: string,
    [title]: string,
@@ -46,9 +46,9 @@
    [___subject]: string
 );
 
-.alter table [FireIncident] docstring "{\"description\": \"Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.\"}";
+.alter table ['AU.Gov.Emergency.Wildfires.FireIncident'] docstring "{\"description\": \"Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.\"}";
 
-.alter table [FireIncident] column-docstrings (
+.alter table ['AU.Gov.Emergency.Wildfires.FireIncident'] column-docstrings (
    [incident_id]: "{\"description\": \"Stable identifier for the fire incident, derived from the source system. NSW: numeric incident ID extracted from the RFS GUID URL. VIC: numeric sourceId from the VicEmergency feed. QLD: alphanumeric UniqueID from the QFD feed (e.g. 'IF39-5661721').\"}",
    [state]: "{\"description\": \"Australian state abbreviation indicating which emergency service reported this incident. One of 'NSW' (New South Wales Rural Fire Service), 'VIC' (VicEmergency / Country Fire Authority / Fire Rescue Victoria), or 'QLD' (Queensland Fire Department).\"}",
    [title]: "{\"description\": \"Human-readable title or headline for the incident as provided by the source agency. NSW: location-based title from the RFS feed (e.g. '(GWYDIR HWY), MATHESON'). VIC: warning name or sourceTitle from VicEmergency. QLD: WarningTitle from the QFD feed.\"}",
@@ -69,7 +69,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [FireIncident] ingestion json mapping "FireIncident_json_flat"
+.create-or-alter table ['AU.Gov.Emergency.Wildfires.FireIncident'] ingestion json mapping "AU.Gov.Emergency.Wildfires.FireIncident_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -93,7 +93,7 @@
 ]
 ```
 
-.create-or-alter table [FireIncident] ingestion json mapping "FireIncident_json_ce_structured"
+.create-or-alter table ['AU.Gov.Emergency.Wildfires.FireIncident'] ingestion json mapping "AU.Gov.Emergency.Wildfires.FireIncident_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -117,13 +117,13 @@
 ]
 ```
 
-.drop materialized-view FireIncidentLatest ifexists;
+.drop materialized-view ['AU.Gov.Emergency.Wildfires.FireIncidentLatest'] ifexists;
 
-.create materialized-view with (backfill=true) FireIncidentLatest on table FireIncident {
-    FireIncident | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['AU.Gov.Emergency.Wildfires.FireIncidentLatest'] on table ['AU.Gov.Emergency.Wildfires.FireIncident'] {
+    ['AU.Gov.Emergency.Wildfires.FireIncident'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [FireIncident] policy update
+.alter table ['AU.Gov.Emergency.Wildfires.FireIncident'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/australia-wildfires/notebook/australia-wildfires-feed.ipynb
+++ b/australia-wildfires/notebook/australia-wildfires-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Australian Wildfires Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls live bushfire incident feeds from three Australian state emergency services (NSW Rural Fire Service, VicEmergency, Queensland Fire Department) and emits normalized FireIncident CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `australia_wildfires` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `australia-wildfires feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"australia-wildfires-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/australia-wildfires/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/australia-wildfires/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing australia_wildfires package from Fabric Environment...')\n",
+    "    from australia_wildfires import australia_wildfires as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['australia-wildfires', 'feed', '--once'] if ONCE_MODE else ['australia-wildfires', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/australia-wildfires/tests/test_once_mode.py
+++ b/australia-wildfires/tests/test_once_mode.py
@@ -1,0 +1,65 @@
+"""Test that --once causes main() to exit after a single polling cycle."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from australia_wildfires import australia_wildfires as bridge
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch):
+    """`--once` must cause main() to return after exactly one feed_incidents call."""
+    monkeypatch.setattr(sys, "argv", [
+        "australia-wildfires", "--connection-string",
+        "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--once", "feed",
+    ])
+
+    fetch_count = {"n": 0}
+
+    def fake_feed_incidents(api, producer, state):
+        fetch_count["n"] += 1
+        return 0
+
+    sleep_calls = {"n": 0}
+
+    def fake_sleep(seconds):
+        sleep_calls["n"] += 1
+        raise AssertionError("time.sleep must not be called when --once is set")
+
+    fake_producer = MagicMock()
+    fake_event_producer = MagicMock()
+
+    with patch.object(bridge, "feed_incidents", side_effect=fake_feed_incidents), \
+         patch.object(bridge, "Producer", return_value=fake_producer), \
+         patch.object(bridge, "AUGovEmergencyWildfiresEventProducer",
+                       return_value=fake_event_producer), \
+         patch.object(bridge.time, "sleep", side_effect=fake_sleep):
+        bridge.main()
+
+    assert fetch_count["n"] == 1, "Expected exactly one polling cycle"
+    assert sleep_calls["n"] == 0, "time.sleep must not run when --once is set"
+
+
+def test_once_via_env_var(monkeypatch):
+    """ONCE_MODE=true env should produce the same single-cycle behaviour."""
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr(sys, "argv", [
+        "australia-wildfires", "--connection-string",
+        "BootstrapServer=localhost:9092;EntityPath=test-topic", "feed",
+    ])
+
+    cycles = {"n": 0}
+
+    def fake_feed_incidents(api, producer, state):
+        cycles["n"] += 1
+        return 0
+
+    with patch.object(bridge, "feed_incidents", side_effect=fake_feed_incidents), \
+         patch.object(bridge, "Producer", return_value=MagicMock()), \
+         patch.object(bridge, "AUGovEmergencyWildfiresEventProducer",
+                       return_value=MagicMock()), \
+         patch.object(bridge.time, "sleep",
+                       side_effect=AssertionError("sleep must not run")):
+        bridge.main()
+
+    assert cycles["n"] == 1

--- a/catalog.json
+++ b/catalog.json
@@ -421,7 +421,8 @@
     "cat": "Disasters",
     "key": false,
     "desc": "Australia — NSW, QLD, VIC bushfire incidents",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "eaws-albina",


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent for source `australia-wildfires`.

## Changes
- `australia-wildfires/notebook/australia-wildfires-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` with mechanical substitutions (package/module/argv/state-path/display-name).
- `catalog.json` — `notebook: true` added after `kql` for the `australia-wildfires` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- Bridge: added `--once` CLI flag (also honors `ONCE_MODE` env var) — required by Fabric notebook scheduled execution; modeled on `pegelonline`.
- `tests/test_once_mode.py` — new unit tests asserting `--once`/`ONCE_MODE` cause `main()` to return after exactly one polling cycle with no `time.sleep` call.
- `kql/australia_wildfires.kql` — regenerated with `-Qualified -Namespace AU.Gov.Emergency.Wildfires` so all tables, MVs, mappings, and update policies are prefixed (single messagegroup namespace in xreg).
- `australia-wildfires/README.md` — one-line bullet pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validation (per `.github/skills/notebook-feeder-retrofit/SKILL.md`)
- Notebook JSON well-formed ✅
- All 5 parameters cell placeholders present (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) ✅
- Forbidden patterns absent in **code cells**: `asyncio.run(`, `%pip install`, literal `CONNECTION_STRING =`, `primaryConnectionString =` ✅
  - Note: the `%pip install` substring appears in the **markdown** intro cell as documentation (`No %pip install is required at runtime`). Per-cell verification confirms no code cell contains it — this is the known false positive flagged by the skill orchestrator.
- Bridge tests: `61 passed` (includes 2 new `test_once_mode` tests) ✅

## Deviations from default skill
- `--once` flag added to bridge (skill explicitly allows this; modeled on pegelonline).
- KQL regeneration with `-Qualified -Namespace AU.Gov.Emergency.Wildfires` performed as the mandated step 5b. xreg has a single messagegroup so a namespace value was supplied.

## Out of scope
- No live Fabric deployment (per skill section 7). The wheel-publish workflow will pick this source on merge to main.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>