### PR TITLE
feat(kmi-belgium): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -261,7 +261,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Belgium — ~14 AWS stations, 10-min observations",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "meteoalarm",

--- a/kmi-belgium/README.md
+++ b/kmi-belgium/README.md
@@ -65,3 +65,7 @@ Build or pull the image and configure it with environment variables as documente
 ### Option 3: Deploy to Azure Container Instances
 
 Run the published container image in Azure Container Instances or another container host and bind a persistent volume for the state file.
+
+### Option 4: Fabric notebook hosting
+
+Deploy as a scheduled Microsoft Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) — see [`notebook/kmi-belgium-feed.ipynb`](notebook/kmi-belgium-feed.ipynb).

--- a/kmi-belgium/kmi_belgium/kmi_belgium.py
+++ b/kmi-belgium/kmi_belgium/kmi_belgium.py
@@ -256,7 +256,11 @@ def main():
                         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.kmi_belgium_state.json")))
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List active stations")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+                             help="Exit after one polling cycle (also via ONCE_MODE env var). "
+                                  "Useful for scheduled execution in Fabric notebooks.")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
     api = KMIBelgiumAPI(polling_interval=args.polling_interval)
@@ -295,6 +299,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if getattr(args, "once", False):
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         logger.info("%s", parser.format_help().rstrip())

--- a/kmi-belgium/kql/create-kql-script.ps1
+++ b/kmi-belgium/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\kmi_belgium.xreg.json"
 $kqlFile = Join-Path $scriptDir "kmi_belgium.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "BE.Gov.KMI.Weather"

--- a/kmi-belgium/kql/kmi_belgium.kql
+++ b/kmi-belgium/kql/kmi_belgium.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['BE.Gov.KMI.Weather.Station'] (
    [station_code]: string,
    [latitude]: real,
    [longitude]: real,
@@ -36,9 +36,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for a KMI/RMI automatic weather station derived from the latest aws:aws_10min observation features published through the public WFS service.\"}";
+.alter table ['BE.Gov.KMI.Weather.Station'] docstring "{\"description\": \"Reference metadata for a KMI/RMI automatic weather station derived from the latest aws:aws_10min observation features published through the public WFS service.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['BE.Gov.KMI.Weather.Station'] column-docstrings (
    [station_code]: "{\"description\": \"KMI/RMI automatic weather station code from the GeoJSON feature property `code`, unique within the Belgian AWS network.\"}",
    [latitude]: "{\"description\": \"Geographic latitude of the station in decimal degrees (WGS 84), derived from the second value of the GeoJSON `geometry.coordinates` array.\"}",
    [longitude]: "{\"description\": \"Geographic longitude of the station in decimal degrees (WGS 84), derived from the first value of the GeoJSON `geometry.coordinates` array.\"}",
@@ -49,7 +49,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['BE.Gov.KMI.Weather.Station'] ingestion json mapping "BE.Gov.KMI.Weather.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -63,7 +63,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['BE.Gov.KMI.Weather.Station'] ingestion json mapping "BE.Gov.KMI.Weather.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -77,13 +77,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['BE.Gov.KMI.Weather.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['BE.Gov.KMI.Weather.StationLatest'] on table ['BE.Gov.KMI.Weather.Station'] {
+    ['BE.Gov.KMI.Weather.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['BE.Gov.KMI.Weather.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -94,7 +94,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['BE.Gov.KMI.Weather.WeatherObservation'] (
    [station_code]: string,
    [observation_time]: datetime,
    [precip_quantity]: real,
@@ -121,9 +121,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"Ten-minute automatic weather station observation from the KMI/RMI aws:aws_10min feed, containing precipitation, temperature, wind, humidity, pressure, radiation, and soil measurements.\"}";
+.alter table ['BE.Gov.KMI.Weather.WeatherObservation'] docstring "{\"description\": \"Ten-minute automatic weather station observation from the KMI/RMI aws:aws_10min feed, containing precipitation, temperature, wind, humidity, pressure, radiation, and soil measurements.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['BE.Gov.KMI.Weather.WeatherObservation'] column-docstrings (
    [station_code]: "{\"description\": \"KMI/RMI automatic weather station code from the `code` property of the reporting observation feature.\"}",
    [observation_time]: "{\"description\": \"Observation timestamp in UTC from the feature property `timestamp`.\"}",
    [precip_quantity]: "{\"description\": \"Precipitation quantity reported for the 10-minute observation period.\"}",
@@ -150,7 +150,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['BE.Gov.KMI.Weather.WeatherObservation'] ingestion json mapping "BE.Gov.KMI.Weather.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -180,7 +180,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['BE.Gov.KMI.Weather.WeatherObservation'] ingestion json mapping "BE.Gov.KMI.Weather.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -210,13 +210,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['BE.Gov.KMI.Weather.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['BE.Gov.KMI.Weather.WeatherObservationLatest'] on table ['BE.Gov.KMI.Weather.WeatherObservation'] {
+    ['BE.Gov.KMI.Weather.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['BE.Gov.KMI.Weather.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/kmi-belgium/notebook/kmi-belgium-feed.ipynb
+++ b/kmi-belgium/notebook/kmi-belgium-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KMI Belgium Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Royal Meteorological Institute of Belgium (KMI/RMI) open-data OGC WFS endpoint for ~14 automatic weather stations on a 10-minute cadence and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `kmi_belgium` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `kmi-belgium feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"kmi-belgium-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/kmi-belgium/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/kmi-belgium/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing kmi_belgium package from Fabric Environment...')\n",
+    "    from kmi_belgium import kmi_belgium as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['kmi-belgium', 'feed', '--once'] if ONCE_MODE else ['kmi-belgium', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/kmi-belgium/tests/test_once_mode.py
+++ b/kmi-belgium/tests/test_once_mode.py
@@ -1,0 +1,49 @@
+"""Verify the ``--once`` flag exits the polling loop after one cycle.
+
+This guards the contract relied on by the Fabric notebook hosting option,
+which runs ``kmi-belgium feed --once`` on a schedule and expects the
+process to exit after a single polling cycle.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+# Re-use the stubs configured in test_kmi_belgium so the bridge module imports.
+from . import test_kmi_belgium  # noqa: F401
+
+from kmi_belgium import kmi_belgium as bridge
+
+
+def test_feed_once_exits_after_single_cycle():
+    call_count = {"feed": 0, "sleep": 0}
+
+    def fake_feed(api, producer, previous_readings):
+        call_count["feed"] += 1
+        return 0
+
+    def fake_sleep(_seconds):
+        call_count["sleep"] += 1
+        raise AssertionError("time.sleep must not be called when --once is set")
+
+    argv = [
+        "kmi-belgium",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=kmi-belgium",
+        "--state-file", "/tmp/kmi-belgium-test-state.json",
+        "feed", "--once",
+    ]
+
+    with patch.object(bridge, "Producer", lambda *a, **kw: object()), \
+         patch.object(bridge, "BEGovKMIWeatherEventProducer", lambda *a, **kw: object()), \
+         patch.object(bridge, "KMIBelgiumAPI", lambda *a, **kw: object()), \
+         patch.object(bridge, "send_stations", lambda api, producer: None), \
+         patch.object(bridge, "feed_observations", fake_feed), \
+         patch.object(bridge, "_load_state", lambda path: {}), \
+         patch.object(bridge, "_save_state", lambda path, state: None), \
+         patch.object(bridge.time, "sleep", fake_sleep), \
+         patch.object(sys, "argv", argv):
+        bridge.main()
+
+    assert call_count["feed"] == 1, f"expected exactly one feed cycle, got {call_count['feed']}"
+    assert call_count["sleep"] == 0, "time.sleep must not run in --once mode"


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (.github/skills/notebook-feeder-retrofit/SKILL.md) for source `kmi-belgium`.

## Changes
- `kmi-belgium/notebook/kmi-belgium-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per `references/notebook-substitution-table.md` (package `kmi_belgium`, module `kmi_belgium`, argv-0 `kmi-belgium`, subcommand `feed`, display `KMI Belgium`, Lakehouse paths under `feeder-state/kmi-belgium/`).
- `catalog.json` — added `"notebook": true` to the `kmi-belgium` entry after `"kql": true`.
- `kmi-belgium/kmi_belgium/kmi_belgium.py` — added `--once` flag (also reads `ONCE_MODE` env var) to the `feed` subcommand, breaks the polling loop after one cycle. Bridge was eligible (poll-based, `time.sleep`); flag added per skill allowance.
- `kmi-belgium/tests/test_once_mode.py` — new unit test asserting `feed --once` calls `feed_observations` exactly once and never calls `time.sleep`.
- `kmi-belgium/kql/create-kql-script.ps1` + regenerated `kmi-belgium/kql/kmi_belgium.kql` — regenerated with `-Qualified -Namespace BE.Gov.KMI.Weather` (xreg has a single `BE.Gov.KMI.Weather` messagegroup namespace), so tables are now `[BE.Gov.KMI.Weather.Station]` and `[BE.Gov.KMI.Weather.WeatherObservation]`.
- `kmi-belgium/README.md` — one-sentence bullet for Fabric notebook hosting.

## Validations (local)
- ✅ Notebook JSON well-formed (`json.load`).
- ✅ Bridge test suite passes (`python -m pytest tests/ -x`: 5 passed).
- ✅ New `test_once_mode.py` passes.
- ✅ Parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- ✅ Forbidden patterns: `asyncio.run(`, `CONNECTION_STRING="…"`, baked `primaryConnectionString` — none present. `%pip install` appears only inside a markdown sentence stating it is **not** used at runtime (per-cell verified false positive).
- ✅ Cell structure unchanged (4 cells; CS-lookup, worker-thread, OneLake log path layout preserved).

## Out of scope
No live Fabric deployment; the wheel-publish workflow handles wheel bundling on merge. Manual end-to-end Fabric verification is a separate serial step.