### PR TITLE
feat(dwd-pollenflug): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -218,7 +218,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Germany — daily pollen forecasts, 27 regions",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "environment-canada",

--- a/dwd-pollenflug/README.md
+++ b/dwd-pollenflug/README.md
@@ -34,6 +34,7 @@ Intensity values range from 0 (no load) to 3 (high load) with intermediate half-
 - **Deduplication**: Tracks the `last_update` timestamp to avoid reprocessing unchanged data.
 - **Kafka Integration**: Sends forecasts to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: Can run as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) (`--once` single-cycle execution).
 
 ## Installation
 

--- a/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
+++ b/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
@@ -227,8 +227,13 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        help="Run a single polling cycle and exit (used by scheduled hosts e.g. Fabric notebooks)")
 
     args = parser.parse_args()
+
+    once_env = os.getenv('ONCE_MODE', '').strip().lower() in ('1', 'true', 'yes')
+    once = bool(args.once or once_env)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
@@ -275,7 +280,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=once)
 
 
 if __name__ == "__main__":

--- a/dwd-pollenflug/kql/create-kql-script.ps1
+++ b/dwd-pollenflug/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\dwd_pollenflug.xreg.json"
 $kqlFile = Join-Path $scriptDir "dwd_pollenflug.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace DE.DWD.Pollenflug

--- a/dwd-pollenflug/kql/dwd_pollenflug.kql
+++ b/dwd-pollenflug/kql/dwd_pollenflug.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Region] (
+.create-merge table ['DE.DWD.Pollenflug.Region'] (
    [region_id]: int,
    [region_name]: string,
    [partregion_id]: int,
@@ -37,9 +37,9 @@
    [___subject]: string
 );
 
-.alter table [Region] docstring "{\"description\": \"Reference data for a DWD pollen forecast region or sub-region. Germany is divided into 11 main regions, some of which are subdivided into 2\\u20134 sub-regions for a total of 27 forecast areas. Emitted at bridge startup so downstream consumers can correlate forecast events with region metadata.\"}";
+.alter table ['DE.DWD.Pollenflug.Region'] docstring "{\"description\": \"Reference data for a DWD pollen forecast region or sub-region. Germany is divided into 11 main regions, some of which are subdivided into 2\\u20134 sub-regions for a total of 27 forecast areas. Emitted at bridge startup so downstream consumers can correlate forecast events with region metadata.\"}";
 
-.alter table [Region] column-docstrings (
+.alter table ['DE.DWD.Pollenflug.Region'] column-docstrings (
    [region_id]: "{\"description\": \"Unique numeric identifier for the forecast area. For regions without sub-regions this is the main region_id (e.g. 20 for Mecklenburg-Vorpommern). For sub-regions it is the partregion_id (e.g. 11 for 'Inseln und Marschen' within Schleswig-Holstein). Derived from the DWD JSON fields region_id and partregion_id.\"}",
    [region_name]: "{\"description\": \"Name of the main geographic region as published by DWD (e.g. 'Schleswig-Holstein und Hamburg', 'Bayern'). Sourced from the 'region_name' field in the DWD API response.\"}",
    [partregion_id]: "{\"description\": \"Numeric identifier of the sub-region within the parent region. Set to -1 by DWD when the region has no sub-divisions; the bridge emits null in that case. Sourced from the 'partregion_id' field in the DWD API response.\"}",
@@ -51,7 +51,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Region] ingestion json mapping "Region_json_flat"
+.create-or-alter table ['DE.DWD.Pollenflug.Region'] ingestion json mapping "DE.DWD.Pollenflug.Region_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -66,7 +66,7 @@
 ]
 ```
 
-.create-or-alter table [Region] ingestion json mapping "Region_json_ce_structured"
+.create-or-alter table ['DE.DWD.Pollenflug.Region'] ingestion json mapping "DE.DWD.Pollenflug.Region_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -81,13 +81,13 @@
 ]
 ```
 
-.drop materialized-view RegionLatest ifexists;
+.drop materialized-view ['DE.DWD.Pollenflug.RegionLatest'] ifexists;
 
-.create materialized-view with (backfill=true) RegionLatest on table Region {
-    Region | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.DWD.Pollenflug.RegionLatest'] on table ['DE.DWD.Pollenflug.Region'] {
+    ['DE.DWD.Pollenflug.Region'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Region] policy update
+.alter table ['DE.DWD.Pollenflug.Region'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -98,7 +98,7 @@
 }]
 ```
 
-.create-merge table [PollenForecast] (
+.create-merge table ['DE.DWD.Pollenflug.PollenForecast'] (
    [region_id]: int,
    [region_name]: string,
    [last_update]: string,
@@ -135,9 +135,9 @@
    [___subject]: string
 );
 
-.alter table [PollenForecast] docstring "{\"description\": \"Daily pollen forecast for a single German region or sub-region, published by the Deutscher Wetterdienst (DWD). Contains intensity values for eight pollen types across three forecast days (today, tomorrow, day after tomorrow). Intensity is on a scale from 0 (no load) to 3 (high load) with intermediate half-step ranges such as '0-1', '1-2', '2-3'. The bridge maps the German pollen names from the upstream API to English equivalents.\"}";
+.alter table ['DE.DWD.Pollenflug.PollenForecast'] docstring "{\"description\": \"Daily pollen forecast for a single German region or sub-region, published by the Deutscher Wetterdienst (DWD). Contains intensity values for eight pollen types across three forecast days (today, tomorrow, day after tomorrow). Intensity is on a scale from 0 (no load) to 3 (high load) with intermediate half-step ranges such as '0-1', '1-2', '2-3'. The bridge maps the German pollen names from the upstream API to English equivalents.\"}";
 
-.alter table [PollenForecast] column-docstrings (
+.alter table ['DE.DWD.Pollenflug.PollenForecast'] column-docstrings (
    [region_id]: "{\"description\": \"Unique numeric identifier for the forecast area. Same identity model as Region: uses partregion_id when the area is a sub-region, otherwise uses the main region_id.\"}",
    [region_name]: "{\"description\": \"Display name of the forecast area. Uses partregion_name when available, otherwise region_name.\"}",
    [last_update]: "{\"description\": \"Timestamp of the last forecast update as published by DWD, e.g. '2025-04-08 11:00 Uhr'. Retained as a string because the upstream format includes the German suffix 'Uhr'.\"}",
@@ -174,7 +174,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [PollenForecast] ingestion json mapping "PollenForecast_json_flat"
+.create-or-alter table ['DE.DWD.Pollenflug.PollenForecast'] ingestion json mapping "DE.DWD.Pollenflug.PollenForecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -214,7 +214,7 @@
 ]
 ```
 
-.create-or-alter table [PollenForecast] ingestion json mapping "PollenForecast_json_ce_structured"
+.create-or-alter table ['DE.DWD.Pollenflug.PollenForecast'] ingestion json mapping "DE.DWD.Pollenflug.PollenForecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -254,13 +254,13 @@
 ]
 ```
 
-.drop materialized-view PollenForecastLatest ifexists;
+.drop materialized-view ['DE.DWD.Pollenflug.PollenForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) PollenForecastLatest on table PollenForecast {
-    PollenForecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.DWD.Pollenflug.PollenForecastLatest'] on table ['DE.DWD.Pollenflug.PollenForecast'] {
+    ['DE.DWD.Pollenflug.PollenForecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [PollenForecast] policy update
+.alter table ['DE.DWD.Pollenflug.PollenForecast'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/dwd-pollenflug/notebook/dwd-pollenflug-feed.ipynb
+++ b/dwd-pollenflug/notebook/dwd-pollenflug-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DWD Pollenflug Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Deutscher Wetterdienst (DWD) open-data pollen forecast API for daily pollen-load forecasts across 27 German regions and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `dwd_pollenflug` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `dwd-pollenflug --once`, exits after one polling cycle, and persists dedupe state (the last seen `last_update` timestamp) to a Lakehouse Files path so the next scheduled run only emits when DWD publishes a new forecast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"dwd-pollenflug-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/dwd-pollenflug/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/dwd-pollenflug/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing dwd_pollenflug package from Fabric Environment...')\n",
+    "    from dwd_pollenflug import dwd_pollenflug as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['dwd-pollenflug', '--once'] if ONCE_MODE else ['dwd-pollenflug']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/dwd-pollenflug/tests/test_once_mode.py
+++ b/dwd-pollenflug/tests/test_once_mode.py
@@ -1,0 +1,85 @@
+"""Tests for the --once / ONCE_MODE single-cycle execution path.
+
+Used by the Fabric notebook host, which invokes the bridge once per
+scheduled run instead of running an in-process polling loop.
+"""
+
+import json
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+SAMPLE_RESPONSE = {
+    "last_update": "2025-04-08 11:00 Uhr",
+    "next_update": "2025-04-09 11:00 Uhr",
+    "sender": "Deutscher Wetterdienst - Medizin-Meteorologie",
+    "content": [
+        {
+            "region_id": 10,
+            "region_name": "Schleswig-Holstein und Hamburg",
+            "partregion_id": 11,
+            "partregion_name": "Inseln und Marschen",
+            "Pollen": {
+                "Hasel": {"today": "0", "tomorrow": "0", "dayafter_to": "0"},
+            },
+        },
+    ],
+}
+
+
+def _patched_main_returns(argv, env=None):
+    """Invoke main() with the given argv/env and a fully mocked stack.
+
+    The polling loop must exit after exactly one cycle. The test fails
+    fast (via the time.sleep mock raising) if the loop iterates again.
+    """
+    env = env or {}
+
+    def _fake_sleep(_seconds):
+        raise AssertionError("Polling loop should not sleep when --once is set")
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = SAMPLE_RESPONSE
+    fake_response.raise_for_status.return_value = None
+
+    fake_producer_cls = MagicMock()
+    fake_kafka_producer_cls = MagicMock()
+
+    with patch.dict(sys.modules, {
+        "confluent_kafka": MagicMock(Producer=fake_kafka_producer_cls),
+    }), patch.dict("os.environ", env, clear=False), \
+         patch("dwd_pollenflug.dwd_pollenflug.requests.get", return_value=fake_response), \
+         patch("dwd_pollenflug.dwd_pollenflug.DEDWDPollenflugEventProducer", fake_producer_cls), \
+         patch("dwd_pollenflug.dwd_pollenflug.time.sleep", side_effect=_fake_sleep), \
+         patch.object(sys, "argv", argv):
+        from dwd_pollenflug.dwd_pollenflug import main
+        main()
+
+
+def test_once_flag_exits_after_one_cycle(tmp_path):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "dwd-pollenflug",
+        "--once",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--last-polled-file", str(state_file),
+    ]
+    # Disable TLS so the bridge does not try to configure SSL.
+    _patched_main_returns(argv, env={"KAFKA_ENABLE_TLS": "false"})
+    # State must have been persisted on the single cycle.
+    assert state_file.exists()
+    persisted = json.loads(state_file.read_text())
+    assert persisted.get("last_update") == SAMPLE_RESPONSE["last_update"]
+
+
+def test_once_mode_env_var_exits_after_one_cycle(tmp_path):
+    state_file = tmp_path / "state.json"
+    argv = [
+        "dwd-pollenflug",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--last-polled-file", str(state_file),
+    ]
+    _patched_main_returns(argv, env={"KAFKA_ENABLE_TLS": "false", "ONCE_MODE": "true"})
+    assert state_file.exists()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` skill for source `dwd-pollenflug`.

## Changes

- `dwd-pollenflug/notebook/dwd-pollenflug-feed.ipynb` — copy of canonical `pegelonline/notebook/pegelonline-feed.ipynb` with the exact substitutions from `references/notebook-substitution-table.md` (no subcommand variant: `sys.argv = ['dwd-pollenflug', '--once']`).
- `catalog.json` — added `notebook: true` after `kql` for the `dwd-pollenflug` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py` — added `--once` CLI flag and `ONCE_MODE` env-var fallback (existing `poll_and_send(once=...)` already supported single-cycle exit).
- `dwd-pollenflug/tests/test_once_mode.py` — new unit tests asserting `--once` and `ONCE_MODE=true` cause `main()` to return after exactly one cycle (`time.sleep` mock raises on second iteration).
- `dwd-pollenflug/kql/create-kql-script.ps1` + `dwd-pollenflug/kql/dwd_pollenflug.kql` — regenerated with `-Qualified -Namespace DE.DWD.Pollenflug` so tables/MVs/mappings are prefixed (`[DE.DWD.Pollenflug.Region]`, `[DE.DWD.Pollenflug.PollenForecast]`) and don't collide with other feeders in a shared Eventhouse.
- `dwd-pollenflug/README.md` — added one-sentence Fabric notebook hosting bullet linking to the deploy script.

## Validation performed locally

- Notebook JSON parses (`json.load`).
- `catalog.json` parses.
- `python -m pytest tests/ -x -q` → **54 passed** (52 pre-existing + 2 new `test_once_mode` cases).
- Parameters cell contains all required placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden-pattern sweep (per-cell, code cells only): no `asyncio.run(`, no `%pip install`, no hardcoded `CONNECTION_STRING = "..."`, no `primaryConnectionString = ...` assignment. The `%pip install` and `primaryConnectionString` occurrences in markdown commentary / load-bearing CS-lookup code are copied verbatim from the pegelonline template and are documented false positives (per skill instructions).
- KQL regeneration verified: all source tables (`Region`, `PollenForecast`), materialized views, and ingestion mappings are now namespace-qualified.

## Deviations

- The bridge had no `--once` flag, so one was added (allowed per skill §'Add `--once` if missing'). Modeled after `pegelonline`.
- The bridge has no subcommand (entry point is `dwd-pollenflug` with flags), so the notebook uses the `Variant: bridge with no subcommand` form from the substitution table.

## Not done (out of scope per skill)

No live Fabric deployment. The wheel-bundle workflow ( `.github/workflows/publish-notebook-wheels.yml` ) will publish `dwd-pollenflug-notebook-wheels.zip` on merge to main; end-to-end Fabric verification is a separate manual step.