### PR TITLE
feat(singapore-nea): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -309,7 +309,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Singapore — 62 weather stations + 5 air-quality regions",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "smhi-weather",

--- a/singapore-nea/README.md
+++ b/singapore-nea/README.md
@@ -70,3 +70,7 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fsingapore-nea%2Fazure-template-with-eventhub.json)
+
+## Fabric notebook hosting
+
+This source can also run as a scheduled Microsoft Fabric notebook (single-cycle execution per run). Deploy via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1); the notebook template lives at [`notebook/singapore-nea-feed.ipynb`](notebook/singapore-nea-feed.ipynb).

--- a/singapore-nea/notebook/singapore-nea-feed.ipynb
+++ b/singapore-nea/notebook/singapore-nea-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Singapore NEA Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Singapore National Environment Agency (NEA) data.gov.sg APIs for real-time weather observations (62 stations) and regional air quality (PSI and PM2.5 across 5 regions), and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `singapore_nea` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `singapore-nea feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"singapore-nea-ingest\"   # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/singapore-nea/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/singapore-nea/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing singapore_nea package from Fabric Environment...')\n",
+    "    from singapore_nea import singapore_nea as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['singapore-nea', 'feed', '--once'] if ONCE_MODE else ['singapore-nea', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/singapore-nea/singapore_nea/singapore_nea.py
+++ b/singapore-nea/singapore_nea/singapore_nea.py
@@ -319,6 +319,12 @@ def main():
         type=str,
         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.singapore_nea_state.json")),
     )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List weather stations")
     subparsers.add_parser("list-air-quality", help="List air quality regions")
@@ -375,6 +381,9 @@ def main():
         now + AIR_QUALITY_REFERENCE_REFRESH_INTERVAL if airquality_event_producer else float("inf")
     )
 
+    did_weather = False
+    did_airquality = not bool(airquality_event_producer)
+
     while True:
         now = time.monotonic()
         next_due = min(next_weather_poll, next_airquality_poll, next_airquality_region_refresh)
@@ -385,6 +394,7 @@ def main():
         state_changed = False
 
         if now >= next_weather_poll:
+            did_weather = True
             next_weather_poll = now + args.polling_interval
             try:
                 count = feed_observations(weather_api, weather_event_producer, weather_state)
@@ -401,6 +411,7 @@ def main():
                 logger.error("Error refreshing air quality regions: %s", exc)
 
         if airquality_event_producer and now >= next_airquality_poll:
+            did_airquality = True
             next_airquality_poll = now + args.airquality_polling_interval
             try:
                 psi_count = fetch_and_send_psi(air_quality_api, airquality_event_producer, psi_state)
@@ -420,6 +431,10 @@ def main():
 
         if state_changed:
             _save_state(args.state_file, _compose_state(weather_state, psi_state, pm25_state))
+
+        if args.once and did_weather and did_airquality:
+            logger.info("--once mode: exiting after first polling cycle")
+            break
 
 
 if __name__ == "__main__":

--- a/singapore-nea/tests/test_once_mode.py
+++ b/singapore-nea/tests/test_once_mode.py
@@ -1,0 +1,76 @@
+"""Tests for --once / ONCE_MODE single-cycle execution."""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from singapore_nea import singapore_nea as bridge
+
+
+@pytest.fixture
+def fake_kafka(monkeypatch):
+    fake = MagicMock()
+    monkeypatch.setattr(bridge, "Producer", lambda *a, **kw: fake)
+    return fake
+
+
+def _run_main_with_argv(argv, monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    # --state-file is a top-level parser arg; insert before the subcommand
+    if "feed" in argv:
+        idx = argv.index("feed")
+        argv = argv[:idx] + ["--state-file", str(state_file)] + argv[idx:]
+    else:
+        argv = argv + ["--state-file", str(state_file)]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    monkeypatch.setattr(bridge, "send_stations", lambda *a, **kw: 0)
+    monkeypatch.setattr(bridge, "fetch_and_send_regions", lambda *a, **kw: 0)
+    monkeypatch.setattr(bridge, "feed_observations", lambda *a, **kw: 0)
+    monkeypatch.setattr(bridge, "fetch_and_send_psi", lambda *a, **kw: 0)
+    monkeypatch.setattr(bridge, "fetch_and_send_pm25", lambda *a, **kw: 0)
+
+    def _no_sleep(_seconds):
+        raise AssertionError("--once mode should not sleep between cycles")
+
+    monkeypatch.setattr(bridge.time, "sleep", _no_sleep)
+
+    bridge.main()
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch, tmp_path, fake_kafka):
+    argv = [
+        "singapore-nea",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--topic", "test-topic",
+        "--airquality-topic", "test-airquality",
+        "--once",
+        "feed",
+    ]
+    _run_main_with_argv(argv, monkeypatch, tmp_path)
+
+
+def test_once_mode_env_var(monkeypatch, tmp_path, fake_kafka):
+    monkeypatch.setenv("ONCE_MODE", "true")
+    argv = [
+        "singapore-nea",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--topic", "test-topic",
+        "--airquality-topic", "test-airquality",
+        "feed",
+    ]
+    _run_main_with_argv(argv, monkeypatch, tmp_path)
+
+
+def test_once_without_airquality(monkeypatch, tmp_path, fake_kafka):
+    argv = [
+        "singapore-nea",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=test-topic",
+        "--topic", "test-topic",
+        "--airquality-topic", "",
+        "--once",
+        "feed",
+    ]
+    _run_main_with_argv(argv, monkeypatch, tmp_path)


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes
- `singapore-nea/notebook/singapore-nea-feed.ipynb` — copied from the canonical pegelonline template with the documented substitutions (display name, package/module, `sys.argv`, lakehouse paths, eventstream name).
- `singapore-nea/singapore_nea/singapore_nea.py` — added `--once` flag (with `ONCE_MODE` env-var fallback) so the bridge exits cleanly after one polling cycle of both weather and air-quality, modeled on pegelonline.
- `singapore-nea/tests/test_once_mode.py` — new unit tests covering `--once` flag, `ONCE_MODE` env, and once-mode with air quality disabled.
- `catalog.json` — `notebook: true` for `singapore-nea` (inserted after `kql`).
- `singapore-nea/README.md` — one-sentence Fabric notebook hosting bullet linking to the deploy script.
- `singapore-nea/kql/singapore_nea.kql` — regenerated with `-Qualified` per upgrade directive (no `-Namespace` because xreg has two messagegroup namespaces); content unchanged on disk.

## Validations performed locally
- Notebook JSON parses with `json.load`.
- All 23 bridge tests pass (`pytest tests/`), including the 3 new once-mode tests.
- Parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns: no `asyncio.run(`, no `%pip install` in any cell, no hard-coded `CONNECTION_STRING=`, no `primaryConnectionString =` assignment.

## Not done (by skill design)
- No live Fabric deployment. The `publish-notebook-wheels.yml` workflow picks up this source on merge and publishes wheels to the `notebook-wheels` release; the portal exposes the button once `update-ghpages-catalog.yml` syncs the flag.