### PR TITLE
feat(eaws-albina): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -429,7 +429,8 @@
     "cat": "Disasters",
     "key": false,
     "desc": "European Alps — daily avalanche bulletins, CAAMLv6",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "gdacs",

--- a/eaws-albina/README.md
+++ b/eaws-albina/README.md
@@ -28,6 +28,10 @@ See [EVENTS.md](EVENTS.md) for the full event schema documentation.
 
 See [CONTAINER.md](CONTAINER.md) for Docker deployment instructions and environment variable reference.
 
+## Fabric notebook hosting
+
+This source ships a Fabric notebook (`notebook/eaws-albina-feed.ipynb`) that runs the bridge on a Fabric schedule with `--once` semantics. Deploy via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Local Development
 
 ```bash

--- a/eaws-albina/eaws_albina/eaws_albina.py
+++ b/eaws-albina/eaws_albina/eaws_albina.py
@@ -242,8 +242,14 @@ class AlbinaPoller:
             self.kafka_producer.flush()
         return count
 
-    def poll_and_send(self):
-        """Main loop: emit region catalog once, then poll today and yesterday on a schedule."""
+    def poll_and_send(self, once: bool = False):
+        """Emit region catalog once, then poll today and yesterday.
+
+        When ``once`` is True the loop runs exactly one polling cycle and
+        returns, which is the execution model used by the Fabric notebook
+        scheduler. Otherwise it runs forever, sleeping ``POLL_INTERVAL_SECONDS``
+        between cycles.
+        """
         print(f"Starting EAWS ALBINA Avalanche Bulletin poller, polling every {POLL_INTERVAL_SECONDS}s")
         print(f"  Regions: {self.regions}")
         print(f"  Language: {self.lang}")
@@ -263,6 +269,10 @@ class AlbinaPoller:
                         print(f"Sent {count} bulletin event(s) for {date_str}")
             except Exception as e:
                 print(f"Error in polling loop: {e}")
+
+            if once:
+                print("--once mode: exiting after first polling cycle")
+                return
 
             time.sleep(POLL_INTERVAL_SECONDS)
 
@@ -315,6 +325,12 @@ def main():
         help="Comma-separated region codes (default: AT-07,IT-32-BZ,IT-32-TN,AT-02)",
     )
     parser.add_argument("--lang", type=str, default="en", help="Language code (default: en)")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
 
@@ -375,7 +391,7 @@ def main():
         regions=regions,
         lang=lang,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/eaws-albina/kql/eaws_albina.kql
+++ b/eaws-albina/kql/eaws_albina.kql
@@ -25,7 +25,80 @@
 ]
 ```
 
-.create-merge table [AvalancheBulletin] (
+.create-merge table ['org.EAWS.ALBINA.AvalancheRegion'] (
+   [region_id]: string,
+   [lang]: string,
+   [configured_at]: datetime,
+   [bulletin_base_url]: string,
+   [___type]: string,
+   [___source]: string,
+   [___id]: string,
+   [___time]: datetime,
+   [___subject]: string
+);
+
+.alter table ['org.EAWS.ALBINA.AvalancheRegion'] docstring "{\"description\": \"Reference record describing an EAWS region (or super-region) the bridge is configured to observe. Emitted at startup so that downstream consumers know the regional context even in summer months when no daily bulletins are published.\"}";
+
+.alter table ['org.EAWS.ALBINA.AvalancheRegion'] column-docstrings (
+   [region_id]: "{\"description\": \"EAWS region identifier (country prefix plus warning service code), e.g. AT-07 for Tirol, IT-32-BZ for South Tyrol. Matches the regionID used in CAAMLv6 bulletins.\"}",
+   [lang]: "{\"description\": \"ISO 639-1 language code used by the bridge when requesting bulletins for this region (de, en, it, fr, etc.).\"}",
+   [configured_at]: "{\"description\": \"ISO 8601 UTC timestamp when this region was registered in the bridge configuration. Updated whenever the bridge starts and re-emits its catalog.\"}",
+   [bulletin_base_url]: "{\"description\": \"Base URL used by the bridge to fetch CAAMLv6 bulletins for this region (typically https://avalanche.report/albina_files). Null when not provided.\"}",
+   [___type] : 'Event type',
+   [___source]: 'Context origin/source of the event',
+   [___id]: 'Event identifier',
+   [___time]: 'Event generation time',
+   [___subject]: 'Context subject of the event'
+);
+
+.create-or-alter table ['org.EAWS.ALBINA.AvalancheRegion'] ingestion json mapping "org.EAWS.ALBINA.AvalancheRegion_json_flat"
+```
+[
+  {"column": "___type", "path": "$.type"},
+  {"column": "___source", "path": "$.source"},
+  {"column": "___id", "path": "$.id"},
+  {"column": "___time", "path": "$.time"},
+  {"column": "___subject", "path": "$.subject"},
+  {"column": "region_id", "path": "$.region_id"},
+  {"column": "lang", "path": "$.lang"},
+  {"column": "configured_at", "path": "$.configured_at"},
+  {"column": "bulletin_base_url", "path": "$.bulletin_base_url"},
+]
+```
+
+.create-or-alter table ['org.EAWS.ALBINA.AvalancheRegion'] ingestion json mapping "org.EAWS.ALBINA.AvalancheRegion_json_ce_structured"
+```
+[
+  {"column": "___type", "path": "$.type"},
+  {"column": "___source", "path": "$.source"},
+  {"column": "___id", "path": "$.id"},
+  {"column": "___time", "path": "$.time"},
+  {"column": "___subject", "path": "$.subject"},
+  {"column": "region_id", "path": "$.data.region_id"},
+  {"column": "lang", "path": "$.data.lang"},
+  {"column": "configured_at", "path": "$.data.configured_at"},
+  {"column": "bulletin_base_url", "path": "$.data.bulletin_base_url"},
+]
+```
+
+.drop materialized-view ['org.EAWS.ALBINA.AvalancheRegionLatest'] ifexists;
+
+.create materialized-view with (backfill=true) ['org.EAWS.ALBINA.AvalancheRegionLatest'] on table ['org.EAWS.ALBINA.AvalancheRegion'] {
+    ['org.EAWS.ALBINA.AvalancheRegion'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
+}
+
+.alter table ['org.EAWS.ALBINA.AvalancheRegion'] policy update
+```
+[{
+  "IsEnabled": true,
+  "Source": "_cloudevents_dispatch",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'org.EAWS.ALBINA.AvalancheRegion') | project['region_id'] = tostring(data.['region_id']),['lang'] = tostring(data.['lang']),['configured_at'] = todatetime(data.['configured_at']),['bulletin_base_url'] = tostring(data.['bulletin_base_url']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "IsTransactional": false,
+  "PropagateIngestionProperties": true,
+}]
+```
+
+.create-merge table ['org.EAWS.ALBINA.AvalancheBulletin'] (
    [region_id]: string,
    [region_name]: string,
    [bulletin_id]: string,
@@ -48,7 +121,7 @@
    [___subject]: string
 );
 
-.alter table [AvalancheBulletin] column-docstrings (
+.alter table ['org.EAWS.ALBINA.AvalancheBulletin'] column-docstrings (
    [region_id]: "{\"description\": \"EAWS micro-region identifier from the CAAMLv6 regions array, e.g. AT-07-04-02 for Karwendel Mountains East.\"}",
    [region_name]: "{\"description\": \"Human-readable name of the EAWS micro-region, e.g. 'Karwendel Mountains East'.\"}",
    [bulletin_id]: "{\"description\": \"Unique UUID assigned to this bulletin by the ALBINA system, from the CAAMLv6 bulletinID field.\"}",
@@ -71,7 +144,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [AvalancheBulletin] ingestion json mapping "AvalancheBulletin_json_flat"
+.create-or-alter table ['org.EAWS.ALBINA.AvalancheBulletin'] ingestion json mapping "org.EAWS.ALBINA.AvalancheBulletin_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -97,7 +170,7 @@
 ]
 ```
 
-.create-or-alter table [AvalancheBulletin] ingestion json mapping "AvalancheBulletin_json_ce_structured"
+.create-or-alter table ['org.EAWS.ALBINA.AvalancheBulletin'] ingestion json mapping "org.EAWS.ALBINA.AvalancheBulletin_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -123,13 +196,13 @@
 ]
 ```
 
-.drop materialized-view AvalancheBulletinLatest ifexists;
+.drop materialized-view ['org.EAWS.ALBINA.AvalancheBulletinLatest'] ifexists;
 
-.create materialized-view with (backfill=true) AvalancheBulletinLatest on table AvalancheBulletin {
-    AvalancheBulletin | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['org.EAWS.ALBINA.AvalancheBulletinLatest'] on table ['org.EAWS.ALBINA.AvalancheBulletin'] {
+    ['org.EAWS.ALBINA.AvalancheBulletin'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [AvalancheBulletin] policy update
+.alter table ['org.EAWS.ALBINA.AvalancheBulletin'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/eaws-albina/notebook/eaws-albina-feed.ipynb
+++ b/eaws-albina/notebook/eaws-albina-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EAWS ALBINA Avalanche Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the EAWS ALBINA avalanche.report CAAMLv6 API for daily avalanche bulletins across European Alps regions and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `eaws_albina` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `eaws-albina --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new bulletins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"eaws-albina-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/eaws-albina/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/eaws-albina/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing eaws_albina package from Fabric Environment...')\n",
+    "    from eaws_albina import eaws_albina as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['eaws-albina', '--once'] if ONCE_MODE else ['eaws-albina']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/eaws-albina/tests/test_once_mode.py
+++ b/eaws-albina/tests/test_once_mode.py
@@ -1,0 +1,89 @@
+"""Tests that the bridge supports single-cycle execution via --once / ONCE_MODE.
+
+These cover the contract required by the Fabric notebook scheduler: the
+``poll_and_send`` loop must return after exactly one polling cycle when
+``once=True``, and the ``main()`` argparse plumbing must accept the
+``--once`` flag and the ``ONCE_MODE`` env var.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class OnceModeUnitTests(unittest.TestCase):
+    def test_poll_and_send_once_returns_after_one_cycle(self):
+        from eaws_albina.eaws_albina import AlbinaPoller
+
+        with patch.object(AlbinaPoller, "__init__", lambda self, *a, **kw: None):
+            poller = AlbinaPoller.__new__(AlbinaPoller)
+            poller.regions = ["AT-07"]
+            poller.lang = "en"
+            poller.kafka_topic = "test"
+            poller.emit_region_catalog = MagicMock(return_value=1)
+            poller.fetch_and_send = MagicMock(return_value=0)
+
+            with patch("eaws_albina.eaws_albina.time.sleep") as sleep_mock:
+                poller.poll_and_send(once=True)
+
+            sleep_mock.assert_not_called()
+            # Today + yesterday => exactly 2 fetch_and_send calls in one cycle
+            self.assertEqual(poller.fetch_and_send.call_count, 2)
+            poller.emit_region_catalog.assert_called_once()
+
+    def test_main_accepts_once_flag(self):
+        from eaws_albina import eaws_albina as bridge
+
+        captured = {}
+
+        class _FakePoller:
+            def __init__(self, **kwargs):
+                captured["init"] = kwargs
+
+            def poll_and_send(self, once=False):
+                captured["once"] = once
+
+        argv = [
+            "eaws-albina",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=t",
+            "--last-polled-file",
+            os.devnull,
+            "--once",
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch.object(bridge, "AlbinaPoller", _FakePoller):
+            bridge.main()
+
+        self.assertTrue(captured.get("once"))
+
+    def test_main_honors_once_mode_env_var(self):
+        from eaws_albina import eaws_albina as bridge
+
+        captured = {}
+
+        class _FakePoller:
+            def __init__(self, **kwargs):
+                pass
+
+            def poll_and_send(self, once=False):
+                captured["once"] = once
+
+        argv = [
+            "eaws-albina",
+            "--connection-string",
+            "BootstrapServer=localhost:9092;EntityPath=t",
+            "--last-polled-file",
+            os.devnull,
+        ]
+        with patch.dict(os.environ, {"ONCE_MODE": "true"}, clear=False), \
+             patch.object(sys, "argv", argv), \
+             patch.object(bridge, "AlbinaPoller", _FakePoller):
+            bridge.main()
+
+        self.assertTrue(captured.get("once"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (one source per PR).

## Changes
- `eaws-albina/notebook/eaws-albina-feed.ipynb` — copied from the canonical `pegelonline` template, applied the substitution table; uses the no-subcommand variant (`sys.argv = ['eaws-albina', '--once']`) because the bridge's argparse has no subcommands.
- `eaws-albina/eaws_albina/eaws_albina.py` — adds `--once` flag and `ONCE_MODE` env var, modeled on `pegelonline`. `poll_and_send(once=True)` returns after exactly one polling cycle.
- `eaws-albina/tests/test_once_mode.py` — covers the flag, the env var, and single-cycle exit.
- `catalog.json` — adds `"notebook": true` after `"kql"` so the gh-pages portal exposes the Fabric Notebook deploy button.
- `eaws-albina/kql/eaws_albina.kql` — regenerated with `-Qualified -Namespace org.EAWS.ALBINA` per the mandatory step 5b. Single messagegroup, so the namespace override is unambiguous. Tables are now `[org.EAWS.ALBINA.AvalancheBulletin]` / `[org.EAWS.ALBINA.AvalancheRegion]`; previously-missing AvalancheRegion table is now generated.
- `eaws-albina/README.md` — one-sentence Fabric notebook hosting bullet.

## Validations
- ✅ Notebook JSON parses cleanly.
- ✅ All 5 placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present.
- ✅ No forbidden patterns in code cells (`asyncio.run(`, `%pip install`, hardcoded `CONNECTION_STRING=`, baked `primaryConnectionString=`).
- ✅ Bridge test suite green: 49/49 passing, including the new 3 `--once` tests.
- ✅ KQL regenerated and qualified.

## Deviations
- Added `--once` to the bridge as explicitly allowed by the operator (modeled on `pegelonline`).
- Used `-Qualified -Namespace org.EAWS.ALBINA` (single messagegroup ⇒ single namespace, per the operator rule).
- No Fabric deployment performed — that's the post-merge wheel-publish + manual verification step.