### PR TITLE
feat(noaa-goes): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -301,7 +301,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Global — space weather, solar wind, K-index",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "singapore-nea",

--- a/noaa-goes/README.md
+++ b/noaa-goes/README.md
@@ -18,6 +18,7 @@ The poller fetches three types of space weather data:
 - **Deduplication**: Tracks last-seen timestamps per data type to avoid reprocessing.
 - **Kafka Integration**: Sends space weather data to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: A scheduled-execution notebook is shipped at `notebook/noaa-goes-feed.ipynb` and can be deployed with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
 
 ## Installation
 

--- a/noaa-goes/noaa_goes/noaa_goes.py
+++ b/noaa-goes/noaa_goes/noaa_goes.py
@@ -178,7 +178,7 @@ class SWPCPoller:
         except (ValueError, TypeError):
             return None
 
-    def poll_and_send(self):
+    def poll_and_send(self, once: bool = False):
         logger.info("Starting SWPC Space Weather poller, polling every %ds", self.POLL_INTERVAL_SECONDS)
         logger.info("  Kafka topic: %s", self.kafka_topic)
 
@@ -206,6 +206,10 @@ class SWPCPoller:
 
             except Exception as e:
                 logger.error("Error in polling loop: %s", e)
+
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
 
             time.sleep(self.POLL_INTERVAL_SECONDS)
 
@@ -464,6 +468,10 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                             'Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -472,6 +480,8 @@ def main():
         args.connection_string = os.getenv('CONNECTION_STRING')
     if not args.last_polled_file:
         args.last_polled_file = os.getenv('SWPC_LAST_POLLED_FILE')
+        if not args.last_polled_file:
+            args.last_polled_file = os.getenv('STATE_FILE')
         if not args.last_polled_file:
             args.last_polled_file = os.path.expanduser('~/.swpc_last_polled.json')
 
@@ -512,7 +522,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/noaa-goes/notebook/noaa-goes-feed.ipynb
+++ b/noaa-goes/notebook/noaa-goes-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NOAA GOES / SWPC Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the NOAA Space Weather Prediction Center (SWPC) public JSON endpoints for space-weather products — geomagnetic alerts, planetary K-index, solar-wind plasma and magnetic-field summaries, and GOES X-ray / proton / electron / magnetometer time-series — and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `noaa_goes` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `noaa-goes --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"noaa-goes-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/noaa-goes/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/noaa-goes/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing noaa_goes package from Fabric Environment...')\n",
+    "    from noaa_goes import noaa_goes as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['noaa-goes', '--once'] if ONCE_MODE else ['noaa-goes']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/noaa-goes/tests/test_once_mode.py
+++ b/noaa-goes/tests/test_once_mode.py
@@ -1,0 +1,71 @@
+"""Unit test: --once flag causes poll_and_send to exit after one cycle."""
+
+from unittest.mock import MagicMock, patch
+
+from noaa_goes.noaa_goes import SWPCPoller
+
+
+def _build_poller():
+    with patch('noaa_goes.noaa_goes.MicrosoftOpenDataUSNOAASWPCAlertsEventProducer'), \
+         patch('noaa_goes.noaa_goes.MicrosoftOpenDataUSNOAASWPCObservationsEventProducer'), \
+         patch('noaa_goes.noaa_goes.MicrosoftOpenDataUSNOAASWPCGOESParticleFluxEventProducer'), \
+         patch('noaa_goes.noaa_goes.MicrosoftOpenDataUSNOAASWPCGOESMagnetometerEventProducer'), \
+         patch('noaa_goes.noaa_goes.MicrosoftOpenDataUSNOAASWPCSolarFlaresEventProducer'), \
+         patch('confluent_kafka.Producer'):
+        poller = SWPCPoller(
+            kafka_config={'bootstrap.servers': 'localhost:9092'},
+            kafka_topic='test',
+            last_polled_file='/tmp/test_state.json',
+        )
+    poller.kafka_producer = MagicMock()
+    for attr in ('alerts_producer', 'observations_producer',
+                 'particle_flux_producer', 'magnetometer_producer',
+                 'flares_producer'):
+        setattr(poller, attr, MagicMock())
+    return poller
+
+
+def test_once_mode_exits_after_single_cycle():
+    poller = _build_poller()
+    poller.load_state = MagicMock(return_value={})
+    poller.save_state = MagicMock()
+    for name in ('_send_alerts', '_send_k_index', '_send_solar_wind_summary',
+                 '_send_plasma', '_send_mag', '_send_goes_xrays',
+                 '_send_goes_protons', '_send_goes_electrons',
+                 '_send_goes_magnetometers', '_send_xray_flares'):
+        setattr(poller, name, MagicMock(return_value=0))
+
+    with patch('noaa_goes.noaa_goes.time.sleep') as mock_sleep:
+        poller.poll_and_send(once=True)
+        mock_sleep.assert_not_called()
+
+    poller.load_state.assert_called_once()
+    poller.save_state.assert_called_once()
+    poller._send_alerts.assert_called_once()
+
+
+def test_default_mode_does_not_exit_after_single_cycle():
+    """Without once=True, the loop calls time.sleep between cycles."""
+    poller = _build_poller()
+    poller.load_state = MagicMock(return_value={})
+    poller.save_state = MagicMock()
+    for name in ('_send_alerts', '_send_k_index', '_send_solar_wind_summary',
+                 '_send_plasma', '_send_mag', '_send_goes_xrays',
+                 '_send_goes_protons', '_send_goes_electrons',
+                 '_send_goes_magnetometers', '_send_xray_flares'):
+        setattr(poller, name, MagicMock(return_value=0))
+
+    # Make the second sleep break out so the test terminates.
+    call_count = {'n': 0}
+
+    def fake_sleep(_seconds):
+        call_count['n'] += 1
+        raise KeyboardInterrupt()
+
+    with patch('noaa_goes.noaa_goes.time.sleep', side_effect=fake_sleep):
+        try:
+            poller.poll_and_send(once=False)
+        except KeyboardInterrupt:
+            pass
+
+    assert call_count['n'] == 1


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## What changed

- New `noaa-goes/notebook/noaa-goes-feed.ipynb` — copy of the canonical `pegelonline/notebook/pegelonline-feed.ipynb` with the exact mechanical substitutions from `references/notebook-substitution-table.md`. Uses the no-subcommand variant (`sys.argv = ['noaa-goes', '--once']`) because the bridge has no subcommand.
- `catalog.json`: added `"notebook": true` to the `noaa-goes` entry (placed after `kql`).
- `noaa-goes/noaa_goes/noaa_goes.py`: added `--once` argparse flag (also honors `ONCE_MODE` env var), threaded `once` through `poll_and_send()`, and added `STATE_FILE` as a fallback env var for `SWPC_LAST_POLLED_FILE` to match the notebook params contract. Default behavior (no flag) is unchanged.
- `noaa-goes/tests/test_once_mode.py`: two new unit tests asserting `poll_and_send(once=True)` runs exactly one cycle and that the default mode still sleeps between cycles.
- `noaa-goes/README.md`: one-line bullet pointing at the notebook deploy script.

## Validations performed locally

- `python -c "import json; json.load(open('.../noaa-goes-feed.ipynb'))"` → OK
- All five required params present in the parameters cell (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`).
- Per-cell forbidden-pattern scan (`asyncio.run`, `%pip install`, hardcoded `CONNECTION_STRING`, `primaryConnectionString =`) → none present.
- `pytest tests/test_once_mode.py tests/test_noaa_goes_unit.py` → 39 passed.
- KQL regenerated with `tools/generate-kql-from-xreg.ps1 -Qualified` (no `-Namespace` because the xreg has 5 messagegroup namespaces). Output identical to the on-disk file.

## Deviations from the skill

- The skill template uses `sys.argv = [\, \, '--once']`. This bridge has no subcommand, so I used the documented no-subcommand variant from `notebook-substitution-table.md` (`['noaa-goes', '--once']`).
- The bridge originally read `SWPC_LAST_POLLED_FILE`; I added a fallback to the generic `STATE_FILE` env var (which the notebook sets per the canonical template). No change to existing behavior when `SWPC_LAST_POLLED_FILE` is set.

## Out of scope

- No live Fabric deployment. The wheel-publish workflow will pick this up on merge.