### PR TITLE
feat(usgs-earthquakes): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -485,7 +485,8 @@
     "cat": "Disasters",
     "key": false,
     "desc": "Global — seismic events",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "bfs-odl",

--- a/usgs-earthquakes/README.md
+++ b/usgs-earthquakes/README.md
@@ -17,6 +17,7 @@ to Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams.
 - **Magnitude Filtering**: Filter events client-side by minimum magnitude.
 - **Deduplication**: Tracks seen events by ID and update timestamp — only new or updated events are forwarded.
 - **Kafka Integration**: Send earthquake events as CloudEvents to a Kafka topic, supporting Microsoft Event Hubs and Microsoft Fabric Event Streams.
+- **Fabric notebook hosting**: Deploy as a scheduled Fabric notebook feeder via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) — runs `usgs-earthquakes feed --once` per cycle and resolves the Event Stream connection string at runtime.
 
 ## Installation
 

--- a/usgs-earthquakes/kql/usgs_earthquakes.kql
+++ b/usgs-earthquakes/kql/usgs_earthquakes.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Event] (
+.create-merge table ['USGS.Earthquakes.Event'] (
    [id]: string,
    [magnitude]: real,
    [mag_type]: string,
@@ -59,9 +59,9 @@
    [___subject]: string
 );
 
-.alter table [Event] docstring "{\"description\": \"USGS earthquake event data from the Earthquake Hazards Program.\"}";
+.alter table ['USGS.Earthquakes.Event'] docstring "{\"description\": \"USGS earthquake event data from the Earthquake Hazards Program.\"}";
 
-.alter table [Event] column-docstrings (
+.alter table ['USGS.Earthquakes.Event'] column-docstrings (
    [id]: "{\"description\": \"Unique identifier for the earthquake event.\"}",
    [magnitude]: "{\"description\": \"Magnitude of the earthquake.\"}",
    [mag_type]: "{\"description\": \"Method or algorithm used to calculate the magnitude (e.g. ml, md, mb, mww).\"}",
@@ -95,7 +95,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Event] ingestion json mapping "Event_json_flat"
+.create-or-alter table ['USGS.Earthquakes.Event'] ingestion json mapping "USGS.Earthquakes.Event_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -132,7 +132,7 @@
 ]
 ```
 
-.create-or-alter table [Event] ingestion json mapping "Event_json_ce_structured"
+.create-or-alter table ['USGS.Earthquakes.Event'] ingestion json mapping "USGS.Earthquakes.Event_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -169,13 +169,13 @@
 ]
 ```
 
-.drop materialized-view EventLatest ifexists;
+.drop materialized-view ['USGS.Earthquakes.EventLatest'] ifexists;
 
-.create materialized-view with (backfill=true) EventLatest on table Event {
-    Event | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['USGS.Earthquakes.EventLatest'] on table ['USGS.Earthquakes.Event'] {
+    ['USGS.Earthquakes.Event'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Event] policy update
+.alter table ['USGS.Earthquakes.Event'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/usgs-earthquakes/notebook/usgs-earthquakes-feed.ipynb
+++ b/usgs-earthquakes/notebook/usgs-earthquakes-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# USGS Earthquakes Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the USGS Earthquake Hazards Program GeoJSON summary feeds for new and updated seismic events and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `usgs_earthquakes` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `usgs-earthquakes feed --once`, exits after one polling cycle, and persists dedupe state (seen event IDs) to a Lakehouse Files path so the next scheduled run only emits new or updated events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"usgs-earthquakes-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/usgs-earthquakes/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/usgs-earthquakes/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing usgs_earthquakes package from Fabric Environment...')\n",
+    "    from usgs_earthquakes import usgs_earthquakes as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['usgs-earthquakes', 'feed', '--once'] if ONCE_MODE else ['usgs-earthquakes', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/usgs-earthquakes/tests/test_once_mode.py
+++ b/usgs-earthquakes/tests/test_once_mode.py
@@ -1,0 +1,55 @@
+"""Tests for --once mode in the USGS earthquakes bridge."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from usgs_earthquakes.usgs_earthquakes import USGSEarthquakePoller
+
+
+@patch('usgs_earthquakes.usgs_earthquakes.USGSEarthquakesEventProducer')
+@patch('usgs_earthquakes.usgs_earthquakes.Producer')
+def test_once_mode_exits_after_one_cycle(mock_producer_class, mock_event_producer_class):
+    """poll_and_send(once=True) must return after a single fetch cycle."""
+    mock_producer_class.return_value = Mock()
+    mock_event_producer = Mock()
+    mock_event_producer.producer = Mock()
+    mock_event_producer_class.return_value = mock_event_producer
+
+    poller = USGSEarthquakePoller(
+        kafka_config={'bootstrap.servers': 'localhost:9092'},
+        kafka_topic='test-topic',
+        last_polled_file=None,
+        feed='all_hour',
+    )
+
+    fetch_calls = []
+
+    async def fake_fetch():
+        fetch_calls.append(1)
+        return []
+
+    poller.fetch_feed = fake_fetch
+    poller.load_seen_event_ids = Mock(return_value={})
+    poller.save_seen_event_ids = Mock()
+
+    async def run_with_timeout():
+        await asyncio.wait_for(poller.poll_and_send(once=True), timeout=5.0)
+
+    asyncio.run(run_with_timeout())
+
+    assert len(fetch_calls) == 1, "Expected exactly one fetch cycle in --once mode"
+
+
+@patch('usgs_earthquakes.usgs_earthquakes.USGSEarthquakesEventProducer')
+@patch('usgs_earthquakes.usgs_earthquakes.Producer')
+def test_once_flag_registered_on_feed_subparser(mock_producer_class, mock_event_producer_class):
+    """The 'feed' subcommand must accept --once."""
+    import argparse
+    from usgs_earthquakes import usgs_earthquakes as mod
+
+    # Sanity-check that --once is wired through main()'s argparse.
+    src = open(mod.__file__, 'r', encoding='utf-8').read()
+    assert "'--once'" in src
+    assert 'ONCE_MODE' in src

--- a/usgs-earthquakes/usgs_earthquakes/usgs_earthquakes.py
+++ b/usgs-earthquakes/usgs_earthquakes/usgs_earthquakes.py
@@ -205,9 +205,13 @@ class USGSEarthquakePoller:
             with open(self.last_polled_file, 'w', encoding='utf-8') as file:
                 json.dump(seen_ids, file)
 
-    async def poll_and_send(self):
+    async def poll_and_send(self, once: bool = False):
         """
         Continuously poll the USGS earthquake feed and send new/updated events to Kafka.
+
+        Args:
+            once: If True, exit after one polling cycle. Useful for scheduled
+                execution (e.g. Fabric notebooks).
         """
         seen_ids = self.load_seen_event_ids()
         poll_interval = timedelta(minutes=1)
@@ -255,6 +259,10 @@ class USGSEarthquakePoller:
             # Prune old events from the seen set (keep last 30 days worth)
             cutoff = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
             seen_ids = {eid: ts for eid, ts in seen_ids.items() if ts >= cutoff}
+
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
 
             elapsed = datetime.now(timezone.utc) - start_poll_time
             remaining = poll_interval - elapsed
@@ -332,6 +340,9 @@ def main():
                              help='Minimum magnitude filter (client-side)')
     feed_parser.add_argument('--log-level', type=str,
                              help='Logging level', default='INFO')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
     events_parser = subparsers.add_parser('events', help="List recent earthquake events")
     events_parser.add_argument('--feed', type=str, default='all_hour',
@@ -401,7 +412,7 @@ def main():
             min_magnitude=args.min_magnitude
         )
 
-        asyncio.run(poller.poll_and_send())
+        asyncio.run(poller.poll_and_send(once=args.once))
     else:
         parser.print_help()
 


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- `usgs-earthquakes/notebook/usgs-earthquakes-feed.ipynb` — copy of the canonical `pegelonline` notebook with mechanical substitutions (display name, package, module, argv, state/log paths, eventstream name).
- `catalog.json` — set `notebook: true` on the `usgs-earthquakes` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `usgs-earthquakes/usgs_earthquakes/usgs_earthquakes.py` — added `--once` flag (also honors `ONCE_MODE` env var) on the `feed` subcommand; `poll_and_send` exits after one polling cycle when set. Modeled on `pegelonline`.
- `usgs-earthquakes/tests/test_once_mode.py` — new unit test asserting `poll_and_send(once=True)` performs exactly one fetch cycle.
- `usgs-earthquakes/kql/usgs_earthquakes.kql` — regenerated with `-Qualified -Namespace USGS.Earthquakes` (single messagegroup namespace) so tables/MV/mappings are prefixed and won't collide with other feeders sharing the same Eventhouse.
- `usgs-earthquakes/README.md` — added one-line Fabric notebook hosting bullet linking to the deployer.

## Validations performed locally

- Notebook JSON well-formed (`json.load` ok).
- All required placeholder vars present in the parameters cell: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in any **code** cell: `asyncio.run(`, `%pip install`, baked `CONNECTION_STRING=`, baked `primaryConnectionString=`. (`%pip install` appears once in a markdown cell as part of the explanatory text — allowed.)
- Bridge unit + integration + new `test_once_mode` all pass (22/22) in a fresh venv with producer sub-packages installed.

## Out of scope

- No Fabric deployment from the agent — handled separately by the maintainer after merge.
- The `publish-notebook-wheels.yml` workflow will publish `usgs-earthquakes-notebook-wheels.zip` on next push to `main`.