### PR TITLE
feat(smhi-weather): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -317,7 +317,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "Sweden — ~232 stations, hourly obs",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "canada-aqhi",

--- a/smhi-weather/README.md
+++ b/smhi-weather/README.md
@@ -55,3 +55,12 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fsmhi-weather%2Fazure-template-with-eventhub.json)
+
+## Fabric notebook hosting
+
+The bridge can also be hosted as a Microsoft Fabric scheduled notebook
+(see [`smhi-weather/notebook/smhi-weather-feed.ipynb`](notebook/smhi-weather-feed.ipynb)).
+Deploy it with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which builds a per-source Fabric Environment, binds Lakehouse + KQL + Environment
+to the notebook, resolves the Event Stream connection string at runtime, and
+schedules single-cycle (`--once`) executions.

--- a/smhi-weather/kql/create-kql-script.ps1
+++ b/smhi-weather/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\smhi_weather.xreg.json"
 $kqlFile = Join-Path $scriptDir "smhi_weather.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'SE.Gov.SMHI.Weather'

--- a/smhi-weather/kql/smhi_weather.kql
+++ b/smhi-weather/kql/smhi_weather.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['SE.Gov.SMHI.Weather.Station'] (
    [station_id]: string,
    [name]: string,
    [owner]: string,
@@ -41,9 +41,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for a SMHI meteorological observation station. Stations report hourly surface observations of temperature, wind, pressure, humidity, precipitation, and other parameters across Sweden.\"}";
+.alter table ['SE.Gov.SMHI.Weather.Station'] docstring "{\"description\": \"Reference metadata for a SMHI meteorological observation station. Stations report hourly surface observations of temperature, wind, pressure, humidity, precipitation, and other parameters across Sweden.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['SE.Gov.SMHI.Weather.Station'] column-docstrings (
    [station_id]: "{\"description\": \"SMHI numeric station identifier, unique within the SMHI observation network.\"}",
    [name]: "{\"description\": \"Human-readable station name as assigned by SMHI, e.g. 'Abisko Aut' or 'Stockholm-Arlanda'.\"}",
    [owner]: "{\"description\": \"Organization or entity that owns and operates the station, e.g. 'SMHI' or 'Polarforskningssekretariatet'.\"}",
@@ -59,7 +59,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['SE.Gov.SMHI.Weather.Station'] ingestion json mapping "SE.Gov.SMHI.Weather.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -78,7 +78,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['SE.Gov.SMHI.Weather.Station'] ingestion json mapping "SE.Gov.SMHI.Weather.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -97,13 +97,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['SE.Gov.SMHI.Weather.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['SE.Gov.SMHI.Weather.StationLatest'] on table ['SE.Gov.SMHI.Weather.Station'] {
+    ['SE.Gov.SMHI.Weather.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['SE.Gov.SMHI.Weather.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -114,7 +114,7 @@
 }]
 ```
 
-.create-merge table [WeatherObservation] (
+.create-merge table ['SE.Gov.SMHI.Weather.WeatherObservation'] (
    [station_id]: string,
    [station_name]: string,
    [observation_time]: datetime,
@@ -141,9 +141,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherObservation] docstring "{\"description\": \"Hourly weather observation from a SMHI meteorological station. Multi-parameter observations are assembled from the per-parameter latest-hour API endpoints. Each record contains the most recent values for temperature, wind, pressure, humidity, precipitation, visibility, cloud cover, irradiance, and present weather.\"}";
+.alter table ['SE.Gov.SMHI.Weather.WeatherObservation'] docstring "{\"description\": \"Hourly weather observation from a SMHI meteorological station. Multi-parameter observations are assembled from the per-parameter latest-hour API endpoints. Each record contains the most recent values for temperature, wind, pressure, humidity, precipitation, visibility, cloud cover, irradiance, and present weather.\"}";
 
-.alter table [WeatherObservation] column-docstrings (
+.alter table ['SE.Gov.SMHI.Weather.WeatherObservation'] column-docstrings (
    [station_id]: "{\"description\": \"SMHI station identifier for the reporting station.\"}",
    [station_name]: "{\"description\": \"Human-readable name of the reporting station.\"}",
    [observation_time]: "{\"description\": \"Timestamp of the observation in UTC, derived from the SMHI epoch millisecond value.\"}",
@@ -170,7 +170,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_flat"
+.create-or-alter table ['SE.Gov.SMHI.Weather.WeatherObservation'] ingestion json mapping "SE.Gov.SMHI.Weather.WeatherObservation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -200,7 +200,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherObservation] ingestion json mapping "WeatherObservation_json_ce_structured"
+.create-or-alter table ['SE.Gov.SMHI.Weather.WeatherObservation'] ingestion json mapping "SE.Gov.SMHI.Weather.WeatherObservation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -230,13 +230,13 @@
 ]
 ```
 
-.drop materialized-view WeatherObservationLatest ifexists;
+.drop materialized-view ['SE.Gov.SMHI.Weather.WeatherObservationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherObservationLatest on table WeatherObservation {
-    WeatherObservation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['SE.Gov.SMHI.Weather.WeatherObservationLatest'] on table ['SE.Gov.SMHI.Weather.WeatherObservation'] {
+    ['SE.Gov.SMHI.Weather.WeatherObservation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherObservation] policy update
+.alter table ['SE.Gov.SMHI.Weather.WeatherObservation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/smhi-weather/notebook/smhi-weather-feed.ipynb
+++ b/smhi-weather/notebook/smhi-weather-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SMHI Weather Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Swedish Meteorological and Hydrological Institute (SMHI) open meteorological observations API for ~232 stations across Sweden and emits CloudEvents (station reference + hourly weather observations) to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `smhi_weather` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `smhi-weather feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"smhi-weather-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/smhi-weather/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/smhi-weather/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing smhi_weather package from Fabric Environment...')\n",
+    "    from smhi_weather import smhi_weather as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['smhi-weather', 'feed', '--once'] if ONCE_MODE else ['smhi-weather', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/smhi-weather/smhi_weather/smhi_weather.py
+++ b/smhi-weather/smhi_weather/smhi_weather.py
@@ -287,7 +287,10 @@ def main():
                         default=os.environ.get("STATE_FILE", os.path.expanduser("~/.smhi_weather_state.json")))
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List active stations")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+                             help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
     api = SMHIWeatherAPI(polling_interval=args.polling_interval)
@@ -327,6 +330,9 @@ def main():
                 logger.info("Sent %d observation events", count)
             except Exception as e:
                 logger.error("Error fetching/sending data: %s", e)
+            if args.once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
             time.sleep(args.polling_interval)
     else:
         parser.print_help()

--- a/smhi-weather/tests/test_once_mode.py
+++ b/smhi-weather/tests/test_once_mode.py
@@ -1,0 +1,74 @@
+"""Verify --once causes main() to return after exactly one polling cycle."""
+
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+from smhi_weather import smhi_weather as bridge
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(sys, "argv", [
+        "smhi-weather",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=t",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+        "--once",
+    ])
+
+    call_count = {"n": 0}
+
+    def fake_feed(api, producer, previous_readings):
+        call_count["n"] += 1
+        return 0
+
+    monkeypatch.setattr(bridge, "feed_observations", fake_feed)
+    monkeypatch.setattr(bridge, "send_stations", lambda *a, **kw: None)
+    monkeypatch.setattr(bridge, "_load_state", lambda *_: {})
+    monkeypatch.setattr(bridge, "_save_state", lambda *_: None)
+    monkeypatch.setattr(bridge, "Producer", lambda cfg: MagicMock())
+    monkeypatch.setattr(bridge, "SEGovSMHIWeatherEventProducer",
+                        lambda producer, topic: MagicMock())
+
+    def fail_if_called(*_a, **_kw):
+        raise AssertionError("time.sleep must not be called when --once is set")
+
+    monkeypatch.setattr(time, "sleep", fail_if_called)
+
+    bridge.main()
+
+    assert call_count["n"] == 1, "feed_observations should be called exactly once with --once"
+
+
+def test_once_env_var_enables_single_cycle(monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr(sys, "argv", [
+        "smhi-weather",
+        "--connection-string", "BootstrapServer=localhost:9092;EntityPath=t",
+        "--state-file", str(state_file),
+        "--polling-interval", "1",
+        "feed",
+    ])
+
+    call_count = {"n": 0}
+
+    def fake_feed(api, producer, previous_readings):
+        call_count["n"] += 1
+        return 0
+
+    monkeypatch.setattr(bridge, "feed_observations", fake_feed)
+    monkeypatch.setattr(bridge, "send_stations", lambda *a, **kw: None)
+    monkeypatch.setattr(bridge, "_load_state", lambda *_: {})
+    monkeypatch.setattr(bridge, "_save_state", lambda *_: None)
+    monkeypatch.setattr(bridge, "Producer", lambda cfg: MagicMock())
+    monkeypatch.setattr(bridge, "SEGovSMHIWeatherEventProducer",
+                        lambda producer, topic: MagicMock())
+    monkeypatch.setattr(time, "sleep",
+                        lambda *_a, **_kw: (_ for _ in ()).throw(
+                            AssertionError("sleep should not be called")))
+
+    bridge.main()
+    assert call_count["n"] == 1


### PR DESCRIPTION
Retrofit by the 
otebook-feeder-retrofit skill agent.

## Changes
- New `smhi-weather/notebook/smhi-weather-feed.ipynb` (copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per `references/notebook-substitution-table.md`).
- `catalog.json`: `smhi-weather` entry gains `""notebook"": true` (inserted after `kql`) so the gh-pages portal exposes the Fabric notebook deploy button.
- `smhi_weather/smhi_weather.py`: adds `--once` to the `feed` subparser (also honoring the `ONCE_MODE` env var) and a single-cycle exit branch in the polling loop. Modeled on `pegelonline`.
- `tests/test_once_mode.py`: asserts `main()` returns after exactly one cycle for both the CLI flag and the env var (HTTP mocked, `time.sleep` patched to fail-on-call).
- `smhi-weather/README.md`: one-paragraph ""Fabric notebook hosting"" pointer to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- `kql/smhi_weather.kql` + `kql/create-kql-script.ps1`: regenerated with `-Qualified -Namespace SE.Gov.SMHI.Weather` (the xreg has a single messagegroup namespace), so KQL tables/mappings/MVs/update-policies are prefixed with the schema namespace and won't collide when multiple feeders share an Eventhouse.

## Local validation
- Notebook JSON parses; 6 cells, structure preserved (markdown, params, markdown, CS-lookup, markdown, worker-thread run).
- All 5 required parameter placeholders (`EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`) present in the params cell.
- Per-cell forbidden-pattern check passes: no `asyncio.run(`, no `%pip install`, no baked `CONNECTION_STRING = ""…""`, no `primaryConnectionString =` assignment.
- `python -m pytest tests/` → 29 passed (includes both new `--once` tests).
- KQL regeneration via `kql/create-kql-script.ps1` succeeds; produced tables are quoted/qualified (`['SE.Gov.SMHI.Weather.Station']`, `['SE.Gov.SMHI.Weather.WeatherObservation']`, etc.).

No Fabric deployment performed (per skill section 7). The `publish-notebook-wheels.yml` workflow will pick up this source on merge to `main`.