### PR TITLE
feat(noaa-nws): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -277,7 +277,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "United States — weather alerts, CAP",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "nws-forecasts",

--- a/noaa-nws/README.md
+++ b/noaa-nws/README.md
@@ -10,6 +10,7 @@
 - **Deduplication**: Tracks seen alert IDs in a state file to avoid reprocessing.
 - **Kafka Integration**: Send weather alerts to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: A Fabric notebook (`notebook/noaa-nws-feed.ipynb`) is provided for scheduled single-cycle execution inside Microsoft Fabric via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
 
 ## Installation
 

--- a/noaa-nws/kql/create-kql-script.ps1
+++ b/noaa-nws/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\noaa_nws.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa_nws.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/noaa-nws/noaa_nws/noaa_nws.py
+++ b/noaa-nws/noaa_nws/noaa_nws.py
@@ -210,10 +210,14 @@ class NWSAlertPoller:
             print(f"Error fetching NWS alerts: {err}")
             return []
 
-    def poll_and_send(self):
+    def poll_and_send(self, once: bool = False):
         """
         Main polling loop. Fetches alerts, deduplicates, and sends new alerts
         to Kafka as CloudEvents. Polls every POLL_INTERVAL_SECONDS.
+
+        Args:
+            once: If True, exit after one polling cycle (alerts + observations).
+                Used for scheduled execution in Fabric notebooks.
         """
         print(f"Starting NWS Weather Alert poller, polling every {self.POLL_INTERVAL_SECONDS}s")
         print(f"  Alerts URL: {self.ALERTS_URL}")
@@ -310,6 +314,10 @@ class NWSAlertPoller:
             except Exception as e:
                 print(f"Error in polling loop: {e}")
 
+            if once:
+                print("--once mode: exiting after first polling cycle")
+                break
+
             time.sleep(self.POLL_INTERVAL_SECONDS)
 
 
@@ -362,6 +370,10 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                             'Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -409,7 +421,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/noaa-nws/notebook/noaa-nws-feed.ipynb
+++ b/noaa-nws/notebook/noaa-nws-feed.ipynb
@@ -1,0 +1,225 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NOAA NWS Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the U.S. National Weather Service (NWS) public API for active weather alerts, forecast-zone metadata, observation stations, and the latest station observations, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `noaa_nws` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `noaa-nws --once`, exits after one polling cycle, and persists dedupe state (seen alert IDs) to a Lakehouse Files path so the next scheduled run only emits new alerts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"noaa-nws-ingest\"        # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/noaa-nws/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/noaa-nws/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    os.environ['NWS_LAST_POLLED_FILE'] = STATE_FILE\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing noaa_nws package from Fabric Environment...')\n",
+    "    from noaa_nws import noaa_nws as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['noaa-nws', '--once'] if ONCE_MODE else ['noaa-nws']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/noaa-nws/tests/test_once_mode.py
+++ b/noaa-nws/tests/test_once_mode.py
@@ -1,0 +1,69 @@
+"""Tests for --once mode in the NOAA NWS bridge.
+
+Verifies that `poll_and_send(once=True)` runs exactly one polling cycle
+and exits without sleeping or re-entering the loop. Used by the Fabric
+notebook hosting path which schedules single-cycle execution.
+"""
+
+import time as _time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from noaa_nws.noaa_nws import NWSAlertPoller
+
+
+@pytest.fixture
+def mock_kafka_config():
+    return {'bootstrap.servers': 'localhost:9092'}
+
+
+def _make_poller(mock_kafka_config, tmp_path):
+    state_file = str(tmp_path / 'state.json')
+    with patch('confluent_kafka.Producer') as mock_producer_class:
+        mock_producer_class.return_value = MagicMock()
+        poller = NWSAlertPoller(
+            kafka_config=mock_kafka_config,
+            kafka_topic='test-topic',
+            last_polled_file=state_file,
+        )
+    poller.alerts_producer = MagicMock()
+    poller.zones_producer = MagicMock()
+    poller.observations_producer = MagicMock()
+    poller.kafka_producer = MagicMock()
+    return poller
+
+
+def test_once_mode_runs_one_cycle_and_exits(mock_kafka_config, tmp_path):
+    poller = _make_poller(mock_kafka_config, tmp_path)
+
+    with patch.object(poller, 'fetch_zones', return_value=[]) as mock_zones, \
+         patch.object(poller, 'fetch_observation_stations', return_value=[]) as mock_stations, \
+         patch.object(poller, 'poll_alerts', return_value=[]) as mock_poll, \
+         patch.object(_time, 'sleep') as mock_sleep:
+        poller.poll_and_send(once=True)
+
+    mock_zones.assert_called_once()
+    mock_stations.assert_called_once()
+    assert mock_poll.call_count == 1, "poll_alerts must be called exactly once in --once mode"
+    mock_sleep.assert_not_called(), "time.sleep must not be called in --once mode"
+
+
+def test_default_mode_does_not_break_after_one_cycle(mock_kafka_config, tmp_path):
+    """Without once=True the loop must continue (we break it via sleep raising)."""
+    poller = _make_poller(mock_kafka_config, tmp_path)
+
+    call_log = {'count': 0}
+
+    def _raise_after_first_sleep(*_args, **_kwargs):
+        call_log['count'] += 1
+        raise KeyboardInterrupt("stop loop for test")
+
+    with patch.object(poller, 'fetch_zones', return_value=[]), \
+         patch.object(poller, 'fetch_observation_stations', return_value=[]), \
+         patch.object(poller, 'poll_alerts', return_value=[]), \
+         patch.object(_time, 'sleep', side_effect=_raise_after_first_sleep):
+        with pytest.raises(KeyboardInterrupt):
+            poller.poll_and_send(once=False)
+
+    assert call_log['count'] == 1, "default mode must reach time.sleep after one iteration"


### PR DESCRIPTION
Retrofit by the 
otebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md) for source `noaa-nws`.

## Changes
- **Notebook**: `noaa-nws/notebook/noaa-nws-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per `references/notebook-substitution-table.md` (no-subcommand variant: `sys.argv = ['noaa-nws', '--once']`).
- **Catalog flag**: `catalog.json` — added `""notebook"": true` to the `noaa-nws` entry (after `kql`).
- **Bridge `--once` support**: `noaa_nws/noaa_nws.py` — new top-level `--once` argparse flag (also honors `ONCE_MODE` env var) plumbed to `NWSAlertPoller.poll_and_send(once=...)` which exits after one polling cycle (zones + stations refresh + alerts + observations).
- **Unit test**: `tests/test_once_mode.py` — verifies `--once` runs exactly one cycle without sleeping and that default mode continues looping.
- **README**: one-sentence Fabric-notebook-hosting bullet added.
- **KQL script**: `noaa-nws/kql/create-kql-script.ps1` now passes `-Qualified` (per retrofit mandate). The xreg has three messagegroup namespaces (Alerts/Zones/Observations), so `-Namespace` is intentionally not passed. The JsonStructure schemas have no top-level `namespace` field, so `noaa_nws.kql` is byte-identical to the prior output — the script flag change is the only change.

## Local validation
- Notebook JSON parses (`json.load`).
- Placeholder cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in any **code** cell (`asyncio.run(`, `%pip install`, hard-coded `CONNECTION_STRING="..."`, `primaryConnectionString = `). The string `%pip install` appears only in the markdown intro as documentation (""No %pip install is required"") — verified per-cell.
- `python -m pytest tests/test_noaa_nws_unit.py tests/test_once_mode.py -x`: **26 passed**.

## Deferred / out of scope
- No Fabric deployment performed (per skill: hand-off to manual verification by maintainer).
- `publish-notebook-wheels.yml` will pick up this source on next push to `main` and publish wheels to the `notebook-wheels` release.