### PR TITLE
feat(nws-forecasts): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -285,7 +285,8 @@
     "cat": "Weather",
     "key": false,
     "desc": "United States — configurable land and marine forecast zones",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "nws-alerts",

--- a/nws-forecasts/README.md
+++ b/nws-forecasts/README.md
@@ -60,3 +60,4 @@ python -m nws_forecasts
 - `nws_forecasts/nws_forecasts.py` - runtime bridge
 - `nws_forecasts_producer/` - generated producer code
 - `tests/` - unit and live API tests
+- `notebook/nws-forecasts-feed.ipynb` - Fabric notebook hosting option, deployed via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) for scheduled single-cycle (`--once`) runs against a Fabric Event Stream.

--- a/nws-forecasts/kql/create-kql-script.ps1
+++ b/nws-forecasts/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\nws_forecasts.xreg.json"
 $kqlFile = Join-Path $scriptDir "nws_forecasts.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "Microsoft.OpenData.US.NOAA.NWS.Forecasts"

--- a/nws-forecasts/kql/nws_forecasts.kql
+++ b/nws-forecasts/kql/nws_forecasts.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [ForecastZone] (
+.create-merge table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] (
    [zone_id]: string,
    [zone_type]: string,
    [name]: string,
@@ -47,9 +47,9 @@
    [___subject]: string
 );
 
-.alter table [ForecastZone] docstring "{\"description\": \"Reference data for an NWS forecast zone selected by the bridge. The api.weather.gov /zones/forecast/{zoneId} endpoint returns both public land forecast zones such as WAZ315 and marine forecast zones such as PZZ135. The bridge emits this reference event at startup and on periodic refresh so downstream consumers can correlate forecast snapshots with stable zone metadata.\"}";
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] docstring "{\"description\": \"Reference data for an NWS forecast zone selected by the bridge. The api.weather.gov /zones/forecast/{zoneId} endpoint returns both public land forecast zones such as WAZ315 and marine forecast zones such as PZZ135. The bridge emits this reference event at startup and on periodic refresh so downstream consumers can correlate forecast snapshots with stable zone metadata.\"}";
 
-.alter table [ForecastZone] column-docstrings (
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] column-docstrings (
    [zone_id]: "{\"description\": \"NWS forecast zone identifier from the upstream properties.id field, such as WAZ315 for the City of Seattle public forecast zone or PZZ135 for the Puget Sound and Hood Canal marine zone.\"}",
    [zone_type]: "{\"description\": \"NWS zone category from the upstream properties.type field. Forecast-zone responses use 'public' for land forecast zones and marine-oriented values such as 'coastal', 'offshore', or 'marine' for waters forecasts.\"}",
    [name]: "{\"description\": \"Human-readable NWS zone name from properties.name, for example 'City of Seattle' or 'Puget Sound and Hood Canal'.\"}",
@@ -71,7 +71,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [ForecastZone] ingestion json mapping "ForecastZone_json_flat"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -96,7 +96,7 @@
 ]
 ```
 
-.create-or-alter table [ForecastZone] ingestion json mapping "ForecastZone_json_ce_structured"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -121,13 +121,13 @@
 ]
 ```
 
-.drop materialized-view ForecastZoneLatest ifexists;
+.drop materialized-view ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZoneLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ForecastZoneLatest on table ForecastZone {
-    ForecastZone | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZoneLatest'] on table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] {
+    ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [ForecastZone] policy update
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.ForecastZone'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -138,7 +138,7 @@
 }]
 ```
 
-.create-merge table [LandZoneForecast] (
+.create-merge table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] (
    [zone_id]: string,
    [updated]: datetime,
    [periods]: dynamic,
@@ -149,9 +149,9 @@
    [___subject]: string
 );
 
-.alter table [LandZoneForecast] docstring "{\"description\": \"Public land-zone forecast snapshot from api.weather.gov /zones/forecast/{zoneId}/forecast. This endpoint returns narrative forecast periods for a land forecast zone such as Seattle or Tacoma. The bridge preserves the ordered forecast periods and emits the zone identifier as the Kafka key so each event represents the current forecast snapshot for one zone.\"}";
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] docstring "{\"description\": \"Public land-zone forecast snapshot from api.weather.gov /zones/forecast/{zoneId}/forecast. This endpoint returns narrative forecast periods for a land forecast zone such as Seattle or Tacoma. The bridge preserves the ordered forecast periods and emits the zone identifier as the Kafka key so each event represents the current forecast snapshot for one zone.\"}";
 
-.alter table [LandZoneForecast] column-docstrings (
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] column-docstrings (
    [zone_id]: "{\"description\": \"Forecast zone identifier for the land forecast snapshot. This matches the configured zone identifier and the upstream properties.zone URL suffix.\"}",
    [updated]: "{\"description\": \"Timestamp from properties.updated indicating when the NWS most recently updated this zone forecast.\"}",
    [periods]: "{\"description\": \"Ordered narrative forecast periods from properties.periods. Each element represents one named daypart or day-level outlook such as Tonight, Tuesday, or Tuesday Night.\", \"schema\": \"{ \\\"doc\\\": \\\"Schema too large to inline. Please refer to the JSON Structure schema for more details.\\\" }\"}",
@@ -162,7 +162,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [LandZoneForecast] ingestion json mapping "LandZoneForecast_json_flat"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -176,7 +176,7 @@
 ]
 ```
 
-.create-or-alter table [LandZoneForecast] ingestion json mapping "LandZoneForecast_json_ce_structured"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -190,13 +190,13 @@
 ]
 ```
 
-.drop materialized-view LandZoneForecastLatest ifexists;
+.drop materialized-view ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) LandZoneForecastLatest on table LandZoneForecast {
-    LandZoneForecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecastLatest'] on table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] {
+    ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [LandZoneForecast] policy update
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.LandZoneForecast'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -207,7 +207,7 @@
 }]
 ```
 
-.create-merge table [MarineZoneForecast] (
+.create-merge table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] (
    [zone_id]: string,
    [zone_name]: string,
    [product_title]: string,
@@ -226,9 +226,9 @@
    [___subject]: string
 );
 
-.alter table [MarineZoneForecast] docstring "{\"description\": \"Marine forecast bulletin snapshot parsed from the NOAA/NWS coastal waters text feed under tgftp.nws.noaa.gov/data/forecasts/marine/coastal/pz/. The upstream feed is plain text rather than structured JSON, so the bridge emits the bulletin metadata plus an ordered array of named narrative periods for the selected marine zone.\"}";
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] docstring "{\"description\": \"Marine forecast bulletin snapshot parsed from the NOAA/NWS coastal waters text feed under tgftp.nws.noaa.gov/data/forecasts/marine/coastal/pz/. The upstream feed is plain text rather than structured JSON, so the bridge emits the bulletin metadata plus an ordered array of named narrative periods for the selected marine zone.\"}";
 
-.alter table [MarineZoneForecast] column-docstrings (
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] column-docstrings (
    [zone_id]: "{\"description\": \"Marine forecast zone identifier parsed from the bulletin zone header line, such as PZZ135 for Puget Sound and Hood Canal.\"}",
    [zone_name]: "{\"description\": \"Marine zone display name parsed from the zone header line immediately following the zone identifier in the text bulletin.\"}",
    [product_title]: "{\"description\": \"Bulletin title line, such as 'Coastal Waters Forecast for Washington'.\"}",
@@ -247,7 +247,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [MarineZoneForecast] ingestion json mapping "MarineZoneForecast_json_flat"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -269,7 +269,7 @@
 ]
 ```
 
-.create-or-alter table [MarineZoneForecast] ingestion json mapping "MarineZoneForecast_json_ce_structured"
+.create-or-alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] ingestion json mapping "Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -291,13 +291,13 @@
 ]
 ```
 
-.drop materialized-view MarineZoneForecastLatest ifexists;
+.drop materialized-view ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecastLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MarineZoneForecastLatest on table MarineZoneForecast {
-    MarineZoneForecast | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecastLatest'] on table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] {
+    ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [MarineZoneForecast] policy update
+.alter table ['Microsoft.OpenData.US.NOAA.NWS.Forecasts.MarineZoneForecast'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/nws-forecasts/notebook/nws-forecasts-feed.ipynb
+++ b/nws-forecasts/notebook/nws-forecasts-feed.ipynb
@@ -1,0 +1,226 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NWS Forecast Zones Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls NWS land-zone forecasts (`api.weather.gov/zones/forecast/{zoneId}/forecast`) and marine-zone bulletins (`tgftp.nws.noaa.gov/data/forecasts/marine/coastal/pz/{zone}.txt`) for a configured set of forecast zones and emits CloudEvents to the bound Fabric Event Stream. Zone reference metadata is published first and refreshed periodically; only changed forecast snapshots are re-emitted (dedupe by `updated` timestamp for land zones, by bulletin content hash for marine zones).\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `nws_forecasts` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No pip install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `nws-forecasts --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits changed forecasts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"nws-forecasts-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/nws-forecasts/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/nws-forecasts/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['NWS_FORECAST_STATE_FILE'] = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['NWS_FORECAST_POLL_INTERVAL_SECONDS'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing nws_forecasts package from Fabric Environment...')\n",
+    "    from nws_forecasts import nws_forecasts as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['nws-forecasts', '--once'] if ONCE_MODE else ['nws-forecasts']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/nws-forecasts/nws_forecasts/nws_forecasts.py
+++ b/nws-forecasts/nws_forecasts/nws_forecasts.py
@@ -402,7 +402,7 @@ class NWSForecastPoller:
             )
         return emitted
 
-    def run(self) -> None:
+    def run(self, once: bool = False) -> None:
         LOGGER.info("Starting NWS forecast poller for zones: %s", ", ".join(self.zones))
         self.refresh_zone_cache()
         self.emit_reference_data()
@@ -415,6 +415,8 @@ class NWSForecastPoller:
 
             emitted = self.poll_once()
             LOGGER.info("Completed forecast poll; emitted %s changed forecast snapshot(s).", emitted)
+            if once:
+                return
             time.sleep(self.poll_interval_seconds)
 
 
@@ -442,6 +444,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
         default=os.getenv("KAFKA_ENABLE_TLS", "true").lower() != "false",
         type=lambda value: str(value).lower() != "false",
     )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "false").lower() == "true",
+        help="Run a single polling cycle and exit (used by Fabric notebook hosting).",
+    )
     return parser
 
 
@@ -460,7 +468,7 @@ def main() -> None:
         poll_interval_seconds=args.poll_interval_seconds,
         reference_refresh_seconds=args.reference_refresh_seconds,
     )
-    poller.run()
+    poller.run(once=args.once)
 
 
 if __name__ == "__main__":

--- a/nws-forecasts/tests/test_once_mode.py
+++ b/nws-forecasts/tests/test_once_mode.py
@@ -1,0 +1,56 @@
+"""Verify the --once flag drives a single polling cycle and exits."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _force_offline_kafka(monkeypatch):
+    monkeypatch.setenv("CONNECTION_STRING", "BootstrapServer=localhost:9092;EntityPath=nws-forecasts")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+
+def test_once_flag_exits_after_single_cycle(monkeypatch):
+    _force_offline_kafka(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["nws-forecasts", "--once"])
+
+    from nws_forecasts.nws_forecasts import NWSForecastPoller, main
+
+    with patch.object(NWSForecastPoller, "refresh_zone_cache", autospec=True) as refresh, \
+            patch.object(NWSForecastPoller, "emit_reference_data", autospec=True) as emit_ref, \
+            patch.object(NWSForecastPoller, "poll_once", autospec=True, return_value=0) as poll_once, \
+            patch("nws_forecasts.nws_forecasts.Producer") as producer_cls, \
+            patch("nws_forecasts.nws_forecasts.MicrosoftOpenDataUSNOAANWSForecastsEventProducer") as ev_producer_cls, \
+            patch("nws_forecasts.nws_forecasts.time.sleep", side_effect=AssertionError("sleep called in --once mode")):
+        producer_cls.return_value = MagicMock()
+        ev_producer_cls.return_value = MagicMock()
+        # main() must return cleanly without ever sleeping.
+        main()
+
+    refresh.assert_called()
+    emit_ref.assert_called()
+    poll_once.assert_called_once()
+
+
+def test_once_flag_via_env_var(monkeypatch):
+    _force_offline_kafka(monkeypatch)
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr(sys, "argv", ["nws-forecasts"])
+
+    from nws_forecasts.nws_forecasts import NWSForecastPoller, main
+
+    with patch.object(NWSForecastPoller, "refresh_zone_cache", autospec=True), \
+            patch.object(NWSForecastPoller, "emit_reference_data", autospec=True), \
+            patch.object(NWSForecastPoller, "poll_once", autospec=True, return_value=0) as poll_once, \
+            patch("nws_forecasts.nws_forecasts.Producer") as producer_cls, \
+            patch("nws_forecasts.nws_forecasts.MicrosoftOpenDataUSNOAANWSForecastsEventProducer") as ev_producer_cls, \
+            patch("nws_forecasts.nws_forecasts.time.sleep", side_effect=AssertionError("sleep called in --once mode")):
+        producer_cls.return_value = MagicMock()
+        ev_producer_cls.return_value = MagicMock()
+        main()
+
+    poll_once.assert_called_once()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent for `nws-forecasts`.

## What this PR does
- Adds `nws-forecasts/notebook/nws-forecasts-feed.ipynb` following the canonical `pegelonline` four-cell pattern (markdown intro / parameters / CS lookup / run cycle).
- Adds a `--once` CLI flag (and `ONCE_MODE` env-var fallback) to the bridge so `poll_once` runs exactly once and the bridge exits — required for scheduled Fabric notebook hosting. New unit tests in `tests/test_once_mode.py` cover both code paths.
- Flips the `nws-forecasts` entry in `catalog.json` to `"notebook": true` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Regenerates `nws-forecasts/kql/nws_forecasts.kql` with `-Qualified -Namespace Microsoft.OpenData.US.NOAA.NWS.Forecasts` (single messagegroup namespace in the xreg) so tables / materialized views / mappings / update policies are namespace-prefixed and safe to share an Eventhouse with other feeders.
- Adds a Fabric-notebook-hosting bullet to `nws-forecasts/README.md` linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations performed locally
- `python -c "import json; json.load(open('nws-forecasts/notebook/nws-forecasts-feed.ipynb'))"` — notebook JSON parses.
- `python -m pytest tests/` — **12 passed** (10 baseline + 2 new `--once` tests).
- Parameters-cell check: all of `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID` present as `<name> =` assignments.
- Forbidden-pattern check: no `asyncio.run(`, no `%pip install`, no hardcoded `CONNECTION_STRING = "…"`, no `primaryConnectionString = …`.

## Not done (per skill)
- No live Fabric deployment from this agent. The wheel-publish workflow runs on PR merge and the portal exposes the button after `update-ghpages-catalog.yml` syncs the flag. End-to-end Fabric validation is performed by the maintainer after merge.

Skill: `.github/skills/notebook-feeder-retrofit/SKILL.md`