### PR TITLE
feat(paris-bicycle-counters): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -605,7 +605,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "Paris — ~141 counting stations, hourly counts",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "seattle-street-closures",

--- a/paris-bicycle-counters/README.md
+++ b/paris-bicycle-counters/README.md
@@ -11,6 +11,7 @@
 - **Deduplication**: Tracks seen counter_id + date pairs in a state file to avoid reprocessing.
 - **Kafka Integration**: Send bicycle counts to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: deploy as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) using [`notebook/paris-bicycle-counters-feed.ipynb`](notebook/paris-bicycle-counters-feed.ipynb).
 
 ## Installation
 

--- a/paris-bicycle-counters/kql/create-kql-script.ps1
+++ b/paris-bicycle-counters/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\paris_bicycle_counters.xreg.json"
 $kqlFile = Join-Path $scriptDir "paris_bicycle_counters.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "FR.Paris.OpenData.Velo"

--- a/paris-bicycle-counters/kql/paris_bicycle_counters.kql
+++ b/paris-bicycle-counters/kql/paris_bicycle_counters.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Counter] (
+.create-merge table ['FR.Paris.OpenData.Velo.Counter'] (
    [counter_id]: string,
    [counter_name]: string,
    [channel_name]: string,
@@ -39,9 +39,9 @@
    [___subject]: string
 );
 
-.alter table [Counter] docstring "{\"description\": \"Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.\"}";
+.alter table ['FR.Paris.OpenData.Velo.Counter'] docstring "{\"description\": \"Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.\"}";
 
-.alter table [Counter] column-docstrings (
+.alter table ['FR.Paris.OpenData.Velo.Counter'] column-docstrings (
    [counter_id]: "{\"description\": \"Unique identifier for the counting channel, combining the site ID and channel ID (mapped from 'id_compteur').\"}",
    [counter_name]: "{\"description\": \"Human-readable name of the counter including street name and direction (mapped from 'nom_compteur').\"}",
    [channel_name]: "{\"description\": \"Directional channel label for the counter, e.g. 'SE-NO' or 'E-O' (mapped from 'channel_name').\"}",
@@ -55,7 +55,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Counter] ingestion json mapping "Counter_json_flat"
+.create-or-alter table ['FR.Paris.OpenData.Velo.Counter'] ingestion json mapping "FR.Paris.OpenData.Velo.Counter_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -72,7 +72,7 @@
 ]
 ```
 
-.create-or-alter table [Counter] ingestion json mapping "Counter_json_ce_structured"
+.create-or-alter table ['FR.Paris.OpenData.Velo.Counter'] ingestion json mapping "FR.Paris.OpenData.Velo.Counter_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -89,13 +89,13 @@
 ]
 ```
 
-.drop materialized-view CounterLatest ifexists;
+.drop materialized-view ['FR.Paris.OpenData.Velo.CounterLatest'] ifexists;
 
-.create materialized-view with (backfill=true) CounterLatest on table Counter {
-    Counter | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['FR.Paris.OpenData.Velo.CounterLatest'] on table ['FR.Paris.OpenData.Velo.Counter'] {
+    ['FR.Paris.OpenData.Velo.Counter'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Counter] policy update
+.alter table ['FR.Paris.OpenData.Velo.Counter'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -106,7 +106,7 @@
 }]
 ```
 
-.create-merge table [BicycleCount] (
+.create-merge table ['FR.Paris.OpenData.Velo.BicycleCount'] (
    [counter_id]: string,
    [counter_name]: string,
    [count]: int,
@@ -120,9 +120,9 @@
    [___subject]: string
 );
 
-.alter table [BicycleCount] docstring "{\"description\": \"Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.\"}";
+.alter table ['FR.Paris.OpenData.Velo.BicycleCount'] docstring "{\"description\": \"Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.\"}";
 
-.alter table [BicycleCount] column-docstrings (
+.alter table ['FR.Paris.OpenData.Velo.BicycleCount'] column-docstrings (
    [counter_id]: "{\"description\": \"Unique identifier for the counting channel (mapped from 'id_compteur').\"}",
    [counter_name]: "{\"description\": \"Human-readable name of the counter including street name and direction (mapped from 'nom_compteur').\"}",
    [count]: "{\"description\": \"Number of bicycles counted during the one-hour window (mapped from 'sum_counts').\"}",
@@ -136,7 +136,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BicycleCount] ingestion json mapping "BicycleCount_json_flat"
+.create-or-alter table ['FR.Paris.OpenData.Velo.BicycleCount'] ingestion json mapping "FR.Paris.OpenData.Velo.BicycleCount_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -153,7 +153,7 @@
 ]
 ```
 
-.create-or-alter table [BicycleCount] ingestion json mapping "BicycleCount_json_ce_structured"
+.create-or-alter table ['FR.Paris.OpenData.Velo.BicycleCount'] ingestion json mapping "FR.Paris.OpenData.Velo.BicycleCount_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -170,13 +170,13 @@
 ]
 ```
 
-.drop materialized-view BicycleCountLatest ifexists;
+.drop materialized-view ['FR.Paris.OpenData.Velo.BicycleCountLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BicycleCountLatest on table BicycleCount {
-    BicycleCount | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['FR.Paris.OpenData.Velo.BicycleCountLatest'] on table ['FR.Paris.OpenData.Velo.BicycleCount'] {
+    ['FR.Paris.OpenData.Velo.BicycleCount'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BicycleCount] policy update
+.alter table ['FR.Paris.OpenData.Velo.BicycleCount'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/paris-bicycle-counters/notebook/paris-bicycle-counters-feed.ipynb
+++ b/paris-bicycle-counters/notebook/paris-bicycle-counters-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Paris Bicycle Counters Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Paris Open Data platform for hourly bicycle counts from ~141 permanent counting stations across Paris and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `paris_bicycle_counters` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `paris-bicycle-counters --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"paris-bicycle-counters-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/paris-bicycle-counters/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/paris-bicycle-counters/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing paris_bicycle_counters package from Fabric Environment...')\n",
+    "    from paris_bicycle_counters import paris_bicycle_counters as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['paris-bicycle-counters', '--once'] if ONCE_MODE else ['paris-bicycle-counters']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
+++ b/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
@@ -290,8 +290,15 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        help='Run a single polling cycle and exit. Honors the ONCE_MODE env var when set to a truthy value.')
 
     args = parser.parse_args()
+
+    if not args.once:
+        once_env = os.getenv('ONCE_MODE', '').strip().lower()
+        if once_env in ('1', 'true', 'yes', 'on'):
+            args.once = True
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
@@ -337,7 +344,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/paris-bicycle-counters/tests/test_once_mode.py
+++ b/paris-bicycle-counters/tests/test_once_mode.py
@@ -1,0 +1,59 @@
+"""Tests for --once / ONCE_MODE single-cycle execution."""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from paris_bicycle_counters import paris_bicycle_counters as bridge
+
+
+def _patched_poller_factory(call_recorder):
+    def _factory(*args, **kwargs):
+        inst = MagicMock()
+        def _poll(once=False):
+            call_recorder['once'] = once
+            call_recorder['calls'] += 1
+        inst.poll_and_send.side_effect = _poll
+        return inst
+    return _factory
+
+
+def test_once_flag_runs_single_cycle(monkeypatch):
+    recorder = {'once': None, 'calls': 0}
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+    monkeypatch.setattr(sys, 'argv', ['paris-bicycle-counters', '--once'])
+    with patch.object(bridge, 'ParisBicycleCounterPoller',
+                      side_effect=_patched_poller_factory(recorder)):
+        bridge.main()
+    assert recorder['calls'] == 1
+    assert recorder['once'] is True
+
+
+def test_once_mode_env_var(monkeypatch):
+    recorder = {'once': None, 'calls': 0}
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+    monkeypatch.setattr(sys, 'argv', ['paris-bicycle-counters'])
+    with patch.object(bridge, 'ParisBicycleCounterPoller',
+                      side_effect=_patched_poller_factory(recorder)):
+        bridge.main()
+    assert recorder['calls'] == 1
+    assert recorder['once'] is True
+
+
+def test_default_runs_continuous(monkeypatch):
+    recorder = {'once': None, 'calls': 0}
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+    monkeypatch.setattr(sys, 'argv', ['paris-bicycle-counters'])
+    with patch.object(bridge, 'ParisBicycleCounterPoller',
+                      side_effect=_patched_poller_factory(recorder)):
+        bridge.main()
+    assert recorder['calls'] == 1
+    assert recorder['once'] is False


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## What
- Adds `paris-bicycle-counters/notebook/paris-bicycle-counters-feed.ipynb` (copied verbatim from the canonical `pegelonline/notebook/pegelonline-feed.ipynb` and mechanically substituted per `references/notebook-substitution-table.md`).
- Flips `catalog.json` `notebook: true` for `paris-bicycle-counters` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds `--once` CLI flag and `ONCE_MODE` env-var support to the bridge (required by the Fabric notebook scheduler — bridge previously had no single-cycle exit path).
- Adds `tests/test_once_mode.py` covering `--once`, `ONCE_MODE`, and default continuous mode.
- README touch linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Bonus (mandatory skill step 5b)
- Regenerated `kql/paris_bicycle_counters.kql` with `-Qualified -Namespace 'FR.Paris.OpenData.Velo'` (xreg has a single messagegroup namespace). Tables/MVs/mappings are now namespace-prefixed so they don't collide with other feeders sharing an Eventhouse.

## Validated locally
- Notebook JSON well-formed (`json.load` ok).
- All bridge tests pass: `46 passed` including the new `test_once_mode.py`.
- Parameters cell contains all five placeholders the deploy script patches: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns: no `asyncio.run(`, no `%pip install` (per-cell check), no hard-coded `CONNECTION_STRING =`, no `primaryConnectionString =`.

## Not done (per skill)
- No live Fabric deployment. The `publish-notebook-wheels.yml` workflow will pick up this source on next push to `main` and publish wheels to the `notebook-wheels` release. End-to-end Fabric validation is a separate, serial step.