### PR TITLE
feat(bfs-odl): Fabric notebook hosting

### DIFF
--- a/bfs-odl/README.md
+++ b/bfs-odl/README.md
@@ -82,3 +82,11 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fbfs-odl%2Fazure-template-with-eventhub.json)
+
+## Fabric notebook hosting
+
+This bridge can also run as a scheduled Fabric notebook
+(`notebook/bfs-odl-feed.ipynb`) deployed via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1),
+which builds a per-source Fabric Environment, binds Lakehouse + KQL +
+Event Stream, and schedules single-cycle runs of `bfs-odl feed --once`.

--- a/bfs-odl/bfs_odl/bfs_odl.py
+++ b/bfs-odl/bfs_odl/bfs_odl.py
@@ -152,6 +152,7 @@ def feed(args):
 
     polling_interval = int(args.polling_interval or os.environ.get("POLLING_INTERVAL", "3600"))
     state_file = args.state_file or os.environ.get("STATE_FILE", "")
+    once_mode = bool(getattr(args, "once", False)) or os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes")
 
     previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -217,6 +218,9 @@ def feed(args):
                 (datetime.now(timezone.utc) + timedelta(seconds=effective_interval)).isoformat(),
             )
             _save_state(state_file, previous_readings)
+            if once_mode:
+                logging.info("--once mode: exiting after first polling cycle")
+                break
             if effective_interval > 0:
                 time.sleep(effective_interval)
         except KeyboardInterrupt:
@@ -224,6 +228,9 @@ def feed(args):
             break
         except Exception as e:
             logging.error("Error occurred: %s", e)
+            if once_mode:
+                logging.info("--once mode: exiting after error")
+                break
             logging.info("Retrying in %d seconds...", polling_interval)
             time.sleep(polling_interval)
 
@@ -236,6 +243,12 @@ def main():
     feed_parser.add_argument("--connection-string", help="Kafka connection string")
     feed_parser.add_argument("--polling-interval", type=int, default=3600, help="Polling interval in seconds (default: 3600)")
     feed_parser.add_argument("--state-file", help="Path to state persistence file")
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command == "feed":

--- a/bfs-odl/kql/bfs_odl.kql
+++ b/bfs-odl/kql/bfs_odl.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['de.bfs.odl.Station'] (
    [station_id]: string,
    [station_code]: string,
    [name]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Metadata for a BfS ODL gamma dose rate monitoring station. Each station is a stationary probe in the IMIS (Integrated Measuring and Information System) network operated by the German Federal Office for Radiation Protection (Bundesamt f\\u00fcr Strahlenschutz). Stations continuously measure ambient gamma dose rate and report hourly averaged values.\"}";
+.alter table ['de.bfs.odl.Station'] docstring "{\"description\": \"Metadata for a BfS ODL gamma dose rate monitoring station. Each station is a stationary probe in the IMIS (Integrated Measuring and Information System) network operated by the German Federal Office for Radiation Protection (Bundesamt f\\u00fcr Strahlenschutz). Stations continuously measure ambient gamma dose rate and report hourly averaged values.\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['de.bfs.odl.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Nine-digit station identifier (Kennziffer) assigned by BfS in the IMIS network. Composed of the official municipality key (AGS) prefix and a station sequence number. Example: '033510091'. This is the stable key used for timeseries retrieval.\"}",
    [station_code]: "{\"description\": \"Short alphanumeric station code assigned by BfS, consisting of a 'DEZ' prefix followed by a four-digit number. Example: 'DEZ0305'. Used in the BfS web interface and download area.\"}",
    [name]: "{\"description\": \"Human-readable name of the station location, typically a German municipality or locality name. Example: 'Flensburg'.\"}",
@@ -63,7 +63,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['de.bfs.odl.Station'] ingestion json mapping "de.bfs.odl.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -84,7 +84,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['de.bfs.odl.Station'] ingestion json mapping "de.bfs.odl.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -105,13 +105,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['de.bfs.odl.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['de.bfs.odl.StationLatest'] on table ['de.bfs.odl.Station'] {
+    ['de.bfs.odl.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['de.bfs.odl.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -122,7 +122,7 @@
 }]
 ```
 
-.create-merge table [DoseRateMeasurement] (
+.create-merge table ['de.bfs.odl.DoseRateMeasurement'] (
    [station_id]: string,
    [start_measure]: string,
    [end_measure]: string,
@@ -138,9 +138,9 @@
    [___subject]: string
 );
 
-.alter table [DoseRateMeasurement] docstring "{\"description\": \"A one-hour averaged ambient gamma dose rate measurement from a BfS ODL station. The gross dose rate value is the total ambient dose equivalent rate H*(10) at 1 meter above ground, expressed in microsieverts per hour (\\u00b5Sv/h). It may be decomposed into a cosmic component (secondary cosmic radiation, altitude-dependent) and a terrestrial component (naturally occurring radionuclides in soil, geology-dependent). Normal background levels in Germany range from approximately 0.05 to 0.18 \\u00b5Sv/h depending on local geology and altitude.\"}";
+.alter table ['de.bfs.odl.DoseRateMeasurement'] docstring "{\"description\": \"A one-hour averaged ambient gamma dose rate measurement from a BfS ODL station. The gross dose rate value is the total ambient dose equivalent rate H*(10) at 1 meter above ground, expressed in microsieverts per hour (\\u00b5Sv/h). It may be decomposed into a cosmic component (secondary cosmic radiation, altitude-dependent) and a terrestrial component (naturally occurring radionuclides in soil, geology-dependent). Normal background levels in Germany range from approximately 0.05 to 0.18 \\u00b5Sv/h depending on local geology and altitude.\"}";
 
-.alter table [DoseRateMeasurement] column-docstrings (
+.alter table ['de.bfs.odl.DoseRateMeasurement'] column-docstrings (
    [station_id]: "{\"description\": \"Nine-digit station identifier (Kennziffer) of the measuring probe. Matches the station_id in the Station schema.\"}",
    [start_measure]: "{\"description\": \"Start of the one-hour measurement period in ISO 8601 UTC format. Example: '2026-04-07T12:00:00Z'.\"}",
    [end_measure]: "{\"description\": \"End of the one-hour measurement period in ISO 8601 UTC format. Example: '2026-04-07T13:00:00Z'.\"}",
@@ -156,7 +156,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [DoseRateMeasurement] ingestion json mapping "DoseRateMeasurement_json_flat"
+.create-or-alter table ['de.bfs.odl.DoseRateMeasurement'] ingestion json mapping "de.bfs.odl.DoseRateMeasurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -175,7 +175,7 @@
 ]
 ```
 
-.create-or-alter table [DoseRateMeasurement] ingestion json mapping "DoseRateMeasurement_json_ce_structured"
+.create-or-alter table ['de.bfs.odl.DoseRateMeasurement'] ingestion json mapping "de.bfs.odl.DoseRateMeasurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -194,13 +194,13 @@
 ]
 ```
 
-.drop materialized-view DoseRateMeasurementLatest ifexists;
+.drop materialized-view ['de.bfs.odl.DoseRateMeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DoseRateMeasurementLatest on table DoseRateMeasurement {
-    DoseRateMeasurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['de.bfs.odl.DoseRateMeasurementLatest'] on table ['de.bfs.odl.DoseRateMeasurement'] {
+    ['de.bfs.odl.DoseRateMeasurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DoseRateMeasurement] policy update
+.alter table ['de.bfs.odl.DoseRateMeasurement'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/bfs-odl/notebook/bfs-odl-feed.ipynb
+++ b/bfs-odl/notebook/bfs-odl-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BfS ODL Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the German Bundesamt für Strahlenschutz (BfS) ODL WFS endpoint for ambient gamma dose rate measurements from ~1,700 stations across Germany and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `bfs_odl` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `bfs-odl feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"bfs-odl-ingest\"          # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/bfs-odl/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/bfs-odl/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing bfs_odl package from Fabric Environment...')\n",
+    "    from bfs_odl import bfs_odl as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['bfs-odl', 'feed', '--once'] if ONCE_MODE else ['bfs-odl', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/bfs-odl/tests/test_once_mode.py
+++ b/bfs-odl/tests/test_once_mode.py
@@ -1,0 +1,125 @@
+"""Tests for --once / ONCE_MODE single-cycle execution."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bfs_odl import bfs_odl as bridge
+
+
+SAMPLE_STATION_FEATURE = {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [9.38, 54.78]},
+    "properties": {
+        "id": "DEZ0001",
+        "kenn": "010010001",
+        "plz": "24941",
+        "name": "Flensburg",
+        "site_status": 1,
+        "site_status_text": "in Betrieb",
+        "kid": 6,
+        "height_above_sea": 39,
+    },
+}
+
+SAMPLE_MEASUREMENT_FEATURE = {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [10.24, 52.74]},
+    "properties": {
+        "id": "DEZ0305",
+        "kenn": "033510091",
+        "plz": "29348",
+        "name": "Eschede",
+        "site_status": 1,
+        "site_status_text": "in Betrieb",
+        "kid": 5,
+        "height_above_sea": 63,
+        "start_measure": "2026-04-07T12:00:00Z",
+        "end_measure": "2026-04-07T13:00:00Z",
+        "value": 0.079,
+        "value_cosmic": 0.043,
+        "value_terrestrial": 0.036,
+        "unit": "µSv/h",
+        "validated": 1,
+        "nuclide": "Gamma-ODL-Brutto",
+        "duration": "1h",
+    },
+}
+
+
+@pytest.fixture
+def _mock_kafka_and_api(monkeypatch):
+    """Patch out Kafka producer + BfsOdlAPI so feed() runs without network."""
+    fake_producer = MagicMock()
+    monkeypatch.setattr(bridge, "Producer", MagicMock(return_value=fake_producer))
+
+    fake_event_producer = MagicMock()
+    monkeypatch.setattr(
+        bridge, "DeBfsOdlEventProducer", MagicMock(return_value=fake_event_producer)
+    )
+
+    fake_api = MagicMock()
+    fake_api.fetch_stations.return_value = [SAMPLE_STATION_FEATURE]
+    fake_api.parse_station.side_effect = lambda f: bridge.BfsOdlAPI.parse_station(f)
+    fake_api.fetch_latest_measurements.return_value = [SAMPLE_MEASUREMENT_FEATURE]
+    fake_api.parse_measurement.side_effect = lambda f: bridge.BfsOdlAPI.parse_measurement(f)
+    monkeypatch.setattr(bridge, "BfsOdlAPI", MagicMock(return_value=fake_api))
+
+    return fake_api, fake_producer
+
+
+def _no_sleep(*_args, **_kwargs):
+    raise AssertionError("time.sleep must not be called in --once mode")
+
+
+def test_once_flag_exits_after_one_cycle(monkeypatch, tmp_path, _mock_kafka_and_api):
+    """`--once` causes feed() to return after exactly one polling cycle."""
+    fake_api, _ = _mock_kafka_and_api
+    monkeypatch.setattr(bridge.time, "sleep", _no_sleep)
+
+    state_file = str(tmp_path / "state.json")
+    argv = [
+        "bfs-odl",
+        "feed",
+        "--connection-string",
+        "BootstrapServer=localhost:9092;EntityPath=test-bfs-odl",
+        "--polling-interval",
+        "1",
+        "--state-file",
+        state_file,
+        "--once",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    # Should return cleanly, not block in the polling loop.
+    bridge.main()
+
+    assert fake_api.fetch_stations.call_count == 1
+    assert fake_api.fetch_latest_measurements.call_count == 1
+
+
+def test_once_mode_env_var_exits_after_one_cycle(monkeypatch, tmp_path, _mock_kafka_and_api):
+    """`ONCE_MODE=true` env var alone (no --once flag) also triggers single-cycle exit."""
+    fake_api, _ = _mock_kafka_and_api
+    monkeypatch.setattr(bridge.time, "sleep", _no_sleep)
+
+    state_file = str(tmp_path / "state.json")
+    argv = [
+        "bfs-odl",
+        "feed",
+        "--connection-string",
+        "BootstrapServer=localhost:9092;EntityPath=test-bfs-odl",
+        "--polling-interval",
+        "1",
+        "--state-file",
+        state_file,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setenv("ONCE_MODE", "true")
+
+    bridge.main()
+
+    assert fake_api.fetch_latest_measurements.call_count == 1

--- a/catalog.json
+++ b/catalog.json
@@ -493,7 +493,8 @@
     "cat": "Radiation",
     "key": false,
     "desc": "Germany — ~1,700 stations, hourly gamma dose rate",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "eurdep-radiation",


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` skill at
`.github/skills/notebook-feeder-retrofit/SKILL.md`.

## What changed

- `bfs-odl/notebook/bfs-odl-feed.ipynb` — verbatim copy of
  `pegelonline/notebook/pegelonline-feed.ipynb` with the mechanical
  substitution table applied (bridge import, `sys.argv`, feeder-state
  paths, `EVENTSTREAM_NAME`, display name).
- `bfs-odl/bfs_odl/bfs_odl.py` — added `--once` CLI flag (also
  honors `ONCE_MODE` env var) and a single-cycle exit branch in the
  polling loop, modeled on `pegelonline`. This is the bridge-side
  change the skill explicitly allows when gate (2) fails but the bridge
  is a clean poller.
- `bfs-odl/tests/test_once_mode.py` — new unit tests asserting
  `main()` returns after one cycle for both the `--once` flag and
  the `ONCE_MODE` env var.
- `bfs-odl/README.md` — one-sentence Fabric notebook hosting bullet
  linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- `catalog.json` — flipped `notebook: true` on the `bfs-odl`
  entry so the gh-pages portal exposes the Fabric Notebook deploy
  button.
- `bfs-odl/kql/bfs_odl.kql` — regenerated with
  `-Qualified -Namespace de.bfs.odl` (single messagegroup namespace)
  so tables, materialized views, mappings, and update policies are
  namespace-qualified (e.g. `['de.bfs.odl.Station']`). Prevents
  collisions when multiple feeders share an Eventhouse.

## Eligibility gate

| Check | Result |
|---|---|
| 1. Source layout (pyproject, xreg, `def main()`) | ✅ |
| 2. Single-cycle execution (`--once` / `ONCE_MODE`) | ✅ added in this PR |
| 3. Poll-based bridge (not websocket/MQTT/SSE) | ✅ `time.sleep` + `POLLING_INTERVAL` |
| 4. Docker E2E test exists on main | ✅ `TestBfsOdlDockerFlow` |
| 5. No pre-existing `notebook/` dir | ✅ |

## Local validations performed

- Notebook JSON well-formed (`json.load`).
- All 17 bridge unit tests pass (15 existing + 2 new `--once` tests) in
  a fresh local `.venv`.
- Notebook parameters cell declares all five placeholders the deploy
  script overwrites: `EVENTSTREAM_NAME`, `STATE_FILE`,
  `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in code cells: `asyncio.run(`,
  `%pip install`, hard-coded `CONNECTION_STRING="..."`, or
  `primaryConnectionString =`.

## Out of scope

- No live Fabric deployment (per skill section 7). The
  `publish-notebook-wheels.yml` workflow will pick up this source on
  merge to main and publish `bfs-odl-notebook-wheels.zip` to the
  `notebook-wheels` release. End-to-end Fabric verification is a
  separate manual step.