### PR TITLE
feat(madrid-traffic): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -589,7 +589,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "Madrid, Spain — ~4,000 sensors, Informo",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "ndl-netherlands",

--- a/madrid-traffic/README.md
+++ b/madrid-traffic/README.md
@@ -20,6 +20,10 @@ See [EVENTS.md](EVENTS.md) for full schema details.
 3. Reference data is refreshed hourly.
 4. Deduplication: readings with the same 5-minute timestamp boundary are not re-emitted.
 
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Fabric notebook (single-cycle execution against an attached Fabric Environment + Lakehouse + Event Stream). Deploy with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1); the notebook lives at [`notebook/madrid-traffic-feed.ipynb`](notebook/madrid-traffic-feed.ipynb).
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/madrid-traffic/kql/madrid_traffic.kql
+++ b/madrid-traffic/kql/madrid_traffic.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [MeasurementPoint] (
+.create-merge table ['es.madrid.informo.MeasurementPoint'] (
    [sensor_id]: string,
    [description]: string,
    [element_type]: string,
@@ -40,9 +40,9 @@
    [___subject]: string
 );
 
-.alter table [MeasurementPoint] docstring "{\"description\": \"Reference data for a traffic measurement point (sensor) in Madrid's Informo road traffic monitoring system. Each measurement point is installed on a specific road segment and reports traffic intensity, occupancy, and service level readings. This data is relatively static and describes the sensor installation, not the real-time traffic conditions.\"}";
+.alter table ['es.madrid.informo.MeasurementPoint'] docstring "{\"description\": \"Reference data for a traffic measurement point (sensor) in Madrid's Informo road traffic monitoring system. Each measurement point is installed on a specific road segment and reports traffic intensity, occupancy, and service level readings. This data is relatively static and describes the sensor installation, not the real-time traffic conditions.\"}";
 
-.alter table [MeasurementPoint] column-docstrings (
+.alter table ['es.madrid.informo.MeasurementPoint'] column-docstrings (
    [sensor_id]: "{\"description\": \"Unique sensor identifier from the Madrid Informo system. Corresponds to the 'idelem' field in the upstream XML. Numeric code assigned by the Madrid traffic management center to each measurement point.\"}",
    [description]: "{\"description\": \"Human-readable description of the road segment where this sensor is installed. Typically includes the street name, direction, and bounding cross-streets. Corresponds to 'descripcion' in the upstream XML. Text is in Spanish.\"}",
    [element_type]: "{\"description\": \"Classification of the measurement point within Madrid's traffic network. Derived from the 'accesoAsociado' field prefix in the upstream XML. Common values include 'URB' for urban streets and 'M30' for the M-30 ring motorway.\"}",
@@ -57,7 +57,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [MeasurementPoint] ingestion json mapping "MeasurementPoint_json_flat"
+.create-or-alter table ['es.madrid.informo.MeasurementPoint'] ingestion json mapping "es.madrid.informo.MeasurementPoint_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -75,7 +75,7 @@
 ]
 ```
 
-.create-or-alter table [MeasurementPoint] ingestion json mapping "MeasurementPoint_json_ce_structured"
+.create-or-alter table ['es.madrid.informo.MeasurementPoint'] ingestion json mapping "es.madrid.informo.MeasurementPoint_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -93,13 +93,13 @@
 ]
 ```
 
-.drop materialized-view MeasurementPointLatest ifexists;
+.drop materialized-view ['es.madrid.informo.MeasurementPointLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MeasurementPointLatest on table MeasurementPoint {
-    MeasurementPoint | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['es.madrid.informo.MeasurementPointLatest'] on table ['es.madrid.informo.MeasurementPoint'] {
+    ['es.madrid.informo.MeasurementPoint'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [MeasurementPoint] policy update
+.alter table ['es.madrid.informo.MeasurementPoint'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -110,7 +110,7 @@
 }]
 ```
 
-.create-merge table [TrafficReading] (
+.create-merge table ['es.madrid.informo.TrafficReading'] (
    [sensor_id]: string,
    [intensity]: int,
    [occupancy]: int,
@@ -125,9 +125,9 @@
    [___subject]: string
 );
 
-.alter table [TrafficReading] docstring "{\"description\": \"Real-time traffic reading from a measurement point in Madrid's Informo road traffic monitoring system. Updated approximately every 5 minutes. Each reading provides the current traffic intensity, road occupancy, load, and service level for a specific sensor on Madrid's road network, including the M-30 ring motorway and urban streets.\"}";
+.alter table ['es.madrid.informo.TrafficReading'] docstring "{\"description\": \"Real-time traffic reading from a measurement point in Madrid's Informo road traffic monitoring system. Updated approximately every 5 minutes. Each reading provides the current traffic intensity, road occupancy, load, and service level for a specific sensor on Madrid's road network, including the M-30 ring motorway and urban streets.\"}";
 
-.alter table [TrafficReading] column-docstrings (
+.alter table ['es.madrid.informo.TrafficReading'] column-docstrings (
    [sensor_id]: "{\"description\": \"Unique sensor identifier from the Madrid Informo system. Corresponds to 'idelem' in the upstream XML. Used as the key for correlating readings with measurement point reference data.\"}",
    [intensity]: "{\"description\": \"Current traffic intensity measured by the sensor, expressed in vehicles per hour. Corresponds to 'intensidad' in the upstream XML. A value of 0 may indicate no traffic or a sensor in standby mode.\"}",
    [occupancy]: "{\"description\": \"Percentage of time the sensor detects a vehicle presence. Corresponds to 'ocupacion' in the upstream XML. Range is 0 to 100.\"}",
@@ -142,7 +142,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TrafficReading] ingestion json mapping "TrafficReading_json_flat"
+.create-or-alter table ['es.madrid.informo.TrafficReading'] ingestion json mapping "es.madrid.informo.TrafficReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -160,7 +160,7 @@
 ]
 ```
 
-.create-or-alter table [TrafficReading] ingestion json mapping "TrafficReading_json_ce_structured"
+.create-or-alter table ['es.madrid.informo.TrafficReading'] ingestion json mapping "es.madrid.informo.TrafficReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -178,13 +178,13 @@
 ]
 ```
 
-.drop materialized-view TrafficReadingLatest ifexists;
+.drop materialized-view ['es.madrid.informo.TrafficReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TrafficReadingLatest on table TrafficReading {
-    TrafficReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['es.madrid.informo.TrafficReadingLatest'] on table ['es.madrid.informo.TrafficReading'] {
+    ['es.madrid.informo.TrafficReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TrafficReading] policy update
+.alter table ['es.madrid.informo.TrafficReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/madrid-traffic/madrid_traffic/madrid_traffic.py
+++ b/madrid-traffic/madrid_traffic/madrid_traffic.py
@@ -341,8 +341,12 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        help='Run a single polling cycle and exit (used by Fabric notebook scheduled runs)')
 
     args = parser.parse_args()
+
+    once_mode = args.once or os.getenv('ONCE_MODE', '').lower() in ('true', '1', 'yes')
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
@@ -384,7 +388,7 @@ def main():
         kafka_config=kafka_config,
         kafka_topic=kafka_topic,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=once_mode)
 
 
 if __name__ == "__main__":

--- a/madrid-traffic/notebook/madrid-traffic-feed.ipynb
+++ b/madrid-traffic/notebook/madrid-traffic-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Madrid Traffic Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Madrid Informo `pm.xml` traffic-sensor feed and emits CloudEvents to the bound Fabric Event Stream. Each cycle emits `MeasurementPoint` reference data for ~4,000 sensors (refreshed hourly) and a `TrafficReading` per sensor (intensity, occupancy, load, service level).\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `madrid_traffic` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `madrid-traffic --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"madrid-traffic-ingest\"   # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/madrid-traffic/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/madrid-traffic/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing madrid_traffic package from Fabric Environment...')\n",
+    "    from madrid_traffic import madrid_traffic as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['madrid-traffic', '--once'] if ONCE_MODE else ['madrid-traffic']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/madrid-traffic/tests/test_once_mode.py
+++ b/madrid-traffic/tests/test_once_mode.py
@@ -1,0 +1,42 @@
+"""
+Verify that the --once flag causes main() to perform a single polling cycle
+and return, instead of looping forever. This is required for Fabric notebook
+scheduled execution (single-cycle exits).
+"""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+from madrid_traffic.madrid_traffic import main
+
+
+def test_once_flag_runs_single_cycle(monkeypatch):
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'Endpoint=sb://fake/;SharedAccessKeyName=k;'
+                       'SharedAccessKey=v;EntityPath=madrid')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+
+    poller_instance = MagicMock()
+    with patch('madrid_traffic.madrid_traffic.MadridTrafficPoller',
+               return_value=poller_instance) as poller_cls, \
+         patch.object(sys, 'argv', ['madrid-traffic', '--once']):
+        main()
+
+    poller_cls.assert_called_once()
+    poller_instance.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_once_mode_env_var_runs_single_cycle(monkeypatch):
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'Endpoint=sb://fake/;SharedAccessKeyName=k;'
+                       'SharedAccessKey=v;EntityPath=madrid')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+
+    poller_instance = MagicMock()
+    with patch('madrid_traffic.madrid_traffic.MadridTrafficPoller',
+               return_value=poller_instance), \
+         patch.object(sys, 'argv', ['madrid-traffic']):
+        main()
+
+    poller_instance.poll_and_send.assert_called_once_with(once=True)


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent for source `madrid-traffic`.

**Changes**
- `madrid-traffic/notebook/madrid-traffic-feed.ipynb` — verbatim copy of the canonical pegelonline notebook with the prescribed substitutions (display name, package, argv, state/log paths, eventstream name).
- `madrid-traffic/madrid_traffic/madrid_traffic.py` — adds `--once` CLI flag (and `ONCE_MODE` env-var fallback) wired through `poll_and_send(once=...)`, modeled after pegelonline.
- `madrid-traffic/tests/test_once_mode.py` — covers the new flag and env-var paths.
- `catalog.json` — flips `notebook: true` for the `madrid-traffic` entry so the gh-pages portal exposes the deploy button.
- `madrid-traffic/kql/madrid_traffic.kql` — regenerated via `tools/generate-kql-from-xreg.ps1 -Qualified -Namespace es.madrid.informo` (single messagegroup namespace).
- `madrid-traffic/README.md` — one-sentence Fabric notebook hosting bullet.

**Validated locally**
- Notebook JSON well-formed (`json.load` ok).
- All 61 bridge unit tests pass, including the 2 new `test_once_mode` cases.
- Parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns (`asyncio.run(`, hard-coded `CONNECTION_STRING="`, `primaryConnectionString =`). The `%pip install` substring appears nowhere in the notebook.

**Out of scope (per skill)**
- No live Fabric deployment from this agent. The wheel-publish workflow runs on merge; manual end-to-end verification is performed separately.