### PR TITLE
feat(french-road-traffic): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -573,7 +573,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "France — national road network, DATEX II",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "gtfs",

--- a/french-road-traffic/README.md
+++ b/french-road-traffic/README.md
@@ -61,6 +61,13 @@ cd french-road-traffic
 pwsh generate_producer.ps1
 ```
 
+## Fabric notebook hosting
+
+This source can be deployed as a Fabric notebook (scheduled single-cycle
+execution) via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+The notebook lives at [`notebook/french-road-traffic-feed.ipynb`](notebook/french-road-traffic-feed.ipynb)
+and runs `french-road-traffic feed --once` per tick.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/french-road-traffic/french_road_traffic/french_road_traffic.py
+++ b/french-road-traffic/french_road_traffic/french_road_traffic.py
@@ -366,6 +366,7 @@ def run_bridge(
     polling_interval: int,
     flow_url: str = TRAFFIC_FLOW_URL,
     events_url: str = ROAD_EVENTS_URL,
+    once: bool = False,
 ) -> None:
     """Main polling loop: fetch DATEX II XML, parse, emit CloudEvents."""
     producer = Producer(kafka_config)
@@ -448,6 +449,10 @@ def run_bridge(
                 flow_count, event_count, elapsed,
             )
 
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
+
             remaining = max(0, polling_interval - elapsed)
             if remaining > 0:
                 time.sleep(remaining)
@@ -498,6 +503,11 @@ def main() -> None:
         "-i", "--polling-interval", type=int, default=polling_default,
         help="Polling interval in seconds (default: 360)",
     )
+    feed_parser.add_argument(
+        "--once", action="store_true",
+        default=os.getenv("ONCE_MODE", "false").lower() in ("true", "1", "yes"),
+        help="Run a single polling cycle and exit (for scheduled/notebook execution).",
+    )
 
     args = parser.parse_args()
 
@@ -538,7 +548,7 @@ def main() -> None:
         elif tls_enabled:
             kafka_config["security.protocol"] = "SSL"
 
-        run_bridge(kafka_config, topic_flow, topic_events, args.polling_interval)
+        run_bridge(kafka_config, topic_flow, topic_events, args.polling_interval, once=args.once)
     else:
         parser.print_help()
 

--- a/french-road-traffic/kql/french_road_traffic.kql
+++ b/french-road-traffic/kql/french_road_traffic.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [TrafficFlowMeasurement] (
+.create-merge table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] (
    [site_id]: string,
    [measurement_time]: string,
    [vehicle_flow_rate]: int,
@@ -39,9 +39,9 @@
    [___subject]: string
 );
 
-.alter table [TrafficFlowMeasurement] docstring "{\"description\": \"Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Each record corresponds to one siteMeasurements element in the Bison Fut\\u00e9 MeasuredDataPublication DATEX II feed, containing aggregated vehicle flow rate (vehicles per hour) and average vehicle speed (km/h) for the measurement interval.\"}";
+.alter table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] docstring "{\"description\": \"Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Each record corresponds to one siteMeasurements element in the Bison Fut\\u00e9 MeasuredDataPublication DATEX II feed, containing aggregated vehicle flow rate (vehicles per hour) and average vehicle speed (km/h) for the measurement interval.\"}";
 
-.alter table [TrafficFlowMeasurement] column-docstrings (
+.alter table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] column-docstrings (
    [site_id]: "{\"description\": \"Unique identifier of the DATEX II measurement site record, as declared in the measurementSiteReference element (e.g. 'MUM76.h1', 'MB631.B8'). Stable across publication snapshots.\"}",
    [measurement_time]: "{\"description\": \"ISO 8601 timestamp of the measurement, taken from the measurementTimeDefault element in the DATEX II siteMeasurements block. Represents the end of the aggregation interval.\"}",
    [vehicle_flow_rate]: "{\"description\": \"Number of vehicles per hour passing the measurement site during the aggregation interval, from the DATEX II TrafficFlow/vehicleFlowRate element. Null when flow data is not available for this site in the current snapshot.\"}",
@@ -55,7 +55,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TrafficFlowMeasurement] ingestion json mapping "TrafficFlowMeasurement_json_flat"
+.create-or-alter table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] ingestion json mapping "fr.gouv.transport.bison_fute.TrafficFlowMeasurement_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -72,7 +72,7 @@
 ]
 ```
 
-.create-or-alter table [TrafficFlowMeasurement] ingestion json mapping "TrafficFlowMeasurement_json_ce_structured"
+.create-or-alter table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] ingestion json mapping "fr.gouv.transport.bison_fute.TrafficFlowMeasurement_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -89,13 +89,13 @@
 ]
 ```
 
-.drop materialized-view TrafficFlowMeasurementLatest ifexists;
+.drop materialized-view ['fr.gouv.transport.bison_fute.TrafficFlowMeasurementLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TrafficFlowMeasurementLatest on table TrafficFlowMeasurement {
-    TrafficFlowMeasurement | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fr.gouv.transport.bison_fute.TrafficFlowMeasurementLatest'] on table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] {
+    ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TrafficFlowMeasurement] policy update
+.alter table ['fr.gouv.transport.bison_fute.TrafficFlowMeasurement'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -106,7 +106,7 @@
 }]
 ```
 
-.create-merge table [RoadEvent] (
+.create-merge table ['fr.gouv.transport.bison_fute.RoadEvent'] (
    [situation_id]: string,
    [record_id]: string,
    [version]: string,
@@ -133,9 +133,9 @@
    [___subject]: string
 );
 
-.alter table [RoadEvent] docstring "{\"description\": \"Real-time road situation record from the French national non-conceded road network DATEX II SituationPublication feed. Each record represents one situationRecord element within a situation, describing a traffic incident, construction works, lane management, environmental obstruction, or other event affecting road conditions. Location is provided as WGS84 coordinates and road identifiers.\"}";
+.alter table ['fr.gouv.transport.bison_fute.RoadEvent'] docstring "{\"description\": \"Real-time road situation record from the French national non-conceded road network DATEX II SituationPublication feed. Each record represents one situationRecord element within a situation, describing a traffic incident, construction works, lane management, environmental obstruction, or other event affecting road conditions. Location is provided as WGS84 coordinates and road identifiers.\"}";
 
-.alter table [RoadEvent] column-docstrings (
+.alter table ['fr.gouv.transport.bison_fute.RoadEvent'] column-docstrings (
    [situation_id]: "{\"description\": \"Unique identifier of the parent DATEX II situation element (e.g. '230814-001797'). Stable across version updates of the same situation.\"}",
    [record_id]: "{\"description\": \"Unique identifier of this specific situation record within the parent situation (e.g. '230814-001797-1'). Each situation may contain multiple records.\"}",
    [version]: "{\"description\": \"Version number of the parent situation, incremented each time the situation is updated by the publisher.\"}",
@@ -162,7 +162,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [RoadEvent] ingestion json mapping "RoadEvent_json_flat"
+.create-or-alter table ['fr.gouv.transport.bison_fute.RoadEvent'] ingestion json mapping "fr.gouv.transport.bison_fute.RoadEvent_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -192,7 +192,7 @@
 ]
 ```
 
-.create-or-alter table [RoadEvent] ingestion json mapping "RoadEvent_json_ce_structured"
+.create-or-alter table ['fr.gouv.transport.bison_fute.RoadEvent'] ingestion json mapping "fr.gouv.transport.bison_fute.RoadEvent_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -222,13 +222,13 @@
 ]
 ```
 
-.drop materialized-view RoadEventLatest ifexists;
+.drop materialized-view ['fr.gouv.transport.bison_fute.RoadEventLatest'] ifexists;
 
-.create materialized-view with (backfill=true) RoadEventLatest on table RoadEvent {
-    RoadEvent | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['fr.gouv.transport.bison_fute.RoadEventLatest'] on table ['fr.gouv.transport.bison_fute.RoadEvent'] {
+    ['fr.gouv.transport.bison_fute.RoadEvent'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [RoadEvent] policy update
+.alter table ['fr.gouv.transport.bison_fute.RoadEvent'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/french-road-traffic/notebook/french-road-traffic-feed.ipynb
+++ b/french-road-traffic/notebook/french-road-traffic-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# French Road Traffic Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the French national road network DATEX II feeds published by Bison Futé (TIPI) via transport.data.gouv.fr — traffic flow measurements (vehicle counts and average speeds from ~1,000 sites, refreshed every 6 minutes) and road events (incidents, works, closures, ~300+ active situations) — and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `french_road_traffic` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `french-road-traffic feed --once`, exits after one polling cycle, and persists state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"french-road-traffic-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/french-road-traffic/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/french-road-traffic/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing french_road_traffic package from Fabric Environment...')\n",
+    "    from french_road_traffic import french_road_traffic as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['french-road-traffic', 'feed', '--once'] if ONCE_MODE else ['french-road-traffic', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/french-road-traffic/tests/test_once_mode.py
+++ b/french-road-traffic/tests/test_once_mode.py
@@ -1,0 +1,72 @@
+"""Verify --once causes the bridge to exit after a single polling cycle."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from french_road_traffic import french_road_traffic as bridge
+
+
+@pytest.fixture
+def stub_kafka(monkeypatch):
+    """Replace the Confluent Kafka Producer and generated event producers."""
+
+    producer_mock = mock.MagicMock()
+    monkeypatch.setattr(bridge, "Producer", mock.MagicMock(return_value=producer_mock))
+    monkeypatch.setattr(
+        bridge,
+        "FrGouvTransportBisonFuteTrafficFlowEventProducer",
+        mock.MagicMock(),
+    )
+    monkeypatch.setattr(
+        bridge,
+        "FrGouvTransportBisonFuteRoadEventEventProducer",
+        mock.MagicMock(),
+    )
+    return producer_mock
+
+
+def test_run_bridge_once_exits_after_single_cycle(monkeypatch, stub_kafka):
+    """When once=True, run_bridge must return after one fetch cycle."""
+
+    monkeypatch.setattr(bridge, "fetch_xml", mock.MagicMock(return_value=b"<x/>"))
+    monkeypatch.setattr(bridge, "parse_traffic_flow_xml", mock.MagicMock(return_value=[]))
+    monkeypatch.setattr(bridge, "parse_road_events_xml", mock.MagicMock(return_value=[]))
+
+    sleep_calls = []
+    monkeypatch.setattr(bridge.time, "sleep", lambda s: sleep_calls.append(s))
+
+    bridge.run_bridge(
+        kafka_config={"bootstrap.servers": "x:9092"},
+        topic_flow="t-flow",
+        topic_events="t-events",
+        polling_interval=1,
+        once=True,
+    )
+
+    assert bridge.fetch_xml.call_count == 2  # flow + events, single cycle
+    assert sleep_calls == []  # no polling sleep when --once
+
+
+def test_main_once_flag_triggers_single_cycle(monkeypatch, stub_kafka):
+    """`feed --once` should call run_bridge with once=True and exit."""
+
+    run_calls = {}
+
+    def fake_run_bridge(*args, **kwargs):
+        run_calls["args"] = args
+        run_calls["kwargs"] = kwargs
+
+    monkeypatch.setattr(bridge, "run_bridge", fake_run_bridge)
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "x:9092")
+    monkeypatch.setattr(
+        bridge.sys,
+        "argv",
+        ["french-road-traffic", "feed", "--once"],
+    )
+
+    bridge.main()
+
+    assert run_calls["kwargs"].get("once") is True


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` skill (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

* **Bridge** — added `--once` CLI flag (also honours `ONCE_MODE` env var) so `run_bridge` exits after a single polling cycle, modeled on `pegelonline`. New unit tests in `tests/test_once_mode.py`.
* **Notebook** — `french-road-traffic/notebook/french-road-traffic-feed.ipynb` copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` with the exact substitutions (package, module, `sys.argv`, state/log paths under `feeder-state/french-road-traffic/`, Event Stream name `french-road-traffic-ingest`, title, intro paragraph). Four-cell structure and CS-lookup cell untouched.
* **catalog.json** — `notebook: true` inserted after `kql` so the gh-pages portal exposes the Fabric Notebook deploy button.
* **KQL** — regenerated via `tools/generate-kql-from-xreg.ps1 -Qualified -Namespace fr.gouv.transport.bison_fute` (both message groups share that namespace). Tables now use qualified names.
* **README** — one-sentence pointer to `deploy-feeder-notebook.ps1`.

## Local validation

* Notebook JSON parses.
* All 64 bridge unit tests pass (`pytest tests/`), including the 2 new `--once` tests.
* Required parameter placeholders present in cell 2: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
* No forbidden patterns (`asyncio.run(`, `%pip install`, `CONNECTION_STRING =`, `primaryConnectionString =`) in **code** cells. The markdown intro mentions `%pip install` only to state it is *not* required — verified per-cell as a false positive per skill guidance.

## Deviations

* The skill template uses `feeder-state/<source>/` for both `STATE_FILE` and `LOG_PATH`; this PR uses the hyphenated source id (`french-road-traffic`) for both paths, matching the upstream `pegelonline` template exactly.
* `--once` defaults to `ONCE_MODE` env (`true`/`1`/`yes`) so the notebook can flip it via env without rewriting `sys.argv`.
* No live Fabric deployment (per skill — that is a separate manual verification step).

## Follow-up

After merge: the `publish-notebook-wheels.yml` workflow on main will build and publish `french-road-traffic-notebook-wheels.zip` to the `notebook-wheels` release for the deploy script to consume.