### PR TITLE
feat(eurdep-radiation): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -501,7 +501,8 @@
     "cat": "Radiation",
     "key": false,
     "desc": "Europe — ~5,500 stations, 39 countries, gamma dose",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "usgs-geomag",

--- a/eurdep-radiation/README.md
+++ b/eurdep-radiation/README.md
@@ -25,6 +25,10 @@ See [EVENTS.md](EVENTS.md) for the full event catalog.
 
 See [CONTAINER.md](CONTAINER.md) for Docker deployment instructions.
 
+## Fabric notebook hosting
+
+A Fabric notebook (`notebook/eurdep-radiation-feed.ipynb`) is available for hosting the bridge inside a Microsoft Fabric workspace. Deploy with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Upstream Source
 
 - EURDEP: https://eurdep.jrc.ec.europa.eu/

--- a/eurdep-radiation/eurdep_radiation/eurdep_radiation.py
+++ b/eurdep-radiation/eurdep_radiation/eurdep_radiation.py
@@ -199,6 +199,7 @@ def feed(args):
 
     polling_interval = int(args.polling_interval or os.environ.get("POLLING_INTERVAL", "3600"))
     state_file = args.state_file or os.environ.get("STATE_FILE", "")
+    once = bool(getattr(args, "once", False)) or os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes")
 
     previous_readings: Dict[str, str] = _load_state(state_file)
 
@@ -286,6 +287,9 @@ def feed(args):
                 (datetime.now(timezone.utc) + timedelta(seconds=effective_interval)).isoformat(),
             )
             _save_state(state_file, previous_readings)
+            if once:
+                logging.info("--once mode: exiting after first polling cycle")
+                break
             if effective_interval > 0:
                 time.sleep(effective_interval)
         except KeyboardInterrupt:
@@ -305,6 +309,12 @@ def main():
     feed_parser.add_argument("--connection-string", help="Kafka connection string")
     feed_parser.add_argument("--polling-interval", type=int, default=3600, help="Polling interval in seconds (default: 3600)")
     feed_parser.add_argument("--state-file", help="Path to state persistence file")
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command == "feed":

--- a/eurdep-radiation/kql/eurdep_radiation.kql
+++ b/eurdep-radiation/kql/eurdep_radiation.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Station] (
+.create-merge table ['eu.jrc.eurdep.Station'] (
    [station_id]: string,
    [name]: string,
    [country_code]: string,
@@ -41,9 +41,9 @@
    [___subject]: string
 );
 
-.alter table [Station] docstring "{\"description\": \"Reference metadata for an ambient gamma dose rate monitoring station in the EURDEP network. EURDEP (European Radiological Data Exchange Platform) is operated by the European Commission's Joint Research Centre (JRC) and aggregates real-time radiological monitoring data from national networks across 39 European countries. Each station is identified by a country-prefixed alphanumeric code (e.g. 'AT0001' for Austria, 'DE0123' for Germany).\"}";
+.alter table ['eu.jrc.eurdep.Station'] docstring "{\"description\": \"Reference metadata for an ambient gamma dose rate monitoring station in the EURDEP network. EURDEP (European Radiological Data Exchange Platform) is operated by the European Commission's Joint Research Centre (JRC) and aggregates real-time radiological monitoring data from national networks across 39 European countries. Each station is identified by a country-prefixed alphanumeric code (e.g. 'AT0001' for Austria, 'DE0123' for Germany).\"}";
 
-.alter table [Station] column-docstrings (
+.alter table ['eu.jrc.eurdep.Station'] column-docstrings (
    [station_id]: "{\"description\": \"Alphanumeric station identifier assigned within the EURDEP network. The first two characters are the ISO 3166-1 alpha-2 country code of the operating country, followed by a numeric station sequence. Example: 'AT0001' (Austria), 'DE0123' (Germany), 'FR0456' (France). This is the stable key used for data retrieval and cross-referencing.\"}",
    [name]: "{\"description\": \"Human-readable name of the station location, typically a city or locality name. Example: 'Laa/ThayaAMS'.\"}",
    [country_code]: "{\"description\": \"ISO 3166-1 alpha-2 country code extracted from the first two characters of the station_id. Identifies the country operating the monitoring station. Example: 'AT' for Austria, 'DE' for Germany, 'CZ' for Czech Republic.\"}",
@@ -59,7 +59,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_flat"
+.create-or-alter table ['eu.jrc.eurdep.Station'] ingestion json mapping "eu.jrc.eurdep.Station_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -78,7 +78,7 @@
 ]
 ```
 
-.create-or-alter table [Station] ingestion json mapping "Station_json_ce_structured"
+.create-or-alter table ['eu.jrc.eurdep.Station'] ingestion json mapping "eu.jrc.eurdep.Station_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -97,13 +97,13 @@
 ]
 ```
 
-.drop materialized-view StationLatest ifexists;
+.drop materialized-view ['eu.jrc.eurdep.StationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) StationLatest on table Station {
-    Station | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['eu.jrc.eurdep.StationLatest'] on table ['eu.jrc.eurdep.Station'] {
+    ['eu.jrc.eurdep.Station'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Station] policy update
+.alter table ['eu.jrc.eurdep.Station'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -114,7 +114,7 @@
 }]
 ```
 
-.create-merge table [DoseRateReading] (
+.create-merge table ['eu.jrc.eurdep.DoseRateReading'] (
    [station_id]: string,
    [name]: string,
    [value]: real,
@@ -131,9 +131,9 @@
    [___subject]: string
 );
 
-.alter table [DoseRateReading] docstring "{\"description\": \"An ambient gamma dose rate reading from a EURDEP monitoring station. The gross dose rate value is the total ambient dose equivalent rate at the station location, expressed in microsieverts per hour (\\u00b5Sv/h). Each reading covers a one-hour measurement window and includes validation status and the nuclide type measured. Normal European background levels range from approximately 0.04 to 0.20 \\u00b5Sv/h depending on local geology and altitude.\"}";
+.alter table ['eu.jrc.eurdep.DoseRateReading'] docstring "{\"description\": \"An ambient gamma dose rate reading from a EURDEP monitoring station. The gross dose rate value is the total ambient dose equivalent rate at the station location, expressed in microsieverts per hour (\\u00b5Sv/h). Each reading covers a one-hour measurement window and includes validation status and the nuclide type measured. Normal European background levels range from approximately 0.04 to 0.20 \\u00b5Sv/h depending on local geology and altitude.\"}";
 
-.alter table [DoseRateReading] column-docstrings (
+.alter table ['eu.jrc.eurdep.DoseRateReading'] column-docstrings (
    [station_id]: "{\"description\": \"Alphanumeric station identifier from the EURDEP network. Matches the station_id in the Station schema. Example: 'AT0001'.\"}",
    [name]: "{\"description\": \"Human-readable name of the station location. Included for convenience so readings are self-describing without a Station reference join.\"}",
    [value]: "{\"description\": \"Gross ambient gamma dose rate averaged over the measurement period in microsieverts per hour (\\u00b5Sv/h). Null if the station did not report a valid measurement for this interval.\"}",
@@ -150,7 +150,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [DoseRateReading] ingestion json mapping "DoseRateReading_json_flat"
+.create-or-alter table ['eu.jrc.eurdep.DoseRateReading'] ingestion json mapping "eu.jrc.eurdep.DoseRateReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -170,7 +170,7 @@
 ]
 ```
 
-.create-or-alter table [DoseRateReading] ingestion json mapping "DoseRateReading_json_ce_structured"
+.create-or-alter table ['eu.jrc.eurdep.DoseRateReading'] ingestion json mapping "eu.jrc.eurdep.DoseRateReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -190,13 +190,13 @@
 ]
 ```
 
-.drop materialized-view DoseRateReadingLatest ifexists;
+.drop materialized-view ['eu.jrc.eurdep.DoseRateReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DoseRateReadingLatest on table DoseRateReading {
-    DoseRateReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['eu.jrc.eurdep.DoseRateReadingLatest'] on table ['eu.jrc.eurdep.DoseRateReading'] {
+    ['eu.jrc.eurdep.DoseRateReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DoseRateReading] policy update
+.alter table ['eu.jrc.eurdep.DoseRateReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/eurdep-radiation/notebook/eurdep-radiation-feed.ipynb
+++ b/eurdep-radiation/notebook/eurdep-radiation-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EURDEP Radiation Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the EURDEP (European Radiological Data Exchange Platform) WFS endpoint hosted by the German BfS for ambient gamma dose rate measurements from ~5,500 monitoring stations across 39 European countries and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `eurdep_radiation` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No pip install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `eurdep-radiation feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"eurdep-radiation-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/eurdep-radiation/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/eurdep-radiation/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing eurdep_radiation package from Fabric Environment...')\n",
+    "    from eurdep_radiation import eurdep_radiation as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['eurdep-radiation', 'feed', '--once'] if ONCE_MODE else ['eurdep-radiation', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/eurdep-radiation/tests/test_once_mode.py
+++ b/eurdep-radiation/tests/test_once_mode.py
@@ -1,0 +1,57 @@
+"""Test that --once causes the EURDEP bridge to exit after one polling cycle."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+from eurdep_radiation.eurdep_radiation import feed
+
+
+SAMPLE_FEATURE = {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [16.39, 48.73]},
+    "properties": {
+        "id": "AT0001",
+        "name": "Laa/Thaya",
+        "site_status": 1,
+        "site_status_text": "in Betrieb",
+        "height_above_sea": 183,
+        "analyzed_range_in_h": 1,
+        "start_measure": "2026-04-08T19:00:00Z",
+        "end_measure": "2026-04-08T20:00:00Z",
+        "value": 0.08,
+        "unit": "µSv/h",
+        "validated": 2,
+        "nuclide": "Gamma-ODL-Brutto",
+        "duration": "1h",
+    },
+}
+
+
+def _make_args(once: bool):
+    return argparse.Namespace(
+        command="feed",
+        connection_string="BootstrapServer=localhost:9092;EntityPath=eurdep-radiation",
+        polling_interval=1,
+        state_file="",
+        once=once,
+    )
+
+
+@patch("eurdep_radiation.eurdep_radiation.time.sleep")
+@patch("eurdep_radiation.eurdep_radiation.EuJrcEurdepEventProducer")
+@patch("eurdep_radiation.eurdep_radiation.Producer")
+@patch("eurdep_radiation.eurdep_radiation.EurdepAPI.fetch_all_features")
+def test_once_mode_exits_after_one_cycle(
+    mock_fetch, mock_producer_cls, mock_event_producer_cls, mock_sleep
+):
+    mock_fetch.return_value = [SAMPLE_FEATURE]
+    mock_producer_cls.return_value = MagicMock()
+    mock_event_producer_cls.return_value = MagicMock()
+
+    # Should return (not loop) when --once is set.
+    feed(_make_args(once=True))
+
+    # Initial reference fetch + one telemetry fetch = 2 calls; no third.
+    assert mock_fetch.call_count == 2
+    # No sleep should be executed in --once mode after the cycle.
+    mock_sleep.assert_not_called()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent. Adds Fabric notebook hosting for the EURDEP radiation source.

## Changes

- `eurdep-radiation/notebook/eurdep-radiation-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per the skill's substitution table (package/module names, EVENTSTREAM_NAME, STATE_FILE, LOG_PATH, sys.argv, markdown title/paragraph).
- `catalog.json` — adds `"notebook": true` to the eurdep-radiation entry (inserted after `kql`) so the gh-pages portal exposes the Fabric Notebook deploy button.
- `eurdep-radiation/eurdep_radiation/eurdep_radiation.py` — adds `--once` CLI flag (also honored via `ONCE_MODE` env var) that exits the polling loop after one cycle. Required because the canonical Fabric notebook pattern runs `<source> feed --once` per scheduled execution.
- `eurdep-radiation/tests/test_once_mode.py` — new unit test asserting `--once` causes `feed()` to return after exactly one cycle (mocks the upstream WFS fetch).
- `eurdep-radiation/kql/eurdep_radiation.kql` — regenerated with `-Qualified -Namespace eu.jrc.eurdep` so table names are namespace-qualified (`[eu.jrc.eurdep.Station]`, `[eu.jrc.eurdep.DoseRateReading]`). The xreg contract has a single messagegroup namespace, so the override is unambiguous.
- `eurdep-radiation/README.md` — one-sentence Fabric notebook hosting bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validation performed locally

- ✅ Notebook JSON parses with `json.load`.
- ✅ All 43 bridge unit tests pass (42 existing + 1 new `test_once_mode`).
- ✅ Parameters cell contains all placeholders the deploy script patches: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- ✅ Notebook contains no forbidden patterns: no `asyncio.run(`, no `%pip install`, no literal `CONNECTION_STRING="..."` or `primaryConnectionString = ...` assignments.
- ✅ Four-cell structure preserved; CS-lookup cell, worker-thread run cell, and OneLake log path layout are byte-identical to the pegelonline template apart from the documented substitutions.

## Deployment

The agent did **not** run a live Fabric deployment per the skill. The `publish-notebook-wheels.yml` workflow will pick up this source on next push to `main` and publish wheels to the `notebook-wheels` release. End-to-end Fabric verification is a separate, serial step performed by the maintainer.

Skill reference: `.github/skills/notebook-feeder-retrofit/SKILL.md`.