### PR TITLE
feat(autobahn): Fabric notebook hosting

### DIFF
--- a/autobahn/README.md
+++ b/autobahn/README.md
@@ -56,6 +56,10 @@ python -m autobahn feed \
   --resources roadworks,warning,closure
 ```
 
+- Fabric notebook hosting: deploy a single-cycle scheduled feeder via
+  [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+  (uses `autobahn/notebook/autobahn-feed.ipynb`).
+
 ## Environment Variables
 
 The bridge accepts these environment variables when the corresponding command

--- a/autobahn/autobahn/autobahn.py
+++ b/autobahn/autobahn/autobahn.py
@@ -747,7 +747,7 @@ class AutobahnPoller:
         self.save_state()
         return changes_by_family
 
-    async def poll_and_send(self) -> None:
+    async def poll_and_send(self, once: bool = False) -> None:
         timeout = aiohttp.ClientTimeout(total=60)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             while True:
@@ -758,6 +758,10 @@ class AutobahnPoller:
                     logger.info("Autobahn cycle complete: %s", summary)
                 else:
                     logger.info("Autobahn cycle complete: no changes")
+
+                if once:
+                    logger.info("--once mode: exiting after first polling cycle")
+                    return
 
                 elapsed = datetime.now(timezone.utc) - cycle_started
                 remaining = timedelta(seconds=self.poll_interval_seconds) - elapsed
@@ -854,6 +858,7 @@ def main() -> None:
     feed_parser.add_argument("--sasl-password", type=str, default=None, help="SASL password")
     feed_parser.add_argument("--connection-string", type=str, default=None, help="Event Hubs or Fabric Event Streams connection string")
     feed_parser.add_argument("--log-level", type=str, default=None, help="Logging level")
+    feed_parser.add_argument("--once", action="store_true", help="Run a single polling cycle and exit (for scheduled hosts like Fabric notebooks)")
 
     args = parser.parse_args()
     if not args.subcommand:
@@ -887,7 +892,8 @@ def main() -> None:
         roads=roads,
         request_concurrency=request_concurrency,
     )
-    asyncio.run(poller.poll_and_send())
+    once_flag = bool(getattr(args, "once", False)) or os.getenv("ONCE_MODE", "").lower() in {"1", "true", "yes"}
+    asyncio.run(poller.poll_and_send(once=once_flag))
 
 
 if __name__ == "__main__":

--- a/autobahn/kql/autobahn.kql
+++ b/autobahn/kql/autobahn.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [RoadEvent] (
+.create-merge table ['DE.Autobahn.RoadEvent'] (
    [identifier]: string,
    [road_ids]: dynamic,
    [event_time]: datetime,
@@ -55,9 +55,9 @@
    [___subject]: string
 );
 
-.alter table [RoadEvent] docstring "{\"description\": \"Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.\"}";
+.alter table ['DE.Autobahn.RoadEvent'] docstring "{\"description\": \"Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.\"}";
 
-.alter table [RoadEvent] column-docstrings (
+.alter table ['DE.Autobahn.RoadEvent'] column-docstrings (
    [identifier]: "{\"description\": \"Stable Autobahn item identifier used for the CloudEvents subject and Kafka key.\"}",
    [road_ids]: "{\"description\": \"Autobahn road identifiers for the road query that yielded this item. The bridge emits the queried road id as a stable array field shared by all Autobahn families.\", \"schema\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"minItems\": 1, \"uniqueItems\": true, \"description\": \"Autobahn road identifiers for the road query that yielded this item. The bridge emits the queried road id as a stable array field shared by all Autobahn families.\"}}",
    [event_time]: "{\"description\": \"CloudEvents event time for the emitted record. For appeared events the bridge uses startTimestamp when the API supplies it; otherwise it uses the poll timestamp.\"}",
@@ -87,7 +87,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [RoadEvent] ingestion json mapping "RoadEvent_json_flat"
+.create-or-alter table ['DE.Autobahn.RoadEvent'] ingestion json mapping "DE.Autobahn.RoadEvent_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -120,7 +120,7 @@
 ]
 ```
 
-.create-or-alter table [RoadEvent] ingestion json mapping "RoadEvent_json_ce_structured"
+.create-or-alter table ['DE.Autobahn.RoadEvent'] ingestion json mapping "DE.Autobahn.RoadEvent_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -153,13 +153,13 @@
 ]
 ```
 
-.drop materialized-view RoadEventLatest ifexists;
+.drop materialized-view ['DE.Autobahn.RoadEventLatest'] ifexists;
 
-.create materialized-view with (backfill=true) RoadEventLatest on table RoadEvent {
-    RoadEvent | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.Autobahn.RoadEventLatest'] on table ['DE.Autobahn.RoadEvent'] {
+    ['DE.Autobahn.RoadEvent'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [RoadEvent] policy update
+.alter table ['DE.Autobahn.RoadEvent'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -170,7 +170,7 @@
 }]
 ```
 
-.create-merge table [WarningEvent] (
+.create-merge table ['DE.Autobahn.WarningEvent'] (
    [identifier]: string,
    [road_ids]: dynamic,
    [event_time]: datetime,
@@ -204,9 +204,9 @@
    [___subject]: string
 );
 
-.alter table [WarningEvent] docstring "{\"description\": \"Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning.\"}";
+.alter table ['DE.Autobahn.WarningEvent'] docstring "{\"description\": \"Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning.\"}";
 
-.alter table [WarningEvent] column-docstrings (
+.alter table ['DE.Autobahn.WarningEvent'] column-docstrings (
    [identifier]: "{\"description\": \"Stable Autobahn warning identifier used for the CloudEvents subject and Kafka key.\"}",
    [road_ids]: "{\"description\": \"Autobahn road identifiers for the road query that yielded this warning item.\", \"schema\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"minItems\": 1, \"uniqueItems\": true, \"description\": \"Autobahn road identifiers for the road query that yielded this warning item.\"}}",
    [event_time]: "{\"description\": \"CloudEvents event time for the emitted warning record. For appeared events the bridge uses startTimestamp when the API supplies it; otherwise it uses the poll timestamp.\"}",
@@ -240,7 +240,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WarningEvent] ingestion json mapping "WarningEvent_json_flat"
+.create-or-alter table ['DE.Autobahn.WarningEvent'] ingestion json mapping "DE.Autobahn.WarningEvent_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -277,7 +277,7 @@
 ]
 ```
 
-.create-or-alter table [WarningEvent] ingestion json mapping "WarningEvent_json_ce_structured"
+.create-or-alter table ['DE.Autobahn.WarningEvent'] ingestion json mapping "DE.Autobahn.WarningEvent_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -314,13 +314,13 @@
 ]
 ```
 
-.drop materialized-view WarningEventLatest ifexists;
+.drop materialized-view ['DE.Autobahn.WarningEventLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WarningEventLatest on table WarningEvent {
-    WarningEvent | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.Autobahn.WarningEventLatest'] on table ['DE.Autobahn.WarningEvent'] {
+    ['DE.Autobahn.WarningEvent'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WarningEvent] policy update
+.alter table ['DE.Autobahn.WarningEvent'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -331,7 +331,7 @@
 }]
 ```
 
-.create-merge table [ParkingLorry] (
+.create-merge table ['DE.Autobahn.ParkingLorry'] (
    [identifier]: string,
    [road_ids]: dynamic,
    [event_time]: datetime,
@@ -359,9 +359,9 @@
    [___subject]: string
 );
 
-.alter table [ParkingLorry] docstring "{\"description\": \"Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry.\"}";
+.alter table ['DE.Autobahn.ParkingLorry'] docstring "{\"description\": \"Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry.\"}";
 
-.alter table [ParkingLorry] column-docstrings (
+.alter table ['DE.Autobahn.ParkingLorry'] column-docstrings (
    [identifier]: "{\"description\": \"Stable Autobahn parking identifier used for the CloudEvents subject and Kafka key.\"}",
    [road_ids]: "{\"description\": \"Autobahn road identifiers for the road query that yielded this parking item.\", \"schema\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"minItems\": 1, \"uniqueItems\": true, \"description\": \"Autobahn road identifiers for the road query that yielded this parking item.\"}}",
    [event_time]: "{\"description\": \"CloudEvents event time for the emitted parking record. The bridge uses the poll timestamp because parking items do not expose startTimestamp in the normalized payload.\"}",
@@ -389,7 +389,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [ParkingLorry] ingestion json mapping "ParkingLorry_json_flat"
+.create-or-alter table ['DE.Autobahn.ParkingLorry'] ingestion json mapping "DE.Autobahn.ParkingLorry_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -420,7 +420,7 @@
 ]
 ```
 
-.create-or-alter table [ParkingLorry] ingestion json mapping "ParkingLorry_json_ce_structured"
+.create-or-alter table ['DE.Autobahn.ParkingLorry'] ingestion json mapping "DE.Autobahn.ParkingLorry_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -451,13 +451,13 @@
 ]
 ```
 
-.drop materialized-view ParkingLorryLatest ifexists;
+.drop materialized-view ['DE.Autobahn.ParkingLorryLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ParkingLorryLatest on table ParkingLorry {
-    ParkingLorry | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.Autobahn.ParkingLorryLatest'] on table ['DE.Autobahn.ParkingLorry'] {
+    ['DE.Autobahn.ParkingLorry'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [ParkingLorry] policy update
+.alter table ['DE.Autobahn.ParkingLorry'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -468,7 +468,7 @@
 }]
 ```
 
-.create-merge table [ChargingStation] (
+.create-merge table ['DE.Autobahn.ChargingStation'] (
    [identifier]: string,
    [road_ids]: dynamic,
    [event_time]: datetime,
@@ -495,9 +495,9 @@
    [___subject]: string
 );
 
-.alter table [ChargingStation] docstring "{\"description\": \"Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.\"}";
+.alter table ['DE.Autobahn.ChargingStation'] docstring "{\"description\": \"Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.\"}";
 
-.alter table [ChargingStation] column-docstrings (
+.alter table ['DE.Autobahn.ChargingStation'] column-docstrings (
    [identifier]: "{\"description\": \"Stable Autobahn charging-station identifier used for the CloudEvents subject and Kafka key.\"}",
    [road_ids]: "{\"description\": \"Autobahn road identifiers for the road query that yielded this charging station item.\", \"schema\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"minItems\": 1, \"uniqueItems\": true, \"description\": \"Autobahn road identifiers for the road query that yielded this charging station item.\"}}",
    [event_time]: "{\"description\": \"CloudEvents event time for the emitted charging-station record. The bridge uses the poll timestamp because charging station items do not expose startTimestamp in the normalized payload.\"}",
@@ -524,7 +524,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [ChargingStation] ingestion json mapping "ChargingStation_json_flat"
+.create-or-alter table ['DE.Autobahn.ChargingStation'] ingestion json mapping "DE.Autobahn.ChargingStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -554,7 +554,7 @@
 ]
 ```
 
-.create-or-alter table [ChargingStation] ingestion json mapping "ChargingStation_json_ce_structured"
+.create-or-alter table ['DE.Autobahn.ChargingStation'] ingestion json mapping "DE.Autobahn.ChargingStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -584,13 +584,13 @@
 ]
 ```
 
-.drop materialized-view ChargingStationLatest ifexists;
+.drop materialized-view ['DE.Autobahn.ChargingStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ChargingStationLatest on table ChargingStation {
-    ChargingStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.Autobahn.ChargingStationLatest'] on table ['DE.Autobahn.ChargingStation'] {
+    ['DE.Autobahn.ChargingStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [ChargingStation] policy update
+.alter table ['DE.Autobahn.ChargingStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -601,7 +601,7 @@
 }]
 ```
 
-.create-merge table [Webcam] (
+.create-merge table ['DE.Autobahn.Webcam'] (
    [identifier]: string,
    [road_ids]: dynamic,
    [event_time]: datetime,
@@ -628,9 +628,9 @@
    [___subject]: string
 );
 
-.alter table [Webcam] docstring "{\"description\": \"Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam.\"}";
+.alter table ['DE.Autobahn.Webcam'] docstring "{\"description\": \"Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam.\"}";
 
-.alter table [Webcam] column-docstrings (
+.alter table ['DE.Autobahn.Webcam'] column-docstrings (
    [identifier]: "{\"description\": \"Stable Autobahn webcam identifier used for the CloudEvents subject and Kafka key.\"}",
    [road_ids]: "{\"description\": \"Autobahn road identifiers for the road query that yielded this webcam item.\", \"schema\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"minItems\": 1, \"uniqueItems\": true, \"description\": \"Autobahn road identifiers for the road query that yielded this webcam item.\"}}",
    [event_time]: "{\"description\": \"CloudEvents event time for the emitted webcam record. The bridge uses the poll timestamp because webcam items do not expose startTimestamp in the normalized payload.\"}",
@@ -657,7 +657,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Webcam] ingestion json mapping "Webcam_json_flat"
+.create-or-alter table ['DE.Autobahn.Webcam'] ingestion json mapping "DE.Autobahn.Webcam_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -687,7 +687,7 @@
 ]
 ```
 
-.create-or-alter table [Webcam] ingestion json mapping "Webcam_json_ce_structured"
+.create-or-alter table ['DE.Autobahn.Webcam'] ingestion json mapping "DE.Autobahn.Webcam_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -717,13 +717,13 @@
 ]
 ```
 
-.drop materialized-view WebcamLatest ifexists;
+.drop materialized-view ['DE.Autobahn.WebcamLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WebcamLatest on table Webcam {
-    Webcam | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['DE.Autobahn.WebcamLatest'] on table ['DE.Autobahn.Webcam'] {
+    ['DE.Autobahn.Webcam'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Webcam] policy update
+.alter table ['DE.Autobahn.Webcam'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/autobahn/kql/create-kql-script.ps1
+++ b/autobahn/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\autobahn.xreg.json"
 $kqlFile = Join-Path $scriptDir "autobahn.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "DE.Autobahn"

--- a/autobahn/notebook/autobahn-feed.ipynb
+++ b/autobahn/notebook/autobahn-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Autobahn Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the German Autobahn API (`verkehr.autobahn.de/o/autobahn`) for roadworks, traffic warnings, closures, entry/exit closures, weight-limit restrictions, lorry parking, electric charging stations, and webcams, then emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `autobahn` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `autobahn feed --once`, exits after one polling cycle, and persists ETag and snapshot dedupe state to a Lakehouse Files path so the next scheduled run only emits new changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"autobahn-ingest\"        # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/autobahn/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/autobahn/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing autobahn package from Fabric Environment...')\n",
+    "    from autobahn import autobahn as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['autobahn', 'feed', '--once'] if ONCE_MODE else ['autobahn', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/autobahn/tests/test_once_mode.py
+++ b/autobahn/tests/test_once_mode.py
@@ -1,0 +1,38 @@
+"""Tests for the --once single-cycle mode used by the Fabric notebook host."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.modules.pop("autobahn", None)
+
+from autobahn.autobahn import AutobahnPoller
+
+
+def test_poll_and_send_once_runs_single_cycle(tmp_path):
+    state_file = tmp_path / "state.json"
+    poller = AutobahnPoller(
+        kafka_config=None,
+        kafka_topic="test-autobahn",
+        state_file=str(state_file),
+        poll_interval_seconds=900,
+        resources=("roadworks",),
+        roads=["A1"],
+        request_concurrency=1,
+    )
+
+    poll_once_mock = AsyncMock(return_value={"roadworks": {"appeared": 0, "updated": 0, "resolved": 0}})
+    sleep_mock = AsyncMock()
+
+    with patch.object(poller, "poll_once", poll_once_mock), \
+         patch("autobahn.autobahn.asyncio.sleep", sleep_mock):
+        asyncio.run(poller.poll_and_send(once=True))
+
+    assert poll_once_mock.await_count == 1
+    assert sleep_mock.await_count == 0

--- a/catalog.json
+++ b/catalog.json
@@ -557,7 +557,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "Germany — roadworks, warnings, closures, webcams",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "digitraffic-road",


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent
(`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- `autobahn/notebook/autobahn-feed.ipynb` — copied verbatim from
  `pegelonline/notebook/pegelonline-feed.ipynb` and substituted per
  the skill's reference substitution table (display name, package,
  module, argv, lakehouse state path, EVENTSTREAM_NAME default,
  bridge description paragraph).
- `catalog.json` — added `"notebook": true` to the `autobahn`
  entry (after `kql`) so the gh-pages portal exposes the Fabric
  Notebook deploy button.
- `autobahn/autobahn/autobahn.py` — added a `--once` flag to the
  `feed` subcommand (also honors `ONCE_MODE` env var) that exits
  `poll_and_send` after a single polling cycle. Required by the
  notebook host's single-cycle scheduled-execution model.
- `autobahn/tests/test_once_mode.py` — new unit test asserting
  `--once` exits after exactly one cycle and never sleeps.
- `autobahn/README.md` — one-sentence Fabric notebook hosting bullet.
- `autobahn/kql/create-kql-script.ps1` + `autobahn/kql/autobahn.kql`
  — regenerated with `-Qualified -Namespace DE.Autobahn` so KQL
  tables, materialized views, mappings, and update policies are
  prefixed with the schema namespace (`'DE.Autobahn.RoadEvent'` etc.),
  avoiding collisions when this source shares an Eventhouse with other
  feeders. The xreg contract has a single messagegroup namespace
  (`DE.Autobahn`).

## Validation performed locally

- Notebook JSON parses (`json.load`).
- All 16 bridge unit tests pass (15 pre-existing + 1 new
  `test_once_mode`).
- Parameters cell declares all 5 placeholders the deploy script
  patches: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`,
  `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden patterns check: clean for `asyncio.run(`, hard-coded
  `CONNECTION_STRING=`, `primaryConnectionString=`. `%pip install`
  appears only in cell 0 (markdown documentation explicitly stating
  `No %pip install is required at runtime`) — verified per-cell, not
  present in any code cell.
- KQL regeneration: table headers verified as
  `['DE.Autobahn.RoadEvent']`, `['DE.Autobahn.WarningEvent']`,
  `['DE.Autobahn.ParkingLorry']`, `['DE.Autobahn.ChargingStation']`,
  `['DE.Autobahn.Webcam']`.

## Not in scope (per skill)

No Fabric deployment from this PR. The
`publish-notebook-wheels.yml` workflow will pick up this source on
next merge to `main` and the portal exposes the button once
`update-ghpages-catalog.yml` syncs the flag.
