### PR TITLE
feat(usgs-geomag): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -509,7 +509,8 @@
     "cat": "Radiation",
     "key": false,
     "desc": "United States — 14 observatories, 1-min geomagnetic field",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "aisstream",

--- a/usgs-geomag/README.md
+++ b/usgs-geomag/README.md
@@ -11,6 +11,7 @@
 - **Deduplication**: Tracks last seen timestamp per observatory in a state file to avoid reprocessing.
 - **Kafka Integration**: Send readings to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: Optionally schedule this feeder as a Microsoft Fabric notebook using [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1); see [`notebook/usgs-geomag-feed.ipynb`](notebook/usgs-geomag-feed.ipynb).
 
 ## Observatories
 

--- a/usgs-geomag/kql/create-kql-script.ps1
+++ b/usgs-geomag/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\usgs_geomag.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs_geomag.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "gov.usgs.geomag"

--- a/usgs-geomag/kql/usgs_geomag.kql
+++ b/usgs-geomag/kql/usgs_geomag.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Observatory] (
+.create-merge table ['gov.usgs.geomag.Observatory'] (
    [iaga_code]: string,
    [name]: string,
    [agency]: string,
@@ -43,9 +43,9 @@
    [___subject]: string
 );
 
-.alter table [Observatory] docstring "{\"description\": \"Reference data for a USGS Geomagnetism Program observatory, sourced from the INTERMAGNET-compatible observatories GeoJSON endpoint at https://geomag.usgs.gov/ws/observatories/. Each feature represents a ground-based magnetometer station that continuously records geomagnetic field variations.\"}";
+.alter table ['gov.usgs.geomag.Observatory'] docstring "{\"description\": \"Reference data for a USGS Geomagnetism Program observatory, sourced from the INTERMAGNET-compatible observatories GeoJSON endpoint at https://geomag.usgs.gov/ws/observatories/. Each feature represents a ground-based magnetometer station that continuously records geomagnetic field variations.\"}";
 
-.alter table [Observatory] column-docstrings (
+.alter table ['gov.usgs.geomag.Observatory'] column-docstrings (
    [iaga_code]: "{\"description\": \"IAGA (International Association of Geomagnetism and Aeronomy) three- or four-character observatory code, e.g. BOU for Boulder, BRW for Barrow. This is the primary stable identifier for an observatory.\"}",
    [name]: "{\"description\": \"Human-readable name of the observatory, e.g. 'Boulder', 'Barrow', 'College'.\"}",
    [agency]: "{\"description\": \"Short identifier of the operating agency, e.g. 'USGS' for United States Geological Survey.\"}",
@@ -63,7 +63,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Observatory] ingestion json mapping "Observatory_json_flat"
+.create-or-alter table ['gov.usgs.geomag.Observatory'] ingestion json mapping "gov.usgs.geomag.Observatory_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -84,7 +84,7 @@
 ]
 ```
 
-.create-or-alter table [Observatory] ingestion json mapping "Observatory_json_ce_structured"
+.create-or-alter table ['gov.usgs.geomag.Observatory'] ingestion json mapping "gov.usgs.geomag.Observatory_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -105,13 +105,13 @@
 ]
 ```
 
-.drop materialized-view ObservatoryLatest ifexists;
+.drop materialized-view ['gov.usgs.geomag.ObservatoryLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ObservatoryLatest on table Observatory {
-    Observatory | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usgs.geomag.ObservatoryLatest'] on table ['gov.usgs.geomag.Observatory'] {
+    ['gov.usgs.geomag.Observatory'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Observatory] policy update
+.alter table ['gov.usgs.geomag.Observatory'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -122,7 +122,7 @@
 }]
 ```
 
-.create-merge table [MagneticFieldReading] (
+.create-merge table ['gov.usgs.geomag.MagneticFieldReading'] (
    [iaga_code]: string,
    [timestamp]: datetime,
    [h]: real,
@@ -136,9 +136,9 @@
    [___subject]: string
 );
 
-.alter table [MagneticFieldReading] docstring "{\"description\": \"One-minute resolution geomagnetic field variation reading from a USGS Geomagnetism Program observatory, sourced from the timeseries web-service at https://geomag.usgs.gov/ws/data/. The H, D, Z, and F elements correspond to the four standard INTERMAGNET variation data components. The timeseries API returns parallel arrays (times + per-element value arrays) which the bridge transforms into individual timestamped events.\"}";
+.alter table ['gov.usgs.geomag.MagneticFieldReading'] docstring "{\"description\": \"One-minute resolution geomagnetic field variation reading from a USGS Geomagnetism Program observatory, sourced from the timeseries web-service at https://geomag.usgs.gov/ws/data/. The H, D, Z, and F elements correspond to the four standard INTERMAGNET variation data components. The timeseries API returns parallel arrays (times + per-element value arrays) which the bridge transforms into individual timestamped events.\"}";
 
-.alter table [MagneticFieldReading] column-docstrings (
+.alter table ['gov.usgs.geomag.MagneticFieldReading'] column-docstrings (
    [iaga_code]: "{\"description\": \"IAGA observatory code identifying the station that produced this reading, e.g. BOU, BRW, FRN.\"}",
    [timestamp]: "{\"description\": \"UTC timestamp of the 1-minute magnetic field sample, in ISO 8601 format. Derived from the 'times' array in the USGS Geomagnetism web-service timeseries response.\"}",
    [h]: "{\"description\": \"Horizontal intensity component of the geomagnetic field vector. Represents the magnitude of the horizontal projection of the total field vector. Null when the observatory does not report this element or the value is missing for this minute.\"}",
@@ -152,7 +152,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [MagneticFieldReading] ingestion json mapping "MagneticFieldReading_json_flat"
+.create-or-alter table ['gov.usgs.geomag.MagneticFieldReading'] ingestion json mapping "gov.usgs.geomag.MagneticFieldReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -169,7 +169,7 @@
 ]
 ```
 
-.create-or-alter table [MagneticFieldReading] ingestion json mapping "MagneticFieldReading_json_ce_structured"
+.create-or-alter table ['gov.usgs.geomag.MagneticFieldReading'] ingestion json mapping "gov.usgs.geomag.MagneticFieldReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -186,13 +186,13 @@
 ]
 ```
 
-.drop materialized-view MagneticFieldReadingLatest ifexists;
+.drop materialized-view ['gov.usgs.geomag.MagneticFieldReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MagneticFieldReadingLatest on table MagneticFieldReading {
-    MagneticFieldReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['gov.usgs.geomag.MagneticFieldReadingLatest'] on table ['gov.usgs.geomag.MagneticFieldReading'] {
+    ['gov.usgs.geomag.MagneticFieldReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [MagneticFieldReading] policy update
+.alter table ['gov.usgs.geomag.MagneticFieldReading'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/usgs-geomag/notebook/usgs-geomag-feed.ipynb
+++ b/usgs-geomag/notebook/usgs-geomag-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# USGS Geomagnetism Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the USGS Geomagnetism web-service for 1-minute geomagnetic field variation data (H, D, Z, F components) from 14 US-operated observatories and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `usgs_geomag` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `usgs-geomag --once`, exits after one polling cycle, and persists per-observatory last-seen timestamps to a Lakehouse Files path so the next scheduled run only emits new readings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"usgs-geomag-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/usgs-geomag/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/usgs-geomag/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing usgs_geomag package from Fabric Environment...')\n",
+    "    from usgs_geomag import usgs_geomag as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['usgs-geomag', '--once'] if ONCE_MODE else ['usgs-geomag']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/usgs-geomag/tests/test_once_mode.py
+++ b/usgs-geomag/tests/test_once_mode.py
@@ -1,0 +1,61 @@
+"""Tests for the --once CLI flag added for Fabric notebook hosting."""
+
+from unittest.mock import patch, MagicMock
+
+from usgs_geomag.usgs_geomag import main as bridge_main
+
+
+def test_once_flag_runs_single_cycle(monkeypatch):
+    """--once must cause main() to return after exactly one polling cycle."""
+    monkeypatch.setenv(
+        "CONNECTION_STRING",
+        "BootstrapServer=localhost:9092;EntityPath=test-topic",
+    )
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setenv("ONCE_MODE", "")  # do not let env override the CLI flag's default
+    monkeypatch.setattr("sys.argv", ["usgs-geomag", "--once"])
+
+    poller_instance = MagicMock()
+
+    with patch("usgs_geomag.usgs_geomag.USGSGeomagPoller", return_value=poller_instance) as poller_cls, \
+         patch("usgs_geomag.usgs_geomag.Producer", create=True):
+        bridge_main()
+
+    poller_cls.assert_called_once()
+    poller_instance.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_no_once_flag_runs_loop(monkeypatch):
+    """Without --once (and ONCE_MODE unset), the bridge must request loop mode."""
+    monkeypatch.setenv(
+        "CONNECTION_STRING",
+        "BootstrapServer=localhost:9092;EntityPath=test-topic",
+    )
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+    monkeypatch.setattr("sys.argv", ["usgs-geomag"])
+
+    poller_instance = MagicMock()
+    with patch("usgs_geomag.usgs_geomag.USGSGeomagPoller", return_value=poller_instance), \
+         patch("usgs_geomag.usgs_geomag.Producer", create=True):
+        bridge_main()
+
+    poller_instance.poll_and_send.assert_called_once_with(once=False)
+
+
+def test_once_mode_env_var_enables_once(monkeypatch):
+    """ONCE_MODE=true env var must enable single-cycle execution."""
+    monkeypatch.setenv(
+        "CONNECTION_STRING",
+        "BootstrapServer=localhost:9092;EntityPath=test-topic",
+    )
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setenv("ONCE_MODE", "true")
+    monkeypatch.setattr("sys.argv", ["usgs-geomag"])
+
+    poller_instance = MagicMock()
+    with patch("usgs_geomag.usgs_geomag.USGSGeomagPoller", return_value=poller_instance), \
+         patch("usgs_geomag.usgs_geomag.Producer", create=True):
+        bridge_main()
+
+    poller_instance.poll_and_send.assert_called_once_with(once=True)

--- a/usgs-geomag/usgs_geomag/usgs_geomag.py
+++ b/usgs-geomag/usgs_geomag/usgs_geomag.py
@@ -322,6 +322,10 @@ def main():
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
     parser.add_argument('--observatories', type=str,
                         help='Comma-separated list of IAGA observatory codes to poll (default: all USGS)')
+    parser.add_argument('--once', action='store_true',
+                        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                        help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                             'Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
 
@@ -377,7 +381,7 @@ def main():
         last_polled_file=args.last_polled_file,
         observatories=observatories
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent for source `usgs-geomag`.

## Changes

- **`usgs-geomag/notebook/usgs-geomag-feed.ipynb`** — copy of the canonical `pegelonline` notebook with the documented substitutions (display name, package import, `sys.argv` invocation without subcommand, state-file path, log path, default Event Stream name). Four-cell structure, CS-lookup logic, worker-thread wrapper, and OneLake log paths preserved verbatim.
- **`catalog.json`** — adds `"notebook": true` to the `usgs-geomag` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **`usgs-geomag/usgs_geomag/usgs_geomag.py`** — adds `--once` CLI flag (defaulted from `ONCE_MODE` env var) and passes it into `poll_and_send`. The poller already had a `once` parameter; this just wires the CLI/env to it. Loop behavior unchanged for container/ACI deployments.
- **`usgs-geomag/tests/test_once_mode.py`** — three unit tests covering `--once` flag, default loop, and `ONCE_MODE=true` env var.
- **`usgs-geomag/kql/create-kql-script.ps1` + regenerated `usgs_geomag.kql`** — passes `-Qualified -Namespace gov.usgs.geomag` (single messagegroup namespace in the xreg) so generated tables, mappings, MVs, and update policies are prefixed (`['gov.usgs.geomag.Observatory']`, `['gov.usgs.geomag.MagneticFieldReading']`) — avoids collisions when multiple feeders share an Eventhouse.
- **`usgs-geomag/README.md`** — one-sentence bullet pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations performed locally

- `python -c "import json; json.load(open('usgs-geomag/notebook/usgs-geomag-feed.ipynb'))"` — JSON parses.
- `pytest tests/` (in a fresh `.venv`) — **41 passed** including the 3 new `test_once_mode.py` cases.
- Placeholder presence check — `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID` all present in code cells.
- Forbidden-pattern check — no `asyncio.run(`, no hard-coded `CONNECTION_STRING = "..."`, no `primaryConnectionString = ...` baked in, and no `%pip install` in any code cell.
- KQL regen produced namespace-qualified tables and 18-line diff against the previous unqualified output.

## Skill

Followed `.github/skills/notebook-feeder-retrofit/SKILL.md`. Bridge had no `--once` so the documented "Add `--once` if missing" allowance was used (modeled on `pegelonline/pegelonline/pegelonline.py`). The bridge has no argparse subcommand (uses top-level args only), so the no-subcommand variant from `references/notebook-substitution-table.md` was applied: `sys.argv = ['usgs-geomag', '--once']`.

## Out of scope

- Live Fabric deployment — handled by the wheel-publish workflow on merge and manual verification by the maintainer.
