### PR TITLE
feat(ndl-netherlands): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -597,7 +597,8 @@
     "cat": "Transport",
     "key": false,
     "desc": "Netherlands — national road traffic, DATEX II",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "paris-bicycle-counters",

--- a/ndl-netherlands/README.md
+++ b/ndl-netherlands/README.md
@@ -25,6 +25,13 @@ situations). No authentication is required.
 See [EVENTS.md](EVENTS.md) for the full schema documentation and
 [CONTAINER.md](CONTAINER.md) for deployment instructions.
 
+## Fabric notebook hosting
+
+This source can also be hosted as a Microsoft Fabric notebook (scheduled
+single-cycle execution) via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1);
+the notebook template lives at [`notebook/ndl-netherlands-feed.ipynb`](notebook/ndl-netherlands-feed.ipynb).
+
 ## Quick Start
 
 ```bash

--- a/ndl-netherlands/kql/ndl_netherlands.kql
+++ b/ndl-netherlands/kql/ndl_netherlands.kql
@@ -25,33 +25,12 @@
 ]
 ```
 
-.create-merge table [ChargingLocation] (
-   [location_id]: string,
-   [country_code]: string,
-   [party_id]: string,
-   [publish]: bool,
-   [name]: string,
-   [address]: string,
-   [city]: string,
-   [postal_code]: string,
-   [state]: string,
-   [country]: string,
-   [latitude]: real,
-   [longitude]: real,
-   [parking_type]: string,
-   [operator_name]: string,
-   [operator_website]: string,
-   [suboperator_name]: string,
-   [owner_name]: string,
-   [facilities]: dynamic,
-   [time_zone]: string,
-   [opening_times_twentyfourseven]: bool,
-   [charging_when_closed]: bool,
-   [energy_mix_is_green_energy]: bool,
-   [energy_mix_supplier_name]: string,
-   [evse_count]: int,
-   [connector_count]: int,
-   [last_updated]: datetime,
+.create-merge table ['nl.ndw.traffic.TrafficSpeed'] (
+   [site_id]: string,
+   [measurement_time]: string,
+   [average_speed]: real,
+   [vehicle_flow_rate]: int,
+   [number_of_lanes_with_data]: int,
    [___type]: string,
    [___source]: string,
    [___id]: string,
@@ -59,35 +38,14 @@
    [___subject]: string
 );
 
-.alter table [ChargingLocation] docstring "{\"description\": \"Reference data for an EV charging location from the NDL. Contains the static properties of an OCPI v2.2 Location object including address, coordinates, operator details, and aggregate counts of EVSEs and connectors.\"}";
+.alter table ['nl.ndw.traffic.TrafficSpeed'] docstring "{\"description\": \"Aggregated traffic speed and flow measurement per road segment from the NDW DATEX II trafficspeed feed. Speed is averaged and flow is summed across all reporting lanes at the measurement site.\"}";
 
-.alter table [ChargingLocation] column-docstrings (
-   [location_id]: "{\"description\": \"OCPI Location.id. Uniquely identifies the charging location within the CPO's platform. This field is the CloudEvents subject and Kafka key. OCPI type: CiString(36).\"}",
-   [country_code]: "{\"description\": \"ISO-3166 alpha-2 country code of the CPO that owns this Location. OCPI type: CiString(2).\"}",
-   [party_id]: "{\"description\": \"CPO party identifier following ISO-15118. Together with country_code this uniquely identifies the operator. OCPI type: CiString(3).\"}",
-   [publish]: "{\"description\": \"Whether the location may be published on websites or apps. When false, only tokens in publish_allowed_to may see this location. OCPI type: boolean.\"}",
-   [name]: "{\"description\": \"Display name of the location. OCPI type: string(255).\"}",
-   [address]: "{\"description\": \"Street/block name and house number if available. OCPI type: string(45).\"}",
-   [city]: "{\"description\": \"City or town. OCPI type: string(45).\"}",
-   [postal_code]: "{\"description\": \"Postal code of the location. May be omitted when the location has no postal code, e.g. highway charging locations. OCPI type: string(10).\"}",
-   [state]: "{\"description\": \"State or province of the location, only used when relevant. OCPI type: string(20).\"}",
-   [country]: "{\"description\": \"ISO 3166-1 alpha-3 code for the country of this location. OCPI type: string(3).\"}",
-   [latitude]: "{\"description\": \"Latitude of the location in decimal degrees (WGS 84). Extracted from the OCPI GeoLocation coordinates object.\"}",
-   [longitude]: "{\"description\": \"Longitude of the location in decimal degrees (WGS 84). Extracted from the OCPI GeoLocation coordinates object.\"}",
-   [parking_type]: "{\"description\": \"General type of parking at the charge point location. OCPI ParkingType enum: ALONG_MOTORWAY (rest area along highway), PARKING_GARAGE (multistorey), PARKING_LOT (cleared area, e.g. supermarket), ON_DRIVEWAY (house/building driveway), ON_STREET (public street), UNDERGROUND_GARAGE (mainly underground).\"}",
-   [operator_name]: "{\"description\": \"Name of the charge point operator. Flattened from OCPI BusinessDetails operator.name. OCPI type: string(100).\"}",
-   [operator_website]: "{\"description\": \"URL to the operator's website. Flattened from OCPI BusinessDetails operator.website.\"}",
-   [suboperator_name]: "{\"description\": \"Name of the suboperator if available. Flattened from OCPI BusinessDetails suboperator.name. OCPI type: string(100).\"}",
-   [owner_name]: "{\"description\": \"Name of the location owner if available. Flattened from OCPI BusinessDetails owner.name. OCPI type: string(100).\"}",
-   [facilities]: "{\"description\": \"Optional list of facilities at this charging location. OCPI Facility OpenEnum values include HOTEL, RESTAURANT, CAFE, MALL, SUPERMARKET, SPORT, RECREATION_AREA, NATURE, MUSEUM, BUS_STOP, TAXI_STAND, TRAIN_STATION, AIRPORT, PARKING_LOT, FUEL_STATION, WIFI, etc.\"}",
-   [time_zone]: "{\"description\": \"IANA TZ-value representing the time zone of the location, e.g. 'Europe/Amsterdam'. OCPI type: string(255).\"}",
-   [opening_times_twentyfourseven]: "{\"description\": \"Whether the location is open 24/7. Extracted from OCPI Hours.twentyfourseven field of the opening_times object.\"}",
-   [charging_when_closed]: "{\"description\": \"Whether EVSEs continue charging outside opening hours, e.g. when a parking garage closes its barriers overnight. OCPI default is true.\"}",
-   [energy_mix_is_green_energy]: "{\"description\": \"Whether 100% of energy is from regenerative sources (CO2 and nuclear waste is zero). Flattened from OCPI EnergyMix.is_green_energy.\"}",
-   [energy_mix_supplier_name]: "{\"description\": \"Name of the energy supplier delivering energy for this location. Flattened from OCPI EnergyMix.supplier_name. OCPI type: string(64).\"}",
-   [evse_count]: "{\"description\": \"Total number of EVSEs at this location. Computed by the bridge from the length of the OCPI evses array.\"}",
-   [connector_count]: "{\"description\": \"Total number of connectors across all EVSEs at this location. Computed by the bridge as the sum of all EVSE connector counts.\"}",
-   [last_updated]: "{\"description\": \"Timestamp when this Location or one of its EVSEs or Connectors was last updated or created. OCPI type: DateTime (ISO 8601).\"}",
+.alter table ['nl.ndw.traffic.TrafficSpeed'] column-docstrings (
+   [site_id]: "{\"description\": \"Unique identifier of the NDW measurement site, taken from the DATEX II measurementSiteReference id attribute. Example: PZH01_MST_0029-00.\"}",
+   [measurement_time]: "{\"description\": \"Timestamp of the measurement in ISO 8601 format (UTC), from the DATEX II measurementTimeDefault element.\"}",
+   [average_speed]: "{\"description\": \"Average vehicle speed in km/h across all lanes with valid data at this site. Null when no lane reported a valid speed (all lanes had speed <= 0).\"}",
+   [vehicle_flow_rate]: "{\"description\": \"Total vehicle flow rate in vehicles per hour, summed across all lanes at this measurement site. Null when no valid flow data was reported.\"}",
+   [number_of_lanes_with_data]: "{\"description\": \"Number of lanes that reported valid measurement data (speed > 0 or flow >= 0) at this measurement site.\"}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',
@@ -95,7 +53,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [ChargingLocation] ingestion json mapping "ChargingLocation_json_flat"
+.create-or-alter table ['nl.ndw.traffic.TrafficSpeed'] ingestion json mapping "nl.ndw.traffic.TrafficSpeed_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -103,36 +61,15 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "location_id", "path": "$.location_id"},
-  {"column": "country_code", "path": "$.country_code"},
-  {"column": "party_id", "path": "$.party_id"},
-  {"column": "publish", "path": "$.publish"},
-  {"column": "name", "path": "$.name"},
-  {"column": "address", "path": "$.address"},
-  {"column": "city", "path": "$.city"},
-  {"column": "postal_code", "path": "$.postal_code"},
-  {"column": "state", "path": "$.state"},
-  {"column": "country", "path": "$.country"},
-  {"column": "latitude", "path": "$.latitude"},
-  {"column": "longitude", "path": "$.longitude"},
-  {"column": "parking_type", "path": "$.parking_type"},
-  {"column": "operator_name", "path": "$.operator_name"},
-  {"column": "operator_website", "path": "$.operator_website"},
-  {"column": "suboperator_name", "path": "$.suboperator_name"},
-  {"column": "owner_name", "path": "$.owner_name"},
-  {"column": "facilities", "path": "$.facilities"},
-  {"column": "time_zone", "path": "$.time_zone"},
-  {"column": "opening_times_twentyfourseven", "path": "$.opening_times_twentyfourseven"},
-  {"column": "charging_when_closed", "path": "$.charging_when_closed"},
-  {"column": "energy_mix_is_green_energy", "path": "$.energy_mix_is_green_energy"},
-  {"column": "energy_mix_supplier_name", "path": "$.energy_mix_supplier_name"},
-  {"column": "evse_count", "path": "$.evse_count"},
-  {"column": "connector_count", "path": "$.connector_count"},
-  {"column": "last_updated", "path": "$.last_updated"},
+  {"column": "site_id", "path": "$.site_id"},
+  {"column": "measurement_time", "path": "$.measurement_time"},
+  {"column": "average_speed", "path": "$.average_speed"},
+  {"column": "vehicle_flow_rate", "path": "$.vehicle_flow_rate"},
+  {"column": "number_of_lanes_with_data", "path": "$.number_of_lanes_with_data"},
 ]
 ```
 
-.create-or-alter table [ChargingLocation] ingestion json mapping "ChargingLocation_json_ce_structured"
+.create-or-alter table ['nl.ndw.traffic.TrafficSpeed'] ingestion json mapping "nl.ndw.traffic.TrafficSpeed_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -140,65 +77,39 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "location_id", "path": "$.data.location_id"},
-  {"column": "country_code", "path": "$.data.country_code"},
-  {"column": "party_id", "path": "$.data.party_id"},
-  {"column": "publish", "path": "$.data.publish"},
-  {"column": "name", "path": "$.data.name"},
-  {"column": "address", "path": "$.data.address"},
-  {"column": "city", "path": "$.data.city"},
-  {"column": "postal_code", "path": "$.data.postal_code"},
-  {"column": "state", "path": "$.data.state"},
-  {"column": "country", "path": "$.data.country"},
-  {"column": "latitude", "path": "$.data.latitude"},
-  {"column": "longitude", "path": "$.data.longitude"},
-  {"column": "parking_type", "path": "$.data.parking_type"},
-  {"column": "operator_name", "path": "$.data.operator_name"},
-  {"column": "operator_website", "path": "$.data.operator_website"},
-  {"column": "suboperator_name", "path": "$.data.suboperator_name"},
-  {"column": "owner_name", "path": "$.data.owner_name"},
-  {"column": "facilities", "path": "$.data.facilities"},
-  {"column": "time_zone", "path": "$.data.time_zone"},
-  {"column": "opening_times_twentyfourseven", "path": "$.data.opening_times_twentyfourseven"},
-  {"column": "charging_when_closed", "path": "$.data.charging_when_closed"},
-  {"column": "energy_mix_is_green_energy", "path": "$.data.energy_mix_is_green_energy"},
-  {"column": "energy_mix_supplier_name", "path": "$.data.energy_mix_supplier_name"},
-  {"column": "evse_count", "path": "$.data.evse_count"},
-  {"column": "connector_count", "path": "$.data.connector_count"},
-  {"column": "last_updated", "path": "$.data.last_updated"},
+  {"column": "site_id", "path": "$.data.site_id"},
+  {"column": "measurement_time", "path": "$.data.measurement_time"},
+  {"column": "average_speed", "path": "$.data.average_speed"},
+  {"column": "vehicle_flow_rate", "path": "$.data.vehicle_flow_rate"},
+  {"column": "number_of_lanes_with_data", "path": "$.data.number_of_lanes_with_data"},
 ]
 ```
 
-.drop materialized-view ChargingLocationLatest ifexists;
+.drop materialized-view ['nl.ndw.traffic.TrafficSpeedLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ChargingLocationLatest on table ChargingLocation {
-    ChargingLocation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.ndw.traffic.TrafficSpeedLatest'] on table ['nl.ndw.traffic.TrafficSpeed'] {
+    ['nl.ndw.traffic.TrafficSpeed'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [ChargingLocation] policy update
+.alter table ['nl.ndw.traffic.TrafficSpeed'] policy update
 ```
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Charging.ChargingLocation') | project['location_id'] = tostring(data.['location_id']),['country_code'] = tostring(data.['country_code']),['party_id'] = tostring(data.['party_id']),['publish'] = tobool(data.['publish']),['name'] = tostring(data.['name']),['address'] = tostring(data.['address']),['city'] = tostring(data.['city']),['postal_code'] = tostring(data.['postal_code']),['state'] = tostring(data.['state']),['country'] = tostring(data.['country']),['latitude'] = toreal(data.['latitude']),['longitude'] = toreal(data.['longitude']),['parking_type'] = tostring(data.['parking_type']),['operator_name'] = tostring(data.['operator_name']),['operator_website'] = tostring(data.['operator_website']),['suboperator_name'] = tostring(data.['suboperator_name']),['owner_name'] = tostring(data.['owner_name']),['facilities'] = todynamic(data.['facilities']),['time_zone'] = tostring(data.['time_zone']),['opening_times_twentyfourseven'] = tobool(data.['opening_times_twentyfourseven']),['charging_when_closed'] = tobool(data.['charging_when_closed']),['energy_mix_is_green_energy'] = tobool(data.['energy_mix_is_green_energy']),['energy_mix_supplier_name'] = tostring(data.['energy_mix_supplier_name']),['evse_count'] = toint(data.['evse_count']),['connector_count'] = toint(data.['connector_count']),['last_updated'] = todatetime(data.['last_updated']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Traffic.TrafficSpeed') | project['site_id'] = tostring(data.['site_id']),['measurement_time'] = tostring(data.['measurement_time']),['average_speed'] = toreal(data.['average_speed']),['vehicle_flow_rate'] = toint(data.['vehicle_flow_rate']),['number_of_lanes_with_data'] = toint(data.['number_of_lanes_with_data']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]
 ```
 
-.create-merge table [EvseStatus] (
-   [location_id]: string,
-   [evse_uid]: string,
-   [evse_id]: string,
-   [status]: string,
-   [capabilities]: dynamic,
-   [floor_level]: string,
-   [latitude]: real,
-   [longitude]: real,
-   [physical_reference]: string,
-   [parking_restrictions]: dynamic,
-   [connectors]: dynamic,
-   [last_updated]: datetime,
+.create-merge table ['nl.ndw.traffic.TravelTime'] (
+   [site_id]: string,
+   [measurement_time]: string,
+   [duration]: real,
+   [reference_duration]: real,
+   [accuracy]: real,
+   [data_quality]: real,
+   [number_of_input_values]: int,
    [___type]: string,
    [___source]: string,
    [___id]: string,
@@ -206,21 +117,16 @@
    [___subject]: string
 );
 
-.alter table [EvseStatus] docstring "{\"description\": \"Telemetry event for an EVSE status change from the NDL. Contains the EVSE identification, current status, and a summary of its connectors.\"}";
+.alter table ['nl.ndw.traffic.TravelTime'] docstring "{\"description\": \"Travel time measurement for a road segment from the NDW DATEX II traveltime feed. Contains actual measured travel time and the static free-flow reference time.\"}";
 
-.alter table [EvseStatus] column-docstrings (
-   [location_id]: "{\"description\": \"OCPI Location.id of the parent location. Together with evse_uid forms the composite CloudEvents subject and Kafka key. OCPI type: CiString(36).\"}",
-   [evse_uid]: "{\"description\": \"OCPI EVSE.uid. Uniquely identifies the EVSE within the CPO's platform. This is the technical identifier, not the human-readable evse_id. OCPI type: CiString(36).\"}",
-   [evse_id]: "{\"description\": \"Human-readable EVSE identifier compliant with eMI3 standard 'E-mobility ID-codes'. May be absent if the EVSE status is REMOVED. OCPI type: CiString(48).\"}",
-   [status]: "{\"description\": \"Current status of the EVSE. OCPI Status enum: AVAILABLE (ready for new session), BLOCKED (physical barrier e.g. parked car), CHARGING (in use), INOPERATIVE (temporarily unavailable but not broken), OUTOFORDER (broken/defect), PLANNED (not yet active), REMOVED (discontinued), RESERVED (reserved for a specific driver), UNKNOWN (no status info available or offline).\"}",
-   [capabilities]: "{\"description\": \"List of functionalities the EVSE is capable of. OCPI Capability OpenEnum values include CHARGING_PROFILE_CAPABLE, CHIP_CARD_SUPPORT, CONTACTLESS_CARD_SUPPORT, CREDIT_CARD_PAYABLE, DEBIT_CARD_PAYABLE, PED_TERMINAL, REMOTE_START_STOP_CAPABLE, RESERVABLE, RFID_READER, UNLOCK_CAPABLE.\"}",
-   [floor_level]: "{\"description\": \"Level on which the EVSE is located in a garage building, in locally displayed numbering. OCPI type: string(4).\"}",
-   [latitude]: "{\"description\": \"Latitude of the EVSE in decimal degrees (WGS 84) if different from the parent location. Extracted from OCPI EVSE.coordinates.\"}",
-   [longitude]: "{\"description\": \"Longitude of the EVSE in decimal degrees (WGS 84) if different from the parent location. Extracted from OCPI EVSE.coordinates.\"}",
-   [physical_reference]: "{\"description\": \"A number/string printed on the outside of the EVSE for visual identification. OCPI type: string(16).\"}",
-   [parking_restrictions]: "{\"description\": \"Restrictions on who can charge at this EVSE. OCPI ParkingRestriction OpenEnum: CUSTOMERS, DISABLED, EMPLOYEES, EV_ONLY, MOTORCYCLES, PLUGGED, TAXIS, TENANTS.\"}",
-   [connectors]: "{\"description\": \"List of connectors on this EVSE. Only one connector per EVSE can be used at any time. Each entry carries connector standard, format, power specs, and tariff references.\", \"schema\": {\"type\": \"array\", \"items\": {\"$ref\": \"#/definitions/ConnectorSummary\"}, \"minItems\": 1, \"description\": \"List of connectors on this EVSE. Only one connector per EVSE can be used at any time. Each entry carries connector standard, format, power specs, and tariff references.\"}}",
-   [last_updated]: "{\"description\": \"Timestamp when this EVSE or one of its Connectors was last updated or created. OCPI type: DateTime (ISO 8601).\"}",
+.alter table ['nl.ndw.traffic.TravelTime'] column-docstrings (
+   [site_id]: "{\"description\": \"Unique identifier of the NDW measurement site, taken from the DATEX II measurementSiteReference id attribute.\"}",
+   [measurement_time]: "{\"description\": \"Timestamp of the measurement in ISO 8601 format (UTC), from the DATEX II measurementTimeDefault element.\"}",
+   [duration]: "{\"description\": \"Actual measured travel time in seconds for this road segment. Null when the measurement has a data error (duration is -1 in the upstream).\"}",
+   [reference_duration]: "{\"description\": \"Static reference (free-flow) travel time in seconds for this road segment. Null when unavailable or when the measurement has a data error.\"}",
+   [accuracy]: "{\"description\": \"Accuracy of the travel time measurement as a percentage (0-100), indicating the quality of the sensor coverage.\"}",
+   [data_quality]: "{\"description\": \"Supplier-calculated data quality score as a percentage (0-100). Higher values indicate more reliable measurements.\"}",
+   [number_of_input_values]: "{\"description\": \"Number of individual vehicle travel times used to compute this aggregate travel time measurement.\"}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',
@@ -228,7 +134,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [EvseStatus] ingestion json mapping "EvseStatus_json_flat"
+.create-or-alter table ['nl.ndw.traffic.TravelTime'] ingestion json mapping "nl.ndw.traffic.TravelTime_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -236,22 +142,17 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "location_id", "path": "$.location_id"},
-  {"column": "evse_uid", "path": "$.evse_uid"},
-  {"column": "evse_id", "path": "$.evse_id"},
-  {"column": "status", "path": "$.status"},
-  {"column": "capabilities", "path": "$.capabilities"},
-  {"column": "floor_level", "path": "$.floor_level"},
-  {"column": "latitude", "path": "$.latitude"},
-  {"column": "longitude", "path": "$.longitude"},
-  {"column": "physical_reference", "path": "$.physical_reference"},
-  {"column": "parking_restrictions", "path": "$.parking_restrictions"},
-  {"column": "connectors", "path": "$.connectors"},
-  {"column": "last_updated", "path": "$.last_updated"},
+  {"column": "site_id", "path": "$.site_id"},
+  {"column": "measurement_time", "path": "$.measurement_time"},
+  {"column": "duration", "path": "$.duration"},
+  {"column": "reference_duration", "path": "$.reference_duration"},
+  {"column": "accuracy", "path": "$.accuracy"},
+  {"column": "data_quality", "path": "$.data_quality"},
+  {"column": "number_of_input_values", "path": "$.number_of_input_values"},
 ]
 ```
 
-.create-or-alter table [EvseStatus] ingestion json mapping "EvseStatus_json_ce_structured"
+.create-or-alter table ['nl.ndw.traffic.TravelTime'] ingestion json mapping "nl.ndw.traffic.TravelTime_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -259,55 +160,42 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "location_id", "path": "$.data.location_id"},
-  {"column": "evse_uid", "path": "$.data.evse_uid"},
-  {"column": "evse_id", "path": "$.data.evse_id"},
-  {"column": "status", "path": "$.data.status"},
-  {"column": "capabilities", "path": "$.data.capabilities"},
-  {"column": "floor_level", "path": "$.data.floor_level"},
-  {"column": "latitude", "path": "$.data.latitude"},
-  {"column": "longitude", "path": "$.data.longitude"},
-  {"column": "physical_reference", "path": "$.data.physical_reference"},
-  {"column": "parking_restrictions", "path": "$.data.parking_restrictions"},
-  {"column": "connectors", "path": "$.data.connectors"},
-  {"column": "last_updated", "path": "$.data.last_updated"},
+  {"column": "site_id", "path": "$.data.site_id"},
+  {"column": "measurement_time", "path": "$.data.measurement_time"},
+  {"column": "duration", "path": "$.data.duration"},
+  {"column": "reference_duration", "path": "$.data.reference_duration"},
+  {"column": "accuracy", "path": "$.data.accuracy"},
+  {"column": "data_quality", "path": "$.data.data_quality"},
+  {"column": "number_of_input_values", "path": "$.data.number_of_input_values"},
 ]
 ```
 
-.drop materialized-view EvseStatusLatest ifexists;
+.drop materialized-view ['nl.ndw.traffic.TravelTimeLatest'] ifexists;
 
-.create materialized-view with (backfill=true) EvseStatusLatest on table EvseStatus {
-    EvseStatus | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.ndw.traffic.TravelTimeLatest'] on table ['nl.ndw.traffic.TravelTime'] {
+    ['nl.ndw.traffic.TravelTime'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [EvseStatus] policy update
+.alter table ['nl.ndw.traffic.TravelTime'] policy update
 ```
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Charging.EvseStatus') | project['location_id'] = tostring(data.['location_id']),['evse_uid'] = tostring(data.['evse_uid']),['evse_id'] = tostring(data.['evse_id']),['status'] = tostring(data.['status']),['capabilities'] = todynamic(data.['capabilities']),['floor_level'] = tostring(data.['floor_level']),['latitude'] = toreal(data.['latitude']),['longitude'] = toreal(data.['longitude']),['physical_reference'] = tostring(data.['physical_reference']),['parking_restrictions'] = todynamic(data.['parking_restrictions']),['connectors'] = todynamic(data.['connectors']),['last_updated'] = todatetime(data.['last_updated']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Traffic.TravelTime') | project['site_id'] = tostring(data.['site_id']),['measurement_time'] = tostring(data.['measurement_time']),['duration'] = toreal(data.['duration']),['reference_duration'] = toreal(data.['reference_duration']),['accuracy'] = toreal(data.['accuracy']),['data_quality'] = toreal(data.['data_quality']),['number_of_input_values'] = toint(data.['number_of_input_values']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]
 ```
 
-.create-merge table [ChargingTariff] (
-   [tariff_id]: string,
-   [country_code]: string,
-   [party_id]: string,
-   [currency]: string,
-   [tariff_type]: string,
-   [tariff_alt_text]: string,
-   [tariff_alt_url]: string,
-   [min_price_excl_vat]: real,
-   [min_price_incl_vat]: real,
-   [max_price_excl_vat]: real,
-   [max_price_incl_vat]: real,
-   [elements]: dynamic,
-   [start_date_time]: datetime,
-   [end_date_time]: datetime,
-   [energy_mix_is_green_energy]: bool,
-   [last_updated]: datetime,
+.create-merge table ['nl.ndw.traffic.TrafficSituation'] (
+   [situation_id]: string,
+   [version_time]: string,
+   [severity]: string,
+   [record_type]: string,
+   [cause_type]: string,
+   [start_time]: string,
+   [end_time]: string,
+   [information_status]: string,
    [___type]: string,
    [___source]: string,
    [___id]: string,
@@ -315,25 +203,17 @@
    [___subject]: string
 );
 
-.alter table [ChargingTariff] docstring "{\"description\": \"Reference data for an EV charging tariff from the NDL. Contains the OCPI v2.2 Tariff object fields including pricing elements, validity period, and tax information.\"}";
+.alter table ['nl.ndw.traffic.TrafficSituation'] docstring "{\"description\": \"Current traffic situation from the NDW DATEX II v3 actueel_beeld feed. Covers road works, lane closures, diversions, and other traffic-affecting events on the Dutch road network.\"}";
 
-.alter table [ChargingTariff] column-docstrings (
-   [tariff_id]: "{\"description\": \"OCPI Tariff.id. Uniquely identifies the tariff within the CPO's platform. This field is the CloudEvents subject and Kafka key. OCPI type: CiString(36).\"}",
-   [country_code]: "{\"description\": \"ISO-3166 alpha-2 country code of the CPO that owns this Tariff. OCPI type: CiString(2).\"}",
-   [party_id]: "{\"description\": \"CPO party identifier following ISO-15118. OCPI type: CiString(3).\"}",
-   [currency]: "{\"description\": \"ISO-4217 currency code for this tariff, e.g. 'EUR'. OCPI type: string(3).\"}",
-   [tariff_type]: "{\"description\": \"Type of tariff for distinguishing charging preferences. When omitted, valid for all sessions. OCPI TariffType enum: AD_HOC_PAYMENT (card terminal), PROFILE_CHEAP, PROFILE_FAST, PROFILE_GREEN, REGULAR (RFID or default).\"}",
-   [tariff_alt_text]: "{\"description\": \"Human-readable alternative tariff text. First available language variant from the OCPI DisplayText array, if any. OCPI type: DisplayText list.\"}",
-   [tariff_alt_url]: "{\"description\": \"URL to a web page with human-readable tariff explanation. OCPI type: URL.\"}",
-   [min_price_excl_vat]: "{\"description\": \"Minimum session cost excluding taxes. Flattened from OCPI PriceLimit min_price.before_taxes.\"}",
-   [min_price_incl_vat]: "{\"description\": \"Minimum session cost including taxes. Flattened from OCPI PriceLimit min_price.after_taxes.\"}",
-   [max_price_excl_vat]: "{\"description\": \"Maximum session cost excluding taxes. Flattened from OCPI PriceLimit max_price.before_taxes.\"}",
-   [max_price_incl_vat]: "{\"description\": \"Maximum session cost including taxes. Flattened from OCPI PriceLimit max_price.after_taxes.\"}",
-   [elements]: "{\"description\": \"List of tariff elements. Each contains price components and optional restrictions. First element with a matching dimension and restriction wins. To define 'free of charge', use one element with FLAT type and price 0.00.\", \"schema\": {\"type\": \"array\", \"items\": {\"$ref\": \"#/definitions/TariffElement\"}, \"minItems\": 1, \"description\": \"List of tariff elements. Each contains price components and optional restrictions. First element with a matching dimension and restriction wins. To define 'free of charge', use one element with FLAT type and price 0.00.\"}}",
-   [start_date_time]: "{\"description\": \"When this tariff becomes active (UTC). Used for pre-announced tariffs at a location before they take effect. OCPI type: DateTime.\"}",
-   [end_date_time]: "{\"description\": \"When this tariff ceases to be valid (UTC). Used when a tariff is being replaced by a new one. OCPI type: DateTime.\"}",
-   [energy_mix_is_green_energy]: "{\"description\": \"Whether 100% of energy supplied under this tariff is from regenerative sources. Flattened from OCPI EnergyMix.is_green_energy.\"}",
-   [last_updated]: "{\"description\": \"Timestamp when this Tariff was last updated or created. OCPI type: DateTime (ISO 8601).\"}",
+.alter table ['nl.ndw.traffic.TrafficSituation'] column-docstrings (
+   [situation_id]: "{\"description\": \"Unique identifier of the traffic situation from the DATEX II situation id attribute. Example: RWS01_SM1117672_D2_WWA.\"}",
+   [version_time]: "{\"description\": \"Timestamp of the latest version of this situation in ISO 8601 format (UTC), from the DATEX II situationVersionTime element.\"}",
+   [severity]: "{\"description\": \"Overall severity of the situation. Values include: low, medium, high, highest, unknown. Null if not specified.\"}",
+   [record_type]: "{\"description\": \"DATEX II situation record type indicating the nature of the event. Common values: RoadOrCarriagewayOrLaneManagement, MaintenanceWorks, ConstructionWorks, ReroutingManagement. Null when not available.\"}",
+   [cause_type]: "{\"description\": \"Cause of the traffic situation. Common values: roadMaintenance, accident, congestion, roadClosed. Null when no cause is specified.\"}",
+   [start_time]: "{\"description\": \"Start time of the situation validity period in ISO 8601 format (UTC). Null when no validity time specification is provided.\"}",
+   [end_time]: "{\"description\": \"End time of the situation validity period in ISO 8601 format (UTC). Null when the end time is open-ended or not specified.\"}",
+   [information_status]: "{\"description\": \"Status of the information: real (confirmed traffic data), test (test data), or exercise (drill/exercise data).\"}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',
@@ -341,7 +221,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [ChargingTariff] ingestion json mapping "ChargingTariff_json_flat"
+.create-or-alter table ['nl.ndw.traffic.TrafficSituation'] ingestion json mapping "nl.ndw.traffic.TrafficSituation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -349,26 +229,18 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "tariff_id", "path": "$.tariff_id"},
-  {"column": "country_code", "path": "$.country_code"},
-  {"column": "party_id", "path": "$.party_id"},
-  {"column": "currency", "path": "$.currency"},
-  {"column": "tariff_type", "path": "$.tariff_type"},
-  {"column": "tariff_alt_text", "path": "$.tariff_alt_text"},
-  {"column": "tariff_alt_url", "path": "$.tariff_alt_url"},
-  {"column": "min_price_excl_vat", "path": "$.min_price_excl_vat"},
-  {"column": "min_price_incl_vat", "path": "$.min_price_incl_vat"},
-  {"column": "max_price_excl_vat", "path": "$.max_price_excl_vat"},
-  {"column": "max_price_incl_vat", "path": "$.max_price_incl_vat"},
-  {"column": "elements", "path": "$.elements"},
-  {"column": "start_date_time", "path": "$.start_date_time"},
-  {"column": "end_date_time", "path": "$.end_date_time"},
-  {"column": "energy_mix_is_green_energy", "path": "$.energy_mix_is_green_energy"},
-  {"column": "last_updated", "path": "$.last_updated"},
+  {"column": "situation_id", "path": "$.situation_id"},
+  {"column": "version_time", "path": "$.version_time"},
+  {"column": "severity", "path": "$.severity"},
+  {"column": "record_type", "path": "$.record_type"},
+  {"column": "cause_type", "path": "$.cause_type"},
+  {"column": "start_time", "path": "$.start_time"},
+  {"column": "end_time", "path": "$.end_time"},
+  {"column": "information_status", "path": "$.information_status"},
 ]
 ```
 
-.create-or-alter table [ChargingTariff] ingestion json mapping "ChargingTariff_json_ce_structured"
+.create-or-alter table ['nl.ndw.traffic.TrafficSituation'] ingestion json mapping "nl.ndw.traffic.TrafficSituation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -376,37 +248,29 @@
   {"column": "___id", "path": "$.id"},
   {"column": "___time", "path": "$.time"},
   {"column": "___subject", "path": "$.subject"},
-  {"column": "tariff_id", "path": "$.data.tariff_id"},
-  {"column": "country_code", "path": "$.data.country_code"},
-  {"column": "party_id", "path": "$.data.party_id"},
-  {"column": "currency", "path": "$.data.currency"},
-  {"column": "tariff_type", "path": "$.data.tariff_type"},
-  {"column": "tariff_alt_text", "path": "$.data.tariff_alt_text"},
-  {"column": "tariff_alt_url", "path": "$.data.tariff_alt_url"},
-  {"column": "min_price_excl_vat", "path": "$.data.min_price_excl_vat"},
-  {"column": "min_price_incl_vat", "path": "$.data.min_price_incl_vat"},
-  {"column": "max_price_excl_vat", "path": "$.data.max_price_excl_vat"},
-  {"column": "max_price_incl_vat", "path": "$.data.max_price_incl_vat"},
-  {"column": "elements", "path": "$.data.elements"},
-  {"column": "start_date_time", "path": "$.data.start_date_time"},
-  {"column": "end_date_time", "path": "$.data.end_date_time"},
-  {"column": "energy_mix_is_green_energy", "path": "$.data.energy_mix_is_green_energy"},
-  {"column": "last_updated", "path": "$.data.last_updated"},
+  {"column": "situation_id", "path": "$.data.situation_id"},
+  {"column": "version_time", "path": "$.data.version_time"},
+  {"column": "severity", "path": "$.data.severity"},
+  {"column": "record_type", "path": "$.data.record_type"},
+  {"column": "cause_type", "path": "$.data.cause_type"},
+  {"column": "start_time", "path": "$.data.start_time"},
+  {"column": "end_time", "path": "$.data.end_time"},
+  {"column": "information_status", "path": "$.data.information_status"},
 ]
 ```
 
-.drop materialized-view ChargingTariffLatest ifexists;
+.drop materialized-view ['nl.ndw.traffic.TrafficSituationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) ChargingTariffLatest on table ChargingTariff {
-    ChargingTariff | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['nl.ndw.traffic.TrafficSituationLatest'] on table ['nl.ndw.traffic.TrafficSituation'] {
+    ['nl.ndw.traffic.TrafficSituation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [ChargingTariff] policy update
+.alter table ['nl.ndw.traffic.TrafficSituation'] policy update
 ```
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Charging.ChargingTariff') | project['tariff_id'] = tostring(data.['tariff_id']),['country_code'] = tostring(data.['country_code']),['party_id'] = tostring(data.['party_id']),['currency'] = tostring(data.['currency']),['tariff_type'] = tostring(data.['tariff_type']),['tariff_alt_text'] = tostring(data.['tariff_alt_text']),['tariff_alt_url'] = tostring(data.['tariff_alt_url']),['min_price_excl_vat'] = toreal(data.['min_price_excl_vat']),['min_price_incl_vat'] = toreal(data.['min_price_incl_vat']),['max_price_excl_vat'] = toreal(data.['max_price_excl_vat']),['max_price_incl_vat'] = toreal(data.['max_price_incl_vat']),['elements'] = todynamic(data.['elements']),['start_date_time'] = todatetime(data.['start_date_time']),['end_date_time'] = todatetime(data.['end_date_time']),['energy_mix_is_green_energy'] = tobool(data.['energy_mix_is_green_energy']),['last_updated'] = todatetime(data.['last_updated']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'NL.NDW.Traffic.TrafficSituation') | project['situation_id'] = tostring(data.['situation_id']),['version_time'] = tostring(data.['version_time']),['severity'] = tostring(data.['severity']),['record_type'] = tostring(data.['record_type']),['cause_type'] = tostring(data.['cause_type']),['start_time'] = tostring(data.['start_time']),['end_time'] = tostring(data.['end_time']),['information_status'] = tostring(data.['information_status']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]

--- a/ndl-netherlands/ndl_netherlands/ndl_netherlands.py
+++ b/ndl-netherlands/ndl_netherlands/ndl_netherlands.py
@@ -518,9 +518,10 @@ class NdwPoller:
         logger.info("Emitted %d situation events (of %d situations)", count, len(records))
         return count
 
-    def run_forever(self) -> None:
-        """Main polling loop."""
-        logger.info("Starting NDW Netherlands traffic poller (interval=%ds)", self.poll_interval)
+    def run_forever(self, once: bool = False) -> None:
+        """Main polling loop. If ``once`` is True, exit after a single cycle."""
+        logger.info("Starting NDW Netherlands traffic poller (interval=%ds, once=%s)",
+                    self.poll_interval, once)
         # Force first situation poll
         self._last_situation_poll = 0
         while True:
@@ -529,6 +530,9 @@ class NdwPoller:
                 logger.info("Poll cycle complete: speed=%d, traveltime=%d, situation=%d", s, t, sit)
             except Exception:
                 logger.exception("Error during poll cycle")
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                return
             time.sleep(self.poll_interval)
 
 
@@ -542,6 +546,13 @@ def main() -> None:
     parser.add_argument("--situations-topic", default=None, help="Kafka topic for situations")
     parser.add_argument("--poll-interval", type=int, default=None, help="Poll interval in seconds")
     parser.add_argument("--state-file", default=None, help="Path to state file for dedup")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). "
+             "Useful for scheduled execution in Fabric notebooks.",
+    )
     args = parser.parse_args()
 
     connection_string = os.environ.get("CONNECTION_STRING", "")
@@ -575,7 +586,7 @@ def main() -> None:
 
     state = StateManager(state_file)
     poller = NdwPoller(measurements_prod, situations_prod, state, poll_interval)
-    poller.run_forever()
+    poller.run_forever(once=args.once)
 
 
 if __name__ == "__main__":

--- a/ndl-netherlands/notebook/ndl-netherlands-feed.ipynb
+++ b/ndl-netherlands/notebook/ndl-netherlands-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NDW Netherlands Traffic Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the NDW (Nationaal Dataportaal Wegverkeer) Dutch national road traffic open-data feed for current traffic speeds, travel times, and traffic situations (DATEX II), and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `ndl_netherlands` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `ndl-netherlands --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"ndl-netherlands-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/ndl-netherlands/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/ndl-netherlands/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing ndl_netherlands package from Fabric Environment...')\n",
+    "    from ndl_netherlands import ndl_netherlands as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['ndl-netherlands', '--once'] if ONCE_MODE else ['ndl-netherlands']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/ndl-netherlands/tests/test_once_mode.py
+++ b/ndl-netherlands/tests/test_once_mode.py
@@ -1,0 +1,41 @@
+"""Verify that ``--once`` causes ``main()`` to exit after a single polling cycle."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ndl_netherlands import ndl_netherlands as bridge
+
+
+def test_run_forever_once_returns_after_single_cycle():
+    """``run_forever(once=True)`` must return after exactly one poll cycle."""
+    poller = bridge.NdwPoller.__new__(bridge.NdwPoller)
+    poller.poll_interval = 60
+    poller._last_situation_poll = 0
+    poller.poll_and_send = MagicMock(return_value=(1, 2, 3))
+
+    with patch.object(bridge.time, "sleep") as sleep_mock:
+        bridge.NdwPoller.run_forever(poller, once=True)
+
+    assert poller.poll_and_send.call_count == 1
+    sleep_mock.assert_not_called()
+
+
+def test_main_once_flag_invokes_run_forever_with_once_true(monkeypatch):
+    """``main`` should propagate ``--once`` to ``poller.run_forever``."""
+    monkeypatch.setenv("CONNECTION_STRING", "BootstrapServer=localhost:9092;EntityPath=t")
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+    monkeypatch.setattr(sys, "argv", ["ndl-netherlands", "--once"])
+
+    fake_poller = MagicMock()
+    with patch.object(bridge, "Producer"), \
+         patch.object(bridge, "NLNDWTrafficMeasurementsEventProducer"), \
+         patch.object(bridge, "NLNDWTrafficSituationsEventProducer"), \
+         patch.object(bridge, "StateManager"), \
+         patch.object(bridge, "NdwPoller", return_value=fake_poller):
+        bridge.main()
+
+    fake_poller.run_forever.assert_called_once_with(once=True)


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent for source `ndl-netherlands`.

## Changes
- **Notebook** `ndl-netherlands/notebook/ndl-netherlands-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` then substituted per `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md`. Uses the no-subcommand variant: `sys.argv = ['ndl-netherlands', '--once']` (the NDW bridge has no argparse subcommand).
- **`--once` flag** added to `ndl-netherlands/ndl_netherlands/ndl_netherlands.py` (also honors `ONCE_MODE` env var). Modeled on pegelonline. `NdwPoller.run_forever(once=...)` returns after the first cycle.
- **`catalog.json`** — flipped `notebook: true` on the `ndl-netherlands` entry, inserted after `kql`.
- **README** — added a one-sentence Fabric notebook hosting bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- **KQL regeneration** (skill step 5b) — re-ran `kql/create-kql-script.ps1` equivalent with `-Qualified -Namespace nl.ndw.traffic` (the xreg has a single messagegroup namespace). Tables are now `['nl.ndw.traffic.TrafficSpeed']`, `['nl.ndw.traffic.TravelTime']`, `['nl.ndw.traffic.TrafficSituation']`.

## Validations performed locally
- `json.load` on the notebook → OK
- Params cell contains all five placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID` → OK
- Forbidden-pattern scan over **code cells only** (per skill allowance, `%pip install` in a markdown cell is a false positive) → no matches for `asyncio.run(`, `%pip install`, `CONNECTION_STRING="`, `primaryConnectionString=` → OK
- Full bridge test suite `pytest tests/` → **42 passed** (40 pre-existing + 2 new for `--once`). Ran in a local `.venv` per task instructions (not gitignored, not staged).

## Notes
- `--once` flag was added (deviation from "no bridge changes"), explicitly allowed by the task brief and modeled on `pegelonline/pegelonline/pegelonline.py`.
- KQL regenerated with `-Qualified -Namespace nl.ndw.traffic` per the mandatory step 5b.
- Agent does **not** deploy to Fabric. Wheel-publish workflow runs on PR merge.

Skill: `.github/skills/notebook-feeder-retrofit/SKILL.md`.
