### PR TITLE
feat(wsdot): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -629,7 +629,8 @@
     "cat": "Transport",
     "key": true,
     "desc": "Washington State — ~1,000 traffic flow sensors (requires free key)",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "irail",

--- a/wsdot/README.md
+++ b/wsdot/README.md
@@ -51,6 +51,7 @@ is polled every 120 seconds (configurable).
 - Ferries API: https://www.wsdot.wa.gov/ferries/api/vessels/rest/
 - Event catalog: [EVENTS.md](EVENTS.md)
 - Container deployment: [CONTAINER.md](CONTAINER.md)
+- Fabric notebook hosting: deploy this feeder as a scheduled Fabric notebook with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) (uses [`wsdot/notebook/wsdot-feed.ipynb`](notebook/wsdot-feed.ipynb)).
 
 ## Deploying into Azure Container Instances
 

--- a/wsdot/kql/create-kql-script.ps1
+++ b/wsdot/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\wsdot.xreg.json"
 $kqlFile = Join-Path $scriptDir "wsdot.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/wsdot/kql/wsdot.kql
+++ b/wsdot/kql/wsdot.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [TrafficFlowStation] (
+.create-merge table ['us.wa.wsdot.traffic.TrafficFlowStation'] (
    [flow_data_id]: string,
    [station_name]: string,
    [region]: string,
@@ -42,9 +42,9 @@
    [___subject]: string
 );
 
-.alter table [TrafficFlowStation] docstring "{\"description\": \"Metadata for a traffic flow sensor station in the WSDOT network. Each sensor is identified by a unique FlowDataID integer.\"}";
+.alter table ['us.wa.wsdot.traffic.TrafficFlowStation'] docstring "{\"description\": \"Metadata for a traffic flow sensor station in the WSDOT network. Each sensor is identified by a unique FlowDataID integer.\"}";
 
-.alter table [TrafficFlowStation] column-docstrings (
+.alter table ['us.wa.wsdot.traffic.TrafficFlowStation'] column-docstrings (
    [flow_data_id]: "{\"description\": \"Unique numeric identifier for this traffic flow sensor station, stringified from upstream FlowDataID.\"}",
    [station_name]: "{\"description\": \"Descriptive name of the flow sensor station.\"}",
    [region]: "{\"description\": \"WSDOT geographic coverage region.\"}",
@@ -61,7 +61,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TrafficFlowStation] ingestion json mapping "TrafficFlowStation_json_flat"
+.create-or-alter table ['us.wa.wsdot.traffic.TrafficFlowStation'] ingestion json mapping "us.wa.wsdot.traffic.TrafficFlowStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -81,7 +81,7 @@
 ]
 ```
 
-.create-or-alter table [TrafficFlowStation] ingestion json mapping "TrafficFlowStation_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.traffic.TrafficFlowStation'] ingestion json mapping "us.wa.wsdot.traffic.TrafficFlowStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -101,13 +101,13 @@
 ]
 ```
 
-.drop materialized-view TrafficFlowStationLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.traffic.TrafficFlowStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TrafficFlowStationLatest on table TrafficFlowStation {
-    TrafficFlowStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.traffic.TrafficFlowStationLatest'] on table ['us.wa.wsdot.traffic.TrafficFlowStation'] {
+    ['us.wa.wsdot.traffic.TrafficFlowStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TrafficFlowStation] policy update
+.alter table ['us.wa.wsdot.traffic.TrafficFlowStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -118,7 +118,7 @@
 }]
 ```
 
-.create-merge table [TrafficFlowReading] (
+.create-merge table ['us.wa.wsdot.traffic.TrafficFlowReading'] (
    [flow_data_id]: string,
    [station_name]: string,
    [region]: string,
@@ -131,9 +131,9 @@
    [___subject]: string
 );
 
-.alter table [TrafficFlowReading] docstring "{\"description\": \"A traffic flow reading from a WSDOT sensor station.\"}";
+.alter table ['us.wa.wsdot.traffic.TrafficFlowReading'] docstring "{\"description\": \"A traffic flow reading from a WSDOT sensor station.\"}";
 
-.alter table [TrafficFlowReading] column-docstrings (
+.alter table ['us.wa.wsdot.traffic.TrafficFlowReading'] column-docstrings (
    [flow_data_id]: "{\"description\": \"Sensor station identifier, stringified from upstream FlowDataID.\"}",
    [station_name]: "{\"description\": \"Station name.\"}",
    [region]: "{\"description\": \"WSDOT region.\"}",
@@ -146,7 +146,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TrafficFlowReading] ingestion json mapping "TrafficFlowReading_json_flat"
+.create-or-alter table ['us.wa.wsdot.traffic.TrafficFlowReading'] ingestion json mapping "us.wa.wsdot.traffic.TrafficFlowReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -162,7 +162,7 @@
 ]
 ```
 
-.create-or-alter table [TrafficFlowReading] ingestion json mapping "TrafficFlowReading_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.traffic.TrafficFlowReading'] ingestion json mapping "us.wa.wsdot.traffic.TrafficFlowReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -178,13 +178,13 @@
 ]
 ```
 
-.drop materialized-view TrafficFlowReadingLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.traffic.TrafficFlowReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TrafficFlowReadingLatest on table TrafficFlowReading {
-    TrafficFlowReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.traffic.TrafficFlowReadingLatest'] on table ['us.wa.wsdot.traffic.TrafficFlowReading'] {
+    ['us.wa.wsdot.traffic.TrafficFlowReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TrafficFlowReading] policy update
+.alter table ['us.wa.wsdot.traffic.TrafficFlowReading'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -195,7 +195,7 @@
 }]
 ```
 
-.create-merge table [TravelTimeRoute] (
+.create-merge table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] (
    [travel_time_id]: string,
    [name]: string,
    [description]: string,
@@ -222,9 +222,9 @@
    [___subject]: string
 );
 
-.alter table [TravelTimeRoute] docstring "{\"description\": \"A named travel time route monitored by WSDOT with historical average and current real-time travel times in minutes.\"}";
+.alter table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] docstring "{\"description\": \"A named travel time route monitored by WSDOT with historical average and current real-time travel times in minutes.\"}";
 
-.alter table [TravelTimeRoute] column-docstrings (
+.alter table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] column-docstrings (
    [travel_time_id]: "{\"description\": \"Unique route identifier, stringified from upstream TravelTimeID.\"}",
    [name]: "{\"description\": \"Short route segment name.\"}",
    [description]: "{\"description\": \"Longer description including lane type.\"}",
@@ -251,7 +251,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TravelTimeRoute] ingestion json mapping "TravelTimeRoute_json_flat"
+.create-or-alter table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] ingestion json mapping "us.wa.wsdot.traveltimes.TravelTimeRoute_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -281,7 +281,7 @@
 ]
 ```
 
-.create-or-alter table [TravelTimeRoute] ingestion json mapping "TravelTimeRoute_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] ingestion json mapping "us.wa.wsdot.traveltimes.TravelTimeRoute_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -311,13 +311,13 @@
 ]
 ```
 
-.drop materialized-view TravelTimeRouteLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.traveltimes.TravelTimeRouteLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TravelTimeRouteLatest on table TravelTimeRoute {
-    TravelTimeRoute | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.traveltimes.TravelTimeRouteLatest'] on table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] {
+    ['us.wa.wsdot.traveltimes.TravelTimeRoute'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TravelTimeRoute] policy update
+.alter table ['us.wa.wsdot.traveltimes.TravelTimeRoute'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -328,7 +328,7 @@
 }]
 ```
 
-.create-merge table [MountainPassCondition] (
+.create-merge table ['us.wa.wsdot.mountainpass.MountainPassCondition'] (
    [mountain_pass_id]: string,
    [mountain_pass_name]: string,
    [elevation_in_feet]: int,
@@ -350,9 +350,9 @@
    [___subject]: string
 );
 
-.alter table [MountainPassCondition] docstring "{\"description\": \"Current conditions at a Washington State mountain pass. WSDOT monitors 16 mountain passes reporting temperature, weather, road conditions, travel advisories, and directional restrictions.\"}";
+.alter table ['us.wa.wsdot.mountainpass.MountainPassCondition'] docstring "{\"description\": \"Current conditions at a Washington State mountain pass. WSDOT monitors 16 mountain passes reporting temperature, weather, road conditions, travel advisories, and directional restrictions.\"}";
 
-.alter table [MountainPassCondition] column-docstrings (
+.alter table ['us.wa.wsdot.mountainpass.MountainPassCondition'] column-docstrings (
    [mountain_pass_id]: "{\"description\": \"Unique pass identifier, stringified from upstream MountainPassId.\"}",
    [mountain_pass_name]: "{\"description\": \"Pass name with highway designation.\"}",
    [elevation_in_feet]: "{\"description\": \"Summit elevation in feet above sea level.\"}",
@@ -374,7 +374,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [MountainPassCondition] ingestion json mapping "MountainPassCondition_json_flat"
+.create-or-alter table ['us.wa.wsdot.mountainpass.MountainPassCondition'] ingestion json mapping "us.wa.wsdot.mountainpass.MountainPassCondition_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -399,7 +399,7 @@
 ]
 ```
 
-.create-or-alter table [MountainPassCondition] ingestion json mapping "MountainPassCondition_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.mountainpass.MountainPassCondition'] ingestion json mapping "us.wa.wsdot.mountainpass.MountainPassCondition_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -424,13 +424,13 @@
 ]
 ```
 
-.drop materialized-view MountainPassConditionLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.mountainpass.MountainPassConditionLatest'] ifexists;
 
-.create materialized-view with (backfill=true) MountainPassConditionLatest on table MountainPassCondition {
-    MountainPassCondition | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.mountainpass.MountainPassConditionLatest'] on table ['us.wa.wsdot.mountainpass.MountainPassCondition'] {
+    ['us.wa.wsdot.mountainpass.MountainPassCondition'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [MountainPassCondition] policy update
+.alter table ['us.wa.wsdot.mountainpass.MountainPassCondition'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -441,7 +441,7 @@
 }]
 ```
 
-.create-merge table [WeatherStation] (
+.create-merge table ['us.wa.wsdot.weather.WeatherStation'] (
    [station_id]: string,
    [station_name]: string,
    [latitude]: real,
@@ -453,9 +453,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherStation] docstring "{\"description\": \"Metadata for a WSDOT RWIS station.\"}";
+.alter table ['us.wa.wsdot.weather.WeatherStation'] docstring "{\"description\": \"Metadata for a WSDOT RWIS station.\"}";
 
-.alter table [WeatherStation] column-docstrings (
+.alter table ['us.wa.wsdot.weather.WeatherStation'] column-docstrings (
    [station_id]: "{\"description\": \"Station identifier from upstream StationCode.\"}",
    [station_name]: "{\"description\": \"Station name with highway and milepost.\"}",
    [latitude]: "{\"description\": \"Latitude in WGS84.\"}",
@@ -467,7 +467,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherStation] ingestion json mapping "WeatherStation_json_flat"
+.create-or-alter table ['us.wa.wsdot.weather.WeatherStation'] ingestion json mapping "us.wa.wsdot.weather.WeatherStation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -482,7 +482,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherStation] ingestion json mapping "WeatherStation_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.weather.WeatherStation'] ingestion json mapping "us.wa.wsdot.weather.WeatherStation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -497,13 +497,13 @@
 ]
 ```
 
-.drop materialized-view WeatherStationLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.weather.WeatherStationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherStationLatest on table WeatherStation {
-    WeatherStation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.weather.WeatherStationLatest'] on table ['us.wa.wsdot.weather.WeatherStation'] {
+    ['us.wa.wsdot.weather.WeatherStation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherStation] policy update
+.alter table ['us.wa.wsdot.weather.WeatherStation'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -514,7 +514,7 @@
 }]
 ```
 
-.create-merge table [WeatherReading] (
+.create-merge table ['us.wa.wsdot.weather.WeatherReading'] (
    [station_id]: string,
    [station_name]: string,
    [reading_time]: string,
@@ -537,9 +537,9 @@
    [___subject]: string
 );
 
-.alter table [WeatherReading] docstring "{\"description\": \"A current weather reading from a WSDOT RWIS station.\"}";
+.alter table ['us.wa.wsdot.weather.WeatherReading'] docstring "{\"description\": \"A current weather reading from a WSDOT RWIS station.\"}";
 
-.alter table [WeatherReading] column-docstrings (
+.alter table ['us.wa.wsdot.weather.WeatherReading'] column-docstrings (
    [station_id]: "{\"description\": \"Station identifier from upstream StationID.\"}",
    [station_name]: "{\"description\": \"Station name.\"}",
    [reading_time]: "{\"description\": \"ISO 8601 UTC timestamp.\"}",
@@ -562,7 +562,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [WeatherReading] ingestion json mapping "WeatherReading_json_flat"
+.create-or-alter table ['us.wa.wsdot.weather.WeatherReading'] ingestion json mapping "us.wa.wsdot.weather.WeatherReading_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -588,7 +588,7 @@
 ]
 ```
 
-.create-or-alter table [WeatherReading] ingestion json mapping "WeatherReading_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.weather.WeatherReading'] ingestion json mapping "us.wa.wsdot.weather.WeatherReading_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -614,13 +614,13 @@
 ]
 ```
 
-.drop materialized-view WeatherReadingLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.weather.WeatherReadingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) WeatherReadingLatest on table WeatherReading {
-    WeatherReading | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.weather.WeatherReadingLatest'] on table ['us.wa.wsdot.weather.WeatherReading'] {
+    ['us.wa.wsdot.weather.WeatherReading'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [WeatherReading] policy update
+.alter table ['us.wa.wsdot.weather.WeatherReading'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -631,7 +631,7 @@
 }]
 ```
 
-.create-merge table [TollRate] (
+.create-merge table ['us.wa.wsdot.tolls.TollRate'] (
    [trip_name]: string,
    [state_route]: string,
    [travel_direction]: string,
@@ -653,9 +653,9 @@
    [___subject]: string
 );
 
-.alter table [TollRate] docstring "{\"description\": \"Current toll rate for a WSDOT tolled route segment with dynamic pricing.\"}";
+.alter table ['us.wa.wsdot.tolls.TollRate'] docstring "{\"description\": \"Current toll rate for a WSDOT tolled route segment with dynamic pricing.\"}";
 
-.alter table [TollRate] column-docstrings (
+.alter table ['us.wa.wsdot.tolls.TollRate'] column-docstrings (
    [trip_name]: "{\"description\": \"Tolled route segment identifier.\"}",
    [state_route]: "{\"description\": \"State route number.\"}",
    [travel_direction]: "{\"description\": \"Travel direction: N, S, E, W.\"}",
@@ -677,7 +677,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [TollRate] ingestion json mapping "TollRate_json_flat"
+.create-or-alter table ['us.wa.wsdot.tolls.TollRate'] ingestion json mapping "us.wa.wsdot.tolls.TollRate_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -702,7 +702,7 @@
 ]
 ```
 
-.create-or-alter table [TollRate] ingestion json mapping "TollRate_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.tolls.TollRate'] ingestion json mapping "us.wa.wsdot.tolls.TollRate_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -727,13 +727,13 @@
 ]
 ```
 
-.drop materialized-view TollRateLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.tolls.TollRateLatest'] ifexists;
 
-.create materialized-view with (backfill=true) TollRateLatest on table TollRate {
-    TollRate | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.tolls.TollRateLatest'] on table ['us.wa.wsdot.tolls.TollRate'] {
+    ['us.wa.wsdot.tolls.TollRate'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [TollRate] policy update
+.alter table ['us.wa.wsdot.tolls.TollRate'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -744,7 +744,7 @@
 }]
 ```
 
-.create-merge table [CommercialVehicleRestriction] (
+.create-merge table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] (
    [state_route_id]: string,
    [bridge_number]: string,
    [bridge_name]: string,
@@ -775,9 +775,9 @@
    [___subject]: string
 );
 
-.alter table [CommercialVehicleRestriction] docstring "{\"description\": \"A commercial vehicle restriction on a Washington State highway bridge or road segment.\"}";
+.alter table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] docstring "{\"description\": \"A commercial vehicle restriction on a Washington State highway bridge or road segment.\"}";
 
-.alter table [CommercialVehicleRestriction] column-docstrings (
+.alter table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] column-docstrings (
    [state_route_id]: "{\"description\": \"State route identifier, first part of composite key.\"}",
    [bridge_number]: "{\"description\": \"Bridge or structure number, second part of composite key.\"}",
    [bridge_name]: "{\"description\": \"Bridge or structure name.\"}",
@@ -808,7 +808,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [CommercialVehicleRestriction] ingestion json mapping "CommercialVehicleRestriction_json_flat"
+.create-or-alter table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] ingestion json mapping "us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -842,7 +842,7 @@
 ]
 ```
 
-.create-or-alter table [CommercialVehicleRestriction] ingestion json mapping "CommercialVehicleRestriction_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] ingestion json mapping "us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -876,13 +876,13 @@
 ]
 ```
 
-.drop materialized-view CommercialVehicleRestrictionLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestrictionLatest'] ifexists;
 
-.create materialized-view with (backfill=true) CommercialVehicleRestrictionLatest on table CommercialVehicleRestriction {
-    CommercialVehicleRestriction | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestrictionLatest'] on table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] {
+    ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [CommercialVehicleRestriction] policy update
+.alter table ['us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -893,7 +893,7 @@
 }]
 ```
 
-.create-merge table [BorderCrossing] (
+.create-merge table ['us.wa.wsdot.border.BorderCrossing'] (
    [crossing_name]: string,
    [wait_time]: int,
    [time]: string,
@@ -908,9 +908,9 @@
    [___subject]: string
 );
 
-.alter table [BorderCrossing] docstring "{\"description\": \"US-Canada border crossing wait time in Washington State.\"}";
+.alter table ['us.wa.wsdot.border.BorderCrossing'] docstring "{\"description\": \"US-Canada border crossing wait time in Washington State.\"}";
 
-.alter table [BorderCrossing] column-docstrings (
+.alter table ['us.wa.wsdot.border.BorderCrossing'] column-docstrings (
    [crossing_name]: "{\"description\": \"Crossing lane identifier.\"}",
    [wait_time]: "{\"description\": \"Wait time in minutes.\"}",
    [time]: "{\"description\": \"ISO 8601 UTC measurement timestamp.\"}",
@@ -925,7 +925,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [BorderCrossing] ingestion json mapping "BorderCrossing_json_flat"
+.create-or-alter table ['us.wa.wsdot.border.BorderCrossing'] ingestion json mapping "us.wa.wsdot.border.BorderCrossing_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -943,7 +943,7 @@
 ]
 ```
 
-.create-or-alter table [BorderCrossing] ingestion json mapping "BorderCrossing_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.border.BorderCrossing'] ingestion json mapping "us.wa.wsdot.border.BorderCrossing_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -961,13 +961,13 @@
 ]
 ```
 
-.drop materialized-view BorderCrossingLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.border.BorderCrossingLatest'] ifexists;
 
-.create materialized-view with (backfill=true) BorderCrossingLatest on table BorderCrossing {
-    BorderCrossing | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.border.BorderCrossingLatest'] on table ['us.wa.wsdot.border.BorderCrossing'] {
+    ['us.wa.wsdot.border.BorderCrossing'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [BorderCrossing] policy update
+.alter table ['us.wa.wsdot.border.BorderCrossing'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -978,7 +978,7 @@
 }]
 ```
 
-.create-merge table [VesselLocation] (
+.create-merge table ['us.wa.wsdot.ferries.VesselLocation'] (
    [vessel_id]: string,
    [vessel_name]: string,
    [mmsi]: int,
@@ -1007,9 +1007,9 @@
    [___subject]: string
 );
 
-.alter table [VesselLocation] docstring "{\"description\": \"Real-time location and status of a Washington State Ferries vessel.\"}";
+.alter table ['us.wa.wsdot.ferries.VesselLocation'] docstring "{\"description\": \"Real-time location and status of a Washington State Ferries vessel.\"}";
 
-.alter table [VesselLocation] column-docstrings (
+.alter table ['us.wa.wsdot.ferries.VesselLocation'] column-docstrings (
    [vessel_id]: "{\"description\": \"Vessel identifier, stringified from upstream VesselID.\"}",
    [vessel_name]: "{\"description\": \"Ferry vessel name.\"}",
    [mmsi]: "{\"description\": \"Maritime Mobile Service Identity for AIS.\"}",
@@ -1038,7 +1038,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [VesselLocation] ingestion json mapping "VesselLocation_json_flat"
+.create-or-alter table ['us.wa.wsdot.ferries.VesselLocation'] ingestion json mapping "us.wa.wsdot.ferries.VesselLocation_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -1070,7 +1070,7 @@
 ]
 ```
 
-.create-or-alter table [VesselLocation] ingestion json mapping "VesselLocation_json_ce_structured"
+.create-or-alter table ['us.wa.wsdot.ferries.VesselLocation'] ingestion json mapping "us.wa.wsdot.ferries.VesselLocation_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -1102,13 +1102,13 @@
 ]
 ```
 
-.drop materialized-view VesselLocationLatest ifexists;
+.drop materialized-view ['us.wa.wsdot.ferries.VesselLocationLatest'] ifexists;
 
-.create materialized-view with (backfill=true) VesselLocationLatest on table VesselLocation {
-    VesselLocation | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['us.wa.wsdot.ferries.VesselLocationLatest'] on table ['us.wa.wsdot.ferries.VesselLocation'] {
+    ['us.wa.wsdot.ferries.VesselLocation'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [VesselLocation] policy update
+.alter table ['us.wa.wsdot.ferries.VesselLocation'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/wsdot/notebook/wsdot-feed.ipynb
+++ b/wsdot/notebook/wsdot-feed.ipynb
@@ -1,0 +1,225 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WSDOT Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Washington State DOT Traveler Information API across all eight channels (traffic flow, travel times, mountain passes, weather, toll rates, commercial-vehicle restrictions, border crossings, ferry vessel locations) and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `wsdot` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The WSDOT API access code is supplied via the `WSDOT_ACCESS_CODE` environment variable (register for a free key at https://www.wsdot.wa.gov/traffic/api/).\n",
+    "- The bridge runs `wsdot feed --once`, exits after one polling cycle, and emits reference data (stations, routes, passes, weather stations, etc.) once per cycle followed by telemetry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"wsdot-ingest\"            # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/wsdot/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/wsdot/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing wsdot package from Fabric Environment...')\n",
+    "    from wsdot import wsdot as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['wsdot', 'feed', '--once'] if ONCE_MODE else ['wsdot', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/wsdot/tests/test_once_mode.py
+++ b/wsdot/tests/test_once_mode.py
@@ -1,0 +1,88 @@
+"""Verify that the --once flag causes wsdot.feed() to exit after one cycle."""
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from wsdot import wsdot
+
+
+def _make_args(**overrides):
+    base = dict(
+        connection_string="BootstrapServer=localhost:9092;EntityPath=test",
+        access_code="dummy",
+        polling_interval=1,
+        region_filter=None,
+        once=True,
+    )
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_feed_once_exits_after_first_cycle():
+    """With --once, feed() must return after the initial reference + telemetry
+    batch without entering the polling loop or calling time.sleep."""
+    with patch.object(wsdot, "Producer") as mock_producer_cls, \
+         patch.object(wsdot, "WSDOTApi") as mock_api_cls, \
+         patch.object(wsdot, "UsWaWsdotTrafficEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotTraveltimesEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotMountainpassEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotWeatherEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotTollsEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotCvrestrictionsEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotBorderEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotFerriesEventProducer"), \
+         patch.object(wsdot.time, "sleep") as mock_sleep:
+        api = mock_api_cls.return_value
+        for fetch in (
+            "fetch_traffic_flows",
+            "fetch_travel_times",
+            "fetch_mountain_pass_conditions",
+            "fetch_weather_stations",
+            "fetch_weather_information",
+            "fetch_toll_rates",
+            "fetch_cv_restrictions",
+            "fetch_border_crossings",
+            "fetch_vessel_locations",
+        ):
+            getattr(api, fetch).return_value = []
+
+        mock_producer_cls.return_value = MagicMock()
+
+        wsdot.feed(_make_args())
+
+        mock_sleep.assert_not_called()
+
+
+def test_feed_once_env_var_triggers_single_cycle(monkeypatch):
+    """ONCE_MODE env var should also trigger single-cycle exit even when the
+    CLI flag is absent."""
+    monkeypatch.setenv("ONCE_MODE", "true")
+    args = _make_args(once=False)
+
+    with patch.object(wsdot, "Producer") as mock_producer_cls, \
+         patch.object(wsdot, "WSDOTApi") as mock_api_cls, \
+         patch.object(wsdot, "UsWaWsdotTrafficEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotTraveltimesEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotMountainpassEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotWeatherEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotTollsEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotCvrestrictionsEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotBorderEventProducer"), \
+         patch.object(wsdot, "UsWaWsdotFerriesEventProducer"), \
+         patch.object(wsdot.time, "sleep") as mock_sleep:
+        api = mock_api_cls.return_value
+        for fetch in (
+            "fetch_traffic_flows",
+            "fetch_travel_times",
+            "fetch_mountain_pass_conditions",
+            "fetch_weather_stations",
+            "fetch_weather_information",
+            "fetch_toll_rates",
+            "fetch_cv_restrictions",
+            "fetch_border_crossings",
+            "fetch_vessel_locations",
+        ):
+            getattr(api, fetch).return_value = []
+        mock_producer_cls.return_value = MagicMock()
+
+        wsdot.feed(args)
+        mock_sleep.assert_not_called()

--- a/wsdot/wsdot/wsdot.py
+++ b/wsdot/wsdot/wsdot.py
@@ -403,6 +403,7 @@ def feed(args):
 
     polling_interval = int(args.polling_interval or os.environ.get("POLLING_INTERVAL", "120"))
     region_filter = args.region_filter or os.environ.get("REGION_FILTER", "")
+    once = bool(getattr(args, "once", False)) or os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes")
 
     producer = Producer(kafka_config)
     traffic_ep = UsWaWsdotTrafficEventProducer(producer, kafka_topic)
@@ -534,6 +535,11 @@ def feed(args):
     # Initial: emit reference data + first round of telemetry
     total = _poll_and_emit(is_initial=True, emit_reference=True)
     logging.info("Initial batch: %d total events", total)
+    producer.flush()
+
+    if once:
+        logging.info("--once mode: exiting after first polling cycle")
+        return
 
     # Polling loop
     last_reference_time = datetime.now(timezone.utc)
@@ -570,6 +576,13 @@ def main():
     feed_parser.add_argument("--access-code", help="WSDOT API access code")
     feed_parser.add_argument("--polling-interval", type=int, default=120, help="Polling interval in seconds")
     feed_parser.add_argument("--region-filter", help="Comma-separated WSDOT regions for traffic flow")
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). "
+             "Useful for scheduled execution in Fabric notebooks.",
+    )
 
     args = parser.parse_args()
     if args.command == "feed":


### PR DESCRIPTION
Retrofits the WSDOT source with a Fabric notebook hosting option, following the canonical `pegelonline` pattern (per `.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- `wsdot/notebook/wsdot-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` with the documented substitutions (display name, package/module imports, `sys.argv`, state/log paths, EVENTSTREAM_NAME default). Four-cell structure, CS-lookup cell, worker-thread cell, and OneLake log layout are unchanged.
- `catalog.json` — adds `"notebook": true` to the wsdot entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `wsdot/wsdot/wsdot.py` — adds a `--once` CLI flag (and `ONCE_MODE` env-var alias) that exits after the initial reference+telemetry cycle. Modeled on pegelonline's flag.
- `wsdot/tests/test_once_mode.py` — two new unit tests that assert `--once` and `ONCE_MODE=true` each cause `feed()` to return after one cycle without calling `time.sleep`.
- `wsdot/README.md` — one-sentence Fabric notebook hosting link.
- `wsdot/kql/create-kql-script.ps1` + `wsdot/kql/wsdot.kql` — regenerated KQL with the `-Qualified` flag (mandatory step 5b). wsdot has 8 distinct messagegroup namespaces so no `-Namespace` override is passed.

## Validations performed locally

- Notebook JSON parses (`json.load`).
- Required parameter placeholders present in cell 2: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns in any code cell: `asyncio.run(`, `%pip install`, baked `CONNECTION_STRING = "…"`, or `primaryConnectionString = …`. (`%pip install` appears only in the cell-1 markdown explaining that it is *not* required at runtime — false-positive verified per-cell.)
- `python -m pytest wsdot/tests/ -x`: **69 passed**, including the 2 new `test_once_mode` cases.
- `--once` flag verified to skip the polling loop end-to-end via the mocked tests.

## --once status

Added. The bridge previously had no single-cycle exit path; the new flag mirrors the pegelonline implementation (`action='store_true'`, defaults to the `ONCE_MODE` env var).

## Out of scope

No live Fabric deployment performed (per skill section 7). The wheel-publish workflow will pick up `wsdot` on merge to main.