### PR TITLE
feat(vatsim): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -549,7 +549,8 @@
     "cat": "Aviation",
     "key": false,
     "desc": "Global — virtual aviation network, pilots & controllers",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "autobahn",

--- a/vatsim/README.md
+++ b/vatsim/README.md
@@ -39,6 +39,10 @@ pip install .
 
 For containerized deployment, see [CONTAINER.md](CONTAINER.md).
 
+- **Fabric notebook hosting** — schedule the bridge as a Fabric notebook
+  via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+  (see [`notebook/vatsim-feed.ipynb`](notebook/vatsim-feed.ipynb)).
+
 ## Usage
 
 ```bash

--- a/vatsim/notebook/vatsim-feed.ipynb
+++ b/vatsim/notebook/vatsim-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VATSIM Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the VATSIM v3 live data feed for pilot positions, controller positions, and aggregate network status, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `vatsim` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `vatsim feed --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits changed pilot/controller records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"vatsim-ingest\"           # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/vatsim/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/vatsim/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing vatsim package from Fabric Environment...')\n",
+    "    from vatsim import vatsim as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['vatsim', 'feed', '--once'] if ONCE_MODE else ['vatsim', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/vatsim/tests/test_once_mode.py
+++ b/vatsim/tests/test_once_mode.py
@@ -1,0 +1,120 @@
+"""Tests for --once single-cycle execution mode (Fabric notebook hosting)."""
+
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vatsim.vatsim import VatsimBridge, main
+
+
+SAMPLE_DATA = {
+    "general": {
+        "version": 3,
+        "update_timestamp": "2026-05-17T07:48:40.5031859Z",
+        "connected_clients": 2,
+        "unique_users": 2,
+    },
+    "pilots": [
+        {
+            "cid": 1,
+            "callsign": "AAL1",
+            "latitude": 1.0,
+            "longitude": 2.0,
+            "altitude": 30000,
+            "groundspeed": 400,
+            "heading": 90,
+            "transponder": "1200",
+            "qnh_mb": 1013,
+            "pilot_rating": 1,
+            "last_updated": "2026-05-17T07:48:40Z",
+            "flight_plan": None,
+        }
+    ],
+    "controllers": [
+        {
+            "cid": 2,
+            "callsign": "KLAX_TWR",
+            "frequency": "120.950",
+            "facility": 4,
+            "rating": 3,
+            "text_atis": ["Hello"],
+            "last_updated": "2026-05-17T07:48:40Z",
+        }
+    ],
+}
+
+
+@pytest.mark.unit
+def test_feed_once_mode_exits_after_one_cycle():
+    """When once=True, feed() must return after a single polling cycle."""
+    bridge = VatsimBridge()
+    bridge.fetch_data = MagicMock(return_value=SAMPLE_DATA)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        state_file = os.path.join(tmpdir, 'state.json')
+        with patch('vatsim.vatsim.Producer') as MockProducer, \
+             patch('vatsim.vatsim.NetVatsimPilotsEventProducer'), \
+             patch('vatsim.vatsim.NetVatsimControllersEventProducer'), \
+             patch('vatsim.vatsim.NetVatsimStatusEventProducer'), \
+             patch('vatsim.vatsim.time.sleep') as mock_sleep:
+            MockProducer.return_value = MagicMock()
+
+            bridge.feed(
+                kafka_config={'bootstrap.servers': 'localhost:9092'},
+                kafka_topic='test',
+                polling_interval=60,
+                state_file=state_file,
+                once=True,
+            )
+
+        # Single cycle: exactly one upstream fetch, no sleeping between cycles.
+        assert bridge.fetch_data.call_count == 1
+        mock_sleep.assert_not_called()
+        assert os.path.exists(state_file)
+
+
+@pytest.mark.unit
+def test_once_flag_via_cli_argument(monkeypatch):
+    """`--once` CLI flag must propagate into bridge.feed(once=True)."""
+    captured = {}
+
+    def fake_feed(self, kafka_config, kafka_topic, polling_interval, state_file='', once=False):
+        captured['once'] = once
+        captured['topic'] = kafka_topic
+
+    monkeypatch.setattr(VatsimBridge, 'feed', fake_feed)
+    monkeypatch.setattr(sys, 'argv', [
+        'vatsim', 'feed',
+        '--kafka-bootstrap-servers', 'localhost:9092',
+        '--kafka-topic', 'test',
+        '--once',
+    ])
+    monkeypatch.delenv('CONNECTION_STRING', raising=False)
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+
+    main()
+    assert captured == {'once': True, 'topic': 'test'}
+
+
+@pytest.mark.unit
+def test_once_flag_via_env_var(monkeypatch):
+    """ONCE_MODE env var must set the --once default to True."""
+    captured = {}
+
+    def fake_feed(self, kafka_config, kafka_topic, polling_interval, state_file='', once=False):
+        captured['once'] = once
+
+    monkeypatch.setattr(VatsimBridge, 'feed', fake_feed)
+    monkeypatch.setenv('ONCE_MODE', 'true')
+    monkeypatch.setattr(sys, 'argv', [
+        'vatsim', 'feed',
+        '--kafka-bootstrap-servers', 'localhost:9092',
+        '--kafka-topic', 'test',
+    ])
+    monkeypatch.delenv('CONNECTION_STRING', raising=False)
+
+    main()
+    assert captured == {'once': True}

--- a/vatsim/vatsim/vatsim.py
+++ b/vatsim/vatsim/vatsim.py
@@ -176,7 +176,7 @@ class VatsimBridge:
             config_dict['sasl.mechanism'] = 'PLAIN'
         return config_dict
 
-    def feed(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '') -> None:
+    def feed(self, kafka_config: dict, kafka_topic: str, polling_interval: int, state_file: str = '', once: bool = False) -> None:
         """Poll VATSIM and emit events to Kafka."""
         previous_pilots: Dict[str, str] = _load_state(state_file).get('pilots', {})
         previous_controllers: Dict[str, str] = _load_state(state_file).get('controllers', {})
@@ -250,6 +250,9 @@ class VatsimBridge:
                     pilot_count, ctrl_count, elapsed, effective_interval
                 )
                 _save_state(state_file, {'pilots': previous_pilots, 'controllers': previous_controllers})
+                if once:
+                    logging.info("--once mode: exiting after first polling cycle")
+                    break
                 if effective_interval > 0:
                     time.sleep(effective_interval)
             except KeyboardInterrupt:
@@ -291,6 +294,10 @@ def main() -> None:
                              default=polling_interval_default)
     feed_parser.add_argument('--state-file', type=str,
                              default=os.getenv('STATE_FILE', os.path.expanduser('~/.vatsim_state.json')))
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                                  'Useful for scheduled execution in Fabric notebooks.')
 
     args = parser.parse_args()
     bridge = VatsimBridge()
@@ -329,7 +336,7 @@ def main() -> None:
         elif tls_enabled:
             kafka_config['security.protocol'] = 'SSL'
 
-        bridge.feed(kafka_config, kafka_topic, args.polling_interval, args.state_file)
+        bridge.feed(kafka_config, kafka_topic, args.polling_interval, args.state_file, args.once)
     else:
         parser.print_help()
 


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent for source `vatsim`.

## Changes
- `vatsim/notebook/vatsim-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` with the substitutions from `.github/skills/notebook-feeder-retrofit/references/notebook-substitution-table.md` (display name, package import, `sys.argv`, OneLake paths, eventstream name).
- `vatsim/vatsim/vatsim.py` — adds `--once` flag (and `ONCE_MODE` env var) so the polling loop exits after one cycle, modeled on `pegelonline`. Required for scheduled Fabric notebook execution.
- `vatsim/tests/test_once_mode.py` — three new unit tests covering single-cycle exit, CLI flag propagation, and env-var propagation.
- `catalog.json` — sets `notebook: true` on the vatsim entry (inserted after `kql`).
- `vatsim/README.md` — one-line Fabric notebook hosting bullet linking to the deploy script.

## Validations performed
- Notebook JSON parses cleanly.
- All 52 bridge tests pass (3 new `test_once_mode` tests + 49 existing).
- Parameters cell declares all required placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden-pattern scan: clean for `asyncio.run(`, `CONNECTION_STRING="`, `primaryConnectionString=`. The `%pip install` hit is the documented markdown false positive — the only match is the cell-1 markdown stating `No %pip install is required at runtime.` (same line is present in the pegelonline template).

No live Fabric deployment performed; the wheel-publish workflow will pick up this source on merge to `main`.