### PR TITLE
feat(energidataservice-dk): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -661,7 +661,8 @@
     "cat": "Energy",
     "key": false,
     "desc": "Denmark — power system, spot prices, CO₂",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "energy-charts",

--- a/energidataservice-dk/README.md
+++ b/energidataservice-dk/README.md
@@ -17,6 +17,10 @@ See [EVENTS.md](EVENTS.md) for the full event schema documentation.
 
 See [CONTAINER.md](CONTAINER.md) for container deployment instructions.
 
+## Fabric notebook hosting
+
+This source ships a Fabric notebook feeder at [`notebook/energidataservice-dk-feed.ipynb`](notebook/energidataservice-dk-feed.ipynb); deploy it with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) to run scheduled single-cycle polls inside a Microsoft Fabric workspace.
+
 ## Quick Start
 
 ```shell

--- a/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
+++ b/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
@@ -291,8 +291,12 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        help='Run a single polling cycle and exit (used by Fabric notebook scheduler).')
 
     args = parser.parse_args()
+
+    once_mode = args.once or os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes')
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
@@ -339,4 +343,4 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=once_mode)

--- a/energidataservice-dk/kql/energidataservice_dk.kql
+++ b/energidataservice-dk/kql/energidataservice_dk.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [PowerSystemSnapshot] (
+.create-merge table ['dk.energinet.energidataservice.PowerSystemSnapshot'] (
    [minutes1_utc]: string,
    [minutes1_dk]: string,
    [price_area]: string,
@@ -58,9 +58,9 @@
    [___subject]: string
 );
 
-.alter table [PowerSystemSnapshot] docstring "{\"description\": \"Minute-by-minute snapshot of the Danish power system from Energi Data Service (Energinet). Published by the PowerSystemRightNow dataset at approximately 1-minute intervals.\"}";
+.alter table ['dk.energinet.energidataservice.PowerSystemSnapshot'] docstring "{\"description\": \"Minute-by-minute snapshot of the Danish power system from Energi Data Service (Energinet). Published by the PowerSystemRightNow dataset at approximately 1-minute intervals.\"}";
 
-.alter table [PowerSystemSnapshot] column-docstrings (
+.alter table ['dk.energinet.energidataservice.PowerSystemSnapshot'] column-docstrings (
    [minutes1_utc]: "{\"description\": \"UTC timestamp of the snapshot rounded to the nearest minute, in ISO 8601 format. Sourced from the PowerSystemRightNow 'Minutes1UTC' field.\"}",
    [minutes1_dk]: "{\"description\": \"Danish local-time timestamp of the snapshot rounded to the nearest minute, in ISO 8601 format. Sourced from the PowerSystemRightNow 'Minutes1DK' field.\"}",
    [price_area]: "{\"description\": \"Price area code. Set to 'DK' for system-wide power system snapshots that cover the entire Danish grid (both DK1 and DK2).\"}",
@@ -93,7 +93,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [PowerSystemSnapshot] ingestion json mapping "PowerSystemSnapshot_json_flat"
+.create-or-alter table ['dk.energinet.energidataservice.PowerSystemSnapshot'] ingestion json mapping "dk.energinet.energidataservice.PowerSystemSnapshot_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -129,7 +129,7 @@
 ]
 ```
 
-.create-or-alter table [PowerSystemSnapshot] ingestion json mapping "PowerSystemSnapshot_json_ce_structured"
+.create-or-alter table ['dk.energinet.energidataservice.PowerSystemSnapshot'] ingestion json mapping "dk.energinet.energidataservice.PowerSystemSnapshot_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -165,13 +165,13 @@
 ]
 ```
 
-.drop materialized-view PowerSystemSnapshotLatest ifexists;
+.drop materialized-view ['dk.energinet.energidataservice.PowerSystemSnapshotLatest'] ifexists;
 
-.create materialized-view with (backfill=true) PowerSystemSnapshotLatest on table PowerSystemSnapshot {
-    PowerSystemSnapshot | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['dk.energinet.energidataservice.PowerSystemSnapshotLatest'] on table ['dk.energinet.energidataservice.PowerSystemSnapshot'] {
+    ['dk.energinet.energidataservice.PowerSystemSnapshot'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [PowerSystemSnapshot] policy update
+.alter table ['dk.energinet.energidataservice.PowerSystemSnapshot'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -182,7 +182,7 @@
 }]
 ```
 
-.create-merge table [SpotPrice] (
+.create-merge table ['dk.energinet.energidataservice.SpotPrice'] (
    [hour_utc]: string,
    [hour_dk]: string,
    [price_area]: string,
@@ -195,9 +195,9 @@
    [___subject]: string
 );
 
-.alter table [SpotPrice] docstring "{\"description\": \"Day-ahead electricity spot price per bidding zone from Energi Data Service (Energinet / Nord Pool). One record per hour per price area.\"}";
+.alter table ['dk.energinet.energidataservice.SpotPrice'] docstring "{\"description\": \"Day-ahead electricity spot price per bidding zone from Energi Data Service (Energinet / Nord Pool). One record per hour per price area.\"}";
 
-.alter table [SpotPrice] column-docstrings (
+.alter table ['dk.energinet.energidataservice.SpotPrice'] column-docstrings (
    [hour_utc]: "{\"description\": \"UTC hour for which the spot price applies, in ISO 8601 format. Each price applies to the full 60-minute interval starting at this timestamp. Sourced from 'HourUTC'.\"}",
    [hour_dk]: "{\"description\": \"Danish local-time hour for which the spot price applies, in ISO 8601 format. Sourced from 'HourDK'.\"}",
    [price_area]: "{\"description\": \"Nord Pool bidding zone code. 'DK1' is Western Denmark (Jutland and Funen); 'DK2' is Eastern Denmark (Zealand, Lolland-Falster, and Bornholm). Sourced from 'PriceArea'.\"}",
@@ -210,7 +210,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [SpotPrice] ingestion json mapping "SpotPrice_json_flat"
+.create-or-alter table ['dk.energinet.energidataservice.SpotPrice'] ingestion json mapping "dk.energinet.energidataservice.SpotPrice_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -226,7 +226,7 @@
 ]
 ```
 
-.create-or-alter table [SpotPrice] ingestion json mapping "SpotPrice_json_ce_structured"
+.create-or-alter table ['dk.energinet.energidataservice.SpotPrice'] ingestion json mapping "dk.energinet.energidataservice.SpotPrice_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -242,13 +242,13 @@
 ]
 ```
 
-.drop materialized-view SpotPriceLatest ifexists;
+.drop materialized-view ['dk.energinet.energidataservice.SpotPriceLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SpotPriceLatest on table SpotPrice {
-    SpotPrice | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['dk.energinet.energidataservice.SpotPriceLatest'] on table ['dk.energinet.energidataservice.SpotPrice'] {
+    ['dk.energinet.energidataservice.SpotPrice'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [SpotPrice] policy update
+.alter table ['dk.energinet.energidataservice.SpotPrice'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/energidataservice-dk/notebook/energidataservice-dk-feed.ipynb
+++ b/energidataservice-dk/notebook/energidataservice-dk-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Energi Data Service Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Energinet **Energi Data Service** API for Danish power system snapshots (1-minute production, exchange, balancing, CO₂) and day-ahead Elspot prices, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `energidataservice_dk` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `energidataservice-dk --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"energidataservice-dk-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/energidataservice-dk/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/energidataservice-dk/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing energidataservice_dk package from Fabric Environment...')\n",
+    "    from energidataservice_dk import energidataservice_dk as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['energidataservice-dk', '--once'] if ONCE_MODE else ['energidataservice-dk']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/energidataservice-dk/tests/test_once_mode.py
+++ b/energidataservice-dk/tests/test_once_mode.py
@@ -1,0 +1,85 @@
+"""Verify that --once causes the bridge to perform exactly one polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import energidataservice_dk.energidataservice_dk as bridge
+
+
+@pytest.fixture
+def fake_poller():
+    poller = MagicMock()
+    poller.poll_and_send = MagicMock()
+    return poller
+
+
+def test_once_flag_invokes_single_cycle(fake_poller, monkeypatch):
+    """--once CLI flag should cause poll_and_send to be called with once=True."""
+    monkeypatch.setattr(bridge, 'EnergiDataServicePoller', lambda **kw: fake_poller)
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+
+    argv_backup = sys.argv
+    try:
+        sys.argv = ['energidataservice-dk', '--once']
+        bridge.main()
+    finally:
+        sys.argv = argv_backup
+
+    fake_poller.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_no_once_runs_default_loop(fake_poller, monkeypatch):
+    monkeypatch.setattr(bridge, 'EnergiDataServicePoller', lambda **kw: fake_poller)
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+
+    argv_backup = sys.argv
+    try:
+        sys.argv = ['energidataservice-dk']
+        bridge.main()
+    finally:
+        sys.argv = argv_backup
+
+    fake_poller.poll_and_send.assert_called_once_with(once=False)
+
+
+def test_once_mode_env_var_triggers_single_cycle(fake_poller, monkeypatch):
+    monkeypatch.setattr(bridge, 'EnergiDataServicePoller', lambda **kw: fake_poller)
+    monkeypatch.setenv('CONNECTION_STRING',
+                       'BootstrapServer=localhost:9092;EntityPath=test-topic')
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+
+    argv_backup = sys.argv
+    try:
+        sys.argv = ['energidataservice-dk']
+        bridge.main()
+    finally:
+        sys.argv = argv_backup
+
+    fake_poller.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_poller_loop_breaks_after_one_cycle_when_once_true(monkeypatch):
+    """poll_and_send(once=True) should exit after a single iteration."""
+    inst = bridge.EnergiDataServicePoller.__new__(bridge.EnergiDataServicePoller)
+    inst.kafka_topic = 'test'
+    inst.last_polled_file = None
+    inst.producer = MagicMock()
+    inst.load_state = MagicMock(return_value={})
+    inst.save_state = MagicMock()
+    inst.fetch_power_system_records = MagicMock(return_value=[])
+    inst.fetch_spot_price_records = MagicMock(return_value=[])
+
+    with patch.object(bridge.time, 'sleep') as sleep_mock:
+        inst.poll_and_send(once=True)
+
+    sleep_mock.assert_not_called()
+    inst.fetch_power_system_records.assert_called_once()


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` skill (`.github/skills/notebook-feeder-retrofit/SKILL.md`) for source `energidataservice-dk`.

## Changes

- `energidataservice-dk/notebook/energidataservice-dk-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` and mechanically substituted per the skill's substitution table (display name, package/module imports, `sys.argv` shape, Lakehouse state/log paths, EVENTSTREAM_NAME default).
- `energidataservice-dk/energidataservice_dk/energidataservice_dk.py` — added `--once` CLI flag and `ONCE_MODE` env-var fallback. The polling loop already supported `once=True`; the flag is now wired through `main()` so the Fabric scheduler can drive single-cycle runs. Modeled on `pegelonline`.
- `energidataservice-dk/tests/test_once_mode.py` — new tests asserting (a) `--once` causes `poll_and_send(once=True)`, (b) absence runs the default loop, (c) `ONCE_MODE=true` env triggers single-cycle, (d) `poll_and_send(once=True)` exits after one iteration without sleeping.
- `energidataservice-dk/kql/energidataservice_dk.kql` — regenerated with `-Qualified -Namespace dk.energinet.energidataservice` so tables, materialized views, mappings, and update policies are namespace-qualified (avoids collisions with co-tenanted feeders).
- `catalog.json` — flipped `"notebook": true` for `energidataservice-dk`.
- `energidataservice-dk/README.md` — added the required one-sentence Fabric-notebook-hosting bullet pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Local validation

- `python -m pytest tests/` — **56/56 pass** (52 existing + 4 new `--once` tests).
- Notebook JSON parses (`json.load`).
- Parameters cell contains all 5 placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns: no `asyncio.run(`, no `%pip install` in code cells (markdown mentions `%pip install` only descriptively), no `CONNECTION_STRING = "..."` literal, no `primaryConnectionString = ...` assignment.
- KQL regeneration verified — only difference vs. previous file is namespace qualification.

## Not done here

- No live Fabric deployment (per skill: maintainer-driven manual verification once merged).
- The `publish-notebook-wheels.yml` workflow run on the merge commit should be checked to confirm `energidataservice-dk-notebook-wheels.zip` is published before any deploy attempt.

## Deviations from the canonical skill flow

- Added `--once` flag (explicitly allowed by operator, modeled on `pegelonline`).
- Step 5b: regenerated `kql/energidataservice_dk.kql` with `-Qualified -Namespace dk.energinet.energidataservice` (single messagegroup namespace in xreg, so `-Namespace` is safe).
