### PR TITLE
feat(gracedb): Fabric notebook hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ mode-s/kql/aircraft.csv
 # Poetry lock files (generated; not used by Docker builds)
 **/poetry.lock
 **/.playwright-mcp/
+gracedb/.venv/

--- a/catalog.json
+++ b/catalog.json
@@ -717,6 +717,7 @@
     "cat": "Science",
     "key": false,
     "desc": "Global — LIGO/Virgo/KAGRA gravitational wave candidates",
-    "kql": true
+    "kql": true,
+    "notebook": true
   }
 ]

--- a/gracedb/README.md
+++ b/gracedb/README.md
@@ -30,6 +30,12 @@ The bridge emits a single event type, documented in [EVENTS.md](EVENTS.md):
 - [GraceDB API Docs](https://gracedb.ligo.org/documentation/rest.html)
 - [LIGO Scientific Collaboration](https://www.ligo.org/)
 
+## Fabric notebook hosting
+
+This source can also be hosted as a scheduled Fabric notebook via
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1)
+which deploys `gracedb/notebook/gracedb-feed.ipynb` to a Fabric workspace.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/gracedb/gracedb/gracedb.py
+++ b/gracedb/gracedb/gracedb.py
@@ -125,8 +125,12 @@ class GraceDBPoller:
             with open(self.last_polled_file, 'w', encoding='utf-8') as f:
                 json.dump({"seen_ids": sorted(seen_ids)}, f)
 
-    async def poll_and_send(self):
-        """Continuously poll the GraceDB API and send new superevents to Kafka."""
+    async def poll_and_send(self, once: bool = False):
+        """Continuously poll the GraceDB API and send new superevents to Kafka.
+
+        If ``once`` is True, exit after a single polling cycle. Useful for
+        scheduled execution in Fabric notebooks.
+        """
         seen_ids = self.load_seen_ids()
         poll_interval = timedelta(minutes=2)
 
@@ -164,6 +168,10 @@ class GraceDBPoller:
             # Prune seen set to bounded size (keep latest 5000)
             if len(seen_ids) > 5000:
                 seen_ids = set(sorted(seen_ids)[-5000:])
+
+            if once:
+                logger.info("--once mode: exiting after first polling cycle")
+                break
 
             elapsed = datetime.now(timezone.utc) - start_poll_time
             remaining = poll_interval - elapsed
@@ -230,6 +238,10 @@ def main():
     feed_parser.add_argument('--categories', type=str, default=DEFAULT_CATEGORIES,
                              help=f'Comma-separated categories to include (default: {DEFAULT_CATEGORIES})')
     feed_parser.add_argument('--log-level', type=str, help='Logging level', default='INFO')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var). '
+                                  'Useful for scheduled execution in Fabric notebooks.')
 
     events_parser = subparsers.add_parser('events', help="List recent superevents")
     events_parser.add_argument('--count', type=int, default=10, help='Number of events to display')
@@ -292,7 +304,7 @@ def main():
             poll_count=args.poll_count,
             categories=args.categories,
         )
-        asyncio.run(poller.poll_and_send())
+        asyncio.run(poller.poll_and_send(once=args.once))
     else:
         parser.print_help()
 

--- a/gracedb/kql/create-kql-script.ps1
+++ b/gracedb/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\gracedb.xreg.json"
 $kqlFile = Join-Path $scriptDir "gracedb.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "org.ligo.gracedb"

--- a/gracedb/kql/gracedb.kql
+++ b/gracedb/kql/gracedb.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [Superevent] (
+.create-merge table ['org.ligo.gracedb.Superevent'] (
    [superevent_id]: string,
    [category]: string,
    [created]: string,
@@ -54,9 +54,9 @@
    [___subject]: string
 );
 
-.alter table [Superevent] docstring "{\"description\": \"A gravitational wave candidate superevent from the LIGO/Virgo/KAGRA collaboration, published via GraceDB. A superevent aggregates one or more pipeline detections into a single candidate and carries significance, classification, and alert-lifecycle metadata.\"}";
+.alter table ['org.ligo.gracedb.Superevent'] docstring "{\"description\": \"A gravitational wave candidate superevent from the LIGO/Virgo/KAGRA collaboration, published via GraceDB. A superevent aggregates one or more pipeline detections into a single candidate and carries significance, classification, and alert-lifecycle metadata.\"}";
 
-.alter table [Superevent] column-docstrings (
+.alter table ['org.ligo.gracedb.Superevent'] column-docstrings (
    [superevent_id]: "{\"description\": \"Unique identifier for the superevent assigned by GraceDB, e.g. 'S240414a' for production events or 'MS260408x' for MDC (mock data challenge) events.\"}",
    [category]: "{\"description\": \"Category of the superevent. 'Production' for real observing-run candidates, 'MDC' for mock data challenge injections, 'Test' for engineering/test events.\"}",
    [created]: "{\"description\": \"ISO-8601 UTC timestamp when the superevent was first created in GraceDB, e.g. '2026-04-08 23:59:34 UTC'.\"}",
@@ -85,7 +85,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [Superevent] ingestion json mapping "Superevent_json_flat"
+.create-or-alter table ['org.ligo.gracedb.Superevent'] ingestion json mapping "org.ligo.gracedb.Superevent_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -117,7 +117,7 @@
 ]
 ```
 
-.create-or-alter table [Superevent] ingestion json mapping "Superevent_json_ce_structured"
+.create-or-alter table ['org.ligo.gracedb.Superevent'] ingestion json mapping "org.ligo.gracedb.Superevent_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -149,13 +149,13 @@
 ]
 ```
 
-.drop materialized-view SupereventLatest ifexists;
+.drop materialized-view ['org.ligo.gracedb.SupereventLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SupereventLatest on table Superevent {
-    Superevent | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['org.ligo.gracedb.SupereventLatest'] on table ['org.ligo.gracedb.Superevent'] {
+    ['org.ligo.gracedb.Superevent'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [Superevent] policy update
+.alter table ['org.ligo.gracedb.Superevent'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/gracedb/notebook/gracedb-feed.ipynb
+++ b/gracedb/notebook/gracedb-feed.ipynb
@@ -1,0 +1,225 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GraceDB Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the public LIGO/Virgo/KAGRA GraceDB superevent REST API for gravitational-wave candidate events and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `gracedb` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No pip install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `gracedb feed --once`, exits after one polling cycle, and persists dedupe state (seen superevent IDs) to a Lakehouse Files path so the next scheduled run only emits new superevents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"gracedb-ingest\"          # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/gracedb/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/gracedb/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    os.environ['GRACEDB_LAST_POLLED_FILE'] = STATE_FILE\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing gracedb package from Fabric Environment...')\n",
+    "    from gracedb import gracedb as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['gracedb', 'feed', '--once'] if ONCE_MODE else ['gracedb', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/gracedb/tests/test_once_mode.py
+++ b/gracedb/tests/test_once_mode.py
@@ -1,0 +1,55 @@
+"""Tests for the --once single-cycle exit path used by Fabric notebook hosting."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gracedb.gracedb import GraceDBPoller
+
+
+@pytest.fixture
+def poller(tmp_path):
+    """A GraceDBPoller wired with a mock producer and a tmp state file."""
+    state_file = tmp_path / "seen.json"
+    p = GraceDBPoller(
+        kafka_config=None,
+        kafka_topic="test-gracedb",
+        last_polled_file=str(state_file),
+        poll_count=5,
+        categories="MDC",
+    )
+    p.event_producer = MagicMock()
+    p.event_producer.producer = MagicMock()
+    return p
+
+
+def test_once_mode_exits_after_single_cycle(poller):
+    """poll_and_send(once=True) must return after exactly one fetch."""
+    fetch_calls = 0
+
+    async def fake_fetch(count=None):  # noqa: D401, ARG001
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return []
+
+    with patch.object(poller, "fetch_superevents", side_effect=fake_fetch):
+        async def runner():
+            await asyncio.wait_for(poller.poll_and_send(once=True), timeout=5)
+
+        asyncio.run(runner())
+
+    assert fetch_calls == 1, f"Expected exactly one upstream fetch, got {fetch_calls}"
+    poller.event_producer.producer.flush.assert_called_once()
+
+
+def test_once_flag_in_argparse():
+    """`main()` argparse must expose a --once flag wired to ONCE_MODE env."""
+    import argparse
+    import inspect
+
+    from gracedb import gracedb as mod
+
+    source = inspect.getsource(mod.main)
+    assert "--once" in source, "main() argparse must declare --once"
+    assert "ONCE_MODE" in source, "--once default must honor ONCE_MODE env var"


### PR DESCRIPTION
Retrofit by 
otebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- **gracedb/notebook/gracedb-feed.ipynb** — copied verbatim from pegelonline/notebook/pegelonline-feed.ipynb and substituted per eferences/notebook-substitution-table.md (display name, package/module, argv, `EVENTSTREAM_NAME`, `STATE_FILE`, `LOG_PATH`). Four-cell structure, CS-lookup cell, worker-thread run cell, and OneLake log path layout are unchanged.
- **gracedb/gracedb/gracedb.py** — added `--once` flag (also reads `ONCE_MODE` env var) and a single-cycle break in `GraceDBPoller.poll_and_send`, modeled on `pegelonline`. Required so the scheduled notebook can exit after one polling cycle.
- **gracedb/tests/test_once_mode.py** — asserts `poll_and_send(once=True)` exits after exactly one upstream fetch and that `main()` declares `--once` wired to `ONCE_MODE`.
- **`catalog.json`** — added `""notebook"": true` after `""kql""` on the gracedb entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- **`gracedb/kql/create-kql-script.ps1` + `gracedb/kql/gracedb.kql`** — mandatory step 5b: regenerated with `-Qualified -Namespace org.ligo.gracedb` (xreg has a single messagegroup namespace). Tables, mappings, materialized view, and update policy are now namespace-prefixed (`['org.ligo.gracedb.Superevent']`) so the source is safe to co-host with other feeders in a shared Eventhouse.
- **`gracedb/README.md`** — one-sentence ""Fabric notebook hosting"" bullet linking to `tools/deploy-fabric/deploy-feeder-notebook.ps1`.
- **`.gitignore`** — ignore local `gracedb/.venv/`.

## Local validation

- `python -m pytest tests/` → **42 passed** (including 2 new `test_once_mode.py` tests).
- Notebook JSON parses cleanly.
- Parameters cell contains `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- No forbidden patterns: `asyncio.run(` absent, no `%pip install`, no baked `CONNECTION_STRING = ""..""`, no baked `primaryConnectionString = ""..""`.
- KQL regenerated with `-Qualified -Namespace org.ligo.gracedb`.

## Out of scope

- No Fabric deployment from this agent (per skill step 7). The wheel-publish workflow runs on merge; manual end-to-end verification happens after.
