### PR TITLE
feat(carbon-intensity): Fabric notebook hosting

### DIFF
--- a/carbon-intensity/README.md
+++ b/carbon-intensity/README.md
@@ -52,6 +52,10 @@ pip install -e .
 python -m pytest tests/ -v
 ```
 
+## Fabric notebook hosting
+
+- This source ships a Fabric notebook (`notebook/carbon-intensity-feed.ipynb`) that runs the bridge with `--once` on the Fabric scheduler. Deploy it with [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## Project Structure
 
 | Path | Description |

--- a/carbon-intensity/carbon_intensity/carbon_intensity.py
+++ b/carbon-intensity/carbon_intensity/carbon_intensity.py
@@ -298,11 +298,16 @@ class CarbonIntensityPoller:
         self.producer.producer.flush()
         return emitted_key
 
-    def poll_and_send(self) -> None:
-        """Continuous polling loop with deduplication."""
+    def poll_and_send(self, once: bool = False) -> None:
+        """Polling loop with deduplication.
+
+        When ``once`` is True the loop exits after a single cycle. This is
+        used for scheduled execution (e.g. Fabric notebook hosting) where
+        the scheduler invokes the bridge once per interval.
+        """
         state = self.load_state()
         last_period = state.get("last_period_from")
-        print(f"Starting Carbon Intensity poller (last_period={last_period})")
+        print(f"Starting Carbon Intensity poller (last_period={last_period}, once={once})")
 
         while True:
             try:
@@ -313,6 +318,10 @@ class CarbonIntensityPoller:
                     self.save_state(state)
             except Exception as exc:
                 print(f"Error during poll cycle: {exc}")
+
+            if once:
+                print("--once mode: exiting after first polling cycle")
+                return
 
             print(f"Sleeping {POLL_INTERVAL_SECONDS}s until next poll…")
             time.sleep(POLL_INTERVAL_SECONDS)
@@ -327,6 +336,13 @@ def main():
     parser.add_argument('--sasl-password', type=str)
     parser.add_argument('--connection-string', type=str)
     parser.add_argument('--last-polled-file', type=str)
+    parser.add_argument(
+        '--once',
+        action='store_true',
+        default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+        help='Exit after one polling cycle (also via ONCE_MODE env var). '
+             'Useful for scheduled execution in Fabric notebooks.',
+    )
 
     args = parser.parse_args()
 
@@ -334,8 +350,11 @@ def main():
         args.connection_string = os.getenv('CONNECTION_STRING')
     if not args.last_polled_file:
         args.last_polled_file = os.getenv(
-            'CARBON_INTENSITY_LAST_POLLED_FILE',
-            os.path.expanduser('~/.carbon_intensity_last_polled.json'),
+            'STATE_FILE',
+            os.getenv(
+                'CARBON_INTENSITY_LAST_POLLED_FILE',
+                os.path.expanduser('~/.carbon_intensity_last_polled.json'),
+            ),
         )
 
     if args.connection_string:
@@ -376,7 +395,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/carbon-intensity/notebook/carbon-intensity-feed.ipynb
+++ b/carbon-intensity/notebook/carbon-intensity-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Carbon Intensity UK Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the [National Grid ESO Carbon Intensity API](https://api.carbonintensity.org.uk/) every cycle and emits CloudEvents (national intensity, generation mix, and 17-region regional intensity) to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `carbon_intensity` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `carbon-intensity --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"carbon-intensity-ingest\" # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/carbon-intensity/state.json\"\n",
+    "POLLING_INTERVAL = 1800                      # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/carbon-intensity/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing carbon_intensity package from Fabric Environment...')\n",
+    "    from carbon_intensity import carbon_intensity as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['carbon-intensity', '--once'] if ONCE_MODE else ['carbon-intensity']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/carbon-intensity/tests/test_once_mode.py
+++ b/carbon-intensity/tests/test_once_mode.py
@@ -1,0 +1,77 @@
+"""Tests for --once / ONCE_MODE single-cycle execution.
+
+Asserts that the carbon-intensity bridge exits after one polling cycle when
+``--once`` is supplied. Used by the Fabric notebook hosting pattern, where the
+scheduler invokes the bridge once per interval rather than relying on the
+in-process ``time.sleep`` loop.
+"""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from carbon_intensity import carbon_intensity as bridge
+
+
+@pytest.fixture
+def fake_kafka_env(monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("CONNECTION_STRING",
+                       "Endpoint=sb://example.servicebus.windows.net/;"
+                       "SharedAccessKeyName=k;SharedAccessKey=v;EntityPath=t")
+    monkeypatch.setenv("STATE_FILE", str(state_file))
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+
+def test_once_flag_returns_after_single_cycle(fake_kafka_env):
+    """--once must cause main() to invoke poll_once exactly once and return."""
+    with patch.object(bridge, "CarbonIntensityPoller") as poller_cls, \
+         patch.object(bridge.time, "sleep") as sleep_mock:
+        poller = MagicMock()
+        poller.poll_and_send.side_effect = (
+            lambda once=False: bridge.CarbonIntensityPoller.poll_and_send(poller, once=once)
+        )
+        poller_cls.return_value = poller
+
+        old_argv = sys.argv
+        try:
+            sys.argv = ["carbon-intensity", "--once"]
+            bridge.main()
+        finally:
+            sys.argv = old_argv
+
+        poller.poll_and_send.assert_called_once()
+        _, kwargs = poller.poll_and_send.call_args
+        assert kwargs.get("once") is True
+        sleep_mock.assert_not_called()
+
+
+def test_once_mode_env_var_enables_single_cycle(monkeypatch, fake_kafka_env):
+    """ONCE_MODE=true must behave identically to --once for the scheduler."""
+    monkeypatch.setenv("ONCE_MODE", "true")
+    with patch.object(bridge, "CarbonIntensityPoller") as poller_cls:
+        poller = MagicMock()
+        poller_cls.return_value = poller
+
+        old_argv = sys.argv
+        try:
+            sys.argv = ["carbon-intensity"]
+            bridge.main()
+        finally:
+            sys.argv = old_argv
+
+        poller.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_poll_and_send_once_breaks_loop():
+    """The loop body itself must exit when ``once=True`` after one cycle."""
+    poller = MagicMock(spec=bridge.CarbonIntensityPoller)
+    poller.load_state.return_value = {}
+    poller.poll_once.return_value = "2026-04-06T09:30:00+00:00"
+
+    with patch.object(bridge.time, "sleep") as sleep_mock:
+        bridge.CarbonIntensityPoller.poll_and_send(poller, once=True)
+
+    poller.poll_once.assert_called_once()
+    sleep_mock.assert_not_called()

--- a/catalog.json
+++ b/catalog.json
@@ -645,7 +645,8 @@
     "cat": "Energy",
     "key": false,
     "desc": "United Kingdom — national grid carbon intensity",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "elexon-bmrs",


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## Changes

- `carbon-intensity/notebook/carbon-intensity-feed.ipynb` — copied verbatim from `pegelonline/notebook/pegelonline-feed.ipynb` with the mandatory substitutions from the skill's substitution table. The bridge has no CLI subcommand, so the `no subcommand` variant is used: `sys.argv = ['carbon-intensity', '--once']`.
- `carbon-intensity/carbon_intensity/carbon_intensity.py` — adds a `--once` flag (also honored via the `ONCE_MODE` env var) and threads it through `poll_and_send` so a single cycle exits cleanly. Also honors the `STATE_FILE` env var (Fabric notebook deploy script convention) in addition to the legacy `CARBON_INTENSITY_LAST_POLLED_FILE`.
- `carbon-intensity/tests/test_once_mode.py` — three new unit tests asserting `--once` / `ONCE_MODE` cause `main()` to invoke `poll_once` exactly once and never sleep.
- `catalog.json` — flips `notebook: true` on the `carbon-intensity` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `carbon-intensity/README.md` — one-sentence pointer to the notebook deploy script (per skill rules).
- `carbon-intensity/kql/carbon_intensity.kql` — regenerated with `-Qualified` per the agent invocation. `-Namespace` deliberately omitted: the xreg has two messagegroups (`uk.org.carbonintensity` and `uk.org.carbonintensity.Regional`). The schemas declare no namespace, so the regenerated file is byte-identical to the checked-in one; no diff.

## Validations (all green locally)

- `python -c "import json; json.load(open(...))"` — notebook JSON parses.
- `pytest tests/` — **52 passed** (49 existing + 3 new).
- Parameter placeholders present: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden patterns absent: no `asyncio.run(`, no inline `CONNECTION_STRING="..."`, no leaked `primaryConnectionString =`.
- `%pip install` per-cell check (markdown false-positive aware): no code cell contains `%pip install`.

## Out of scope (per skill)

- No live Fabric deployment. The wheel-publish workflow will pick up this source on merge to `main`.