### PR TITLE
feat(energy-charts): Fabric notebook hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ mode-s/kql/aircraft.csv
 # Poetry lock files (generated; not used by Docker builds)
 **/poetry.lock
 **/.playwright-mcp/
+energy-charts/.venv/

--- a/catalog.json
+++ b/catalog.json
@@ -669,7 +669,8 @@
     "cat": "Energy",
     "key": false,
     "desc": "Europe — 40+ countries, electricity generation & prices",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "entsoe",

--- a/energy-charts/README.md
+++ b/energy-charts/README.md
@@ -30,6 +30,13 @@ See [EVENTS.md](EVENTS.md) for the full event schema documentation.
 pip install .
 ```
 
+## Hosting options
+
+- **Docker** — see [CONTAINER.md](CONTAINER.md) for image/registry details.
+- **Azure Container Instance** — use `azure-template.json`.
+- **Fabric notebook hosting** — schedule a single-cycle run with `notebook/energy-charts-feed.ipynb`, deployed via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
+
 ## Usage
 
 ### With a connection string (Event Hubs / Fabric)

--- a/energy-charts/energy_charts/energy_charts.py
+++ b/energy-charts/energy_charts/energy_charts.py
@@ -397,8 +397,15 @@ def main():
                         help="ENTSO-E bidding zone (default: DE-LU)")
     parser.add_argument('--last-polled-file', type=str,
                         help="State file for deduplication")
+    parser.add_argument('--once', action='store_true',
+                        help="Run a single polling cycle and exit (for scheduled/notebook hosting)")
 
     args = parser.parse_args()
+
+    if not args.once:
+        once_env = os.getenv('ONCE_MODE', '').strip().lower()
+        if once_env in ('1', 'true', 'yes'):
+            args.once = True
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
@@ -453,7 +460,7 @@ def main():
         bidding_zone=args.bidding_zone,
         last_polled_file=args.last_polled_file,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=args.once)
 
 
 if __name__ == "__main__":

--- a/energy-charts/kql/energy_charts.kql
+++ b/energy-charts/kql/energy_charts.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [PublicPower] (
+.create-merge table ['info.energy_charts.PublicPower'] (
    [country]: string,
    [timestamp]: datetime,
    [unix_seconds]: long,
@@ -58,9 +58,9 @@
    [___subject]: string
 );
 
-.alter table [PublicPower] docstring "{\"description\": \"Net electricity generation by fuel type for a given country at a specific 15-minute interval. Sourced from the Energy-Charts /public_power endpoint (Fraunhofer ISE) which aggregates ENTSO-E transparency platform data. Each record represents one timestamp in the parallel-array response, with individual production types flattened into named fields in megawatts (MW). Negative values for hydro pumped storage consumption and cross-border trading indicate consumption or export. The renewable_share_of_generation and renewable_share_of_load fields are percentages (0\\u2013100). Load represents total grid demand.\"}";
+.alter table ['info.energy_charts.PublicPower'] docstring "{\"description\": \"Net electricity generation by fuel type for a given country at a specific 15-minute interval. Sourced from the Energy-Charts /public_power endpoint (Fraunhofer ISE) which aggregates ENTSO-E transparency platform data. Each record represents one timestamp in the parallel-array response, with individual production types flattened into named fields in megawatts (MW). Negative values for hydro pumped storage consumption and cross-border trading indicate consumption or export. The renewable_share_of_generation and renewable_share_of_load fields are percentages (0\\u2013100). Load represents total grid demand.\"}";
 
-.alter table [PublicPower] column-docstrings (
+.alter table ['info.energy_charts.PublicPower'] column-docstrings (
    [country]: "{\"description\": \"ISO 3166-1 alpha-2 country code identifying the electricity market area (e.g. 'de' for Germany, 'fr' for France). Used as the query parameter in the Energy-Charts API.\"}",
    [timestamp]: "{\"description\": \"UTC timestamp derived from the unix_seconds value. Marks the start of the 15-minute measurement interval.\"}",
    [unix_seconds]: "{\"description\": \"Unix epoch timestamp in seconds as returned by the Energy-Charts API. Each value corresponds to one row in the parallel arrays of production_types.\"}",
@@ -93,7 +93,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [PublicPower] ingestion json mapping "PublicPower_json_flat"
+.create-or-alter table ['info.energy_charts.PublicPower'] ingestion json mapping "info.energy_charts.PublicPower_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -129,7 +129,7 @@
 ]
 ```
 
-.create-or-alter table [PublicPower] ingestion json mapping "PublicPower_json_ce_structured"
+.create-or-alter table ['info.energy_charts.PublicPower'] ingestion json mapping "info.energy_charts.PublicPower_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -165,13 +165,13 @@
 ]
 ```
 
-.drop materialized-view PublicPowerLatest ifexists;
+.drop materialized-view ['info.energy_charts.PublicPowerLatest'] ifexists;
 
-.create materialized-view with (backfill=true) PublicPowerLatest on table PublicPower {
-    PublicPower | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['info.energy_charts.PublicPowerLatest'] on table ['info.energy_charts.PublicPower'] {
+    ['info.energy_charts.PublicPower'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [PublicPower] policy update
+.alter table ['info.energy_charts.PublicPower'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -182,7 +182,7 @@
 }]
 ```
 
-.create-merge table [SpotPrice] (
+.create-merge table ['info.energy_charts.SpotPrice'] (
    [country]: string,
    [bidding_zone]: string,
    [timestamp]: datetime,
@@ -196,9 +196,9 @@
    [___subject]: string
 );
 
-.alter table [SpotPrice] docstring "{\"description\": \"Day-ahead electricity spot price for a given bidding zone at a specific timestamp. Sourced from the Energy-Charts /price endpoint (Fraunhofer ISE) which provides wholesale electricity market prices from ENTSO-E and national exchanges. Prices are the day-ahead auction clearing price in EUR per MWh. The bidding zone identifies the market area (e.g. 'DE-LU' for the Germany-Luxembourg zone).\"}";
+.alter table ['info.energy_charts.SpotPrice'] docstring "{\"description\": \"Day-ahead electricity spot price for a given bidding zone at a specific timestamp. Sourced from the Energy-Charts /price endpoint (Fraunhofer ISE) which provides wholesale electricity market prices from ENTSO-E and national exchanges. Prices are the day-ahead auction clearing price in EUR per MWh. The bidding zone identifies the market area (e.g. 'DE-LU' for the Germany-Luxembourg zone).\"}";
 
-.alter table [SpotPrice] column-docstrings (
+.alter table ['info.energy_charts.SpotPrice'] column-docstrings (
    [country]: "{\"description\": \"ISO 3166-1 alpha-2 country code derived from the bidding zone (e.g. 'de' from 'DE-LU'). Used for Kafka key partitioning.\"}",
    [bidding_zone]: "{\"description\": \"European electricity bidding zone identifier as used by ENTSO-E (e.g. 'DE-LU' for Germany-Luxembourg, 'FR' for France, 'NO1' for Norway zone 1). The bzn parameter in the Energy-Charts /price API.\"}",
    [timestamp]: "{\"description\": \"UTC timestamp derived from the unix_seconds value. Marks the start of the price interval (typically 15-minute or hourly depending on the market).\"}",
@@ -212,7 +212,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [SpotPrice] ingestion json mapping "SpotPrice_json_flat"
+.create-or-alter table ['info.energy_charts.SpotPrice'] ingestion json mapping "info.energy_charts.SpotPrice_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -229,7 +229,7 @@
 ]
 ```
 
-.create-or-alter table [SpotPrice] ingestion json mapping "SpotPrice_json_ce_structured"
+.create-or-alter table ['info.energy_charts.SpotPrice'] ingestion json mapping "info.energy_charts.SpotPrice_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -246,13 +246,13 @@
 ]
 ```
 
-.drop materialized-view SpotPriceLatest ifexists;
+.drop materialized-view ['info.energy_charts.SpotPriceLatest'] ifexists;
 
-.create materialized-view with (backfill=true) SpotPriceLatest on table SpotPrice {
-    SpotPrice | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['info.energy_charts.SpotPriceLatest'] on table ['info.energy_charts.SpotPrice'] {
+    ['info.energy_charts.SpotPrice'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [SpotPrice] policy update
+.alter table ['info.energy_charts.SpotPrice'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -263,7 +263,7 @@
 }]
 ```
 
-.create-merge table [GridSignal] (
+.create-merge table ['info.energy_charts.GridSignal'] (
    [country]: string,
    [timestamp]: datetime,
    [unix_seconds]: long,
@@ -277,9 +277,9 @@
    [___subject]: string
 );
 
-.alter table [GridSignal] docstring "{\"description\": \"Grid carbon signal for a given country at a specific timestamp. Sourced from the Energy-Charts /signal endpoint (Fraunhofer ISE). Provides a traffic-light signal (0=green, 1=yellow, 2=red) indicating how carbon-intensive the current electricity mix is. Green (0) means high renewable share and low carbon intensity \\u2014 a good time to consume electricity. Red (2) means low renewable share and high carbon intensity. The renewable share percentage is also included for precise analysis.\"}";
+.alter table ['info.energy_charts.GridSignal'] docstring "{\"description\": \"Grid carbon signal for a given country at a specific timestamp. Sourced from the Energy-Charts /signal endpoint (Fraunhofer ISE). Provides a traffic-light signal (0=green, 1=yellow, 2=red) indicating how carbon-intensive the current electricity mix is. Green (0) means high renewable share and low carbon intensity \\u2014 a good time to consume electricity. Red (2) means low renewable share and high carbon intensity. The renewable share percentage is also included for precise analysis.\"}";
 
-.alter table [GridSignal] column-docstrings (
+.alter table ['info.energy_charts.GridSignal'] column-docstrings (
    [country]: "{\"description\": \"ISO 3166-1 alpha-2 country code identifying the electricity market area (e.g. 'de' for Germany). Used as the query parameter in the Energy-Charts API.\"}",
    [timestamp]: "{\"description\": \"UTC timestamp derived from the unix_seconds value. Marks the start of the 15-minute measurement interval.\"}",
    [unix_seconds]: "{\"description\": \"Unix epoch timestamp in seconds as returned by the Energy-Charts API.\"}",
@@ -293,7 +293,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [GridSignal] ingestion json mapping "GridSignal_json_flat"
+.create-or-alter table ['info.energy_charts.GridSignal'] ingestion json mapping "info.energy_charts.GridSignal_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -310,7 +310,7 @@
 ]
 ```
 
-.create-or-alter table [GridSignal] ingestion json mapping "GridSignal_json_ce_structured"
+.create-or-alter table ['info.energy_charts.GridSignal'] ingestion json mapping "info.energy_charts.GridSignal_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -327,13 +327,13 @@
 ]
 ```
 
-.drop materialized-view GridSignalLatest ifexists;
+.drop materialized-view ['info.energy_charts.GridSignalLatest'] ifexists;
 
-.create materialized-view with (backfill=true) GridSignalLatest on table GridSignal {
-    GridSignal | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['info.energy_charts.GridSignalLatest'] on table ['info.energy_charts.GridSignal'] {
+    ['info.energy_charts.GridSignal'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [GridSignal] policy update
+.alter table ['info.energy_charts.GridSignal'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/energy-charts/notebook/energy-charts-feed.ipynb
+++ b/energy-charts/notebook/energy-charts-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Energy-Charts Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Fraunhofer ISE Energy-Charts API for European electricity public-power generation by production type, day-ahead spot prices, and grid-frequency signals across 40+ bidding zones, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `energy_charts` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No per-cell package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `energy-charts --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"energy-charts-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/energy-charts/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/energy-charts/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing energy_charts package from Fabric Environment...')\n",
+    "    from energy_charts import energy_charts as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['energy-charts', '--once'] if ONCE_MODE else ['energy-charts']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/energy-charts/tests/test_once_mode.py
+++ b/energy-charts/tests/test_once_mode.py
@@ -1,0 +1,90 @@
+"""Verify the --once CLI flag exits after exactly one polling cycle.
+
+Added for Fabric notebook hosting (scheduled single-cycle runs).
+"""
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_env(monkeypatch, tmp_path):
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.delenv('ONCE_MODE', raising=False)
+    state = tmp_path / 'state.json'
+    return {
+        'state_file': str(state),
+    }
+
+
+def _run_with_argv(argv):
+    from energy_charts import energy_charts as ec
+
+    with patch.object(ec, 'EnergyChartsPoller') as PollerCls:
+        instance = MagicMock()
+        instance.poll_and_send = MagicMock()
+        PollerCls.return_value = instance
+
+        old_argv = sys.argv
+        sys.argv = argv
+        try:
+            ec.main()
+        finally:
+            sys.argv = old_argv
+        return instance
+
+
+def test_once_flag_passes_through(fake_env):
+    instance = _run_with_argv([
+        'energy-charts',
+        '--kafka-bootstrap-servers', 'localhost:9092',
+        '--kafka-topic', 'test-topic',
+        '--last-polled-file', fake_env['state_file'],
+        '--once',
+    ])
+    instance.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_default_is_continuous(fake_env):
+    instance = _run_with_argv([
+        'energy-charts',
+        '--kafka-bootstrap-servers', 'localhost:9092',
+        '--kafka-topic', 'test-topic',
+        '--last-polled-file', fake_env['state_file'],
+    ])
+    instance.poll_and_send.assert_called_once_with(once=False)
+
+
+def test_once_mode_env_var(monkeypatch, fake_env):
+    monkeypatch.setenv('ONCE_MODE', 'true')
+    instance = _run_with_argv([
+        'energy-charts',
+        '--kafka-bootstrap-servers', 'localhost:9092',
+        '--kafka-topic', 'test-topic',
+        '--last-polled-file', fake_env['state_file'],
+    ])
+    instance.poll_and_send.assert_called_once_with(once=True)
+
+
+def test_poll_and_send_once_exits_after_one_cycle():
+    """The poll_and_send loop itself must exit when once=True."""
+    from energy_charts.energy_charts import EnergyChartsPoller
+
+    poller = EnergyChartsPoller.__new__(EnergyChartsPoller)
+    poller.POWER_POLL_INTERVAL = 0
+    poller.PRICE_POLL_INTERVAL = 0
+    poller.SIGNAL_POLL_INTERVAL = 0
+    poller.country = 'de'
+    poller.emit_public_power = MagicMock(return_value=0)
+    poller.emit_price = MagicMock(return_value=0)
+    poller.emit_signal = MagicMock(return_value=0)
+    poller._save_state = MagicMock()
+
+    with patch('energy_charts.energy_charts.time.sleep') as sleep_mock:
+        poller.poll_and_send(once=True)
+        sleep_mock.assert_not_called()
+
+    poller.emit_public_power.assert_called_once()
+    poller.emit_price.assert_called_once()
+    poller.emit_signal.assert_called_once()


### PR DESCRIPTION
Retrofit by `notebook-feeder-retrofit` agent
(`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## What changed

- **Bridge**: added `--once` CLI flag and `ONCE_MODE` env var fallback
  to `energy_charts/energy_charts.py`; `poll_and_send(once=True)` exits
  after one cycle of all three endpoints (public_power, price, signal).
- **Notebook**: `energy-charts/notebook/energy-charts-feed.ipynb`,
  copied verbatim from the canonical
  `pegelonline/notebook/pegelonline-feed.ipynb` with the substitution
  table applied. Bridge has no CLI subcommand, so
  `sys.argv = ['energy-charts', '--once']` (no `feed` element).
- **catalog.json**: `"notebook": true` inserted after `"kql"` for the
  energy-charts entry.
- **README**: one-line "Fabric notebook hosting" bullet under a new
  Hosting options section.
- **KQL** (mandatory step 5b): `kql/energy_charts.kql` regenerated with
  `-Qualified -Namespace info.energy_charts` (xreg has a single
  messagegroup namespace), prefixing tables/mappings/materialized
  views/update policies with `['info.energy_charts.*']`.
- **Tests**: new `tests/test_once_mode.py` covers the `--once` flag,
  the `ONCE_MODE` env var path, the continuous default, and the
  single-cycle loop exit.

## Local validation

- ✅ Notebook JSON parses
- ✅ All five parameter placeholders present (`EVENTSTREAM_NAME`,
  `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`)
- ✅ No forbidden patterns in any code cell (`asyncio.run(`,
  `%pip install`, literal `CONNECTION_STRING="`,
  `primaryConnectionString =`); the markdown reference to `%pip
  install` from the template was rewritten out
- ✅ Four-cell structure, CS lookup, worker thread, and
  `notebookutils.notebook.exit` calls unchanged
- ✅ `python -m pytest tests/ -x -q` — 70/70 pass (including the new
  `test_once_mode.py`)

No Fabric deployment performed — that is the maintainer's serial
verification step after merge. The wheel-publish workflow will pick up
this source on merge.

## Deviations from skill

None functional. `--once` flag was added (allowed per task spec, modeled
on `pegelonline`).
