### PR TITLE
feat(elexon-bmrs): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -653,7 +653,8 @@
     "cat": "Energy",
     "key": false,
     "desc": "Great Britain — electricity market, generation, demand",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "energidataservice-dk",

--- a/elexon-bmrs/README.md
+++ b/elexon-bmrs/README.md
@@ -11,6 +11,7 @@
 - **Deduplication**: Tracks last seen settlement periods in a state file to avoid reprocessing.
 - **Kafka Integration**: Send events to a Kafka topic using SASL PLAIN authentication.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
+- **Fabric notebook hosting**: Deployable as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) using [`notebook/elexon-bmrs-feed.ipynb`](notebook/elexon-bmrs-feed.ipynb).
 
 ## Installation
 

--- a/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
+++ b/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
@@ -334,15 +334,22 @@ def main():
                         help="Password for SASL PLAIN authentication")
     parser.add_argument('--connection-string', type=str,
                         help='Microsoft Event Hubs or Microsoft Fabric Event Stream connection string')
+    parser.add_argument('--once', action='store_true',
+                        help='Run a single polling cycle and exit (used by Fabric notebook hosting)')
 
     args = parser.parse_args()
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')
     if not args.last_polled_file:
-        args.last_polled_file = os.getenv('BMRS_LAST_POLLED_FILE')
+        args.last_polled_file = (
+            os.getenv('BMRS_LAST_POLLED_FILE')
+            or os.getenv('STATE_FILE')
+        )
         if not args.last_polled_file:
             args.last_polled_file = os.path.expanduser('~/.bmrs_last_polled.json')
+
+    once_mode = args.once or os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes')
 
     if args.connection_string:
         config_params = parse_connection_string(args.connection_string)
@@ -382,7 +389,7 @@ def main():
         kafka_topic=kafka_topic,
         last_polled_file=args.last_polled_file,
     )
-    poller.poll_and_send()
+    poller.poll_and_send(once=once_mode)
 
 
 if __name__ == "__main__":

--- a/elexon-bmrs/kql/create-kql-script.ps1
+++ b/elexon-bmrs/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\elexon_bmrs.xreg.json"
 $kqlFile = Join-Path $scriptDir "elexon_bmrs.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace UK.Co.Elexon.BMRS

--- a/elexon-bmrs/kql/elexon_bmrs.kql
+++ b/elexon-bmrs/kql/elexon_bmrs.kql
@@ -25,7 +25,7 @@
 ]
 ```
 
-.create-merge table [GenerationMix] (
+.create-merge table ['UK.Co.Elexon.BMRS.GenerationMix'] (
    [settlement_period]: int,
    [start_time]: datetime,
    [biomass_mw]: real,
@@ -52,9 +52,9 @@
    [___subject]: string
 );
 
-.alter table [GenerationMix] docstring "{\"description\": \"Half-hourly generation outturn summary for the GB electricity system from the Elexon BMRS API. Each record represents one settlement period and contains the generation output in megawatts (MW) broken down by fuel type, including domestic generation (biomass, CCGT, coal, nuclear, wind, OCGT, oil, hydro, pumped storage) and interconnector imports (France IFA, France IFA2, Netherlands BritNed, Belgium Nemo, Ireland EWIC, Norway NSL, Denmark Viking Link). Sourced from the BMRS /generation/outturn/summary endpoint.\"}";
+.alter table ['UK.Co.Elexon.BMRS.GenerationMix'] docstring "{\"description\": \"Half-hourly generation outturn summary for the GB electricity system from the Elexon BMRS API. Each record represents one settlement period and contains the generation output in megawatts (MW) broken down by fuel type, including domestic generation (biomass, CCGT, coal, nuclear, wind, OCGT, oil, hydro, pumped storage) and interconnector imports (France IFA, France IFA2, Netherlands BritNed, Belgium Nemo, Ireland EWIC, Norway NSL, Denmark Viking Link). Sourced from the BMRS /generation/outturn/summary endpoint.\"}";
 
-.alter table [GenerationMix] column-docstrings (
+.alter table ['UK.Co.Elexon.BMRS.GenerationMix'] column-docstrings (
    [settlement_period]: "{\"description\": \"GB electricity settlement period number (1-50). Each settlement period is 30 minutes long, starting at midnight UTC. Period 1 covers 00:00-00:30, period 2 covers 00:30-01:00, and so on.\"}",
    [start_time]: "{\"description\": \"UTC start time of the settlement period as reported by the BMRS generation outturn summary endpoint.\"}",
    [biomass_mw]: "{\"description\": \"Generation output from biomass-fuelled power stations in megawatts (MW). Biomass includes dedicated biomass plants and biomass co-firing units.\"}",
@@ -81,7 +81,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [GenerationMix] ingestion json mapping "GenerationMix_json_flat"
+.create-or-alter table ['UK.Co.Elexon.BMRS.GenerationMix'] ingestion json mapping "UK.Co.Elexon.BMRS.GenerationMix_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -111,7 +111,7 @@
 ]
 ```
 
-.create-or-alter table [GenerationMix] ingestion json mapping "GenerationMix_json_ce_structured"
+.create-or-alter table ['UK.Co.Elexon.BMRS.GenerationMix'] ingestion json mapping "UK.Co.Elexon.BMRS.GenerationMix_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -141,13 +141,13 @@
 ]
 ```
 
-.drop materialized-view GenerationMixLatest ifexists;
+.drop materialized-view ['UK.Co.Elexon.BMRS.GenerationMixLatest'] ifexists;
 
-.create materialized-view with (backfill=true) GenerationMixLatest on table GenerationMix {
-    GenerationMix | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['UK.Co.Elexon.BMRS.GenerationMixLatest'] on table ['UK.Co.Elexon.BMRS.GenerationMix'] {
+    ['UK.Co.Elexon.BMRS.GenerationMix'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [GenerationMix] policy update
+.alter table ['UK.Co.Elexon.BMRS.GenerationMix'] policy update
 ```
 [{
   "IsEnabled": true,
@@ -158,7 +158,7 @@
 }]
 ```
 
-.create-merge table [DemandOutturn] (
+.create-merge table ['UK.Co.Elexon.BMRS.DemandOutturn'] (
    [settlement_period]: int,
    [settlement_date]: string,
    [start_time]: datetime,
@@ -172,9 +172,9 @@
    [___subject]: string
 );
 
-.alter table [DemandOutturn] docstring "{\"description\": \"Half-hourly demand outturn for the GB electricity transmission system from the Elexon BMRS API. Each record represents one settlement period and contains the initial national demand outturn (INDO) and initial transmission system demand outturn (ITSDO) in megawatts (MW). Sourced from the BMRS /demand/outturn endpoint. Published under CC-BY 4.0 licence by Elexon.\"}";
+.alter table ['UK.Co.Elexon.BMRS.DemandOutturn'] docstring "{\"description\": \"Half-hourly demand outturn for the GB electricity transmission system from the Elexon BMRS API. Each record represents one settlement period and contains the initial national demand outturn (INDO) and initial transmission system demand outturn (ITSDO) in megawatts (MW). Sourced from the BMRS /demand/outturn endpoint. Published under CC-BY 4.0 licence by Elexon.\"}";
 
-.alter table [DemandOutturn] column-docstrings (
+.alter table ['UK.Co.Elexon.BMRS.DemandOutturn'] column-docstrings (
    [settlement_period]: "{\"description\": \"GB electricity settlement period number (1-50). Each settlement period is 30 minutes long, starting at midnight UTC.\"}",
    [settlement_date]: "{\"description\": \"Settlement date in ISO 8601 format (YYYY-MM-DD) as reported by the BMRS demand outturn endpoint.\"}",
    [start_time]: "{\"description\": \"UTC start time of the settlement period as reported by the BMRS demand outturn endpoint.\"}",
@@ -188,7 +188,7 @@
    [___subject]: 'Context subject of the event'
 );
 
-.create-or-alter table [DemandOutturn] ingestion json mapping "DemandOutturn_json_flat"
+.create-or-alter table ['UK.Co.Elexon.BMRS.DemandOutturn'] ingestion json mapping "UK.Co.Elexon.BMRS.DemandOutturn_json_flat"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -205,7 +205,7 @@
 ]
 ```
 
-.create-or-alter table [DemandOutturn] ingestion json mapping "DemandOutturn_json_ce_structured"
+.create-or-alter table ['UK.Co.Elexon.BMRS.DemandOutturn'] ingestion json mapping "UK.Co.Elexon.BMRS.DemandOutturn_json_ce_structured"
 ```
 [
   {"column": "___type", "path": "$.type"},
@@ -222,13 +222,13 @@
 ]
 ```
 
-.drop materialized-view DemandOutturnLatest ifexists;
+.drop materialized-view ['UK.Co.Elexon.BMRS.DemandOutturnLatest'] ifexists;
 
-.create materialized-view with (backfill=true) DemandOutturnLatest on table DemandOutturn {
-    DemandOutturn | summarize arg_max(___time, *) by ___type, ___source, ___subject
+.create materialized-view with (backfill=true) ['UK.Co.Elexon.BMRS.DemandOutturnLatest'] on table ['UK.Co.Elexon.BMRS.DemandOutturn'] {
+    ['UK.Co.Elexon.BMRS.DemandOutturn'] | summarize arg_max(___time, *) by ___type, ___source, ___subject
 }
 
-.alter table [DemandOutturn] policy update
+.alter table ['UK.Co.Elexon.BMRS.DemandOutturn'] policy update
 ```
 [{
   "IsEnabled": true,

--- a/elexon-bmrs/notebook/elexon-bmrs-feed.ipynb
+++ b/elexon-bmrs/notebook/elexon-bmrs-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Elexon BMRS Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the Elexon Balancing Mechanism Reporting Service (BMRS) API for GB electricity market generation mix (MW by fuel type) and demand outturn data, and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `elexon_bmrs` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `elexon-bmrs --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new settlement-period observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"elexon-bmrs-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/elexon-bmrs/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/elexon-bmrs/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing elexon_bmrs package from Fabric Environment...')\n",
+    "    from elexon_bmrs import elexon_bmrs as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['elexon-bmrs', '--once'] if ONCE_MODE else ['elexon-bmrs']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/elexon-bmrs/tests/test_once_mode.py
+++ b/elexon-bmrs/tests/test_once_mode.py
@@ -1,0 +1,76 @@
+"""Test that --once causes the bridge to exit after a single polling cycle."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import elexon_bmrs.elexon_bmrs as bridge
+
+
+def _fake_poller_factory(call_counter):
+    def _ctor(*_args, **_kwargs):
+        instance = MagicMock()
+
+        def _poll(once=False):
+            call_counter['calls'] += 1
+            call_counter['once'] = once
+
+        instance.poll_and_send.side_effect = _poll
+        return instance
+
+    return _ctor
+
+
+def test_once_flag_runs_single_cycle(monkeypatch):
+    """--once must be threaded into poll_and_send(once=True) so the loop exits."""
+    counter = {'calls': 0, 'once': None}
+
+    monkeypatch.setattr(
+        bridge,
+        'ElexonBMRSPoller',
+        _fake_poller_factory(counter),
+    )
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'elexon-bmrs',
+            '--once',
+            '--connection-string',
+            'BootstrapServer=localhost:9092;EntityPath=test',
+        ],
+    )
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+
+    bridge.main()
+
+    assert counter['calls'] == 1
+    assert counter['once'] is True
+
+
+def test_once_mode_env_var(monkeypatch):
+    """ONCE_MODE=true env var must also trigger single-cycle exit."""
+    counter = {'calls': 0, 'once': None}
+
+    monkeypatch.setattr(
+        bridge,
+        'ElexonBMRSPoller',
+        _fake_poller_factory(counter),
+    )
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'elexon-bmrs',
+            '--connection-string',
+            'BootstrapServer=localhost:9092;EntityPath=test',
+        ],
+    )
+    monkeypatch.setenv('KAFKA_ENABLE_TLS', 'false')
+    monkeypatch.setenv('ONCE_MODE', 'true')
+
+    bridge.main()
+
+    assert counter['calls'] == 1
+    assert counter['once'] is True


### PR DESCRIPTION
Retrofit by the `notebook-feeder-retrofit` agent (`.github/skills/notebook-feeder-retrofit/SKILL.md`).

## Changes

- `elexon-bmrs/notebook/elexon-bmrs-feed.ipynb` — canonical pegelonline notebook copied verbatim and adapted via the substitution table. Four-cell structure, CS-lookup, worker-thread, and OneLake log layout preserved.
- `catalog.json` — adds `notebook: true` for the `elexon-bmrs` entry so the gh-pages portal exposes the Fabric Notebook deploy button.
- `elexon-bmrs/elexon_bmrs/elexon_bmrs.py` — adds a `--once` CLI flag (also honors `ONCE_MODE` env var) so the bridge exits after a single poll cycle, as required by the Fabric notebook scheduler. `STATE_FILE` env var is now honored alongside `BMRS_LAST_POLLED_FILE`.
- `elexon-bmrs/tests/test_once_mode.py` — asserts both `--once` and `ONCE_MODE=true` invoke `poll_and_send(once=True)` exactly once.
- `elexon-bmrs/kql/create-kql-script.ps1` + `elexon-bmrs/kql/elexon_bmrs.kql` — KQL regenerated with `-Qualified -Namespace UK.Co.Elexon.BMRS` (single messagegroup namespace) so tables, materialized views, mappings, and update policies are namespace-prefixed and do not collide when multiple feeders share an Eventhouse.
- `elexon-bmrs/README.md` — one-line bullet pointing at `tools/deploy-fabric/deploy-feeder-notebook.ps1`.

## Validations performed locally

- Notebook JSON parses cleanly (`json.load`).
- Bridge test suite passes: **100 passed** (`python -m pytest tests/ -x`), including the two new `test_once_mode.py` cases.
- Parameters cell contains all five required placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden patterns absent in code cells: no `asyncio.run(`, no `CONNECTION_STRING = "..."` assignment, no `primaryConnectionString = ...` assignment.
- The substring `%pip install` appears only inside the cell-0 markdown sentence *"No `%pip install` is required at runtime"*. Verified per-cell — false positive, allowed by the agent invocation.

## Not done (per skill)

- No live Fabric deployment. `publish-notebook-wheels.yml` will pick up this source on merge to main and publish wheels to the `notebook-wheels` release; end-to-end Fabric verification is a separate manual step.
