### PR TITLE
feat(wikimedia-osm-diffs): Fabric notebook hosting

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -693,7 +693,8 @@
     "cat": "Social",
     "key": false,
     "desc": "Global — OSM minutely replication diffs",
-    "kql": true
+    "kql": true,
+    "notebook": true
   },
   {
     "id": "rss",

--- a/wikimedia-osm-diffs/README.md
+++ b/wikimedia-osm-diffs/README.md
@@ -45,6 +45,12 @@ pip install .
 For a packaged install, consider using the [CONTAINER.md](CONTAINER.md)
 instructions.
 
+### Fabric notebook hosting
+
+A scheduled Fabric notebook (`notebook/wikimedia-osm-diffs-feed.ipynb`)
+is provided as an alternative to a long-running container. Deploy it with
+[`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1).
+
 ## How to Use
 
 After installation, the tool can be run with `wikimedia-osm-diffs`.

--- a/wikimedia-osm-diffs/kql/create-kql-script.ps1
+++ b/wikimedia-osm-diffs/kql/create-kql-script.ps1
@@ -3,4 +3,4 @@ $inputFile = Join-Path $scriptDir "..\xreg\wikimedia_osm_diffs.xreg.json"
 $kqlFile = Join-Path $scriptDir "wikimedia_osm_diffs.kql"
 $generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
 
-& $generatorScript -XregPath $inputFile -OutputPath $kqlFile
+& $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/wikimedia-osm-diffs/notebook/wikimedia-osm-diffs-feed.ipynb
+++ b/wikimedia-osm-diffs/notebook/wikimedia-osm-diffs-feed.ipynb
@@ -1,0 +1,224 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "display_name": "Synapse PySpark",
+   "language": "Python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenStreetMap Diffs Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the OpenStreetMap minutely replication feed (`planet.openstreetmap.org/replication/minute`) and emits every node/way/relation create/modify/delete as a CloudEvent to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `wikimedia_osm_diffs` package (with both generated producer sub-packages) is pre-installed by the **attached Fabric Environment**. No package install is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `wikimedia-osm-diffs feed --once`, processes any new replication sequences (up to 5 per cycle), and persists the last processed sequence number to a Lakehouse Files path so the next scheduled run only emits new diffs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"wikimedia-osm-diffs-ingest\"     # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/wikimedia-osm-diffs/state.json\"\n",
+    "POLLING_INTERVAL = 900                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/wikimedia-osm-diffs/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['STATE_FILE']       = STATE_FILE\n",
+    "    os.environ['POLLING_INTERVAL'] = str(POLLING_INTERVAL)\n",
+    "    os.environ['ONCE_MODE']        = 'true' if ONCE_MODE else 'false'\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing wikimedia_osm_diffs package from Fabric Environment...')\n",
+    "    from wikimedia_osm_diffs import wikimedia_osm_diffs as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        sys.argv = ['wikimedia-osm-diffs', 'feed', '--once'] if ONCE_MODE else ['wikimedia-osm-diffs', 'feed']\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}

--- a/wikimedia-osm-diffs/tests/test_once_mode.py
+++ b/wikimedia-osm-diffs/tests/test_once_mode.py
@@ -1,0 +1,107 @@
+"""Test that the bridge exits after a single polling cycle in --once mode."""
+
+from __future__ import annotations
+
+import gzip
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wikimedia_osm_diffs.wikimedia_osm_diffs import (
+    OsmDiffsBridge,
+    StateStore,
+    build_parser,
+    main,
+)
+
+
+SAMPLE_STATE_TXT = (
+    "#header\n"
+    "sequenceNumber=7062480\n"
+    "timestamp=2026-04-09T01\\:32\\:55Z\n"
+)
+
+SAMPLE_OSC_XML = (
+    b"<?xml version='1.0' encoding='UTF-8'?>"
+    b"<osmChange version='0.6'>"
+    b"<create>"
+    b"<node id='1' version='1' timestamp='2026-04-09T01:30:00Z' "
+    b"uid='1' user='u' changeset='1' lat='0.0' lon='0.0'/>"
+    b"</create>"
+    b"</osmChange>"
+)
+
+
+def test_once_flag_parses() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["feed", "--connection-string", "x", "--once"])
+    assert args.once is True
+
+
+def test_once_flag_default_false_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ONCE_MODE", raising=False)
+    parser = build_parser()
+    args = parser.parse_args(["feed", "--connection-string", "x"])
+    assert args.once is False
+
+
+def test_bridge_run_exits_after_one_cycle_when_once(tmp_path) -> None:
+    """OsmDiffsBridge.run() must return after exactly one _poll_cycle when once=True."""
+    diffs_producer = MagicMock()
+    state_producer = MagicMock()
+    kafka_producer = MagicMock()
+    state_store = StateStore(str(tmp_path / "state.json"))
+
+    bridge = OsmDiffsBridge(
+        diffs_producer,
+        state_producer,
+        kafka_producer,
+        state_store=state_store,
+        poll_interval=60,
+        once=True,
+    )
+
+    # Mock the HTTP session: state.txt then a single .osc.gz
+    state_resp = MagicMock()
+    state_resp.text = SAMPLE_STATE_TXT
+    state_resp.raise_for_status = MagicMock()
+
+    diff_resp = MagicMock()
+    diff_resp.content = gzip.compress(SAMPLE_OSC_XML)
+    diff_resp.raise_for_status = MagicMock()
+
+    bridge._session = MagicMock()
+    bridge._session.get = MagicMock(side_effect=[state_resp, diff_resp])
+
+    with patch("wikimedia_osm_diffs.wikimedia_osm_diffs.time.sleep") as sleep_mock:
+        bridge.run()
+
+    # Run must return without ever calling time.sleep (sleep would mean looping)
+    sleep_mock.assert_not_called()
+    # Exactly one cycle: one state fetch + one diff fetch
+    assert bridge._session.get.call_count == 2
+    # State was advanced
+    assert bridge._last_sequence == 7062480
+
+
+def test_main_feed_once_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: `feed --once -c X` must invoke bridge.run() once and exit cleanly."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["wikimedia-osm-diffs", "feed", "--connection-string",
+         "BootstrapServer=localhost:9092;EntityPath=test", "--once"],
+    )
+    monkeypatch.setenv("KAFKA_ENABLE_TLS", "false")
+
+    fake_bridge = MagicMock()
+    fake_bridge_cls = MagicMock(return_value=fake_bridge)
+
+    with patch("wikimedia_osm_diffs.wikimedia_osm_diffs.OsmDiffsBridge", fake_bridge_cls), \
+         patch("wikimedia_osm_diffs.wikimedia_osm_diffs.Producer"):
+        rc = main()
+
+    assert rc == 0
+    # Once flag forwarded to bridge constructor
+    assert fake_bridge_cls.call_args.kwargs["once"] is True
+    fake_bridge.run.assert_called_once()
+    fake_bridge.flush.assert_called_once()

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
@@ -226,6 +226,7 @@ class OsmDiffsBridge:
         user_agent: str = DEFAULT_USER_AGENT,
         poll_interval: int = 60,
         max_retry_delay: int = 120,
+        once: bool = False,
     ) -> None:
         self._diffs_producer = diffs_producer
         self._state_producer = state_producer
@@ -236,6 +237,7 @@ class OsmDiffsBridge:
         self._user_agent = user_agent
         self._poll_interval = poll_interval
         self._max_retry_delay = max_retry_delay
+        self._once = once
         self._last_sequence = state_store.load()
         self._total_events = 0
         self._session = requests.Session()
@@ -248,11 +250,17 @@ class OsmDiffsBridge:
             try:
                 self._poll_cycle()
                 retry_delay = 1
+                if self._once:
+                    logger.info("--once mode: exiting after first polling cycle")
+                    return
                 time.sleep(self._poll_interval)
             except KeyboardInterrupt:
                 raise
             except Exception as exc:
                 logger.warning("Poll cycle error: %s. Retrying in %ds.", exc, retry_delay)
+                if self._once:
+                    logger.info("--once mode: exiting after error")
+                    return
                 time.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, self._max_retry_delay)
 
@@ -398,6 +406,7 @@ def run_feed(args: argparse.Namespace) -> int:
         user_agent=args.user_agent,
         poll_interval=args.poll_interval,
         max_retry_delay=args.max_retry_delay,
+        once=args.once,
     )
 
     try:
@@ -483,6 +492,12 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser.add_argument(
         "--user-agent",
         default=os.getenv("OSM_DIFFS_USER_AGENT", DEFAULT_USER_AGENT),
+    )
+    feed_parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
     )
 
     probe_parser = subparsers.add_parser("probe", help="Print current state and a few changes")


### PR DESCRIPTION
Retrofit by notebook-feeder-retrofit agent (.github/skills/notebook-feeder-retrofit/SKILL.md).

## What

- Adds `wikimedia-osm-diffs/notebook/wikimedia-osm-diffs-feed.ipynb` following the canonical `pegelonline` four-cell pattern (markdown intro, parameters cell, CS-lookup cell, worker-thread run cell).
- Adds a `--once` CLI flag to the bridge (also honored via `ONCE_MODE` env var), modeled on `pegelonline`. `--once` is required for scheduled notebook execution: the bridge runs one polling cycle and exits cleanly.
- Adds `tests/test_once_mode.py` covering argparse, default behavior, single-cycle exit via `OsmDiffsBridge.run()`, and end-to-end `main()` invocation.
- Regenerates KQL via `create-kql-script.ps1 -Qualified`. The output is byte-identical: the JsonStructure schemas declare no namespace, and the xreg has two distinct messagegroup namespaces (`Org.OpenStreetMap.Diffs` and `Org.OpenStreetMap.Diffs.State`), so `-Namespace` is intentionally not passed.
- Flips `catalog.json` `notebook: true` for `wikimedia-osm-diffs` so the gh-pages portal exposes the Fabric Notebook deploy button.
- Adds a one-sentence "Fabric notebook hosting" section to `wikimedia-osm-diffs/README.md` linking to the deploy script.

## Validations performed locally

- Notebook JSON well-formed (`json.load`).
- `pytest tests/` in `wikimedia-osm-diffs/` → **51 passed** (47 existing + 4 new `--once` tests).
- Parameters cell contains all five required placeholders: `EVENTSTREAM_NAME`, `STATE_FILE`, `POLLING_INTERVAL`, `ONCE_MODE`, `WORKSPACE_ID`.
- Forbidden patterns absent: no `asyncio.run(`, no `%pip install`, no hardcoded `CONNECTION_STRING = "..."`, no `primaryConnectionString = …`.

## Not done (per skill)

No live Fabric deployment. The wheel-bundle workflow (`publish-notebook-wheels.yml`) will publish wheels for this source on merge to `main`; end-to-end Fabric verification is performed manually by the maintainer afterward.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
