### PR TITLE
mode-s: tune internal queue and Kafka producer batching to avoid drops

### DIFF
--- a/mode-s/mode_s_kafka_bridge/mode_s.py
+++ b/mode-s/mode_s_kafka_bridge/mode_s.py
@@ -63,9 +63,10 @@ class ADSBClient(TcpClient):
         try:
             if self.stop_flag:
                 return
-            if (len(self.task_queue ) + 1) > 200:
-                logger.warning("Dropping input. Queue capacity exceeded.")   
-                return             
+            queue_cap = int(os.environ.get('MODE_S_QUEUE_CAPACITY', '20000'))
+            if (len(self.task_queue) + 1) > queue_cap:
+                logger.warning("Dropping input. Queue capacity exceeded (cap=%d).", queue_cap)
+                return
             msgs = []
             for msg, ts in messages:
                 try:
@@ -167,7 +168,9 @@ class ADSBClient(TcpClient):
                             content_type="application/json",
                             flush_producer=False
                         )
-                        if (datetime.now() - last_flush) > timedelta(seconds=1) or self.records_since_last_flush >= 1000:
+                        flush_interval_s = int(os.environ.get('MODE_S_FLUSH_INTERVAL_SECONDS', '10'))
+                        flush_record_threshold = int(os.environ.get('MODE_S_FLUSH_RECORD_THRESHOLD', '50000'))
+                        if (datetime.now() - last_flush) > timedelta(seconds=flush_interval_s) or self.records_since_last_flush >= flush_record_threshold:
                             if last_info_log < datetime.now() - timedelta(seconds=5*60):
                                 logger.info("Messages %d, records %d, queue length is %d", messages_since_last_log, records_since_last_log, len(self.task_queue))
                                 last_info_log = datetime.now()
@@ -308,6 +311,14 @@ async def run():
             tls_enabled = os.getenv('KAFKA_ENABLE_TLS', 'true').lower() not in ('false', '0', 'no')
             kafka_config = {
                 'bootstrap.servers': kafka_bootstrap_servers,
+                # Batching/throughput tuning for high-rate Mode-S feeds.
+                # Override any of these via the matching env var if needed.
+                'linger.ms': int(os.environ.get('KAFKA_LINGER_MS', '500')),
+                'batch.num.messages': int(os.environ.get('KAFKA_BATCH_NUM_MESSAGES', '10000')),
+                'queue.buffering.max.messages': int(os.environ.get('KAFKA_QUEUE_BUFFERING_MAX_MESSAGES', '1000000')),
+                'queue.buffering.max.kbytes': int(os.environ.get('KAFKA_QUEUE_BUFFERING_MAX_KBYTES', '1048576')),
+                'compression.type': os.environ.get('KAFKA_COMPRESSION_TYPE', 'lz4'),
+                'socket.send.buffer.bytes': int(os.environ.get('KAFKA_SOCKET_SEND_BUFFER_BYTES', '1048576')),
             }
             if sasl_username and sasl_password:
                 kafka_config.update({


### PR DESCRIPTION
## Problem

Running the mode-s bridge against a busy dump1090 feed (~50k records/sec) with Azure Event Hubs as the Kafka target produced sustained `Dropping input. Queue capacity exceeded.` warnings within seconds of startup. In a 2-minute window the log was ~199/200 lines drop warnings and only ~4316 messages had been published vs ~305071 records ingested.

Root cause is on the consumer side, not the wire:

- The in-memory `task_queue` is hard-capped at 200 bundles.
- `queue_consumer` calls `self.producer.producer.flush()` every 1 s or every 1000 records. `flush()` is a synchronous, blocking call on librdkafka; with a high-RTT Event Hubs broker it stalls the `popleft()` loop, the producer side falls behind, and `handle_messages` starts dropping at the 200-bundle cap.
- librdkafka batching used defaults — no `linger.ms`, no compression, default buffers — so each flush had little to amortize.

## Changes (batching/flushing only, no wire-format or content-mode changes)

1. **Internal queue cap**: `200` → `20000` bundles. Overridable via `MODE_S_QUEUE_CAPACITY`.
2. **Flush cadence**: `1 s` / `1000 records` → `10 s` / `50000 records`. Overridable via `MODE_S_FLUSH_INTERVAL_SECONDS` and `MODE_S_FLUSH_RECORD_THRESHOLD`.
3. **librdkafka batching defaults**: add `linger.ms=500`, `batch.num.messages=10000`, `queue.buffering.max.messages=1000000`, `queue.buffering.max.kbytes=1048576`, `compression.type=lz4`, `socket.send.buffer.bytes=1048576`. Each overridable via the matching `KAFKA_*` env var.

No changes to CloudEvents content mode, message format, schema, or producer API. Generated producer code is untouched.

## Verification

Deployed as a Windows service (NSSM) on a Win11 host, pulling BEAST from a remote dump1090, publishing to an Event Hubs namespace.

- **Before**: 199/200 of last log lines were `Dropping input...`; only sporadic INFO `Messages 4316, records 305071, queue length is 199` after 5 min.
- **After**: 0 drops in last 200 lines over a 2-minute observation window; stderr empty; service stable.