### PR TITLE
pegelonline(mqtt-eg): drop unused imageRegistry* parameters

### DIFF
--- a/.github/skills/mqtt-uns-feeder/SKILL.md
+++ b/.github/skills/mqtt-uns-feeder/SKILL.md
@@ -356,8 +356,9 @@ Provisions, in order:
   `reference(<namespaceResourceId>, '2025-07-15-preview').topicSpacesConfiguration.hostname`.
   Do not assemble it from the region — the Event Grid team has reserved
   the right to change the suffix.
-- `imageRegistryCredentials` for optional ACR pulls:
-  `[if(empty(parameters('imageRegistryServer')), json('[]'), createArray(createObject(...)))]`.
+- The container image defaults to the public ghcr.io image published by
+  the repo build; no `imageRegistryCredentials` are needed. Add them back
+  only if you fork and host the image in a private registry.
 
 Use `pegelonline/azure-template-with-eventgrid-mqtt.json` as the
 template — copy and adapt the namePrefix / topicRoot / imageName.

--- a/pegelonline/azure-template-with-eventgrid-mqtt.json
+++ b/pegelonline/azure-template-with-eventgrid-mqtt.json
@@ -49,28 +49,7 @@
       "type": "string",
       "defaultValue": "ghcr.io/clemensv/real-time-sources-pegelonline-mqtt:latest",
       "metadata": {
-        "description": "Container image reference. Override to point at a private registry."
-      }
-    },
-    "imageRegistryServer": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional container registry server (e.g. myacr.azurecr.io) for imagePull credentials."
-      }
-    },
-    "imageRegistryUsername": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional container registry username."
-      }
-    },
-    "imageRegistryPassword": {
-      "type": "securestring",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional container registry password."
+        "description": "Container image reference. Defaults to the public ghcr.io image published by the real-time-sources repo build."
       }
     }
   },
@@ -242,7 +221,6 @@
             }
           }
         ],
-        "imageRegistryCredentials": "[if(empty(parameters('imageRegistryServer')), json('[]'), createArray(createObject('server', parameters('imageRegistryServer'), 'username', parameters('imageRegistryUsername'), 'password', parameters('imageRegistryPassword'))))]",
         "volumes": [
           {
             "name": "bridge-state",


### PR DESCRIPTION
The ACI in `azure-template-with-eventgrid-mqtt.json` now pulls from the public `ghcr.io/clemensv/real-time-sources-pegelonline-mqtt` image published by the repo's docker build workflow, so the optional Image Registry Server / Username / Password fields the portal was rendering are dead weight.

- Remove `imageRegistryServer`, `imageRegistryUsername`, `imageRegistryPassword` parameters.
- Remove the conditional `imageRegistryCredentials` wiring on the container group.
- Tighten the `imageName` description and update `.github/skills/mqtt-uns-feeder/SKILL.md` to match.