### PR TITLE
fix(pegelonline): post-#340 contract polish + xrcg 0.10.6 regen + CI AMQP wiring

### DIFF
--- a/.github/skills/feeder-release-checklist/SKILL.md
+++ b/.github/skills/feeder-release-checklist/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: feeder-release-checklist
+description: "Use this checklist BEFORE merging any feeder change in this repo (new source, new transport variant, contract change, schema change, env-var change, deploy template change, doc change). Covers schema description quality, transport completeness (Kafka + MQTT + AMQP), ghpages portal deploy buttons, README + CONTAINER.md business-value framing, env-var documentation, ARM templates, EVENTS.md regen, Docker E2E coverage. EVERY item must be ticked or explicitly justified as not-applicable before the PR is shippable."
+argument-hint: "Name of the feeder being released and the scope of the change (new transport, contract bump, doc refresh, etc.)."
+---
+
+# Feeder Release Checklist
+
+This is a hard gate. Before any feeder PR is considered shippable in
+this repo, every item below must be **passed** (✅) or explicitly
+declared **N/A** with a one-line justification in the PR description.
+"I'll do it later" is not an acceptable status — open a follow-up
+issue and tick a separate box for it.
+
+Pass criteria are stated as observable artifacts (file content, test
+exit code, deployed button) — not "I think I did this".
+
+## Use specialist sub-agents wherever they exist
+
+Several sections below are best validated by **specialist agents
+available via the `task` tool**. When you are running this checklist
+inside an agent runtime that exposes them, delegating is **strongly
+preferred** over self-review — these agents are tuned for the exact
+artifact under review and produce higher-signal findings than a
+generalist sweep. Launch them in parallel (one `task` call per agent,
+all in the same response) and feed their findings back into the
+checklist before ticking the relevant bullets.
+
+| When you reach… | Delegate to | What to ask for |
+|---|---|---|
+| Section 1 — schema descriptions, JsonStructure extensions, key/subject design, **Avro/JsonStructure parity and per-field `doc`/`description` coverage in both formats** | **xRegistry Expert** + **JSON Structure Expert** (parallel) | Full review of `xreg/<source>.xreg.json` for contract correctness, key/subject alignment, exhaustive field descriptions grounded in upstream docs **on every record/field of every schema in every format (JsonStructure AND Avro)**, JSON Structure extension coverage on every measured value, anyOf/composition violations, `$id`/`name` uniqueness, Avro/JsonStructure drift |
+| Section 4 — test rigor | **code-review** | High-signal review of new/changed test files for spec-compliant assertions, missing reference-event validation, hidden workarounds for upstream bugs |
+| Section 5 / 6 — Dockerfile, ARM template, identity / role-assignment correctness | **code-review** | Review Dockerfile + every `azure-template-*.json` for missing OCI labels, broken `path =` refs, missing UAMI / role assignments, missing state file share |
+| Any KQL ships under `kql/` or `fabric/` | **KQL Optimizer** | Review every `.kql` file for performance, table/column drift against the current xreg schema, and idiomatic Kusto |
+| Any Fabric asset ships under `fabric/` (Eventstreams, Eventhouses, notebooks, pipelines) | **Fabric Deployer** | Review item definitions, deployment scripts, and connection wiring for current Fabric REST API + `fab` CLI patterns |
+| Section 8 — README + CONTAINER.md business-value framing and consumer clarity | **code-review** | Critique whether the first 200 words of README.md actually convey business value to a non-domain reader; flag stale snippets, missing transports, missing buttons |
+
+If the agent runtime does **not** expose a given specialist agent
+locally, fall back to self-review and note `(no specialist agent
+available)` next to the affected bullet so the gate stays honest.
+
+Do not skip the checklist bullets themselves just because an agent
+ran — the agent's findings are inputs to your tick/justification, not
+a replacement for it.
+
+## 0. Scope check
+
+- [ ] **Transport scope declared.** State which transports the feeder
+      supports: Kafka, MQTT, AMQP, or any subset. Any transport not
+      shipped must have an explicit "not planned" or "tracked in
+      issue #N" note.
+- [ ] **Change scope declared.** New source / new transport variant /
+      contract change / schema change / env-var change / deploy
+      template change / doc-only refresh. Drives which sections below
+      apply.
+
+## 1. xRegistry contract quality (`xreg/<source>.xreg.json`)
+
+> **Delegate first:** launch **xRegistry Expert** and **JSON Structure
+> Expert** in parallel via `task` against `xreg/<source>.xreg.json`.
+> Use their findings to tick the bullets below. If neither agent is
+> available locally, self-review and annotate `(no specialist)`.
+
+- [ ] **Subject + Kafka key alignment.** Every CloudEvents message
+      declares a `subject` of type `uritemplate`. Every Kafka endpoint
+      declares `protocoloptions.options.key` and the template matches
+      the subject template **exactly**. Multi-part identities stay
+      aligned across both. See
+      `.github/instructions/xregistry-keying.instructions.md`.
+- [ ] **Keys come from stable domain identifiers.** Station IDs, MMSI,
+      alert IDs, gauge numbers — never mutable names or descriptive
+      labels.
+- [ ] **Distinct identity shapes ⇒ separate messagegroups.** If event
+      families use different key models, they live in separate groups
+      and separate Kafka endpoints.
+- [ ] **Schemas are JsonStructure, not anyOf.** No `anyOf`. No
+      conditional composition. Nullable / alternative fields use type
+      unions or `choice`.
+- [ ] **Every schema and every field has an exhaustive description**
+      grounded in the upstream API docs, **in every schema format
+      shipped (JsonStructure AND Avro)**. "string", "the value",
+      "TBD", or single-sentence placeholders are not acceptable.
+      Descriptions must explain the **business meaning**, the
+      **unit / encoding**, the **valid range** if applicable, the
+      **upstream documentation reference**, and the **consumer's
+      intended use** where non-obvious. For Avro this means every
+      `record` carries a `doc`, every `field` carries a `doc`, and
+      every named `enum` / `fixed` carries a `doc` — no exceptions.
+      The Avro descriptions must say the same thing as the
+      JsonStructure descriptions (they describe the same fields);
+      keeping them in sync is part of the release.
+- [ ] **JSON Structure extensions used where they add fidelity.**
+      `unit` / `symbol` on measured values, `altnames` for upstream
+      JSON keys, `altenums` / `descriptions` for documented labels,
+      validation keywords for ranges / formats / patterns. Missing
+      extensions on a measured field is a defect.
+- [ ] **Reference data modeled as named event types** in the same
+      message group as the telemetry it describes, with the same key
+      model and topic. Station lists, sensor catalogs, zone
+      definitions — these are events, not out-of-band context.
+- [ ] **Schema `$id` and `name` are globally unique.** Same `name`
+      across multiple schemas breaks avrotize deduplication.
+- [ ] **Both schema formats ship and stay in sync.** This repo
+      requires **both** a JsonStructure schemagroup **and** a
+      parallel Avro schemagroup for every source. They are not
+      alternatives — Avro is a required downstream artifact and must
+      be checked in alongside the jstruct schemas. When fields, types,
+      enums, required-ness, or descriptions change in one, the other
+      must be updated in the same PR. Drift between the two formats
+      is a blocker.
+
+## 2. Generated producer code (per transport)
+
+- [ ] **Generator pinned and current.** `tools/require-xrcg.ps1`
+      points at the xrcg version required. The release was tested
+      against that exact version.
+- [ ] **Producer regenerated from the manifest.** Re-ran
+      `generate_producer.ps1` after the last contract change. **No
+      hand-edits** to `*_producer/` directories.
+- [ ] **All targeted transports regenerated.** Kafka, MQTT, AMQP
+      producers are all up to date — not just the one you touched. A
+      contract change touches all of them.
+- [ ] **Generated code parses + imports.** Smoke test:
+      `python -c "from <source>_<transport>_producer.<...> import *"`.
+
+## 3. Runtime bridge (per transport)
+
+- [ ] **Reference data emitted first** at startup and refreshed
+      periodically (interval documented). Telemetry never publishes
+      before the catalog the consumer needs to interpret it.
+- [ ] **Subject / key placeholders passed explicitly** to the
+      generated producer — no ad-hoc key mappers, no hidden coupling
+      to upstream payload field names.
+- [ ] **State, dedupe, reconnect** implemented where the source
+      requires it. ETag / If-Modified-Since on REST; offset / cursor
+      on streams; lock renewal on session-aware brokers.
+- [ ] **Config surface mirrors the canonical env-var conventions.**
+      Kafka uses `CONNECTION_STRING` + `KAFKA_*` + `SASL_*`; MQTT
+      uses `MQTT_*` + auth-mode + Entra plumbing; AMQP uses `AMQP_*`
+      + auth-mode (`password` / `entra` / `sas`) + matching Entra /
+      SAS plumbing. Deviation requires justification.
+- [ ] **All auth modes wired and validated up front.** For AMQP that
+      means SASL PLAIN, Entra CBS, and SAS-token CBS are all
+      reachable and mutually exclusive at `__init__`. For MQTT that
+      means password + Entra OAUTH2-JWT. For Kafka that means SASL
+      PLAIN with optional `CONNECTION_STRING` shortcut.
+
+## 4. Tests
+
+> **Delegate first:** launch **code-review** via `task` against the
+> changed test files for spec-compliance and hidden workarounds.
+
+- [ ] **Source-local unit tests pass.** `pytest <source>/tests/`.
+- [ ] **Docker E2E exists for every transport.** Kafka via the shared
+      `tests/docker_e2e/test_docker_kafka_flow.py`; MQTT via its own
+      test class; AMQP via the Artemis test **and** the Service Bus
+      emulator test (post xrcg 0.10.5). Missing a transport's E2E
+      class is a blocker.
+- [ ] **Every Docker E2E passes locally.** Run before requesting
+      review. Cached image runs are typically 1–3 min each.
+- [ ] **E2E asserts the spec-compliant wire format.** No "accept both
+      `ce-` and `cloudEvents:` prefixes" workarounds. No "decode body
+      twice" workarounds. If a generator bug forces a workaround,
+      file the upstream issue, tag it `WORKAROUND(<issue>):`, and
+      note it in the PR (per repo policy "Real Bugs Are Blockers").
+- [ ] **E2E validates BOTH reference and telemetry event types**
+      against the checked-in JsonStructure schemas. A green E2E that
+      never saw a reference event is not actually green.
+
+## 5. Container packaging (per transport)
+
+- [ ] **`Dockerfile.<transport>` exists** with OCI labels: `source`,
+      `title`, `description`, `documentation`, `license`. The
+      `documentation` label points at the source `CONTAINER.md`.
+- [ ] **Base image `python:3.10-slim`** unless documented otherwise.
+- [ ] **Entry point** invokes the right module: `python -m
+      <source>_<transport> feed`. Configuration is via env vars only
+      — no command-line-only args in the published image.
+- [ ] **Image builds clean.** No untracked editable installs, no
+      broken `path = ...` references in pyproject.
+
+## 6. Azure deployment templates (per realistic target)
+
+> **Delegate first:** launch **code-review** via `task` against every
+> `azure-template-*.json` for missing UAMI / role assignments, broken
+> resource refs, and missing state share. If `kql/` or `fabric/`
+> assets ship, also launch **KQL Optimizer** and **Fabric Deployer**
+> in parallel.
+
+Every realistic Azure target must have an `azure-template-*.json` ARM
+template **and** a working "Deploy to Azure" button. The realistic
+targets per transport are:
+
+| Transport | Realistic Azure targets |
+|---|---|
+| Kafka | (a) bring-your-own Event Hubs / Fabric connection string → `azure-template.json`; (b) provision new Event Hubs namespace → `azure-template-with-eventhub.json` |
+| MQTT | (c) bring-your-own MQTT 5 broker → `azure-template-mqtt.json`; (d) provision new Event Grid MQTT broker → `azure-template-with-eventgrid-mqtt.json` |
+| AMQP | (e) provision new Azure Service Bus namespace → `azure-template-with-servicebus.json` |
+
+For each in-scope target:
+
+- [ ] **ARM template exists** at the canonical filename above.
+- [ ] **Template provisions identity + role assignment** where Entra
+      ID is the auth path (UAMI + the right
+      `Microsoft.Authorization/roleAssignments` per resource).
+- [ ] **Storage account + file share** mounted for persistent dedupe
+      state.
+- [ ] **Template tested by clicking the actual deploy button** (or
+      via `az deployment group create` against a scratch RG) within
+      the last 30 days.
+
+## 7. ghpages portal (`catalog.json` + `app.js`)
+
+- [ ] **Source entry exists in `catalog.json`** with all in-scope
+      transport flags set (`mqtt: true`, `amqp: true`, etc.).
+- [ ] **Deploy button(s) render** on the live portal for every
+      shipped transport. Check by inspecting the rendered card after
+      the `update-ghpages-catalog` workflow runs on `main`.
+- [ ] **`app.js` button plumbing exists** for every shipped transport
+      (the catalog flag is necessary but not sufficient). Look for
+      `btn-container-<transport>` containers and the matching hash
+      route handlers.
+
+## 8. Documentation
+
+> **Delegate first:** launch **code-review** via `task` to critique
+> whether README.md's first 200 words convey business value to a
+> non-domain reader, and to flag stale snippets, missing transports,
+> missing buttons, and missing env-var rows across README +
+> CONTAINER.md + EVENTS.md.
+
+### `README.md`
+
+- [ ] **Business value framed up front.** Open with **who consumes
+      this feed in production** and **what decisions they drive** —
+      flood early warning, shipping operations, energy dispatch,
+      compliance, insurance, research, etc. Not just "this is a
+      bridge that polls X". A reader who does not work in the source
+      domain must finish the first 200 words knowing why they should
+      care.
+- [ ] **All shipped transports listed** in the variant table with
+      image, transport stack, and default delivery shape.
+- [ ] **Quick-start Docker snippet for every transport.**
+- [ ] **All in-scope deploy buttons present** (same set as section 6
+      above). Do not list only the Kafka buttons.
+- [ ] **Repository layout** reflects current directory structure
+      (every `*_producer/`, every `Dockerfile.*`, every feeder
+      package).
+- [ ] **Configuration reference** either fully enumerated here or
+      explicitly delegated to `CONTAINER.md` with a one-line pointer
+      — do not half-document.
+
+### `CONTAINER.md`
+
+- [ ] **Title names every shipped transport.** Not "Kafka & MQTT" if
+      AMQP is also shipped.
+- [ ] **Business-value paragraph** mirrors the README (it is fine to
+      condense, but a pure technical document is not acceptable for a
+      consumer-facing container manifest).
+- [ ] **`docker pull`** commands for every image.
+- [ ] **`docker run`** examples for every realistic auth mode of
+      every transport. For AMQP that means: generic broker + SASL
+      PLAIN, Service Bus + Entra, Service Bus emulator + SAS. For
+      MQTT: generic broker + password, Event Grid + Entra
+      OAUTH2-JWT. For Kafka: bootstrap servers + SASL, Event Hubs
+      connection string.
+- [ ] **Environment variable tables** complete for every transport.
+      Every env var the feeder reads is listed with description,
+      default (if any), and which auth mode it applies to. Adding a
+      new env var without updating this table is a blocker.
+- [ ] **All in-scope deploy buttons present** with a one-paragraph
+      description of what each template provisions and what role
+      assignments / identities it creates.
+
+### `EVENTS.md`
+
+- [ ] **Regenerated from the current `xreg/<source>.xreg.json`** —
+      never edited by hand. Refresh after any contract change.
+- [ ] **Covers both reference and telemetry event types** with the
+      full schema, subject template, and Kafka key template.
+
+### Root `README.md`
+
+- [ ] **Source listed** in the appropriate topic category section. A
+      new source that does not appear in the root catalog is
+      invisible to discovery.
+
+## 9. Pre-merge gate
+
+- [ ] **Branch rebased on `main`.** No merge commits introduced by
+      the rebase.
+- [ ] **All checks above ticked** in the PR description with the
+      observable artifact (test exit code, file path, deployed URL,
+      etc.). Items declared N/A include a one-line justification.
+- [ ] **Co-authored-by trailer** present on the merge commit (see
+      `<git_commit_trailer>` in repo conventions).
+- [ ] **Upstream issues filed** for any generator / spec bug that
+      forced a workaround. The PR cross-references them and the
+      workaround is tagged `WORKAROUND(<issue>):` in code.
+
+## Outputs
+
+When using this skill, produce a PR-ready checklist comment
+containing exactly the bullets above with ✅ / ❌ / N/A status and the
+observable artifact for each one. Do not paraphrase the bullets —
+copy them verbatim so the gate stays auditable across releases.
+
+## See Also
+
+- `bootstrap-real-time-source` — start-of-source checklist.
+- `xreg-source-contract` — contract authoring.
+- `stream-bridge-implementation` — runtime bridge patterns.
+- `container-and-delivery` — packaging baseline.
+- `mqtt-uns-feeder` — MQTT delta over Kafka baseline.
+- `amqp-feeder` — AMQP delta over Kafka baseline.
+- `.github/instructions/xregistry-keying.instructions.md` — subject /
+  key alignment rules.

--- a/.github/workflows/test-pegelonline.yml
+++ b/.github/workflows/test-pegelonline.yml
@@ -38,12 +38,15 @@ jobs:
           pip install -e ./pegelonline_producer/pegelonline_producer_kafka_producer
           pip install -e ./pegelonline_mqtt_producer/pegelonline_mqtt_producer_data
           pip install -e ./pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client
+          pip install -e ./pegelonline_amqp_producer/pegelonline_amqp_producer_data
+          pip install -e ./pegelonline_amqp_producer/pegelonline_amqp_producer_amqp_producer
 
       - name: Install transport-agnostic core and transport apps
         run: |
           pip install -e ./pegelonline_core
           pip install -e ./pegelonline_kafka
           pip install -e ./pegelonline_mqtt
+          pip install -e ./pegelonline_amqp
 
       - name: Run unit tests
         run: pytest tests/test_pegelonline_unit.py -v --tb=short -p no:cacheprovider --override-ini="addopts="
@@ -57,11 +60,15 @@ jobs:
       - name: Run MQTT app tests
         run: pytest tests/test_pegelonline_mqtt_app.py -v --tb=short -p no:cacheprovider --override-ini="addopts="
 
+      - name: Run AMQP app tests
+        run: pytest tests/test_pegelonline_amqp_app.py -v --tb=short -p no:cacheprovider --override-ini="addopts="
+        if: ${{ hashFiles('pegelonline/tests/test_pegelonline_amqp_app.py') != '' }}
+
       - name: Run all tests with coverage
         run: |
           pytest tests/ -v \
             --ignore=tests/test_pegelonline_e2e.py \
-            --cov=pegelonline_core --cov=pegelonline_kafka --cov=pegelonline_mqtt \
+            --cov=pegelonline_core --cov=pegelonline_kafka --cov=pegelonline_mqtt --cov=pegelonline_amqp \
             --cov-report=term-missing --cov-report=xml --cov-fail-under=20 \
             -p no:cacheprovider --override-ini="addopts="
 

--- a/pegelonline/CONTAINER.md
+++ b/pegelonline/CONTAINER.md
@@ -1,16 +1,38 @@
-# WSV PegelOnline → Apache Kafka & MQTT/UNS
+# WSV PegelOnline → Apache Kafka, MQTT/UNS & AMQP 1.0
 
-This source ships two container images backed by the same upstream poller
-and the same xRegistry contract:
+## Why this container
+
+The German Federal Waterways and Shipping Administration (**WSV**)
+publishes [PegelOnline](https://www.pegelonline.wsv.de/), the
+authoritative real-time water-level feed for every federally
+administered inland and coastal gauge in Germany — more than 1,200
+stations on the Rhine, Elbe, Danube, Weser, Main, Mosel, Oder, Kiel
+Canal and tributaries. The feed is free and open, but it is a REST
+API: every consumer ends up writing the same polling, dedupe, schema-
+validation, retry and identity glue.
+
+These container images do that work once and re-emit the feed as
+**CloudEvents** on the messaging fabric of your choice — so flood
+agencies, inland-shipping operators (Rhine/Elbe cargo scheduling and
+fairway-depth decisions), hydropower dispatchers, environmental data
+platforms (Fabric Eventhouse / ADX / data lakes), parametric insurers
+and research consortia can subscribe to a topic instead of scraping a
+REST endpoint from inside their business systems.
+
+## What ships in the box
+
+This source ships three container images backed by the same upstream
+poller and the same xRegistry contract:
 
 | Image | Transport | Default behavior |
 |---|---|---|
 | `ghcr.io/clemensv/real-time-sources-pegelonline-kafka` | Apache Kafka 2.x (Azure Event Hubs, Microsoft Fabric Event Streams, Confluent Cloud, plain Kafka) | One topic, JSON CloudEvents (binary mode), key = `{station_id}` |
 | `ghcr.io/clemensv/real-time-sources-pegelonline-mqtt` | MQTT 5.0 broker (Mosquitto, EMQX, HiveMQ, Azure Event Grid MQTT, Microsoft Fabric MQTT) | Unified-Namespace topic tree `hydro/de/wsv/pegelonline/{water}/{station}/...`, retained QoS 1, CloudEvent attributes as MQTT 5 user properties |
-| `ghcr.io/clemensv/real-time-sources-pegelonline-amqp` | AMQP 1.0 (RabbitMQ AMQP 1.0 plugin, ActiveMQ Artemis, Qpid Dispatch, Azure Service Bus, Azure Event Hubs) | One AMQP node (queue/topic), binary CloudEvents, SASL PLAIN for generic brokers, Microsoft Entra ID via AMQP CBS for Service Bus / Event Hubs |
+| `ghcr.io/clemensv/real-time-sources-pegelonline-amqp` | AMQP 1.0 (RabbitMQ AMQP 1.0 plugin, ActiveMQ Artemis, Qpid Dispatch, Azure Service Bus, Azure Event Hubs, Azure Service Bus emulator) | One AMQP node (queue/topic), binary CloudEvents, SASL PLAIN for generic brokers, Microsoft Entra ID via AMQP CBS for Service Bus / Event Hubs, or SAS-token CBS for the emulator and SAS-only namespaces |
 
-Both images consume the WSV PegelOnline REST API (German Federal Waterways
-and Shipping Administration) and re-emit two CloudEvent types:
+All three images consume the WSV PegelOnline REST API (German Federal
+Waterways and Shipping Administration) and re-emit two CloudEvent
+types:
 
 * `de.wsv.pegelonline.Station` — station catalog (reference, emitted at
   startup; retained on MQTT).
@@ -145,6 +167,28 @@ The bridge mints an Entra access token via `DefaultAzureCredential` and
 hands it to the broker through the AMQP CBS (Claims-Based Security) put-
 token control link — no SAS-key rotation required.
 
+### Azure Service Bus emulator / SAS-only namespaces (SAS-token CBS)
+
+For local development against the
+[Azure Service Bus emulator](https://learn.microsoft.com/azure/service-bus-messaging/test-locally-with-service-bus-emulator)
+or for Service Bus / Event Hubs namespaces still configured for SAS
+authentication (no Entra ID), use `AMQP_AUTH_MODE=sas`. The bridge
+mints a `SharedAccessSignature` token from the key + key-name and
+presents it via AMQP CBS (`type=servicebus.windows.net:sastoken`):
+
+```shell
+$ docker run --rm \
+    -e AMQP_HOST='servicebus-emulator' \
+    -e AMQP_PORT=5672 \
+    -e AMQP_ADDRESS='pegelonline' \
+    -e AMQP_AUTH_MODE=sas \
+    -e AMQP_SAS_KEY_NAME='RootManageSharedAccessKey' \
+    -e AMQP_SAS_KEY='SAS_KEY_VALUE' \
+    ghcr.io/clemensv/real-time-sources-pegelonline-amqp:latest
+```
+
+For live Azure namespaces, set `AMQP_TLS=true` and `AMQP_PORT=5671`.
+
 ## Environment Variables
 
 ### Kafka image
@@ -184,9 +228,11 @@ token control link — no SAS-key rotation required.
 | `AMQP_HOST` / `AMQP_PORT` / `AMQP_TLS` | Component-level alternative to `AMQP_BROKER_URL` (default port 5672, or 5671 with `AMQP_TLS=true`). |
 | `AMQP_ADDRESS` | AMQP node (queue / topic) name (default `pegelonline`). |
 | `AMQP_USERNAME` / `AMQP_PASSWORD` | SASL PLAIN credentials, used when `AMQP_AUTH_MODE=password` (default). |
-| `AMQP_AUTH_MODE` | `password` (default) or `entra` for Microsoft Entra ID via AMQP CBS (Service Bus / Event Hubs). |
-| `AMQP_ENTRA_AUDIENCE` | Token audience (default `https://servicebus.azure.net/.default`). Use `https://eventhubs.azure.net/.default` for Event Hubs. |
-| `AMQP_ENTRA_CLIENT_ID` | Optional user-assigned managed-identity client id; otherwise `DefaultAzureCredential` selection applies. |
+| `AMQP_AUTH_MODE` | `password` (default), `entra` for Microsoft Entra ID via AMQP CBS (Service Bus / Event Hubs), or `sas` for SAS-token CBS (Service Bus emulator, or SAS-only namespaces). |
+| `AMQP_ENTRA_AUDIENCE` | Token audience (default `https://servicebus.azure.net/.default`). Use `https://eventhubs.azure.net/.default` for Event Hubs. Used only when `AMQP_AUTH_MODE=entra`. |
+| `AMQP_ENTRA_CLIENT_ID` | Optional user-assigned managed-identity client id; otherwise `DefaultAzureCredential` selection applies. Used only when `AMQP_AUTH_MODE=entra`. |
+| `AMQP_SAS_KEY_NAME` | SAS policy / key name (e.g. `RootManageSharedAccessKey`). **Required when `AMQP_AUTH_MODE=sas`.** |
+| `AMQP_SAS_KEY` | SAS key value (base64-encoded shared secret). **Required when `AMQP_AUTH_MODE=sas`.** |
 | `AMQP_CONTENT_MODE` | `binary` (default) or `structured` CloudEvents content mode. |
 | `POLLING_INTERVAL` | Seconds between polling cycles (default `60`). |
 | `STATE_FILE` | Path to the dedupe state file. |

--- a/pegelonline/README.md
+++ b/pegelonline/README.md
@@ -1,5 +1,42 @@
 # PegelOnline → Apache Kafka, MQTT/UNS & AMQP 1.0
 
+## Why this bridge
+
+The German Federal Waterways and Shipping Administration (Wasserstraßen-
+und Schifffahrtsverwaltung des Bundes, **WSV**) publishes
+[PegelOnline](https://www.pegelonline.wsv.de/), the canonical real-time
+water-level feed for every federally administered inland and coastal
+gauge in Germany — over **1,200 stations** on rivers, canals and
+estuaries including the Rhine, Elbe, Danube, Weser, Main, Mosel, Oder
+and Kiel Canal. The data is free, open, and the authoritative source
+that downstream consumers (flood agencies, ports, ship pilots,
+hydropower operators, insurers) build on.
+
+This bridge turns that REST API into a first-class real-time event
+stream so you can stop polling REST endpoints from inside your
+business systems and start subscribing to a topic:
+
+- **Flood early warning and civil protection** — react to rising
+  gauges within one polling cycle (default 60 s) across an entire
+  river basin, drive alerts and dashboards.
+- **Inland shipping operations** — Rhine, Mosel and Elbe cargo
+  scheduling depends on minimum-fairway-depth thresholds at named
+  gauges (Kaub, Maxau, Emmerich, …); stream the values directly into
+  voyage-planning, ETA prediction and demurrage workflows.
+- **Hydropower and water-management dispatch** — bid into intraday
+  electricity markets with up-to-the-minute headwater and tailwater
+  readings; feed real-time inflows into reservoir-control SCADA.
+- **Environmental compliance and research** — long-running, dedupe-
+  aware ingestion into Microsoft Fabric Eventhouse / Azure Data
+  Explorer / a data lake for low-flow analysis, climate-impact studies
+  and statutory reporting.
+- **Insurance and risk** — drive parametric flood triggers and live
+  exposure dashboards from the same feed the public authorities use.
+
+The bridge does the boring work — REST polling with ETag awareness,
+state-file dedupe, JSON-Structure–validated CloudEvents, identity
+plumbing, retries — so the consumer just subscribes.
+
 ## Overview
 
 **PegelOnline** is a bridge that polls the German WSV PegelOnline REST API
@@ -11,9 +48,9 @@ upstream poller:
 |---|---|---|---|
 | **Kafka** | `ghcr.io/clemensv/real-time-sources-pegelonline-kafka` | Apache Kafka 2.x compatible (incl. Azure Event Hubs, Microsoft Fabric Event Streams, Confluent Cloud) | One topic, JSON CloudEvents (binary mode), key = `{station_id}` |
 | **MQTT** | `ghcr.io/clemensv/real-time-sources-pegelonline-mqtt` | MQTT 5.0 broker (incl. Mosquitto, EMQX, HiveMQ, Azure Event Grid MQTT, Microsoft Fabric Real-Time Hub MQTT broker) | Unified-Namespace topic tree under `hydro/de/wsv/pegelonline/{water}/{station}/...`, JSON body, CloudEvent attributes as MQTT 5 user properties, retained at QoS 1 |
-| **AMQP** | `ghcr.io/clemensv/real-time-sources-pegelonline-amqp` | AMQP 1.0 (RabbitMQ AMQP 1.0 plugin, ActiveMQ Artemis, Qpid Dispatch, Azure Service Bus, Azure Event Hubs) | Single AMQP node (queue/topic), binary CloudEvents, SASL PLAIN for generic brokers or Microsoft Entra ID via AMQP CBS for Service Bus / Event Hubs |
+| **AMQP** | `ghcr.io/clemensv/real-time-sources-pegelonline-amqp` | AMQP 1.0 (RabbitMQ AMQP 1.0 plugin, ActiveMQ Artemis, Qpid Dispatch, Azure Service Bus, Azure Event Hubs, Azure Service Bus emulator) | Single AMQP node (queue/topic), binary CloudEvents, SASL PLAIN for generic brokers, Microsoft Entra ID via AMQP CBS for Service Bus / Event Hubs, or SAS-token CBS for the emulator and SAS-only namespaces |
 
-Both variants share:
+All three variants share:
 
 * The upstream poller (`pegelonline_core`).
 * The xRegistry contract (`xreg/pegelonline.xreg.json`).
@@ -21,17 +58,22 @@ Both variants share:
   `CurrentMeasurement` telemetry event.
 
 ## Key Features
-- **Station catalog** emitted at startup as reference CloudEvents.
-- **Live water-level measurements** with ETag-aware polling and per-station
-  dedup state.
-- **Three transport binaries** with identical configuration knobs upstream
-  (polling interval, state file, once-mode).
-- **Microsoft Event Hubs / Fabric Event Stream** ready via standard
+- **Station catalog** emitted at startup as reference CloudEvents and
+  refreshed periodically — consumers learn the universe of gauges
+  without a separate metadata fetch.
+- **Live water-level measurements** with ETag-aware polling and per-
+  station dedupe state, so only genuinely new readings are republished.
+- **Three transport binaries** with identical configuration knobs
+  upstream (polling interval, state file, once-mode) — switch transport
+  without changing the data model.
+- **Microsoft Event Hubs / Fabric Event Streams** ready via standard
   connection strings (Kafka variant).
-- **Unified Namespace** ready out of the box with retained MQTT 5.0 binary
-  CloudEvents (MQTT variant).
-- **Azure Service Bus / Event Hubs over AMQP 1.0 with Microsoft Entra ID**
-  (no SAS-key rotation) via the AMQP variant's CBS put-token flow.
+- **Unified Namespace** ready out of the box with retained MQTT 5.0
+  binary CloudEvents (MQTT variant).
+- **Azure Service Bus / Event Hubs over AMQP 1.0 with Microsoft Entra
+  ID** (no SAS-key rotation) via the AMQP variant's CBS put-token flow,
+  plus SAS-token CBS for the Service Bus emulator and SAS-only
+  namespaces.
 
 ## Repository Layout
 
@@ -78,114 +120,74 @@ hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info          # Station 
 hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level   # CurrentMeasurement telemetry
 ```
 
-The legacy single-image deployment (`Dockerfile`) has been retired in favor
-of the two transport-specific images above. Existing Kafka-side environment
-variables (`CONNECTION_STRING`, `KAFKA_*`, `SASL_*`, `POLLING_INTERVAL`,
-`STATE_FILE`, `ONCE_MODE`) are preserved unchanged on the Kafka variant.
-
-## Local development
-
-For a packaged install, consider using the [CONTAINER.md](CONTAINER.md) instructions.
-
-## How to Use
-
-After installation, the tool can be run using the `pegelonline` command. It supports multiple subcommands:
-- **List Stations (`list`)**: Fetch and display all available monitoring stations.
-- **Get Water Level (`level`)**: Retrieve the current water level for a specific station.
-- **Feed Stations (`feed`)**: Continuously poll PegelOnline API for water levels and send updates to a Kafka topic.
-
-### **List Stations (`list`)**
-
-Fetches and displays all available monitoring stations from the PegelOnline API.
-
-#### Example Usage:
+### AMQP 1.0
 
 ```bash
-pegelonline list
+docker run --rm \
+  -e AMQP_BROKER_URL='amqp://user:pw@broker.example.com:5672/pegelonline' \
+  ghcr.io/clemensv/real-time-sources-pegelonline-amqp:latest
 ```
 
-### **Get Water Level (`level`)**
+For Azure Service Bus or Event Hubs with Microsoft Entra ID, the SAS
+emulator, or SAS-only namespaces, see [CONTAINER.md](CONTAINER.md#using-the-amqp-image)
+for the full env-var matrix.
 
-Retrieves the current water level for the specified station.
+## Configuration reference
 
-- `shortname`: The short name of the station to query.
-
-#### Example Usage:
-
-```bash
-pegelonline level <station_shortname>
-```
-
-### **Feed Stations (`feed`)**
-
-Polls the PegelOnline API for water level measurements and sends them as
-CloudEvents to a Kafka topic. The events are formatted using CloudEvents
-structured JSON format and described in [EVENTS.md](EVENTS.md).
-
-- `--kafka-bootstrap-servers`: Comma-separated list of Kafka bootstrap servers.
-- `--kafka-topic`: Kafka topic to send messages to.
-- `--sasl-username`: Username for SASL PLAIN authentication.
-- `--sasl-password`: Password for SASL PLAIN authentication.
-- `--connection-string`: Microsoft Event Hubs or Microsoft Fabric Event Stream [connection string](#connection-string-for-microsoft-event-hubs-or-fabric-event-streams) (overrides other Kafka parameters).
-- `--polling-interval`: Interval in seconds between API polling requests
-  (default is 60 seconds; the data is for most stations is only updated once
-  every 6 minutes, but different for each station).
-
-#### Example Usage:
-
-```bash
-pegelonline feed --kafka-bootstrap-servers "<bootstrap_servers>" --kafka-topic "<topic_name>" --sasl-username "<username>" --sasl-password "<password>" --polling-interval 60
-```
-
-Alternatively, using a connection string for Microsoft Event Hubs or Microsoft Fabric Event Streams:
-
-```bash
-pegelonline feed --connection-string "<your_connection_string>" --polling-interval 60
-```
-
-### Connection String for Microsoft Event Hubs or Fabric Event Streams
-
-The connection string format is as follows:
-
-```
-Endpoint=sb://<your-event-hubs-namespace>.servicebus.windows.net/;SharedAccessKeyName=<policy-name>;SharedAccessKey=<access-key>;EntityPath=<event-hub-name>
-```
-
-When provided, the connection string is parsed to extract the Kafka configuration parameters:
-- **Bootstrap Servers**: Derived from the `Endpoint` value.
-- **Kafka Topic**: Derived from the `EntityPath` value.
-- **SASL Username and Password**: The username is set to `'$ConnectionString'`, and the password is the entire connection string.
-
-### Environment Variables
-The tool supports the following environment variables to avoid passing them via the command line:
-- `KAFKA_BOOTSTRAP_SERVERS`: Kafka bootstrap servers (comma-separated list).
-- `KAFKA_TOPIC`: Kafka topic for publishing.
-- `SASL_USERNAME`: SASL username for Kafka authentication.
-- `SASL_PASSWORD`: SASL password for Kafka authentication.
-- `CONNECTION_STRING`: Microsoft Event Hubs or Microsoft Fabric Event Stream connection string.
-- `POLLING_INTERVAL`: Polling interval in seconds.
-
-## State Management
-
-The tool handles state internally for efficient API polling and sending updates.
+The complete list of environment variables for every variant
+(Kafka / MQTT / AMQP), every authentication mode (SASL PLAIN, Microsoft
+Entra ID via CBS / OAUTH2-JWT, SAS-token CBS), and every Azure
+deployment shape lives in [CONTAINER.md](CONTAINER.md). The runtime
+also exposes a `pegelonline` CLI inside each container for ad-hoc
+probing — `docker run --rm <image> pegelonline --help`.
 
 ## Deploying into Azure Container Instances
 
-You can deploy this bridge directly to Azure Container Instances. Two deployment
-options are available:
+Five one-click deployment templates are available — one for each
+realistic Azure target. All templates create a storage account and
+file share for persistent dedupe state.
 
-### Option 1: Bring your own Event Hub
+### Kafka — bring your own Event Hub / Kafka
 
-Deploy the container and provide your own Azure Event Hubs or Fabric Event
-Streams connection string. The template creates a storage account and file share
-for persistent state.
+Deploy the Kafka container with your own Azure Event Hubs or Fabric Event
+Stream connection string.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fpegelonline%2Fazure-template.json)
 
-### Option 2: Deploy with a new Event Hub
+### Kafka — provision a new Event Hub
 
-Deploy the container together with a new Event Hub namespace (Standard SKU, 1
-throughput unit) and event hub. The connection string is automatically
-configured.
+Deploy the Kafka container together with a new Event Hubs namespace
+(Standard SKU, 1 throughput unit) and event hub. The connection string
+is wired automatically.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fpegelonline%2Fazure-template-with-eventhub.json)
+
+### MQTT — bring your own broker
+
+Deploy the MQTT container against an existing MQTT 5 broker. You
+provide the `mqtts://` URL and optional credentials.
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fpegelonline%2Fazure-template-mqtt.json)
+
+### MQTT — provision a new Event Grid namespace MQTT broker
+
+Deploy the MQTT container together with a new
+[Azure Event Grid namespace](https://learn.microsoft.com/azure/event-grid/mqtt-overview)
+with the MQTT broker enabled, a topic space rooted at `hydro/#`, a
+user-assigned managed identity, and the **EventGrid TopicSpaces
+Publisher** role assignment. The feeder authenticates with MQTT v5
+enhanced authentication (`OAUTH2-JWT`).
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fpegelonline%2Fazure-template-with-eventgrid-mqtt.json)
+
+### AMQP — provision a new Azure Service Bus namespace
+
+Deploy the AMQP container together with a new
+[Azure Service Bus Standard namespace](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview)
+with a queue named `pegelonline`, a user-assigned managed identity, and
+the **Azure Service Bus Data Sender** role assignment. The feeder
+authenticates via AMQP CBS put-token with Microsoft Entra ID — no SAS
+key rotation required.
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fpegelonline%2Fazure-template-with-servicebus.json)
+

--- a/pegelonline/pegelonline_amqp/pegelonline_amqp/app.py
+++ b/pegelonline/pegelonline_amqp/pegelonline_amqp/app.py
@@ -48,7 +48,7 @@ def _build_station(raw: Dict[str, Any]) -> Station:
         number=raw.get("number"),
         shortname=raw.get("shortname"),
         longname=raw.get("longname"),
-        km=raw.get("km") if raw.get("km") is not None else -1,
+        km=raw.get("km"),
         agency=raw.get("agency"),
         longitude=raw.get("longitude") if raw.get("longitude") is not None else -1,
         latitude=raw.get("latitude") if raw.get("latitude") is not None else -1,
@@ -61,9 +61,30 @@ def _build_measurement(station_id: str, raw: Dict[str, Any]) -> CurrentMeasureme
         station_id=station_id,
         timestamp=raw["timestamp"],
         value=raw["value"],
-        stateMnwMhw=raw["stateMnwMhw"],
-        stateNswHsw=raw["stateNswHsw"],
+        stateMnwMhw=raw.get("stateMnwMhw"),
+        stateNswHsw=raw.get("stateNswHsw"),
+        trend=raw.get("trend"),
     )
+
+
+def _water_shortname(raw_station: Dict[str, Any]) -> str:
+    """Pick the URL-safe water shortname carried as AMQP application property.
+
+    Mirrors the helper in ``pegelonline_mqtt`` so SB/EH subscription filters
+    and AMQP routers can route by waterway without cracking the JSON body.
+    """
+    water = raw_station.get("water") or {}
+    raw = (water.get("shortname") or water.get("longname") or "unknown").strip().lower()
+    out_chars = []
+    for ch in raw:
+        if ch.isalnum() or ch in ("-", "_"):
+            out_chars.append(ch)
+        else:
+            out_chars.append("-")
+    safe = "".join(out_chars).strip("-")
+    while "--" in safe:
+        safe = safe.replace("--", "-")
+    return safe or "unknown"
 
 
 def _publish_stations(
@@ -78,6 +99,7 @@ def _publish_stations(
             data=_build_station(station),
             _feedurl=f"{FEED_URL_ROOT}/stations/{station['shortname']}",
             _station_id=station["uuid"],
+            _water_shortname=_water_shortname(station),
         )
 
 
@@ -188,11 +210,13 @@ def feed(
                     if prior is not None and measurement.get("timestamp") == prior.get("timestamp"):
                         continue
                     count += 1
+                    station_meta = station_index.get(station_id) or {}
                     try:
                         producer.send_current_measurement(
                             data=_build_measurement(station_id, measurement),
                             _feedurl=f"{FEED_URL_ROOT}/stations/{station_id}/W/currentmeasurement.json",
                             _station_id=station_id,
+                            _water_shortname=_water_shortname(station_meta),
                         )
                     except Exception as e:  # pylint: disable=broad-except
                         logger.error("Error publishing measurement for %s: %s", station_id, e)

--- a/pegelonline/pegelonline_amqp_producer/README.md
+++ b/pegelonline/pegelonline_amqp_producer/README.md
@@ -164,7 +164,9 @@ The producer constructor accepts:
 
 
 ##### `send_station()`
-PegelOnline station metadata with location and water body information.
+Reference catalog entry for one WSV PegelOnline gauge installation. Emitted at bridge startup and periodically refreshed
+so downstream consumers can interpret CurrentMeasurement events without an out-of-band lookup. Sourced from `GET
+/stations.json` on the PegelOnline REST API v2.
 
 **Parameters:**
 - `data` (Station): The message data object
@@ -185,7 +187,9 @@ Send multiple Station messages in sequence.
 
 
 ##### `send_current_measurement()`
-PegelOnline current water level measurement.
+Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from `GET
+/stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Telemetry counterpart to the Station
+reference event; both share the `station_id` keying.
 
 **Parameters:**
 - `data` (CurrentMeasurement): The message data object

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_amqp_producer/src/pegelonline_amqp_producer_amqp_producer/producer.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_amqp_producer/src/pegelonline_amqp_producer_amqp_producer/producer.py
@@ -602,14 +602,16 @@ class DeWsvPegelonlineAmqpProducer:
         data: Station,
         _feedurl: str,
         _station_id: str,
+        _water_shortname: str,
         content_type: str = 'application/json') -> None:
         """
         Send the `de.wsv.pegelonline.amqp.Station` message
-        PegelOnline station metadata with location and water body information.
+        Reference catalog entry for one WSV PegelOnline gauge installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API v2.
         
         Args:
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _water_shortname (str): Value for AMQP protocol option placeholder water_shortname
             data (Station): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -651,6 +653,15 @@ class DeWsvPegelonlineAmqpProducer:
             amqp_msg.content_type = content_type
             if headers:
                 amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{station_id}".format(station_id=_station_id)
+
+        app_properties = {}
+        app_properties["water_shortname"] = "{water_shortname}".format(water_shortname=_water_shortname)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
         
         # Send message
         if getattr(self, "_handler", None) is not None:
@@ -662,6 +673,7 @@ class DeWsvPegelonlineAmqpProducer:
         data_array: typing.List[Station],
         _feedurl: str,
         _station_id: str,
+        _water_shortname: str,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `de.wsv.pegelonline.amqp.Station` messages
@@ -670,24 +682,32 @@ class DeWsvPegelonlineAmqpProducer:
             data_array (typing.List[Station]): Array of message data objects
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _water_shortname (str): Value for AMQP protocol option placeholder water_shortname
             content_type (str): The content type of the message data
         """
         for data in data_array:
-            self.send_station(data, _feedurl, _station_id, content_type)
+            self.send_station(
+                data=data,
+                _feedurl=_feedurl,
+                _station_id=_station_id,
+                _water_shortname=_water_shortname,
+                content_type=content_type)
     
     
     def send_current_measurement(self,
         data: CurrentMeasurement,
         _feedurl: str,
         _station_id: str,
+        _water_shortname: str,
         content_type: str = 'application/json') -> None:
         """
         Send the `de.wsv.pegelonline.amqp.CurrentMeasurement` message
-        PegelOnline current water level measurement.
+        Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.
         
         Args:
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _water_shortname (str): Value for AMQP protocol option placeholder water_shortname
             data (CurrentMeasurement): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -729,6 +749,15 @@ class DeWsvPegelonlineAmqpProducer:
             amqp_msg.content_type = content_type
             if headers:
                 amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{station_id}".format(station_id=_station_id)
+
+        app_properties = {}
+        app_properties["water_shortname"] = "{water_shortname}".format(water_shortname=_water_shortname)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
         
         # Send message
         if getattr(self, "_handler", None) is not None:
@@ -740,6 +769,7 @@ class DeWsvPegelonlineAmqpProducer:
         data_array: typing.List[CurrentMeasurement],
         _feedurl: str,
         _station_id: str,
+        _water_shortname: str,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `de.wsv.pegelonline.amqp.CurrentMeasurement` messages
@@ -748,10 +778,16 @@ class DeWsvPegelonlineAmqpProducer:
             data_array (typing.List[CurrentMeasurement]): Array of message data objects
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _water_shortname (str): Value for AMQP protocol option placeholder water_shortname
             content_type (str): The content type of the message data
         """
         for data in data_array:
-            self.send_current_measurement(data, _feedurl, _station_id, content_type)
+            self.send_current_measurement(
+                data=data,
+                _feedurl=_feedurl,
+                _station_id=_station_id,
+                _water_shortname=_water_shortname,
+                content_type=content_type)
     
     
     def close(self) -> None:

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_amqp_producer/tests/test_producer.py
@@ -259,15 +259,15 @@ class TestDeWsvPegelonlineAmqpProducer:
                 producer.send_station(
                     data=payload,
                     _feedurl="value",
-                
-                    _station_id="value"
-                ,
-                content_type="application/json"
+                    _station_id="value",
+                    _water_shortname="value",
+                    content_type="application/json"
                 )
 
             # Receive and verify all 5 messages
             for i in range(5):
                 received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
 
                 if True:
                     body = received.body
@@ -286,10 +286,10 @@ class TestDeWsvPegelonlineAmqpProducer:
                     # Verify data section exists (either as data or data_base64)
                     assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
                 else:
-                    properties = received.properties or {}
-                    assert properties.get('subject') == 'de.wsv.pegelonline.amqp.Station'
                     # Verify message body is not empty
                     assert received.body is not None
+                assert received.subject == "{station_id}".format(station_id="value")
+                assert properties.get('water_shortname') == "{water_shortname}".format(water_shortname="value")
         finally:
             producer.close()
     
@@ -318,15 +318,15 @@ class TestDeWsvPegelonlineAmqpProducer:
                 producer.send_current_measurement(
                     data=payload,
                     _feedurl="value",
-                
-                    _station_id="value"
-                ,
-                content_type="application/json"
+                    _station_id="value",
+                    _water_shortname="value",
+                    content_type="application/json"
                 )
 
             # Receive and verify all 5 messages
             for i in range(5):
                 received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
 
                 if True:
                     body = received.body
@@ -345,10 +345,10 @@ class TestDeWsvPegelonlineAmqpProducer:
                     # Verify data section exists (either as data or data_base64)
                     assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
                 else:
-                    properties = received.properties or {}
-                    assert properties.get('subject') == 'de.wsv.pegelonline.amqp.CurrentMeasurement'
                     # Verify message body is not empty
                     assert received.body is not None
+                assert received.subject == "{station_id}".format(station_id="value")
+                assert properties.get('water_shortname') == "{water_shortname}".format(water_shortname="value")
         finally:
             producer.close()
 

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/__init__.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import CurrentMeasurement, Water, Station
+from .de import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["CurrentMeasurement", "Water", "Station"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/__init__.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .wsv import CurrentMeasurement, Water, Station
+from .wsv import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["CurrentMeasurement", "Water", "Station"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/__init__.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/__init__.py
@@ -1,3 +1,3 @@
-from .pegelonline import CurrentMeasurement, Water, Station
+from .pegelonline import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["CurrentMeasurement", "Water", "Station"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/__init__.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/__init__.py
@@ -1,5 +1,8 @@
+from .statemnwmhwenum import StateMnwMhwEnum
+from .statenswhswenum import StateNswHswEnum
+from .trendenum import TrendEnum
 from .currentmeasurement import CurrentMeasurement
 from .water import Water
 from .station import Station
 
-__all__ = ["CurrentMeasurement", "Water", "Station"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/currentmeasurement.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/currentmeasurement.py
@@ -10,29 +10,36 @@ import dataclasses
 from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
 import json
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+import datetime
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class CurrentMeasurement:
     """
-    Schema representing the current measurement for a PEGELONLINE station.
+    Latest 15-minute water-level reading for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Carries only the W (water-level) timeseries; other timeseries (Q discharge, LT water temperature) are not emitted by this source.
     
     Attributes:
         station_id (str)
-        timestamp (str)
+        timestamp (datetime.datetime)
         value (float)
-        stateMnwMhw (str)
-        stateNswHsw (str)
+        stateMnwMhw (typing.Optional[StateMnwMhwEnum])
+        stateNswHsw (typing.Optional[StateNswHswEnum])
+        trend (typing.Optional[TrendEnum])
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
-    timestamp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp"))
+    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     value: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value"))
-    stateMnwMhw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
-    stateNswHsw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    stateMnwMhw: typing.Optional[StateMnwMhwEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
+    stateNswHsw: typing.Optional[StateNswHswEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    trend: typing.Optional[TrendEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="trend"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'CurrentMeasurement':
@@ -159,9 +166,10 @@ class CurrentMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='jzewsloirebtkgkckxpk',
-            timestamp='uqlkuoocllkwcoehlbqi',
-            value=float(74.58890674472416),
-            stateMnwMhw='ggruxsfndkjgtlkjvifj',
-            stateNswHsw='bjmidamgthwdjppknujg'
+            station_id='fjteqljlkvwbfgmtaxsk',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(68.22003062311794),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
@@ -1,0 +1,48 @@
+from enum import Enum
+
+
+class StateMnwMhwEnum(Enum):
+    """
+    Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values, as computed by the upstream feed. Omitted by upstream when the gauge has no MNW/MHW reference series configured (treat absence as 'unknown').
+    """
+    low = 'low'
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateMnwMhwEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateMnwMhwEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateMnwMhwEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/statenswhswenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/statenswhswenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class StateNswHswEnum(Enum):
+    """
+    Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series — HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown').
+    """
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateNswHswEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateNswHswEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateNswHswEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/station.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/station.py
@@ -18,14 +18,14 @@ from pegelonline_amqp_producer_data.de.wsv.pegelonline.water import Water
 @dataclass
 class Station:
     """
-    Schema representing a PEGELONLINE station with location and water body information.
+    WSV PegelOnline gauge installation. Each instance represents one physical Pegelmessstelle on a federally administered German inland or coastal waterway. Sourced from `GET /stations.json` on the PegelOnline REST API v2 (https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Emitted as reference data at bridge startup and re-emitted periodically.
     
     Attributes:
         station_id (str)
         number (str)
         shortname (str)
         longname (str)
-        km (float)
+        km (typing.Optional[float])
         agency (str)
         longitude (float)
         latitude (float)
@@ -37,7 +37,7 @@ class Station:
     number: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="number"))
     shortname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="shortname"))
     longname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longname"))
-    km: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
+    km: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
     agency: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="agency"))
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
@@ -168,13 +168,13 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='hufbhrpaibcbmvbhdujz',
-            number='vvvzamrwtqmphcurcwea',
-            shortname='xnyjnnlkknrgckqutgin',
-            longname='ylvgofwrioeqzwcnalhw',
-            km=float(28.10022427810984),
-            agency='oktxyhajfexdkcywxmdq',
-            longitude=float(11.065448545201484),
-            latitude=float(30.786497578642603),
+            station_id='fkhmfyyafcjboswbnchc',
+            number='stelafuhbtcgsxgtytwg',
+            shortname='pgreoejiugrzwcnimmlj',
+            longname='ccruiowvsgattkaujafo',
+            km=float(48.05237603334906),
+            agency='ryniwunafrkvxnywnscb',
+            longitude=float(13.054366195131228),
+            latitude=float(99.53327772712156),
             water=None
         )

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/trendenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/trendenum.py
@@ -1,0 +1,45 @@
+from enum import IntEnum
+
+
+class TrendEnum(IntEnum):
+    """
+    Short-term trend of the water level relative to the previous reading, as classified by the upstream feed. First-class signal for flood-monitoring dashboards. Sourced from the upstream `trend` field; omitted when upstream cannot compute a trend (e.g. first reading after a gap).
+    """
+    VALUE_NEG_1 = -1
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'TrendEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'TrendEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (TrendEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/water.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/src/pegelonline_amqp_producer_data/de/wsv/pegelonline/water.py
@@ -17,7 +17,7 @@ import json
 @dataclass
 class Water:
     """
-    Details of the water body associated with the station.
+    Federal waterway / water body the gauge measures, as returned in the nested `water` object of `GET /stations.json` on the PegelOnline REST API v2. Acts as the routing hierarchy for the MQTT Unified Namespace topology.
     
     Attributes:
         shortname (str)
@@ -153,6 +153,6 @@ class Water:
             An instance of the dataclass.
         """
         return cls(
-            shortname='qplzanijhbbtqwuqykmy',
-            longname='dbzqgzorwgblewxbzhgq'
+            shortname='wrdmzxxohakmnotcxcty',
+            longname='itsfpyovyunmijzvvmxp'
         )

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_currentmeasurement.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_currentmeasurement.py
@@ -9,6 +9,10 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from pegelonline_amqp_producer_data.de.wsv.pegelonline.currentmeasurement import CurrentMeasurement
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+import datetime
 
 
 class Test_CurrentMeasurement(unittest.TestCase):
@@ -28,11 +32,12 @@ class Test_CurrentMeasurement(unittest.TestCase):
         Create instance of CurrentMeasurement for testing
         """
         instance = CurrentMeasurement(
-            station_id='jzewsloirebtkgkckxpk',
-            timestamp='uqlkuoocllkwcoehlbqi',
-            value=float(74.58890674472416),
-            stateMnwMhw='ggruxsfndkjgtlkjvifj',
-            stateNswHsw='bjmidamgthwdjppknujg'
+            station_id='fjteqljlkvwbfgmtaxsk',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(68.22003062311794),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )
         return instance
 
@@ -41,7 +46,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'jzewsloirebtkgkckxpk'
+        test_value = 'fjteqljlkvwbfgmtaxsk'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -49,7 +54,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'uqlkuoocllkwcoehlbqi'
+        test_value = datetime.datetime.now(datetime.timezone.utc)
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -57,7 +62,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(74.58890674472416)
+        test_value = float(68.22003062311794)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -65,7 +70,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateMnwMhw property
         """
-        test_value = 'ggruxsfndkjgtlkjvifj'
+        test_value = StateMnwMhwEnum.low
         self.instance.stateMnwMhw = test_value
         self.assertEqual(self.instance.stateMnwMhw, test_value)
     
@@ -73,9 +78,17 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateNswHsw property
         """
-        test_value = 'bjmidamgthwdjppknujg'
+        test_value = StateNswHswEnum.normal
         self.instance.stateNswHsw = test_value
         self.assertEqual(self.instance.stateNswHsw, test_value)
+    
+    def test_trend_property(self):
+        """
+        Test trend property
+        """
+        test_value = TrendEnum.VALUE_NEG_1
+        self.instance.trend = test_value
+        self.assertEqual(self.instance.trend, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_statemnwmhwenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_statemnwmhwenum.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+
+
+class Test_StateMnwMhwEnum(unittest.TestCase):
+    """
+    Test case for StateMnwMhwEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateMnwMhwEnum.low
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateMnwMhwEnum
+        """
+        return StateMnwMhwEnum.low
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateMnwMhwEnum.low.value, 'low')
+        self.assertEqual(StateMnwMhwEnum.normal.value, 'normal')
+        self.assertEqual(StateMnwMhwEnum.high.value, 'high')
+        self.assertEqual(StateMnwMhwEnum.unknown.value, 'unknown')
+        self.assertEqual(StateMnwMhwEnum.commented.value, 'commented')
+        self.assertEqual(StateMnwMhwEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_statenswhswenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_statenswhswenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+
+
+class Test_StateNswHswEnum(unittest.TestCase):
+    """
+    Test case for StateNswHswEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateNswHswEnum.normal
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateNswHswEnum
+        """
+        return StateNswHswEnum.normal
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateNswHswEnum.normal.value, 'normal')
+        self.assertEqual(StateNswHswEnum.high.value, 'high')
+        self.assertEqual(StateNswHswEnum.unknown.value, 'unknown')
+        self.assertEqual(StateNswHswEnum.commented.value, 'commented')
+        self.assertEqual(StateNswHswEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_station.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_station.py
@@ -29,14 +29,14 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='hufbhrpaibcbmvbhdujz',
-            number='vvvzamrwtqmphcurcwea',
-            shortname='xnyjnnlkknrgckqutgin',
-            longname='ylvgofwrioeqzwcnalhw',
-            km=float(28.10022427810984),
-            agency='oktxyhajfexdkcywxmdq',
-            longitude=float(11.065448545201484),
-            latitude=float(30.786497578642603),
+            station_id='fkhmfyyafcjboswbnchc',
+            number='stelafuhbtcgsxgtytwg',
+            shortname='pgreoejiugrzwcnimmlj',
+            longname='ccruiowvsgattkaujafo',
+            km=float(48.05237603334906),
+            agency='ryniwunafrkvxnywnscb',
+            longitude=float(13.054366195131228),
+            latitude=float(99.53327772712156),
             water=None
         )
         return instance
@@ -46,7 +46,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'hufbhrpaibcbmvbhdujz'
+        test_value = 'fkhmfyyafcjboswbnchc'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +54,7 @@ class Test_Station(unittest.TestCase):
         """
         Test number property
         """
-        test_value = 'vvvzamrwtqmphcurcwea'
+        test_value = 'stelafuhbtcgsxgtytwg'
         self.instance.number = test_value
         self.assertEqual(self.instance.number, test_value)
     
@@ -62,7 +62,7 @@ class Test_Station(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'xnyjnnlkknrgckqutgin'
+        test_value = 'pgreoejiugrzwcnimmlj'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -70,7 +70,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'ylvgofwrioeqzwcnalhw'
+        test_value = 'ccruiowvsgattkaujafo'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     
@@ -78,7 +78,7 @@ class Test_Station(unittest.TestCase):
         """
         Test km property
         """
-        test_value = float(28.10022427810984)
+        test_value = float(48.05237603334906)
         self.instance.km = test_value
         self.assertEqual(self.instance.km, test_value)
     
@@ -86,7 +86,7 @@ class Test_Station(unittest.TestCase):
         """
         Test agency property
         """
-        test_value = 'oktxyhajfexdkcywxmdq'
+        test_value = 'ryniwunafrkvxnywnscb'
         self.instance.agency = test_value
         self.assertEqual(self.instance.agency, test_value)
     
@@ -94,7 +94,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(11.065448545201484)
+        test_value = float(13.054366195131228)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -102,7 +102,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(30.786497578642603)
+        test_value = float(99.53327772712156)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_trendenum.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_trendenum.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_amqp_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+
+
+class Test_TrendEnum(unittest.TestCase):
+    """
+    Test case for TrendEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = TrendEnum.VALUE_NEG_1
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of TrendEnum
+        """
+        return TrendEnum.VALUE_NEG_1
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(TrendEnum.VALUE_NEG_1.value, -1)
+        self.assertEqual(TrendEnum.VALUE_0.value, 0)
+        self.assertEqual(TrendEnum.VALUE_1.value, 1)

--- a/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_water.py
+++ b/pegelonline/pegelonline_amqp_producer/pegelonline_amqp_producer_data/tests/test_water.py
@@ -28,8 +28,8 @@ class Test_Water(unittest.TestCase):
         Create instance of Water for testing
         """
         instance = Water(
-            shortname='qplzanijhbbtqwuqykmy',
-            longname='dbzqgzorwgblewxbzhgq'
+            shortname='wrdmzxxohakmnotcxcty',
+            longname='itsfpyovyunmijzvvmxp'
         )
         return instance
 
@@ -38,7 +38,7 @@ class Test_Water(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'qplzanijhbbtqwuqykmy'
+        test_value = 'wrdmzxxohakmnotcxcty'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -46,7 +46,7 @@ class Test_Water(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'dbzqgzorwgblewxbzhgq'
+        test_value = 'itsfpyovyunmijzvvmxp'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     

--- a/pegelonline/pegelonline_kafka/pegelonline_kafka/app.py
+++ b/pegelonline/pegelonline_kafka/pegelonline_kafka/app.py
@@ -43,7 +43,7 @@ def _build_station(raw: Dict[str, Any]) -> Station:
         number=raw.get("number"),
         shortname=raw.get("shortname"),
         longname=raw.get("longname"),
-        km=raw.get("km") if raw.get("km") is not None else -1,
+        km=raw.get("km"),
         agency=raw.get("agency"),
         longitude=raw.get("longitude") if raw.get("longitude") is not None else -1,
         latitude=raw.get("latitude") if raw.get("latitude") is not None else -1,
@@ -56,8 +56,9 @@ def _build_measurement(station_id: str, raw: Dict[str, Any]) -> CurrentMeasureme
         station_id=station_id,
         timestamp=raw["timestamp"],
         value=raw["value"],
-        stateMnwMhw=raw["stateMnwMhw"],
-        stateNswHsw=raw["stateNswHsw"],
+        stateMnwMhw=raw.get("stateMnwMhw"),
+        stateNswHsw=raw.get("stateNswHsw"),
+        trend=raw.get("trend"),
     )
 
 

--- a/pegelonline/pegelonline_mqtt/pegelonline_mqtt/app.py
+++ b/pegelonline/pegelonline_mqtt/pegelonline_mqtt/app.py
@@ -44,7 +44,7 @@ def _build_station(raw: Dict[str, Any]) -> Station:
         number=raw.get("number"),
         shortname=raw.get("shortname"),
         longname=raw.get("longname"),
-        km=raw.get("km") if raw.get("km") is not None else -1,
+        km=raw.get("km"),
         agency=raw.get("agency"),
         longitude=raw.get("longitude") if raw.get("longitude") is not None else -1,
         latitude=raw.get("latitude") if raw.get("latitude") is not None else -1,
@@ -57,8 +57,9 @@ def _build_measurement(station_id: str, raw: Dict[str, Any]) -> CurrentMeasureme
         station_id=station_id,
         timestamp=raw["timestamp"],
         value=raw["value"],
-        stateMnwMhw=raw["stateMnwMhw"],
-        stateNswHsw=raw["stateNswHsw"],
+        stateMnwMhw=raw.get("stateMnwMhw"),
+        stateNswHsw=raw.get("stateNswHsw"),
+        trend=raw.get("trend"),
     )
 
 

--- a/pegelonline/pegelonline_mqtt_producer/README.md
+++ b/pegelonline/pegelonline_mqtt_producer/README.md
@@ -155,8 +155,10 @@ de_wsv_pegelonline_mqtt_station_async:  Callable[[PartitionContext, EventData, C
 
 make test
 
-```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.Station`: PegelOnline station metadata with location and water
-body information.
+```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.Station`: Reference catalog entry for one WSV PegelOnline
+gauge installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret
+CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API
+v2.
 
 
 The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
@@ -199,8 +201,9 @@ CurrentMeasurement], Awaitable[None]]
 
 make test
 
-```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.CurrentMeasurement`: PegelOnline current water level
-measurement.
+```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.CurrentMeasurement`: Latest 15-minute water-level reading (W
+timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the
+PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.
 
 
 The assigned handler must be a coroutine (`async def`) that accepts the following parameters:

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/__init__.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import Water, Station, CurrentMeasurement
+from .de import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/__init__.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .wsv import Water, Station, CurrentMeasurement
+from .wsv import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/__init__.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/__init__.py
@@ -1,3 +1,3 @@
-from .pegelonline import Water, Station, CurrentMeasurement
+from .pegelonline import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/__init__.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/__init__.py
@@ -1,5 +1,8 @@
+from .statemnwmhwenum import StateMnwMhwEnum
+from .statenswhswenum import StateNswHswEnum
+from .trendenum import TrendEnum
+from .currentmeasurement import CurrentMeasurement
 from .water import Water
 from .station import Station
-from .currentmeasurement import CurrentMeasurement
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/currentmeasurement.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/currentmeasurement.py
@@ -10,29 +10,36 @@ import dataclasses
 from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
 import json
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+import datetime
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class CurrentMeasurement:
     """
-    Schema representing the current measurement for a PEGELONLINE station.
+    Latest 15-minute water-level reading for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Carries only the W (water-level) timeseries; other timeseries (Q discharge, LT water temperature) are not emitted by this source.
     
     Attributes:
         station_id (str)
-        timestamp (str)
+        timestamp (datetime.datetime)
         value (float)
-        stateMnwMhw (str)
-        stateNswHsw (str)
+        stateMnwMhw (typing.Optional[StateMnwMhwEnum])
+        stateNswHsw (typing.Optional[StateNswHswEnum])
+        trend (typing.Optional[TrendEnum])
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
-    timestamp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp"))
+    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     value: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value"))
-    stateMnwMhw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
-    stateNswHsw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    stateMnwMhw: typing.Optional[StateMnwMhwEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
+    stateNswHsw: typing.Optional[StateNswHswEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    trend: typing.Optional[TrendEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="trend"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'CurrentMeasurement':
@@ -159,9 +166,10 @@ class CurrentMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='frrgixknroilsefebipr',
-            timestamp='kuuchdkwjlxtolxxwcnp',
-            value=float(34.65327089723381),
-            stateMnwMhw='unjxwgwypgqqjhenavnq',
-            stateNswHsw='ojrgzpqqttrzduooguhh'
+            station_id='vsedjwdllxnnsowwyzgd',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(26.44582040417354),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
@@ -1,0 +1,48 @@
+from enum import Enum
+
+
+class StateMnwMhwEnum(Enum):
+    """
+    Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values, as computed by the upstream feed. Omitted by upstream when the gauge has no MNW/MHW reference series configured (treat absence as 'unknown').
+    """
+    low = 'low'
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateMnwMhwEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateMnwMhwEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateMnwMhwEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/statenswhswenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/statenswhswenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class StateNswHswEnum(Enum):
+    """
+    Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series — HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown').
+    """
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateNswHswEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateNswHswEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateNswHswEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/station.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/station.py
@@ -18,14 +18,14 @@ from pegelonline_mqtt_producer_data.de.wsv.pegelonline.water import Water
 @dataclass
 class Station:
     """
-    Schema representing a PEGELONLINE station with location and water body information.
+    WSV PegelOnline gauge installation. Each instance represents one physical Pegelmessstelle on a federally administered German inland or coastal waterway. Sourced from `GET /stations.json` on the PegelOnline REST API v2 (https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Emitted as reference data at bridge startup and re-emitted periodically.
     
     Attributes:
         station_id (str)
         number (str)
         shortname (str)
         longname (str)
-        km (float)
+        km (typing.Optional[float])
         agency (str)
         longitude (float)
         latitude (float)
@@ -37,7 +37,7 @@ class Station:
     number: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="number"))
     shortname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="shortname"))
     longname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longname"))
-    km: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
+    km: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
     agency: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="agency"))
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
@@ -168,13 +168,13 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='ohpvnojepacdxqtxtqrh',
-            number='vkcumjtwgnugocogpuem',
-            shortname='cgendwdskiilccyzruge',
-            longname='fcjrzmnetasdbfwprcud',
-            km=float(82.90445072976947),
-            agency='yxipaucuxtdmgmuwncnh',
-            longitude=float(9.549718525242735),
-            latitude=float(69.4136276017481),
+            station_id='kzdpykbcqqgzvelfnkki',
+            number='dumvaykuwuandljookao',
+            shortname='oniamautigdbzyktuquh',
+            longname='ongbqnrpnntlifcxftod',
+            km=float(48.90586839505602),
+            agency='jcpbfukajbutucymnrbu',
+            longitude=float(31.99545063211955),
+            latitude=float(28.4026986369164),
             water=None
         )

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/trendenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/trendenum.py
@@ -1,0 +1,45 @@
+from enum import IntEnum
+
+
+class TrendEnum(IntEnum):
+    """
+    Short-term trend of the water level relative to the previous reading, as classified by the upstream feed. First-class signal for flood-monitoring dashboards. Sourced from the upstream `trend` field; omitted when upstream cannot compute a trend (e.g. first reading after a gap).
+    """
+    VALUE_NEG_1 = -1
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'TrendEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'TrendEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (TrendEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/water.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/water.py
@@ -17,7 +17,7 @@ import json
 @dataclass
 class Water:
     """
-    Details of the water body associated with the station.
+    Federal waterway / water body the gauge measures, as returned in the nested `water` object of `GET /stations.json` on the PegelOnline REST API v2. Acts as the routing hierarchy for the MQTT Unified Namespace topology.
     
     Attributes:
         shortname (str)
@@ -153,6 +153,6 @@ class Water:
             An instance of the dataclass.
         """
         return cls(
-            shortname='kfxurieejtwkpsiesogs',
-            longname='acrlkridumsgmaemmvye'
+            shortname='lewyhgvqvuqoenxuiwpg',
+            longname='wsrtqiwwtnwxhsovibmi'
         )

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_currentmeasurement.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_currentmeasurement.py
@@ -9,6 +9,10 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from pegelonline_mqtt_producer_data.de.wsv.pegelonline.currentmeasurement import CurrentMeasurement
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+import datetime
 
 
 class Test_CurrentMeasurement(unittest.TestCase):
@@ -28,11 +32,12 @@ class Test_CurrentMeasurement(unittest.TestCase):
         Create instance of CurrentMeasurement for testing
         """
         instance = CurrentMeasurement(
-            station_id='frrgixknroilsefebipr',
-            timestamp='kuuchdkwjlxtolxxwcnp',
-            value=float(34.65327089723381),
-            stateMnwMhw='unjxwgwypgqqjhenavnq',
-            stateNswHsw='ojrgzpqqttrzduooguhh'
+            station_id='vsedjwdllxnnsowwyzgd',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(26.44582040417354),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )
         return instance
 
@@ -41,7 +46,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'frrgixknroilsefebipr'
+        test_value = 'vsedjwdllxnnsowwyzgd'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -49,7 +54,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'kuuchdkwjlxtolxxwcnp'
+        test_value = datetime.datetime.now(datetime.timezone.utc)
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -57,7 +62,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(34.65327089723381)
+        test_value = float(26.44582040417354)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -65,7 +70,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateMnwMhw property
         """
-        test_value = 'unjxwgwypgqqjhenavnq'
+        test_value = StateMnwMhwEnum.low
         self.instance.stateMnwMhw = test_value
         self.assertEqual(self.instance.stateMnwMhw, test_value)
     
@@ -73,9 +78,17 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateNswHsw property
         """
-        test_value = 'ojrgzpqqttrzduooguhh'
+        test_value = StateNswHswEnum.normal
         self.instance.stateNswHsw = test_value
         self.assertEqual(self.instance.stateNswHsw, test_value)
+    
+    def test_trend_property(self):
+        """
+        Test trend property
+        """
+        test_value = TrendEnum.VALUE_NEG_1
+        self.instance.trend = test_value
+        self.assertEqual(self.instance.trend, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_statemnwmhwenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_statemnwmhwenum.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+
+
+class Test_StateMnwMhwEnum(unittest.TestCase):
+    """
+    Test case for StateMnwMhwEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateMnwMhwEnum.low
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateMnwMhwEnum
+        """
+        return StateMnwMhwEnum.low
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateMnwMhwEnum.low.value, 'low')
+        self.assertEqual(StateMnwMhwEnum.normal.value, 'normal')
+        self.assertEqual(StateMnwMhwEnum.high.value, 'high')
+        self.assertEqual(StateMnwMhwEnum.unknown.value, 'unknown')
+        self.assertEqual(StateMnwMhwEnum.commented.value, 'commented')
+        self.assertEqual(StateMnwMhwEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_statenswhswenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_statenswhswenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+
+
+class Test_StateNswHswEnum(unittest.TestCase):
+    """
+    Test case for StateNswHswEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateNswHswEnum.normal
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateNswHswEnum
+        """
+        return StateNswHswEnum.normal
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateNswHswEnum.normal.value, 'normal')
+        self.assertEqual(StateNswHswEnum.high.value, 'high')
+        self.assertEqual(StateNswHswEnum.unknown.value, 'unknown')
+        self.assertEqual(StateNswHswEnum.commented.value, 'commented')
+        self.assertEqual(StateNswHswEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_station.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_station.py
@@ -29,14 +29,14 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='ohpvnojepacdxqtxtqrh',
-            number='vkcumjtwgnugocogpuem',
-            shortname='cgendwdskiilccyzruge',
-            longname='fcjrzmnetasdbfwprcud',
-            km=float(82.90445072976947),
-            agency='yxipaucuxtdmgmuwncnh',
-            longitude=float(9.549718525242735),
-            latitude=float(69.4136276017481),
+            station_id='kzdpykbcqqgzvelfnkki',
+            number='dumvaykuwuandljookao',
+            shortname='oniamautigdbzyktuquh',
+            longname='ongbqnrpnntlifcxftod',
+            km=float(48.90586839505602),
+            agency='jcpbfukajbutucymnrbu',
+            longitude=float(31.99545063211955),
+            latitude=float(28.4026986369164),
             water=None
         )
         return instance
@@ -46,7 +46,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'ohpvnojepacdxqtxtqrh'
+        test_value = 'kzdpykbcqqgzvelfnkki'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +54,7 @@ class Test_Station(unittest.TestCase):
         """
         Test number property
         """
-        test_value = 'vkcumjtwgnugocogpuem'
+        test_value = 'dumvaykuwuandljookao'
         self.instance.number = test_value
         self.assertEqual(self.instance.number, test_value)
     
@@ -62,7 +62,7 @@ class Test_Station(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'cgendwdskiilccyzruge'
+        test_value = 'oniamautigdbzyktuquh'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -70,7 +70,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'fcjrzmnetasdbfwprcud'
+        test_value = 'ongbqnrpnntlifcxftod'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     
@@ -78,7 +78,7 @@ class Test_Station(unittest.TestCase):
         """
         Test km property
         """
-        test_value = float(82.90445072976947)
+        test_value = float(48.90586839505602)
         self.instance.km = test_value
         self.assertEqual(self.instance.km, test_value)
     
@@ -86,7 +86,7 @@ class Test_Station(unittest.TestCase):
         """
         Test agency property
         """
-        test_value = 'yxipaucuxtdmgmuwncnh'
+        test_value = 'jcpbfukajbutucymnrbu'
         self.instance.agency = test_value
         self.assertEqual(self.instance.agency, test_value)
     
@@ -94,7 +94,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(9.549718525242735)
+        test_value = float(31.99545063211955)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -102,7 +102,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(69.4136276017481)
+        test_value = float(28.4026986369164)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_trendenum.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_trendenum.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+
+
+class Test_TrendEnum(unittest.TestCase):
+    """
+    Test case for TrendEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = TrendEnum.VALUE_NEG_1
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of TrendEnum
+        """
+        return TrendEnum.VALUE_NEG_1
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(TrendEnum.VALUE_NEG_1.value, -1)
+        self.assertEqual(TrendEnum.VALUE_0.value, 0)
+        self.assertEqual(TrendEnum.VALUE_1.value, 1)

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_water.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_water.py
@@ -28,8 +28,8 @@ class Test_Water(unittest.TestCase):
         Create instance of Water for testing
         """
         instance = Water(
-            shortname='kfxurieejtwkpsiesogs',
-            longname='acrlkridumsgmaemmvye'
+            shortname='lewyhgvqvuqoenxuiwpg',
+            longname='wsrtqiwwtnwxhsovibmi'
         )
         return instance
 
@@ -38,7 +38,7 @@ class Test_Water(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'kfxurieejtwkpsiesogs'
+        test_value = 'lewyhgvqvuqoenxuiwpg'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -46,7 +46,7 @@ class Test_Water(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'acrlkridumsgmaemmvye'
+        test_value = 'wsrtqiwwtnwxhsovibmi'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     

--- a/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/src/pegelonline_mqtt_producer_mqtt_client/client.py
+++ b/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/src/pegelonline_mqtt_producer_mqtt_client/client.py
@@ -187,8 +187,8 @@ def get_default_topic_mappings_de_wsv_pegelonline_mqtt() -> Dict[str, str]:
         Dictionary mapping message identifiers to their default topic patterns.
     """
     return {
-        "de.wsv.pegelonline.mqtt.Station": "de.wsv.pegelonline.mqtt.Station",
-        "de.wsv.pegelonline.mqtt.CurrentMeasurement": "de.wsv.pegelonline.mqtt.CurrentMeasurement",
+        "de.wsv.pegelonline.mqtt.Station": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info",
+        "de.wsv.pegelonline.mqtt.CurrentMeasurement": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level",
     }
 
 
@@ -359,6 +359,7 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
     async def publish_de_wsv_pegelonline_mqtt_station(self,
         feedurl: str,
         station_id: str,
+        water_shortname: str,
         data: pegelonline_mqtt_producer_data.Station,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
@@ -371,17 +372,19 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
         
             feedurl: URI template variable for 'feedurl'
             station_id: URI template variable for 'station_id'
+            water_shortname: URI template variable for 'water_shortname'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'de.wsv.pegelonline.mqtt.Station'
+            topic: Optional topic override. If not provided, uses default topic 'hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "de.wsv.pegelonline.mqtt.Station"
+        target_topic = topic if topic is not None else "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info"
         _topic_template_values: Dict[str, str] = {
             "feedurl": str(feedurl),
             "station_id": str(station_id),
+            "water_shortname": str(water_shortname),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)
@@ -435,6 +438,7 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
     async def publish_de_wsv_pegelonline_mqtt_current_measurement(self,
         feedurl: str,
         station_id: str,
+        water_shortname: str,
         data: pegelonline_mqtt_producer_data.CurrentMeasurement,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
@@ -447,17 +451,19 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
         
             feedurl: URI template variable for 'feedurl'
             station_id: URI template variable for 'station_id'
+            water_shortname: URI template variable for 'water_shortname'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'de.wsv.pegelonline.mqtt.CurrentMeasurement'
+            topic: Optional topic override. If not provided, uses default topic 'hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "de.wsv.pegelonline.mqtt.CurrentMeasurement"
+        target_topic = topic if topic is not None else "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level"
         _topic_template_values: Dict[str, str] = {
             "feedurl": str(feedurl),
             "station_id": str(station_id),
+            "water_shortname": str(water_shortname),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)

--- a/pegelonline/pegelonline_producer/README.md
+++ b/pegelonline/pegelonline_producer/README.md
@@ -147,8 +147,10 @@ Station], Awaitable[None]]
 
 ```
 
-Asynchronous handler hook for `de.wsv.pegelonline.kafka.Station`: PegelOnline station metadata with location and water
-body information.
+Asynchronous handler hook for `de.wsv.pegelonline.kafka.Station`: Reference catalog entry for one WSV PegelOnline gauge
+installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret
+CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API
+v2.
 
 ## Generated Producer Classes
 
@@ -211,8 +213,9 @@ CloudEvent, CurrentMeasurement], Awaitable[None]]
 
 ```
 
-Asynchronous handler hook for `de.wsv.pegelonline.kafka.CurrentMeasurement`: PegelOnline current water level
-measurement.
+Asynchronous handler hook for `de.wsv.pegelonline.kafka.CurrentMeasurement`: Latest 15-minute water-level reading (W
+timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the
+PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.
 
 ## Generated Producer Classes
 
@@ -293,8 +296,10 @@ async def send_de_wsv_pegelonline_kafka_station(
 
 
 
-Send a single `de.wsv.pegelonline.kafka.Station` message. PegelOnline station metadata with location and water body
-information.Args:
+Send a single `de.wsv.pegelonline.kafka.Station` message. Reference catalog entry for one WSV PegelOnline gauge
+installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret
+CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API
+v2.Args:
 
 - `record`: The Kafka record.
 
@@ -419,7 +424,9 @@ async def send_de_wsv_pegelonline_kafka_current_measurement(
 
 
 
-Send a single `de.wsv.pegelonline.kafka.CurrentMeasurement` message. PegelOnline current water level measurement.Args:
+Send a single `de.wsv.pegelonline.kafka.CurrentMeasurement` message. Latest 15-minute water-level reading (W timeseries)
+for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API
+v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.Args:
 
 - `record`: The Kafka record.
 

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/__init__.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import Water, Station, CurrentMeasurement
+from .de import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/__init__.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .wsv import Water, Station, CurrentMeasurement
+from .wsv import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/__init__.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/__init__.py
@@ -1,3 +1,3 @@
-from .pegelonline import Water, Station, CurrentMeasurement
+from .pegelonline import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/__init__.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/__init__.py
@@ -1,5 +1,8 @@
+from .statemnwmhwenum import StateMnwMhwEnum
+from .statenswhswenum import StateNswHswEnum
+from .trendenum import TrendEnum
+from .currentmeasurement import CurrentMeasurement
 from .water import Water
 from .station import Station
-from .currentmeasurement import CurrentMeasurement
 
-__all__ = ["Water", "Station", "CurrentMeasurement"]
+__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/currentmeasurement.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/currentmeasurement.py
@@ -10,29 +10,36 @@ import dataclasses
 from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
 import json
+from pegelonline_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+from pegelonline_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+import datetime
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class CurrentMeasurement:
     """
-    Schema representing the current measurement for a PEGELONLINE station.
+    Latest 15-minute water-level reading for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Carries only the W (water-level) timeseries; other timeseries (Q discharge, LT water temperature) are not emitted by this source.
     
     Attributes:
         station_id (str)
-        timestamp (str)
+        timestamp (datetime.datetime)
         value (float)
-        stateMnwMhw (str)
-        stateNswHsw (str)
+        stateMnwMhw (typing.Optional[StateMnwMhwEnum])
+        stateNswHsw (typing.Optional[StateNswHswEnum])
+        trend (typing.Optional[TrendEnum])
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
-    timestamp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp"))
+    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     value: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value"))
-    stateMnwMhw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
-    stateNswHsw: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    stateMnwMhw: typing.Optional[StateMnwMhwEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateMnwMhw"))
+    stateNswHsw: typing.Optional[StateNswHswEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="stateNswHsw"))
+    trend: typing.Optional[TrendEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="trend"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'CurrentMeasurement':
@@ -159,9 +166,10 @@ class CurrentMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='qefqwtzaqefdfshyllrr',
-            timestamp='gptvzflxeonhrryljmgb',
-            value=float(8.88179384919442),
-            stateMnwMhw='rkehjvbfnxcqkezuwmda',
-            stateNswHsw='eucpxhzikqzwnhelcfuh'
+            station_id='adblcgadkupgfhgurodj',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(6.807940413193414),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/statemnwmhwenum.py
@@ -1,0 +1,48 @@
+from enum import Enum
+
+
+class StateMnwMhwEnum(Enum):
+    """
+    Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values, as computed by the upstream feed. Omitted by upstream when the gauge has no MNW/MHW reference series configured (treat absence as 'unknown').
+    """
+    low = 'low'
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateMnwMhwEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateMnwMhwEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateMnwMhwEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/statenswhswenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/statenswhswenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class StateNswHswEnum(Enum):
+    """
+    Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series — HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown').
+    """
+    normal = 'normal'
+    high = 'high'
+    unknown = 'unknown'
+    commented = 'commented'
+    out_dated = 'out-dated'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StateNswHswEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StateNswHswEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StateNswHswEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/station.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/station.py
@@ -18,14 +18,14 @@ from pegelonline_producer_data.de.wsv.pegelonline.water import Water
 @dataclass
 class Station:
     """
-    Schema representing a PEGELONLINE station with location and water body information.
+    WSV PegelOnline gauge installation. Each instance represents one physical Pegelmessstelle on a federally administered German inland or coastal waterway. Sourced from `GET /stations.json` on the PegelOnline REST API v2 (https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Emitted as reference data at bridge startup and re-emitted periodically.
     
     Attributes:
         station_id (str)
         number (str)
         shortname (str)
         longname (str)
-        km (float)
+        km (typing.Optional[float])
         agency (str)
         longitude (float)
         latitude (float)
@@ -37,7 +37,7 @@ class Station:
     number: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="number"))
     shortname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="shortname"))
     longname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longname"))
-    km: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
+    km: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="km"))
     agency: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="agency"))
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
@@ -168,13 +168,13 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='mrfcihjjrfihrjmamnac',
-            number='urbaadbztraonqqmbfmb',
-            shortname='lreqnymrgdwtomzbjiic',
-            longname='truwphwkdtgsojawpaha',
-            km=float(8.066165175873719),
-            agency='ylvfqnuffyadtobbqnrf',
-            longitude=float(37.718517858588015),
-            latitude=float(65.46958808839561),
+            station_id='axtcvpsuxnojkftuyxih',
+            number='zlgyeivbtobxxgylfgre',
+            shortname='wzxdozkctqeuaxithqhw',
+            longname='ddtqikjhhztnllowlhmd',
+            km=float(30.03655535823242),
+            agency='ofjqnqpklaykrkfibgru',
+            longitude=float(24.732418665915425),
+            latitude=float(66.03976113877803),
             water=None
         )

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/trendenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/trendenum.py
@@ -1,0 +1,45 @@
+from enum import IntEnum
+
+
+class TrendEnum(IntEnum):
+    """
+    Short-term trend of the water level relative to the previous reading, as classified by the upstream feed. First-class signal for flood-monitoring dashboards. Sourced from the upstream `trend` field; omitted when upstream cannot compute a trend (e.g. first reading after a gap).
+    """
+    VALUE_NEG_1 = -1
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'TrendEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'TrendEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (TrendEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/water.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/src/pegelonline_producer_data/de/wsv/pegelonline/water.py
@@ -17,7 +17,7 @@ import json
 @dataclass
 class Water:
     """
-    Details of the water body associated with the station.
+    Federal waterway / water body the gauge measures, as returned in the nested `water` object of `GET /stations.json` on the PegelOnline REST API v2. Acts as the routing hierarchy for the MQTT Unified Namespace topology.
     
     Attributes:
         shortname (str)
@@ -153,6 +153,6 @@ class Water:
             An instance of the dataclass.
         """
         return cls(
-            shortname='ivwwawxttykdqwdjjuln',
-            longname='dcwfwzhnxwgeudjpczgf'
+            shortname='tktitqguvpexhdckrzpw',
+            longname='ehpfcavnivhgkceagdvd'
         )

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_currentmeasurement.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_currentmeasurement.py
@@ -9,6 +9,10 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from pegelonline_producer_data.de.wsv.pegelonline.currentmeasurement import CurrentMeasurement
+from pegelonline_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+from pegelonline_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+import datetime
 
 
 class Test_CurrentMeasurement(unittest.TestCase):
@@ -28,11 +32,12 @@ class Test_CurrentMeasurement(unittest.TestCase):
         Create instance of CurrentMeasurement for testing
         """
         instance = CurrentMeasurement(
-            station_id='qefqwtzaqefdfshyllrr',
-            timestamp='gptvzflxeonhrryljmgb',
-            value=float(8.88179384919442),
-            stateMnwMhw='rkehjvbfnxcqkezuwmda',
-            stateNswHsw='eucpxhzikqzwnhelcfuh'
+            station_id='adblcgadkupgfhgurodj',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            value=float(6.807940413193414),
+            stateMnwMhw=StateMnwMhwEnum.low,
+            stateNswHsw=StateNswHswEnum.normal,
+            trend=TrendEnum.VALUE_NEG_1
         )
         return instance
 
@@ -41,7 +46,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'qefqwtzaqefdfshyllrr'
+        test_value = 'adblcgadkupgfhgurodj'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -49,7 +54,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'gptvzflxeonhrryljmgb'
+        test_value = datetime.datetime.now(datetime.timezone.utc)
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -57,7 +62,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(8.88179384919442)
+        test_value = float(6.807940413193414)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -65,7 +70,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateMnwMhw property
         """
-        test_value = 'rkehjvbfnxcqkezuwmda'
+        test_value = StateMnwMhwEnum.low
         self.instance.stateMnwMhw = test_value
         self.assertEqual(self.instance.stateMnwMhw, test_value)
     
@@ -73,9 +78,17 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test stateNswHsw property
         """
-        test_value = 'eucpxhzikqzwnhelcfuh'
+        test_value = StateNswHswEnum.normal
         self.instance.stateNswHsw = test_value
         self.assertEqual(self.instance.stateNswHsw, test_value)
+    
+    def test_trend_property(self):
+        """
+        Test trend property
+        """
+        test_value = TrendEnum.VALUE_NEG_1
+        self.instance.trend = test_value
+        self.assertEqual(self.instance.trend, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_statemnwmhwenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_statemnwmhwenum.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+
+
+class Test_StateMnwMhwEnum(unittest.TestCase):
+    """
+    Test case for StateMnwMhwEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateMnwMhwEnum.low
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateMnwMhwEnum
+        """
+        return StateMnwMhwEnum.low
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateMnwMhwEnum.low.value, 'low')
+        self.assertEqual(StateMnwMhwEnum.normal.value, 'normal')
+        self.assertEqual(StateMnwMhwEnum.high.value, 'high')
+        self.assertEqual(StateMnwMhwEnum.unknown.value, 'unknown')
+        self.assertEqual(StateMnwMhwEnum.commented.value, 'commented')
+        self.assertEqual(StateMnwMhwEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_statenswhswenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_statenswhswenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
+
+
+class Test_StateNswHswEnum(unittest.TestCase):
+    """
+    Test case for StateNswHswEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StateNswHswEnum.normal
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StateNswHswEnum
+        """
+        return StateNswHswEnum.normal
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StateNswHswEnum.normal.value, 'normal')
+        self.assertEqual(StateNswHswEnum.high.value, 'high')
+        self.assertEqual(StateNswHswEnum.unknown.value, 'unknown')
+        self.assertEqual(StateNswHswEnum.commented.value, 'commented')
+        self.assertEqual(StateNswHswEnum.out_dated.value, 'out-dated')

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_station.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_station.py
@@ -29,14 +29,14 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='mrfcihjjrfihrjmamnac',
-            number='urbaadbztraonqqmbfmb',
-            shortname='lreqnymrgdwtomzbjiic',
-            longname='truwphwkdtgsojawpaha',
-            km=float(8.066165175873719),
-            agency='ylvfqnuffyadtobbqnrf',
-            longitude=float(37.718517858588015),
-            latitude=float(65.46958808839561),
+            station_id='axtcvpsuxnojkftuyxih',
+            number='zlgyeivbtobxxgylfgre',
+            shortname='wzxdozkctqeuaxithqhw',
+            longname='ddtqikjhhztnllowlhmd',
+            km=float(30.03655535823242),
+            agency='ofjqnqpklaykrkfibgru',
+            longitude=float(24.732418665915425),
+            latitude=float(66.03976113877803),
             water=None
         )
         return instance
@@ -46,7 +46,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'mrfcihjjrfihrjmamnac'
+        test_value = 'axtcvpsuxnojkftuyxih'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +54,7 @@ class Test_Station(unittest.TestCase):
         """
         Test number property
         """
-        test_value = 'urbaadbztraonqqmbfmb'
+        test_value = 'zlgyeivbtobxxgylfgre'
         self.instance.number = test_value
         self.assertEqual(self.instance.number, test_value)
     
@@ -62,7 +62,7 @@ class Test_Station(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'lreqnymrgdwtomzbjiic'
+        test_value = 'wzxdozkctqeuaxithqhw'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -70,7 +70,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'truwphwkdtgsojawpaha'
+        test_value = 'ddtqikjhhztnllowlhmd'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     
@@ -78,7 +78,7 @@ class Test_Station(unittest.TestCase):
         """
         Test km property
         """
-        test_value = float(8.066165175873719)
+        test_value = float(30.03655535823242)
         self.instance.km = test_value
         self.assertEqual(self.instance.km, test_value)
     
@@ -86,7 +86,7 @@ class Test_Station(unittest.TestCase):
         """
         Test agency property
         """
-        test_value = 'ylvfqnuffyadtobbqnrf'
+        test_value = 'ofjqnqpklaykrkfibgru'
         self.instance.agency = test_value
         self.assertEqual(self.instance.agency, test_value)
     
@@ -94,7 +94,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(37.718517858588015)
+        test_value = float(24.732418665915425)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -102,7 +102,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(65.46958808839561)
+        test_value = float(66.03976113877803)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_trendenum.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_trendenum.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from pegelonline_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+
+
+class Test_TrendEnum(unittest.TestCase):
+    """
+    Test case for TrendEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = TrendEnum.VALUE_NEG_1
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of TrendEnum
+        """
+        return TrendEnum.VALUE_NEG_1
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(TrendEnum.VALUE_NEG_1.value, -1)
+        self.assertEqual(TrendEnum.VALUE_0.value, 0)
+        self.assertEqual(TrendEnum.VALUE_1.value, 1)

--- a/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_water.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_data/tests/test_water.py
@@ -28,8 +28,8 @@ class Test_Water(unittest.TestCase):
         Create instance of Water for testing
         """
         instance = Water(
-            shortname='ivwwawxttykdqwdjjuln',
-            longname='dcwfwzhnxwgeudjpczgf'
+            shortname='tktitqguvpexhdckrzpw',
+            longname='ehpfcavnivhgkceagdvd'
         )
         return instance
 
@@ -38,7 +38,7 @@ class Test_Water(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'ivwwawxttykdqwdjjuln'
+        test_value = 'tktitqguvpexhdckrzpw'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -46,7 +46,7 @@ class Test_Water(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'dcwfwzhnxwgeudjpczgf'
+        test_value = 'ehpfcavnivhgkceagdvd'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     

--- a/pegelonline/pegelonline_producer/pegelonline_producer_kafka_producer/tests/test_producer.py
+++ b/pegelonline/pegelonline_producer/pegelonline_producer_kafka_producer/tests/test_producer.py
@@ -180,3 +180,60 @@ def test_de_wsv_pegelonline_kafka_dewsvpegelonlinekafkacurrentmeasurement(kafka_
         expected_key = "{station_id}".format(station_id=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
     consumer.close()
+
+
+def test_de_wsv_pegelonline_kafka_cross_event_type_kafka_key(kafka_emulator):
+    """Test that different event types in De.Wsv.Pegelonline.Kafka produce the same Kafka key for the same placeholder values"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_de_wsv_pegelonline_kafka_cross_key',
+        'auto.offset.reset': 'latest'
+    })
+    consumer.subscribe([topic])
+
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    # Drain any pre-existing messages before producing our test messages
+    drain_timeout = time.time() + 3
+    while time.time() < drain_timeout:
+        msg = consumer.poll(0.5)
+    time.sleep(1)
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = DeWsvPegelonlineKafkaEventProducer(kafka_producer, topic, 'binary')
+
+    shared_key_value = "shared_entity_42"
+    data1 = Test_Station.create_instance()
+    data2 = Test_CurrentMeasurement.create_instance()
+
+    producer_instance.send_de_wsv_pegelonline_kafka_station(_feedurl = shared_key_value, _station_id = shared_key_value, data = data1)
+    producer_instance.send_de_wsv_pegelonline_kafka_current_measurement(_feedurl = shared_key_value, _station_id = shared_key_value, data = data2)
+    kafka_producer.flush(timeout=5.0)
+
+    # Collect keys from both messages
+    collected_keys = []
+    timeout = time.time() + 20
+    while len(collected_keys) < 2 and time.time() < timeout:
+        msg = consumer.poll(1.0)
+        if msg is None or msg.error():
+            continue
+        cloudevent = parse_cloudevent(msg)
+        if cloudevent['type'] in ["de.wsv.pegelonline.kafka.Station", "de.wsv.pegelonline.kafka.CurrentMeasurement"]:
+            key = msg.key().decode('utf-8') if msg.key() else None
+            collected_keys.append(key)
+
+    assert len(collected_keys) == 2, f"Expected 2 messages but received {len(collected_keys)}"
+    assert collected_keys[0] == collected_keys[1], \
+        f"Expected same Kafka key for different event types but got '{collected_keys[0]}' and '{collected_keys[1]}'"
+    expected_key = "{station_id}".format(station_id=shared_key_value)
+    assert collected_keys[0] == expected_key, \
+        f"Expected Kafka key '{expected_key}' but got '{collected_keys[0]}'"
+    consumer.close()

--- a/pegelonline/xreg/pegelonline.xreg.json
+++ b/pegelonline/xreg/pegelonline.xreg.json
@@ -13,7 +13,8 @@
       "protocoloptions": {
         "deployed": false,
         "options": {
-          "topic": "pegelonline"
+          "topic": "pegelonline",
+          "key": "{station_id}"
         }
       },
       "messagegroups": [
@@ -69,7 +70,7 @@
         "de.wsv.pegelonline.Station": {
           "name": "Station",
           "envelope": "CloudEvents/1.0",
-          "description": "PegelOnline station metadata with location and water body information.",
+          "description": "Reference catalog entry for one WSV PegelOnline gauge installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API v2.",
           "envelopemetadata": {
             "type": {
               "value": "de.wsv.pegelonline.Station"
@@ -89,7 +90,7 @@
         "de.wsv.pegelonline.CurrentMeasurement": {
           "name": "CurrentMeasurement",
           "envelope": "CloudEvents/1.0",
-          "description": "PegelOnline current water level measurement.",
+          "description": "Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.",
           "envelopemetadata": {
             "type": {
               "value": "de.wsv.pegelonline.CurrentMeasurement"
@@ -145,21 +146,9 @@
           "basemessageurl": "/messagegroups/de.wsv.pegelonline/messages/de.wsv.pegelonline.Station",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "properties": {
-              "topic": {
-                "type": "uritemplate",
-                "value": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info",
-                "description": "Unified Namespace topic carrying the station's identity and location as a retained last-known-value."
-              },
-              "qos": {
-                "type": "integer",
-                "value": 1
-              },
-              "retain": {
-                "type": "boolean",
-                "value": true
-              }
-            }
+            "topic_name": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info",
+            "qos": 1,
+            "retain": true
           }
         },
         "de.wsv.pegelonline.mqtt.CurrentMeasurement": {
@@ -167,27 +156,15 @@
           "basemessageurl": "/messagegroups/de.wsv.pegelonline/messages/de.wsv.pegelonline.CurrentMeasurement",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "properties": {
-              "topic": {
-                "type": "uritemplate",
-                "value": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level",
-                "description": "Unified Namespace topic carrying the station's latest water-level measurement as a retained last-known-value."
-              },
-              "qos": {
-                "type": "integer",
-                "value": 1
-              },
-              "retain": {
-                "type": "boolean",
-                "value": true
-              }
-            }
+            "topic_name": "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level",
+            "qos": 1,
+            "retain": true
           }
         }
       }
     },
     "de.wsv.pegelonline.amqp": {
-      "description": "AMQP 1.0 transport variants of the PegelOnline CloudEvents, sent in binary CloudEvents mode to a single AMQP node ('pegelonline') — works with generic brokers (ActiveMQ, RabbitMQ AMQP 1.0 plugin) and with Azure Service Bus / Event Hubs via CBS + Entra ID.",
+      "description": "AMQP 1.0 transport variants of the PegelOnline CloudEvents, sent in binary CloudEvents mode to a single AMQP node ('pegelonline') — works with generic brokers (ActiveMQ Artemis, RabbitMQ AMQP 1.0 plugin, Qpid Dispatch) and with Azure Service Bus / Event Hubs via CBS + Entra ID or SAS-token. Routing key is the CloudEvent subject (`{station_id}`); per-waterway routing is exposed as the `water_shortname` AMQP application property so brokers and SB/EH subscription filters can route without cracking the JSON body.",
       "messages": {
         "de.wsv.pegelonline.amqp.Station": {
           "name": "Station",
@@ -203,8 +180,9 @@
             },
             "application_properties": {
               "water_shortname": {
-                "type": "string",
-                "description": "Lowercase ASCII water-body shortname (e.g. 'rhein'); copied here so message routers/filters don't have to crack the JSON body."
+                "type": "uritemplate",
+                "value": "{water_shortname}",
+                "description": "Lowercase ASCII water-body shortname (e.g. 'rhein'); supplied by the bridge from the station catalog so message routers / filters can route by waterway without cracking the JSON body."
               }
             }
           }
@@ -223,8 +201,9 @@
             },
             "application_properties": {
               "water_shortname": {
-                "type": "string",
-                "description": "Lowercase ASCII water-body shortname (e.g. 'rhein'); copied here so message routers/filters don't have to crack the JSON body."
+                "type": "uritemplate",
+                "value": "{water_shortname}",
+                "description": "Lowercase ASCII water-body shortname (e.g. 'rhein'); supplied by the bridge from the station catalog so message routers / filters can route by waterway without cracking the JSON body."
               }
             }
           }
@@ -243,8 +222,13 @@
             "1": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$schema": "https://json-structure.org/meta/core/v0/#",
-                "$id": "https://example.com/schemas/de/wsv/pegelonline/Station",
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://schemas.real-time-sources.dev/de/wsv/pegelonline/Station/v1",
+                "$uses": [
+                  "JSONStructureUnits",
+                  "JSONStructureAlternateNames",
+                  "JSONStructureValidation"
+                ],
                 "name": "Station",
                 "$root": "#/definitions/de/wsv/pegelonline/Station",
                 "definitions": {
@@ -254,59 +238,75 @@
                         "Water": {
                           "name": "Water",
                           "type": "object",
+                          "description": "Federal waterway / water body the gauge measures, as returned in the nested `water` object of `GET /stations.json` on the PegelOnline REST API v2. Acts as the routing hierarchy for the MQTT Unified Namespace topology.",
                           "properties": {
                             "shortname": {
                               "type": "string",
-                              "description": "Short name of the water body (maximum 40 characters)."
+                              "description": "Lowercase routing token for the waterway as published by WSV — e.g. 'rhein', 'elbe', 'donau', 'mosel'. Used (after ASCII-normalization for non-ASCII characters such as 'ß' → 'ss' or umlauts) as the `{water_shortname}` template variable on the MQTT topic and the AMQP application property. Sourced from the upstream `water.shortname` key. Maximum 40 characters."
                             },
                             "longname": {
                               "type": "string",
-                              "description": "Full name of the water body (maximum 255 characters)."
+                              "description": "Canonical uppercase WSV name of the waterway (e.g. 'RHEIN', 'ELBE') as published in official German hydrology bulletins. Sourced from the upstream `water.longname` key. Maximum 255 characters."
                             }
                           },
                           "required": [
                             "shortname",
                             "longname"
-                          ],
-                          "description": "Details of the water body associated with the station."
+                          ]
                         },
                         "Station": {
                           "name": "Station",
                           "type": "object",
+                          "description": "WSV PegelOnline gauge installation. Each instance represents one physical Pegelmessstelle on a federally administered German inland or coastal waterway. Sourced from `GET /stations.json` on the PegelOnline REST API v2 (https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Emitted as reference data at bridge startup and re-emitted periodically.",
                           "properties": {
                             "station_id": {
                               "type": "string",
-                              "description": "Unique immutable identifier of the station."
+                              "altnames": {
+                                "json": "uuid"
+                              },
+                              "description": "Stable UUID assigned by WSV to identify the gauge installation; persists across station renaming, relocation within the same Pegelmessstelle, and timeseries reconfiguration. Sourced from the upstream `uuid` field. Used as the CloudEvents `subject`, the Kafka partition key, the MQTT topic `{station_id}` segment, and the AMQP message subject for every event emitted by this source."
                             },
                             "number": {
                               "type": "string",
-                              "description": "Station number representing the unique code of the station."
+                              "pattern": "^[0-9]+$",
+                              "description": "Official PegelOnline station number. Carries multiple agency-scoped numbering schemes within the same field: WSV Pegelmessstellennummer (6–8 digits) for German federal gauges; partner-agency identifiers such as Austrian via-donau station numbers (4–5 digits), small Regierungspräsidium-IDs for Bodensee gauges (3-digit numbers e.g. '906' KONSTANZ), and German state-agency IDs (e.g. Ruhrverband 13-digit Messstellennummer). Numeric-only across all observed providers; length is provider-specific. National / agency-scoped identifier — not globally unique across data providers; prefer `station_id` (UUID) for cross-system joins."
                             },
                             "shortname": {
                               "type": "string",
-                              "description": "Short name of the station (maximum 40 characters)."
+                              "description": "Operator-assigned display label for the gauge (≤40 characters). May differ from the town name when multiple gauges share a town. Mutable — do not use as a routing key or stable identifier."
                             },
                             "longname": {
                               "type": "string",
-                              "description": "Full name of the station (maximum 255 characters)."
+                              "description": "Canonical gauge name as used in WSV publications (≤255 characters). Mutable — do not use as a routing key."
                             },
                             "km": {
                               "type": "double",
-                              "description": "River kilometer marking of the station location."
+                              "unit": "km",
+                              "symbol": "km",
+                              "description": "Position along the federal waterway expressed as river-kilometre downstream from the waterway's official origin (e.g. Rhine-km 0 at the Old Rhine Bridge in Konstanz). The decimal fraction is the hectometre offset within the kilometre. Negative values occur on tributaries where the kilometre count is measured upstream from a confluence (e.g. Ohře gauge LOUNY at km -61.4 of the Elbe/Ohře system). **Optional**: absent or null for tidal / coastal gauges (Küstenpegel on the North Sea and Baltic) and for waterways without a kilometre reference. Sourced from the upstream `km` field. Unit: km."
                             },
                             "agency": {
                               "type": "string",
-                              "description": "Waterways and Shipping Office responsible for the station."
+                              "description": "Free-form name of the Wasserstraßen- und Schifffahrtsamt (WSA) operating the gauge — e.g. 'WSA RHEIN', 'WSA ELBE'. Sourced from the upstream `agency` field. Provided so downstream consumers can attribute observations to the operating authority; not a stable identifier and not suitable as a routing key."
                             },
                             "longitude": {
                               "type": "double",
-                              "description": "Longitude coordinate of the station in WGS84 decimal notation."
+                              "unit": "deg",
+                              "symbol": "°",
+                              "minimum": -180,
+                              "maximum": 180,
+                              "description": "WGS84 decimal-degree longitude of the gauge installation; positive east of the prime meridian. Surveyed to the gauge structure, not to the river centreline. Sourced from the upstream `longitude` field."
                             },
                             "latitude": {
                               "type": "double",
-                              "description": "Latitude coordinate of the station in WGS84 decimal notation."
+                              "unit": "deg",
+                              "symbol": "°",
+                              "minimum": -90,
+                              "maximum": 90,
+                              "description": "WGS84 decimal-degree latitude of the gauge installation; positive north of the equator. Surveyed to the gauge structure, not to the river centreline. Sourced from the upstream `latitude` field."
                             },
                             "water": {
+                              "description": "Federal waterway the gauge measures. See the nested Water schema for routing semantics.",
                               "type": {
                                 "$ref": "#/definitions/de/wsv/pegelonline/Water"
                               }
@@ -317,13 +317,11 @@
                             "number",
                             "shortname",
                             "longname",
-                            "km",
                             "agency",
                             "longitude",
                             "latitude",
                             "water"
-                          ],
-                          "description": "Schema representing a PEGELONLINE station with location and water body information."
+                          ]
                         }
                       }
                     }
@@ -341,8 +339,13 @@
             "1": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$schema": "https://json-structure.org/meta/core/v0/#",
-                "$id": "https://example.com/schemas/de/wsv/pegelonline/CurrentMeasurement",
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://schemas.real-time-sources.dev/de/wsv/pegelonline/CurrentMeasurement/v1",
+                "$uses": [
+                  "JSONStructureUnits",
+                  "JSONStructureAlternateNames",
+                  "JSONStructureValidation"
+                ],
                 "name": "CurrentMeasurement",
                 "$root": "#/definitions/de/wsv/pegelonline/CurrentMeasurement",
                 "definitions": {
@@ -352,36 +355,91 @@
                         "CurrentMeasurement": {
                           "name": "CurrentMeasurement",
                           "type": "object",
+                          "description": "Latest 15-minute water-level reading for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Carries only the W (water-level) timeseries; other timeseries (Q discharge, LT water temperature) are not emitted by this source.",
                           "properties": {
                             "station_id": {
                               "type": "string",
-                              "description": "Unique immutable identifier of the station."
+                              "altnames": {
+                                "json": "uuid"
+                              },
+                              "description": "Stable UUID of the gauge this reading was taken at. References the `station_id` of the corresponding Station reference event. Used as the CloudEvents `subject` and the Kafka partition key so all readings for a given gauge land on the same partition / topic key."
                             },
                             "timestamp": {
-                              "type": "string",
-                              "description": "Timestamp of the current measurement encoded in ISO_8601 format."
+                              "type": "datetime",
+                              "description": "Wall-clock time the upstream reading was taken, in ISO 8601 / RFC 3339 with an explicit UTC offset. PegelOnline publishes the value in Europe/Berlin local time, so the offset shifts between `+01:00` (CET) and `+02:00` (CEST) across the DST boundary — preserve the offset when storing. Sourced from the upstream `timestamp` field."
                             },
                             "value": {
                               "type": "double",
-                              "description": "Current measured value as a decimal number in the unit defined by the station's timeseries."
+                              "unit": "cm",
+                              "symbol": "cm",
+                              "minimum": -1000,
+                              "maximum": 2500,
+                              "description": "Water-level reading on the W (water-level) timeseries, in centimetres above the gauge's Pegelnullpunkt (PNP — a geodetically fixed datum specific to each gauge, see https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Typical operational range is 0–1500 cm; flood events at major Rhine gauges can exceed 1000 cm. Negative readings are valid at gauges whose normal pool is below PNP (e.g. tidal Elbe at low water). Unit: cm."
                             },
                             "stateMnwMhw": {
                               "type": "string",
-                              "description": "State of the current water level compared to mean low water (MNW) and mean high water (MHW). Possible values: 'low', 'normal', 'high', 'unknown', 'commented', 'out-dated'."
+                              "enum": [
+                                "low",
+                                "normal",
+                                "high",
+                                "unknown",
+                                "commented",
+                                "out-dated"
+                              ],
+                              "altenums": {
+                                "lang:en": {
+                                  "low": "Below the gauge's mean low water (MNW) reference",
+                                  "normal": "Between MNW and the gauge's mean high water (MHW) reference",
+                                  "high": "Above MHW",
+                                  "unknown": "MNW/MHW reference values are not configured for this station",
+                                  "commented": "Value carries an operator comment overriding the automatic classification",
+                                  "out-dated": "Reading is stale relative to the gauge's configured freshness window (typically 90 minutes) — do not treat as authoritative"
+                                }
+                              },
+                              "description": "Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values, as computed by the upstream feed. Omitted by upstream when the gauge has no MNW/MHW reference series configured (treat absence as 'unknown')."
                             },
                             "stateNswHsw": {
                               "type": "string",
-                              "description": "State of the current water level compared to the highest navigable water level (HSW). Possible values: 'normal', 'high', 'unknown', 'commented', 'out-dated'."
+                              "enum": [
+                                "normal",
+                                "high",
+                                "unknown",
+                                "commented",
+                                "out-dated"
+                              ],
+                              "altenums": {
+                                "lang:en": {
+                                  "normal": "Below the highest navigable water level (HSW / Höchster Schifffahrtswasserstand)",
+                                  "high": "At or above HSW — navigation typically suspended on the affected reach",
+                                  "unknown": "HSW reference value is not configured for this station",
+                                  "commented": "Value carries an operator comment overriding the automatic classification",
+                                  "out-dated": "Reading is stale relative to the gauge's configured freshness window"
+                                }
+                              },
+                              "description": "Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series — HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown')."
+                            },
+                            "trend": {
+                              "type": ["int8", "null"],
+                              "enum": [
+                                -1,
+                                0,
+                                1
+                              ],
+                              "altenums": {
+                                "lang:en": {
+                                  "-1": "Falling — current value is below the previous reading",
+                                  "0": "Steady — within the upstream classification's noise band of the previous reading",
+                                  "1": "Rising — current value is above the previous reading"
+                                }
+                              },
+                              "description": "Short-term trend of the water level relative to the previous reading, as classified by the upstream feed. First-class signal for flood-monitoring dashboards. Sourced from the upstream `trend` field; omitted when upstream cannot compute a trend (e.g. first reading after a gap)."
                             }
                           },
                           "required": [
                             "station_id",
                             "timestamp",
-                            "value",
-                            "stateMnwMhw",
-                            "stateNswHsw"
-                          ],
-                          "description": "Schema representing the current measurement for a PEGELONLINE station."
+                            "value"
+                          ]
                         }
                       }
                     }
@@ -403,64 +461,69 @@
                 "type": "record",
                 "name": "Station",
                 "namespace": "de.wsv.pegelonline",
-                "doc": "Schema representing a PEGELONLINE station with location and water body information.",
+                "doc": "WSV PegelOnline gauge installation. Each record represents one physical Pegelmessstelle on a federally administered German inland or coastal waterway. Sourced from GET /stations.json on the PegelOnline REST API v2. Emitted as reference data at bridge startup and re-emitted periodically. Avro mirror of the JsonStructure Station schema — keep field semantics in sync.",
                 "fields": [
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Unique immutable identifier of the station."
+                    "doc": "Stable UUID assigned by WSV to identify the gauge installation; persists across renaming, relocation, and timeseries reconfiguration. Sourced from the upstream 'uuid' field. Used as the CloudEvents subject and the Kafka partition key."
                   },
                   {
                     "name": "number",
                     "type": "string",
-                    "doc": "Station number representing the unique code of the station."
+                    "doc": "Official WSV Pegelmessstellennummer (6-8 digit numeric identifier) used in published German hydrology bulletins. National identifier only - not globally unique outside Germany; prefer station_id for joins."
                   },
                   {
                     "name": "shortname",
                     "type": "string",
-                    "doc": "Short name of the station (maximum 40 characters)."
+                    "doc": "Operator-assigned display label for the gauge (<=40 characters). May differ from the town name when multiple gauges share a town. Mutable - do not use as a routing key or stable identifier."
                   },
                   {
                     "name": "longname",
                     "type": "string",
-                    "doc": "Full name of the station (maximum 255 characters)."
+                    "doc": "Canonical gauge name as used in WSV publications (<=255 characters). Mutable - do not use as a routing key."
                   },
                   {
                     "name": "km",
-                    "type": "double",
-                    "doc": "River kilometer marking of the station location."
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
+                    "doc": "Position along the federal waterway expressed as river-kilometre downstream from the waterway's official origin (e.g. Rhine-km 0 at the Old Rhine Bridge in Konstanz). Decimal fraction is the hectometre offset within the km. Null for tidal / coastal gauges and for waterways without a km reference. Unit: km."
                   },
                   {
                     "name": "agency",
                     "type": "string",
-                    "doc": "Waterways and Shipping Office responsible for the station."
+                    "doc": "Free-form name of the Wasserstrassen- und Schifffahrtsamt (WSA) operating the gauge - e.g. 'WSA RHEIN', 'WSA ELBE'. Sourced from the upstream 'agency' field. Not a stable identifier and not suitable as a routing key."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "Longitude coordinate of the station in WGS84 decimal notation."
+                    "doc": "WGS84 decimal-degree longitude of the gauge installation; positive east of the prime meridian, range -180..180. Surveyed to the gauge structure, not to the river centreline. Unit: degrees."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "Latitude coordinate of the station in WGS84 decimal notation."
+                    "doc": "WGS84 decimal-degree latitude of the gauge installation; positive north of the equator, range -90..90. Surveyed to the gauge structure, not to the river centreline. Unit: degrees."
                   },
                   {
                     "name": "water",
+                    "doc": "Federal waterway the gauge measures, sourced from the upstream nested 'water' object. Acts as the routing hierarchy for the MQTT Unified Namespace topology.",
                     "type": {
                       "type": "record",
                       "name": "Water",
-                      "doc": "Details of the water body associated with the station.",
+                      "doc": "Federal waterway / water body the gauge measures, as returned in the nested 'water' object of GET /stations.json.",
                       "fields": [
                         {
                           "name": "shortname",
                           "type": "string",
-                          "doc": "Short name of the water body (maximum 40 characters)."
+                          "doc": "Lowercase routing token for the waterway as published by WSV - e.g. 'rhein', 'elbe', 'donau', 'mosel'. Used (after ASCII normalization) as the {water_shortname} template variable on the MQTT topic and the AMQP application property. Sourced from the upstream water.shortname key. Maximum 40 characters."
                         },
                         {
                           "name": "longname",
                           "type": "string",
-                          "doc": "Full name of the water body (maximum 255 characters)."
+                          "doc": "Canonical uppercase WSV name of the waterway (e.g. 'RHEIN', 'ELBE') as published in official German hydrology bulletins. Sourced from the upstream water.longname key. Maximum 255 characters."
                         }
                       ]
                     }
@@ -479,32 +542,75 @@
                 "type": "record",
                 "name": "CurrentMeasurement",
                 "namespace": "de.wsv.pegelonline",
-                "doc": "Schema representing the current measurement for a PEGELONLINE station.",
+                "doc": "Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from GET /stations/{uuid}/W/currentmeasurement.json on the PegelOnline REST API v2. Avro mirror of the JsonStructure CurrentMeasurement schema - keep field semantics in sync.",
                 "fields": [
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Unique immutable identifier of the station."
+                    "doc": "Stable UUID of the gauge this reading was taken at. References the station_id of the corresponding Station reference event. Sourced from the upstream 'uuid' field."
                   },
                   {
                     "name": "timestamp",
-                    "type": "string",
-                    "doc": "Timestamp of the current measurement encoded in ISO_8601 format."
+                    "type": {
+                      "type": "long",
+                      "logicalType": "timestamp-millis"
+                    },
+                    "doc": "Wall-clock time the upstream reading was taken, encoded here as Unix milliseconds since 1970-01-01T00:00:00Z. PegelOnline publishes the value as ISO 8601 with an explicit Europe/Berlin offset (CET +01:00 / CEST +02:00); the bridge converts to UTC milliseconds for Avro encoding."
                   },
                   {
                     "name": "value",
                     "type": "double",
-                    "doc": "Current measured value as a decimal number in the unit defined by the station's timeseries."
+                    "doc": "Water-level reading on the W timeseries, in centimetres above the gauge's Pegelnullpunkt (PNP - a geodetically fixed datum specific to each gauge). Typical operational range 0..1500 cm; flood events at major Rhine gauges exceed 1000 cm. Negative readings are valid at gauges whose normal pool is below PNP. Unit: cm."
                   },
                   {
                     "name": "stateMnwMhw",
-                    "type": "string",
-                    "doc": "State of the current water level compared to mean low water (MNW) and mean high water (MHW). Possible values: 'low', 'normal', 'high', 'unknown', 'commented', 'out-dated'."
+                    "type": [
+                      "null",
+                      {
+                        "type": "enum",
+                        "name": "StateMnwMhw",
+                        "doc": "Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values. Symbol 'out_dated' corresponds to the upstream label 'out-dated'.",
+                        "symbols": [
+                          "low",
+                          "normal",
+                          "high",
+                          "unknown",
+                          "commented",
+                          "out_dated"
+                        ]
+                      }
+                    ],
+                    "default": null,
+                    "doc": "MNW/MHW classification as computed by the upstream feed. Null when the gauge has no MNW/MHW reference series configured. Symbol 'out_dated' means the reading is stale relative to the gauge's freshness window (typically 90 minutes) - do not treat as authoritative."
                   },
                   {
                     "name": "stateNswHsw",
-                    "type": "string",
-                    "doc": "State of the current water level compared to the highest navigable water level (HSW). Possible values: 'normal', 'high', 'unknown', 'commented', 'out-dated'."
+                    "type": [
+                      "null",
+                      {
+                        "type": "enum",
+                        "name": "StateNswHsw",
+                        "doc": "Categorical classification of the current water level against the highest navigable water level (HSW / Hoechster Schifffahrtswasserstand). Symbol 'out_dated' corresponds to the upstream label 'out-dated'.",
+                        "symbols": [
+                          "normal",
+                          "high",
+                          "unknown",
+                          "commented",
+                          "out_dated"
+                        ]
+                      }
+                    ],
+                    "default": null,
+                    "doc": "HSW classification as computed by the upstream feed - drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Null when the gauge has no HSW reference. Upstream never emits 'low' on this series; HSW is an upper bound only."
+                  },
+                  {
+                    "name": "trend",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null,
+                    "doc": "Short-term trend of the water level relative to the previous reading: -1 falling, 0 steady, +1 rising. Sourced from the upstream 'trend' field. Null when upstream cannot compute a trend (e.g. first reading after a gap)."
                   }
                 ]
               }

--- a/tools/require-xrcg.ps1
+++ b/tools/require-xrcg.ps1
@@ -1,4 +1,4 @@
-$script:RequiredXrcgVersion = '0.10.5'
+$script:RequiredXrcgVersion = '0.10.6'
 
 function Assert-XrcgVersion {
     param(


### PR DESCRIPTION
Follow-up to merged #340. Four commits that were pushed to the branch after #340 squash-merged and therefore never ran CI / never reached main:

- `a7705e4e` skill: feeder-release-checklist as a hard pre-merge gate (Avro+JsonStructure parity, exhaustive docs on every record/field/enum, deploy-button coverage).
- `5aa1e43a` fix(pegelonline): contract rewrite per specialist review — units, altnames, datetime, enums, exhaustive docs, Avro parity; bridges updated (`km` optional, `state*` nullable, `trend` added, AMQP bridge passes `_water_shortname`); CONTAINER.md SAS env-var rows; `tools/require-xrcg.ps1` bumped to 0.10.6. Real-world data made the original constraints too strict — `number` pattern widened to `^[0-9]+\$` (real data spans 3-digit Bodensee Regierungspräsidium IDs through 13-digit Ruhrverband IDs); `km.minimum: 0` removed (tributaries measure upstream from confluence, e.g. LOUNY -61.4 on Ohře); `trend` typed nullable (upstream emits null after gaps). Also fixed MQTT messagegroup to use xrcg 0.10.3's flat `topic_name` form — old nested `protocoloptions.properties.topic.value` was silently treated as message-id and never extracted the `water_shortname` placeholder. Restored `application_properties.water_shortname` on both AMQP messages now that xregistry/codegen#292 ships in 0.10.6.
- `99f94391` chore(pegelonline): regenerated all three producer trees with xrcg 0.10.6 + avrotize 3.5.5.
- `d9698c72` ci(pegelonline): per-source workflow now installs the AMQP producer + bridge and runs `test_pegelonline_amqp_app.py` — the matrix was still Kafka+MQTT only.

Local verification (all green):
- `pytest pegelonline/tests/` — 31 passed
- `tests/docker_e2e/test_docker_kafka_flow.py -k pegelonline`
- `tests/docker_e2e/test_docker_mqtt_flow.py -k pegelonline`
- `tests/docker_e2e/test_docker_amqp_artemis_flow.py`
- `tests/docker_e2e/test_docker_amqp_sb_emulator_flow.py`