### PR TITLE
ci(build-containers): pin checkout to v4 + cap matrix parallelism (fix flaky builds)

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -25,7 +25,9 @@ jobs:
       containers: ${{ steps.get-dockerfiles.outputs.containers }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Find all container projects
         id: get-dockerfiles
@@ -56,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         container: ${{ fromJson(needs.find-dockerfiles.outputs.containers) }}
     permissions:
@@ -65,7 +68,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Install cosign
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Closes the random per-source build-container failures seen on PRs #340/#342 and on every recent main run.

## Diagnosis

Each `Build Containers` run on main flakes on a different ~5-8 sources with:

> fatal: could not read Username for 'https://github.com': terminal prompts disabled
> Bad credentials - https://docs.github.com/rest

Last 3 main runs hit disjoint sets:
- `450e8c2`: geosphere-austria, luchtmeetnet-nl, mode-s, laqn-london, ptwc-tsunami, smhi-hydro
- `6740cb6`: dwd, inpe-deter-brazil, cbp-border-wait, environment-canada, paris-bicycle-counters, hubeau-hydrometrie
- `39b2a1f`: gtfs-mta-nyc, ireland-opw-waterlevel, pegelonline-mqtt

Verified locally: the 4 sources that failed on PR #342 (`energy-charts`, `kmi-belgium`, `ndl-netherlands`, `irail`) all `docker build` cleanly. Failures are CI-infrastructure flakes, not source issues.

## Fix

1. **Pin `actions/checkout` from `v6` → `v4`** (both occurrences). `v6` is a very recent major release and is the only meaningful tooling churn coinciding with the start of the flakes.
2. **Cap matrix to `max-parallel: 20`.** The matrix now spawns ~70+ jobs (after the pegelonline transport split + recent additions); staggering issuance avoids the token/scheduler burst that correlates with the flakes.

No source code touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>