### PR TITLE
skill(amqp): require x-opt-partition-key annotation by default for SB/EH

### DIFF
--- a/.github/skills/amqp-feeder/SKILL.md
+++ b/.github/skills/amqp-feeder/SKILL.md
@@ -154,6 +154,13 @@ same data shape:
                 "type": "string",
                 "description": "Short name of the water body (e.g. 'rhein'). Lets brokers like Service Bus topics filter or route by water body without cracking the payload."
               }
+            },
+            "message_annotations": {
+              "x-opt-partition-key": {
+                "type": "uritemplate",
+                "value": "{station_id}",
+                "description": "Service Bus / Event Hubs partition key. UTF-8 string, max 128 characters. Mirrors the CloudEvent subject and the Kafka key so all events for the same station hash to the same partition and ordering is preserved end-to-end across transports."
+              }
             }
           }
         }
@@ -169,9 +176,11 @@ Unlike MQTT (one topic template per message), AMQP 1.0 has one
 **address** per producer link — the queue or topic name. Routing
 within that address is done via:
 
-- The CloudEvent `subject` (mapped to AMQP `properties.subject`), and
+- The CloudEvent `subject` (mapped to AMQP `properties.subject`),
 - AMQP `application_properties`, which subscribers and SQL filters can
-  read.
+  read, and
+- AMQP `message-annotations`, which brokers consume for transport-level
+  behavior (partition keys, session IDs, scheduled enqueue time, etc.).
 
 For Service Bus topics with subscriptions, the natural pattern is **one
 address per source**, with consumers using subscription SQL filters on
@@ -180,12 +189,55 @@ address per source**, with consumers using subscription SQL filters on
 For Event Hubs, the address is the event hub name; there are no
 sub-addresses or filters — consumers read the whole partition stream.
 
-### Kafka key alignment is not required
+### Partition keys are required for Service Bus and Event Hubs
 
-The AMQP endpoint does not need a `protocoloptions.options.key` field
-because AMQP brokers do not partition by key. The CloudEvent `subject`
-plus `application_properties` carry all identity information consumers
-need.
+Every AMQP message group **must** declare a
+`protocoloptions.message_annotations["x-opt-partition-key"]` entry
+whose `uritemplate` value matches the CloudEvent subject and the
+Kafka key. Source: the Microsoft Python SDKs treat this annotation as
+the canonical partition-routing signal for both products.
+
+**Event Hubs** (`azure-eventhub`,
+`azure/eventhub/_constants.py:10`, `_pyamqp_transport.py:393`,
+`_utils.py:116`): the sender writes the annotation
+`b"x-opt-partition-key"` into the message annotations section; the
+broker hashes it to pick a partition. Without it, the sender uses
+round-robin and event ordering for the same logical entity is lost
+across partitions.
+
+**Service Bus** (`azure-servicebus`,
+`azure/servicebus/_common/constants.py:119`,
+`_common/message.py:331`, `_common/message.py:688`): same annotation
+key `b"x-opt-partition-key"`; the broker uses it for partitioned
+queues/topics. If `session_id` is also set, the two values **must be
+equal** (`_common/message.py:329`).
+
+Data type and constraints (verified against the SDK code):
+
+| Field        | Value                                                                          |
+|--------------|--------------------------------------------------------------------------------|
+| Annotation   | `b"x-opt-partition-key"` (AMQP symbol)                                          |
+| Value type   | UTF-8 string (`str` in Python; the EH SDK also accepts the symbol in bytes)     |
+| Max length   | 128 characters (`MESSAGE_PROPERTY_MAX_LENGTH` in `azure/servicebus/_common/constants.py:140`) |
+| Encoding     | AMQP `message-annotations` section, **not** `application_properties`            |
+| SB constraint| If `session_id` is set, `partition_key` must equal it                           |
+
+Choose the partition-key template from the same stable domain identity
+that backs the CloudEvent subject and the Kafka key — never use mutable
+names, descriptive labels, timestamps, or surrogate UUIDs. For
+multi-part identities (`{agency_cd}/{site_no}`), keep the template
+identical across all three (subject, Kafka key, partition key).
+
+> **xrcg support status.** As of xrcg 0.10.6 the Python AMQP producer
+> template reads `properties` and `application_properties` but does
+> **not** yet emit `message_annotations`. Tracked in
+> [xregistry/codegen#294](https://github.com/xregistry/codegen/issues/294).
+> Until annotation codegen lands, bridges declare the annotation in the
+> manifest (so the contract is authoritative and EVENTS.md / KQL
+> generators see it) **and** apply it in the bridge as a thin
+> post-build hook on the generated sender — see the *Partition Key
+> Bridge Workaround* section in
+> [`stream-bridge-implementation`](../stream-bridge-implementation/SKILL.md#partition-key-bridge-workaround-amqp--pending-xrcg-support).
 
 ## Producer Generation
 

--- a/.github/skills/stream-bridge-implementation/SKILL.md
+++ b/.github/skills/stream-bridge-implementation/SKILL.md
@@ -725,3 +725,61 @@ documentation: `tools/deploy-fabric/README.md`.
 - [`xreg-source-contract`](../xreg-source-contract/SKILL.md) — contract authoring (consumed by the mandatory expert review)
 - `pegelonline/notebook/pegelonline-feed.ipynb` — canonical notebook template
 - `tools/deploy-fabric/deploy-feeder-notebook.ps1` — parameter names the deploy script overwrites; the notebook MUST declare all of them
+
+## Partition Key Bridge Workaround (AMQP — pending xrcg support)
+
+Until xrcg emits `message_annotations` codegen (see the
+[`amqp-feeder`](../amqp-feeder/SKILL.md) skill, *Partition keys are
+required for Service Bus and Event Hubs*), AMQP bridges must inject
+`x-opt-partition-key` themselves by wrapping the generated sender's
+underlying `send` callable. This keeps the contract authoritative
+(the manifest declares the annotation, EVENTS.md / KQL generators see
+it) while shipping correct partition routing today.
+
+Apply the patch once, immediately after the producer is constructed
+(typically inside the bridge's `__init__` / `start()`):
+
+```python
+# pegelonline_amqp/app.py — partition-key annotation workaround
+from proton import Message  # or your AMQP client's Message type
+
+_PARTITION_KEY_SYMBOL = b"x-opt-partition-key"
+
+def _patch_partition_key(producer, subject_extractor):
+    """Wrap producer._sender.send so every outgoing message carries
+    the SB/EH partition-key annotation derived from CE subject."""
+    original_send = producer._sender.send
+
+    def send_with_partition_key(amqp_msg, *args, **kwargs):
+        subject = getattr(amqp_msg, "subject", None) or subject_extractor(amqp_msg)
+        if subject:
+            ann = dict(amqp_msg.annotations or {})
+            ann[_PARTITION_KEY_SYMBOL] = str(subject)[:128]
+            amqp_msg.annotations = ann
+        return original_send(amqp_msg, *args, **kwargs)
+
+    producer._sender.send = send_with_partition_key
+```
+
+Rules:
+
+- The annotation value is always a **UTF-8 string** truncated to **128
+  characters** (the Service Bus `MESSAGE_PROPERTY_MAX_LENGTH` limit).
+  Event Hubs accepts longer values but truncating to 128 keeps the
+  contract portable.
+- The value **must** be the same stable domain identity that backs the
+  CE subject and the Kafka key. The default extractor pulls
+  `amqp_msg.subject`; if your bridge uses a different identity for
+  partitioning, document the deviation in the source's `README.md`.
+- When `session_id` is also set (Service Bus only), the bridge must
+  set `partition_key == session_id`; the SDK rejects mismatches.
+- Remove the workaround as soon as the bridge regenerates against an
+  xrcg release that emits annotations natively, and replace it with the
+  generated code path. Track removal as part of the
+  [`feeder-release-checklist`](../feeder-release-checklist/SKILL.md)
+  housekeeping for the source.
+
+Validate the annotation reaches the broker in the AMQP Docker E2E
+(`tests/docker_e2e/test_docker_amqp_artemis_flow.py` and
+`test_docker_amqp_sb_emulator_flow.py`) by asserting on the consumer
+side: `received.annotations[b"x-opt-partition-key"] == expected_id`.


### PR DESCRIPTION
See commit message for SDK citations and verified data type (UTF-8 string, max 128 chars, message-annotations section, key b'x-opt-partition-key'). Tracked xrcg gap as xregistry/codegen#294.