### PR TITLE
ci(docker-e2e): pin checkout v6→v4 and cap matrix parallelism

### DIFF
--- a/.github/workflows/test-docker-e2e.yml
+++ b/.github/workflows/test-docker-e2e.yml
@@ -27,7 +27,7 @@ jobs:
       reason: ${{ steps.compute.outputs.reason }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -71,10 +71,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix: ${{ fromJson(needs.discover.outputs.build_matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Build Docker image
         run: |
@@ -92,10 +93,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix: ${{ fromJson(needs.discover.outputs.flow_matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -112,7 +114,7 @@ jobs:
 
       - name: Run Kafka flow test
         run: |
-          pytest tests/docker_e2e/test_docker_kafka_flow.py \
+          pytest tests/docker_e2e/${{ matrix.test_file || 'test_docker_kafka_flow.py' }} \
             -v --timeout=600 \
             -k "${{ matrix.test_class }}" \
             --tb=long


### PR DESCRIPTION
Mirrors PR #343 (build_containers.yml) for the Docker E2E workflow:

- Pin all three `actions/checkout` usages from `@v6` to `@v4` (v6 races GITHUB_TOKEN provisioning under high parallel matrix concurrency).
- Add `max-parallel: 20` to `docker-build` and `docker-kafka-flow` jobs to keep total concurrency bounded.
- Allow matrix rows to specify `test_file` (defaults to `test_docker_kafka_flow.py`) so MQTT/AMQP feeder flow tests in `test_docker_mqtt_flow.py` / `test_docker_amqp_*_flow.py` can be dispatched by editing only `matrix.json`. Without this, MQTT flow rows on PRs #347 and #348 produce `no tests ran (exit 5)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>