### PR TITLE
fix(pegelonline): declare Station.km as nullable double

### DIFF
--- a/pegelonline/xreg/pegelonline.xreg.json
+++ b/pegelonline/xreg/pegelonline.xreg.json
@@ -280,7 +280,7 @@
                               "description": "Canonical gauge name as used in WSV publications (≤255 characters). Mutable — do not use as a routing key."
                             },
                             "km": {
-                              "type": "double",
+                              "type": ["null", "double"],
                               "unit": "km",
                               "symbol": "km",
                               "description": "Position along the federal waterway expressed as river-kilometre downstream from the waterway's official origin (e.g. Rhine-km 0 at the Old Rhine Bridge in Konstanz). The decimal fraction is the hectometre offset within the kilometre. Negative values occur on tributaries where the kilometre count is measured upstream from a confluence (e.g. Ohře gauge LOUNY at km -61.4 of the Elbe/Ohře system). **Optional**: absent or null for tidal / coastal gauges (Küstenpegel on the North Sea and Baltic) and for waterways without a kilometre reference. Sourced from the upstream `km` field. Unit: km."


### PR DESCRIPTION
The `km` field's description already says "absent or null for tidal/coastal gauges" and the Avro mirror uses `["null","double"]`, but the JsonStructure schema declared just `"double"`. The generated dataclass already uses `Optional[float]` and the runtime emits `null` on the wire, so the Docker E2E validator fails with: `Expected double at #/km, got NoneType`.

This pre-existing schema-vs-runtime drift wasn't surfaced on main because per-PR matrix scoping skipped `pegelonline-kafka` flow; it broke under PR #349 (full-matrix CI), and now blocks PRs #347 (mqtt/hydro-pilot) and #348 (mqtt/firehose-pilot) which both touch infra paths.

Manifest-only fix — producer dataclass is already `Optional[float]`; no regeneration needed.
