### PR TITLE
ci(build-containers): retry cosign sign with explicit ghcr creds

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -126,6 +126,37 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          COSIGN_DOCKER_MEDIA_TYPES: "1"
+          COSIGN_REGISTRY_USERNAME: ${{ github.actor }}
+          COSIGN_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        # against the sigstore community Fulcio instance. Retries absorb
+        # transient ghcr.io BLOB_UNKNOWN / DENIED races right after push.
+        run: |
+          set -u
+          sign_one() {
+            local ref="$1"
+            local attempt=1
+            local max=5
+            local delay=6
+            while [ "$attempt" -le "$max" ]; do
+              echo "cosign sign attempt $attempt/$max for $ref"
+              if cosign sign --yes \
+                  --registry-username "${COSIGN_REGISTRY_USERNAME}" \
+                  --registry-password "${COSIGN_REGISTRY_PASSWORD}" \
+                  "$ref"; then
+                return 0
+              fi
+              echo "cosign sign failed (attempt $attempt); sleeping ${delay}s"
+              sleep "$delay"
+              attempt=$((attempt + 1))
+            done
+            echo "::error::cosign sign failed for $ref after $max attempts"
+            return 1
+          }
+          rc=0
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            sign_one "${tag}@${DIGEST}" || rc=1
+          done <<< "${TAGS}"
+          exit "$rc"


### PR DESCRIPTION
**Root cause:** `cosign sign` runs immediately after `docker/build-push-action` and intermittently hits ghcr.io `BLOB_UNKNOWN` (manifest not yet visible) or `DENIED` (login-action creds not carrying into cosign on ephemeral runners). 3-5 matrix shards fail per run, varying each time. Pre-existing since PR #338.

**Fix:** Pass GHCR creds explicitly via `COSIGN_REGISTRY_USERNAME` / `COSIGN_REGISTRY_PASSWORD` env (plus `COSIGN_DOCKER_MEDIA_TYPES=1`) and wrap each tag's sign in a 5-attempt loop with 6s backoff to absorb registry propagation lag. Touches only `.github/workflows/build_containers.yml`.