### PR TITLE
wikimedia-osm-diffs: ship MQTT/UNS firehose feeder

### DIFF
--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -45,6 +45,7 @@
     { "dir": "usgs-iv", "module": "usgs_iv" },
     { "dir": "waterinfo-vmm", "module": "waterinfo_vmm" },
     { "dir": "wsdot", "module": "wsdot" },
+    { "dir": "wikimedia-osm-diffs", "image": "wikimedia-osm-diffs-mqtt", "file": "Dockerfile.mqtt", "module": "wikimedia_osm_diffs_mqtt" },
     { "dir": "xceed", "module": "xceed" }
   ],
   "flow": [
@@ -82,6 +83,7 @@
     { "dir": "usgs-iv", "test_class": "TestUSGSIVDockerFlow" },
     { "dir": "waterinfo-vmm", "test_class": "TestWaterinfoVMMDockerFlow" },
     { "dir": "wsdot", "test_class": "TestWSDOTDockerFlow" },
+    { "dir": "wikimedia-osm-diffs", "image": "wikimedia-osm-diffs-mqtt", "file": "Dockerfile.mqtt", "test_file": "test_docker_mqtt_flow.py", "test_class": "TestWikimediaOsmDiffsMqttDockerFlow" },
     { "dir": "xceed", "test_class": "TestXceedDockerFlow" }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -1135,3 +1135,300 @@ class TestAisstreamMqttDockerFlow:
 
 
 
+
+# ---------------------------------------------------------------------------
+# Wikimedia OSM Diffs -> MQTT/UNS (firehose + retained state)
+# ---------------------------------------------------------------------------
+
+
+def _load_wikimedia_osm_diffs_mqtt_schemas():
+    xreg_path = os.path.join(REPO_ROOT, 'wikimedia-osm-diffs', 'xreg', 'wikimedia_osm_diffs.xreg.json')
+    with open(xreg_path, 'r', encoding='utf-8') as fh:
+        manifest = json.load(fh)
+    sg = manifest['schemagroups']['Org.OpenStreetMap.Diffs.jstruct']
+    out = {}
+    for full_name, schema in sg['schemas'].items():
+        out[full_name] = schema['versions']['1']['schema']
+    return out
+
+
+@pytest.fixture(scope='module')
+def wikimedia_osm_diffs_mqtt_image():
+    return build_image('wikimedia-osm-diffs', dockerfile='Dockerfile.mqtt', tag='test-wikimedia-osm-diffs-mqtt')
+
+
+@pytest.fixture()
+def wikimedia_osm_diffs_mosquitto_container():
+    container, network, host_port = _generic_mosquitto(
+        'wikimedia-osm-diffs-mqtt-e2e', 'wikimedia-osm-diffs-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'wikimedia-osm-diffs-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestWikimediaOsmDiffsMqttDockerFlow:
+    """Verify the wikimedia-osm-diffs-mqtt container publishes a valid
+    UNS firehose tree for node/way/relation changes plus a retained
+    replication-state side-channel snapshot.
+
+    OSM diffs are a non-retained firehose, so we attach the subscriber
+    first (per the hard rule: ``c.subscribe`` is called inside the paho
+    ``on_connect`` callback so the SUBSCRIBE rides the same TCP connect
+    as the CONNECT/CONNACK), wait for SUBACK, then launch the feeder
+    container in ``--mock`` mode. The mock corpus emits exactly one
+    create-node, one modify-way (no coordinates -> geohash5='nogeo'),
+    one delete-relation (no coordinates -> 'nogeo'), and one retained
+    replication-state event.
+    """
+
+    def test_emits_firehose_and_retained_state(self, wikimedia_osm_diffs_mosquitto_container, wikimedia_osm_diffs_mqtt_image):
+        client = docker.from_env()
+        broker_url = (
+            f"mqtt://{wikimedia_osm_diffs_mosquitto_container['internal_host']}:"
+            f"{wikimedia_osm_diffs_mosquitto_container['internal_port']}"
+        )
+
+        collected = []
+        last_msg_time = [time.time()]
+        subscribe_ready = []
+
+        def on_message(c, u, msg):
+            last_msg_time[0] = time.time()
+            props = {}
+            if msg.properties is not None:
+                for k, v in getattr(msg.properties, 'UserProperty', []) or []:
+                    props[k] = v
+                ct = getattr(msg.properties, 'ContentType', None)
+                if ct:
+                    props['_contenttype'] = ct
+            try:
+                payload = json.loads(msg.payload)
+            except (TypeError, ValueError):
+                payload = None
+            collected.append({
+                'topic': msg.topic,
+                'retain': bool(msg.retain),
+                'qos': msg.qos,
+                'user_properties': props,
+                'payload': payload,
+            })
+
+        def on_subscribe(c, u, mid, reason_codes, props):
+            subscribe_ready.append(True)
+
+        def on_connect(c, u, flags, reason_code, props):
+            # Hard rule: subscribe inside on_connect so SUBSCRIBE rides
+            # the same TCP connect as the CONNACK and the retained
+            # replication-state snapshot is delivered to us.
+            c.subscribe('osm/intl/wikimedia/wikimedia-osm-diffs/#', qos=1)
+
+        sub = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
+        sub.on_message = on_message
+        sub.on_subscribe = on_subscribe
+        sub.on_connect = on_connect
+        sub.connect('127.0.0.1', wikimedia_osm_diffs_mosquitto_container['host_port'], 30)
+        sub.loop_start()
+        ready_deadline = time.time() + 10
+        while not subscribe_ready and time.time() < ready_deadline:
+            time.sleep(0.1)
+        assert subscribe_ready, 'Subscriber failed to receive SUBACK before timeout'
+
+        feeder = client.containers.run(
+            wikimedia_osm_diffs_mqtt_image.id,
+            detach=True,
+            remove=False,
+            network=wikimedia_osm_diffs_mosquitto_container['network'],
+            environment={
+                'MQTT_BROKER_URL': broker_url,
+                'OSM_DIFFS_MOCK': 'true',
+                'PYTHONUNBUFFERED': '1',
+            },
+        )
+        try:
+            result = feeder.wait(timeout=180)
+            logs = feeder.logs().decode('utf-8', errors='replace')
+            assert result.get('StatusCode') == 0, (
+                f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+            )
+        finally:
+            try:
+                feeder.remove(force=True)
+            except docker.errors.APIError:
+                pass
+
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            time.sleep(0.5)
+            if collected and time.time() - last_msg_time[0] > 3.0:
+                break
+        sub.loop_stop()
+        sub.disconnect()
+
+        assert collected, 'No MQTT messages received from broker'
+
+        # Bucket by topic family for clean assertions.
+        node_msgs = [m for m in collected if m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/node/')]
+        way_msgs = [m for m in collected if m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/way/')]
+        relation_msgs = [m for m in collected if m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/relation/')]
+        state_msgs = [m for m in collected if m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/')]
+
+        assert node_msgs, f"no node firehose messages received: {[m['topic'] for m in collected]}"
+        assert way_msgs, f"no way firehose messages received: {[m['topic'] for m in collected]}"
+        assert relation_msgs, f"no relation firehose messages received: {[m['topic'] for m in collected]}"
+        assert state_msgs, f"no replication-state retained message received: {[m['topic'] for m in collected]}"
+
+        # Required CE binary-mode user properties on every published frame.
+        for sample in collected:
+            up = sample['user_properties']
+            for required in ('id', 'source', 'type', 'subject', 'specversion'):
+                assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+            assert up.get('_contenttype') == 'application/json', sample
+
+        # Firehose families: QoS 0, retain=false. CE type is the
+        # base MapChange type regardless of element family; the family
+        # is identified by the topic.
+        for sample in node_msgs + way_msgs + relation_msgs:
+            assert sample['retain'] is False, f"firehose must not retain: {sample}"
+            assert sample['qos'] == 0, f"firehose must be QoS 0: {sample}"
+            assert sample['user_properties'].get('type') == 'Org.OpenStreetMap.Diffs.MapChange', sample
+            parts = sample['topic'].split('/')
+            assert len(parts) == 8, f"unexpected topic depth {len(parts)} for {sample['topic']}"
+            assert parts[0:4] == ['osm', 'intl', 'wikimedia', 'wikimedia-osm-diffs'], parts
+            assert parts[4] in ('node', 'way', 'relation'), parts
+            assert parts[-1] == 'change', parts
+            geohash5_seg = parts[5]
+            element_id_seg = parts[6]
+            assert geohash5_seg, parts
+            assert element_id_seg, parts
+            # subject is the contiguous '{geohash5}/{element_id}' segment of the topic.
+            assert sample['user_properties']['subject'] == f"{geohash5_seg}/{element_id_seg}", (
+                sample['user_properties']['subject'], geohash5_seg, element_id_seg,
+            )
+
+        # Replication-state: distinct CE type, subject is the literal segment.
+        # Note: on a live MQTT delivery (subscriber already connected when the
+        # feeder publishes), the broker forwards the message with retain=False
+        # even if the publisher set retain=true. The retain flag on the wire
+        # is only set true for messages replayed from the retained store at
+        # subscription time. We verify that retention actually happened by
+        # reconnecting a fresh subscriber below.
+        state = state_msgs[0]
+        assert state['qos'] == 0, state
+        assert state['user_properties'].get('type') == 'Org.OpenStreetMap.Diffs.ReplicationState', state
+        assert state['user_properties']['subject'] == 'replication-state', state['user_properties']
+        state_parts = state['topic'].split('/')
+        assert state_parts == [
+            'osm', 'intl', 'wikimedia', 'wikimedia-osm-diffs',
+            'replication-state', 'replication-state',
+        ], state_parts
+
+        # 'nogeo' sentinel applied where OsmChange carries no coordinates.
+        assert all(m['topic'].split('/')[5] == 'nogeo' for m in way_msgs), [m['topic'] for m in way_msgs]
+        assert all(m['topic'].split('/')[5] == 'nogeo' for m in relation_msgs), [m['topic'] for m in relation_msgs]
+        # Nodes have coordinates -> geohash5 should be a non-sentinel base32 token.
+        for m in node_msgs:
+            gh = m['topic'].split('/')[5]
+            assert gh != 'nogeo', m['topic']
+            assert len(gh) == 5, m['topic']
+            assert all(c in '0123456789bcdefghjkmnpqrstuvwxyz' for c in gh), m['topic']
+
+        # Payload sanity: every diff carries the keying axes; topic axes
+        # round-trip from the payload exactly.
+        schemas = _load_wikimedia_osm_diffs_mqtt_schemas()
+        assert 'Org.OpenStreetMap.Diffs.MapChange' in schemas
+        assert 'Org.OpenStreetMap.Diffs.ReplicationState' in schemas
+
+        def _to_dict(p):
+            if isinstance(p, dict):
+                return p
+            if isinstance(p, str):
+                try:
+                    parsed = json.loads(p)
+                    return parsed if isinstance(parsed, dict) else None
+                except json.JSONDecodeError:
+                    return None
+            return None
+
+        for sample in node_msgs + way_msgs + relation_msgs:
+            payload = _to_dict(sample['payload'])
+            assert payload is not None, f"payload not parseable for {sample['topic']}: {sample['payload']!r}"
+            for axis in ('element_type', 'element_id', 'geohash5', 'sequence_number', 'change_type'):
+                assert axis in payload, f"missing axis {axis} in payload for {sample['topic']}: {payload}"
+            parts = sample['topic'].split('/')
+            assert parts[4] == payload['element_type'], (parts[4], payload['element_type'])
+            assert parts[5] == payload['geohash5'], (parts[5], payload['geohash5'])
+            assert str(payload['element_id']) == parts[6], (payload['element_id'], parts[6])
+
+        state_payload = _to_dict(state['payload'])
+        assert state_payload is not None, f"state payload unparseable: {state['payload']!r}"
+        assert 'sequence_number' in state_payload, state_payload
+        assert 'timestamp' in state_payload, state_payload
+
+        # Verify retain semantics: reconnect a fresh subscriber AFTER the
+        # feeder has exited. The retained replication-state must be replayed
+        # from the broker's retained store with retain=True. Firehose
+        # messages must NOT be replayed (they were not retained).
+        replayed = []
+
+        def on_message2(c, u, msg):
+            props = {}
+            if msg.properties is not None:
+                for k, v in getattr(msg.properties, 'UserProperty', []) or []:
+                    props[k] = v
+            replayed.append({
+                'topic': msg.topic,
+                'retain': bool(msg.retain),
+                'qos': msg.qos,
+                'user_properties': props,
+            })
+
+        replay_ready = []
+
+        def on_subscribe2(c, u, mid, reason_codes, props):
+            replay_ready.append(True)
+
+        def on_connect2(c, u, flags, reason_code, props):
+            c.subscribe('osm/intl/wikimedia/wikimedia-osm-diffs/#', qos=1)
+
+        sub2 = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
+        sub2.on_message = on_message2
+        sub2.on_subscribe = on_subscribe2
+        sub2.on_connect = on_connect2
+        sub2.connect('127.0.0.1', wikimedia_osm_diffs_mosquitto_container['host_port'], 30)
+        sub2.loop_start()
+        try:
+            ready_deadline = time.time() + 10
+            while not replay_ready and time.time() < ready_deadline:
+                time.sleep(0.1)
+            # Wait up to 5s to collect any replayed retained messages.
+            time.sleep(3.0)
+        finally:
+            sub2.loop_stop()
+            sub2.disconnect()
+
+        retained_state = [m for m in replayed if m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/')]
+        assert retained_state, (
+            f"replication-state was not retained by broker; replayed topics: {[m['topic'] for m in replayed]}"
+        )
+        for m in retained_state:
+            assert m['retain'] is True, f"retained replay must carry retain=True: {m}"
+            assert m['user_properties'].get('type') == 'Org.OpenStreetMap.Diffs.ReplicationState', m
+
+        retained_firehose = [m for m in replayed if not m['topic'].startswith('osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/')]
+        assert not retained_firehose, (
+            f"firehose messages must not be retained, but broker replayed: {[m['topic'] for m in retained_firehose]}"
+        )

--- a/wikimedia-osm-diffs/CONTAINER.md
+++ b/wikimedia-osm-diffs/CONTAINER.md
@@ -128,3 +128,78 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fwikimedia-osm-diffs%2Fazure-template-with-eventhub.json)
+
+
+---
+
+## MQTT/UNS variant (`Dockerfile.mqtt`)
+
+The `wikimedia-osm-diffs-mqtt` image (built from `Dockerfile.mqtt`) is a
+separate firehose variant of the bridge that publishes MQTT 5.0
+binary-mode CloudEvents into a Unified-Namespace topic tree on a broker
+of your choice. The minutely diff stream is split into three
+non-retained QoS-0 families (one per OSM element type) plus a single
+retained side-channel snapshot for the OSM replication state.
+
+### Topic tree
+
+```
+osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change            # firehose, retain=false, QoS 0
+osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change             # firehose, retain=false, QoS 0
+osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change        # firehose, retain=false, QoS 0
+osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state            # retained, QoS 0
+```
+
+The `{geohash5}` placeholder is the lowercase 5-character base32 geohash
+of the element's coordinates. OSM ways and relations do not carry inline
+coordinates in OsmChange, so `{geohash5}` is the fixed sentinel
+`nogeo` for those families. `{element_id}` is the stringified OSM
+element id.
+
+### Example wildcard subscriptions
+
+```
+# all map changes in a 5-char geohash cell (e.g. `u281`)
+osm/intl/wikimedia/wikimedia-osm-diffs/+/u281+/+/change
+
+# all way edits anywhere
+osm/intl/wikimedia/wikimedia-osm-diffs/way/+/+/change
+
+# all relation deletes/modifies/creates anywhere (no coords -> nogeo)
+osm/intl/wikimedia/wikimedia-osm-diffs/relation/nogeo/+/change
+
+# every change for a known node id 1234567890
+osm/intl/wikimedia/wikimedia-osm-diffs/node/+/1234567890/change
+
+# replication-state snapshot (retained)
+osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/#
+```
+
+### Environment variables
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `MQTT_BROKER_URL` | `mqtt://localhost:1883` | `mqtt://` or `mqtts://`. |
+| `MQTT_ENABLE_TLS` | `false` | Forces TLS even when `mqtt://` is used. |
+| `MQTT_USERNAME` | _(unset)_ | Optional MQTT username. |
+| `MQTT_PASSWORD` | _(unset)_ | Optional MQTT password. |
+| `MQTT_CLIENT_ID` | _(auto)_ | Optional MQTT client id. |
+| `OSM_DIFFS_STATE_URL` | `https://planet.openstreetmap.org/replication/minute/state.txt` | OSM replication state endpoint. |
+| `OSM_DIFFS_BASE_URL` | `https://planet.openstreetmap.org/replication/minute` | OSM replication diff base URL. |
+| `OSM_DIFFS_STATE_FILE` | `~/.wikimedia_osm_diffs_mqtt_state.json` | Local state file to remember the last processed sequence. |
+| `OSM_DIFFS_POLL_INTERVAL` | `60` | Seconds between polls. |
+| `OSM_DIFFS_ONCE` | `false` | Process a single polling cycle and exit. |
+| `OSM_DIFFS_MOCK` | `false` | Skip OSM polling, emit one synthetic change per family + replication-state, then exit (used by Docker E2E). |
+
+### Run
+
+```bash
+docker run --rm \
+  -e MQTT_BROKER_URL=mqtt://broker:1883 \
+  ghcr.io/clemensv/real-time-sources/wikimedia-osm-diffs-mqtt:latest
+```
+
+CloudEvents ride as MQTT 5.0 binary-mode user properties (`id`,
+`source`, `type`, `subject`, `time`, `specversion`); the payload is the
+JSON-serialized `MapChange` / `ReplicationState` dataclass and the MQTT
+`Content-Type` is set to `application/json`.

--- a/wikimedia-osm-diffs/Dockerfile.mqtt
+++ b/wikimedia-osm-diffs/Dockerfile.mqtt
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/wikimedia-osm-diffs"
+LABEL org.opencontainers.image.title="OpenStreetMap minutely diffs → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls the OSM Planet replication state, fetches each minutely OsmChange .osc.gz diff, and republishes node/way/relation create/modify/delete events as non-retained MQTT 5.0 binary-mode CloudEvents under osm/intl/wikimedia/wikimedia-osm-diffs/{element_type}/{geohash5}/{element_id}/change, plus a retained replication-state side-channel."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/wikimedia-osm-diffs/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data \
+ && pip install --no-cache-dir ./wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./wikimedia_osm_diffs_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "wikimedia_osm_diffs_mqtt", "feed"]

--- a/wikimedia-osm-diffs/EVENTS.md
+++ b/wikimedia-osm-diffs/EVENTS.md
@@ -1,94 +1,165 @@
-# OpenStreetMap Minutely Diffs Events
+# Table of Contents
 
-This document describes the events emitted by the OpenStreetMap Minutely
-Diffs bridge.
-
-- [Org.OpenStreetMap.Diffs.State](#message-group-orgopenstreetmapdiffsstate)
-  - [Org.OpenStreetMap.Diffs.ReplicationState](#message-orgopenstreetmapdiffsreplicationstate)
 - [Org.OpenStreetMap.Diffs](#message-group-orgopenstreetmapdiffs)
   - [Org.OpenStreetMap.Diffs.MapChange](#message-orgopenstreetmapdiffsmapchange)
-
----
-
-## Message Group: Org.OpenStreetMap.Diffs.State
-
----
-
-### Message: Org.OpenStreetMap.Diffs.ReplicationState
-
-Current replication state from the OSM minutely diff feed.
-
-#### CloudEvents Attributes
-
-| **Name** | **Value** |
-|----------|-----------|
-| `type` | `Org.OpenStreetMap.Diffs.ReplicationState` |
-| `source` | `https://planet.openstreetmap.org/replication/minute` |
-| `subject` | `replication_state` |
-
-#### Fields
-
-| **Field** | **Type** | **Description** |
-|-----------|----------|-----------------|
-| `sequence_number` | int64 | Monotonically increasing sequence number of the latest processed diff |
-| `timestamp` | datetime | UTC timestamp associated with the replication state |
+- [Org.OpenStreetMap.Diffs.State](#message-group-orgopenstreetmapdiffsstate)
+  - [Org.OpenStreetMap.Diffs.ReplicationState](#message-orgopenstreetmapdiffsreplicationstate)
+- [Org.OpenStreetMap.Diffs.mqtt](#message-group-orgopenstreetmapdiffsmqtt)
+  - [Org.OpenStreetMap.Diffs.mqtt.Node](#message-orgopenstreetmapdiffsmqttnode)
+  - [Org.OpenStreetMap.Diffs.mqtt.Way](#message-orgopenstreetmapdiffsmqttway)
+  - [Org.OpenStreetMap.Diffs.mqtt.Relation](#message-orgopenstreetmapdiffsmqttrelation)
+  - [Org.OpenStreetMap.Diffs.mqtt.ReplicationState](#message-orgopenstreetmapdiffsmqttreplicationstate)
 
 ---
 
 ## Message Group: Org.OpenStreetMap.Diffs
-
 ---
-
 ### Message: Org.OpenStreetMap.Diffs.MapChange
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at https://planet.openstreetmap.org/replication/minute/.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.MapChange` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `{element_type}/{element_id}` |
 
-An individual element change from the OSM minutely replication diff feed.
+#### Schema:
+##### Object: MapChange
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
+| `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
+| `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
+| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
+| `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
+| `user_name` | *string* (optional) | - | `False` | The display name of the OSM user who made this edit. May be null for redacted or anonymous edits. |
+| `user_id` | *int64* (optional) | - | `False` | The numeric user identifier of the OSM contributor. May be null for redacted or anonymous edits. |
+| `latitude` | *double* (optional) | - | `False` | The WGS-84 latitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `longitude` | *double* (optional) | - | `False` | The WGS-84 longitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `tags` | *string* | - | `True` | JSON-encoded object of key-value tag pairs attached to this element. Tags describe the element's real-world features such as name, highway type, or building classification. Encoded as a JSON string because xreg does not natively support map types. |
+| `sequence_number` | *int64* | - | `True` | The replication sequence number of the minutely diff file that contained this change. Useful for correlating changes back to specific replication state. |
+## Message Group: Org.OpenStreetMap.Diffs.State
+---
+### Message: Org.OpenStreetMap.Diffs.ReplicationState
+*Current replication state from the OpenStreetMap minutely diff feed. Emitted once per poll cycle to record which replication sequence was just processed. The state is read from https://planet.openstreetmap.org/replication/minute/state.txt.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.ReplicationState` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `replication_state` |
 
-#### CloudEvents Attributes
+#### Schema:
+##### Object: ReplicationState
+*The current replication state of the OpenStreetMap minutely diff feed. Published once per poll cycle. The sequence_number and timestamp are parsed from the Java-properties-style state.txt file at https://planet.openstreetmap.org/replication/minute/state.txt.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `sequence_number` | *int64* | - | `True` | The monotonically increasing sequence number of the latest processed minutely diff file. Each diff file corresponds to exactly one sequence number. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp associated with the replication state, indicating the point in time up to which the diff file covers OSM edits. |
+| `source_url` | *string* (optional) | - | `False` | The replication state document URL from which this snapshot was parsed. Useful so subscribers can re-derive the diff file URL or compare across mirror feeds. Null when the bridge does not record the URL. |
+## Message Group: Org.OpenStreetMap.Diffs.mqtt
+---
+### Message: Org.OpenStreetMap.Diffs.mqtt.Node
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at https://planet.openstreetmap.org/replication/minute/.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.MapChange` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `{geohash5}/{element_id}` |
 
-| **Name** | **Value** |
-|----------|-----------|
-| `type` | `Org.OpenStreetMap.Diffs.MapChange` |
-| `source` | `https://planet.openstreetmap.org/replication/minute` |
-| `subject` | `{element_type}/{element_id}` |
+#### Schema:
+##### Object: MapChange
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
+| `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
+| `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
+| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
+| `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
+| `user_name` | *string* (optional) | - | `False` | The display name of the OSM user who made this edit. May be null for redacted or anonymous edits. |
+| `user_id` | *int64* (optional) | - | `False` | The numeric user identifier of the OSM contributor. May be null for redacted or anonymous edits. |
+| `latitude` | *double* (optional) | - | `False` | The WGS-84 latitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `longitude` | *double* (optional) | - | `False` | The WGS-84 longitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `tags` | *string* | - | `True` | JSON-encoded object of key-value tag pairs attached to this element. Tags describe the element's real-world features such as name, highway type, or building classification. Encoded as a JSON string because xreg does not natively support map types. |
+| `sequence_number` | *int64* | - | `True` | The replication sequence number of the minutely diff file that contained this change. Useful for correlating changes back to specific replication state. |
+---
+### Message: Org.OpenStreetMap.Diffs.mqtt.Way
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at https://planet.openstreetmap.org/replication/minute/.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.MapChange` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `{geohash5}/{element_id}` |
 
-#### Fields
+#### Schema:
+##### Object: MapChange
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
+| `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
+| `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
+| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
+| `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
+| `user_name` | *string* (optional) | - | `False` | The display name of the OSM user who made this edit. May be null for redacted or anonymous edits. |
+| `user_id` | *int64* (optional) | - | `False` | The numeric user identifier of the OSM contributor. May be null for redacted or anonymous edits. |
+| `latitude` | *double* (optional) | - | `False` | The WGS-84 latitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `longitude` | *double* (optional) | - | `False` | The WGS-84 longitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `tags` | *string* | - | `True` | JSON-encoded object of key-value tag pairs attached to this element. Tags describe the element's real-world features such as name, highway type, or building classification. Encoded as a JSON string because xreg does not natively support map types. |
+| `sequence_number` | *int64* | - | `True` | The replication sequence number of the minutely diff file that contained this change. Useful for correlating changes back to specific replication state. |
+---
+### Message: Org.OpenStreetMap.Diffs.mqtt.Relation
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at https://planet.openstreetmap.org/replication/minute/.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.MapChange` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `{geohash5}/{element_id}` |
 
-| **Field** | **Type** | **Description** |
-|-----------|----------|-----------------|
-| `change_type` | string | Change type: create, modify, or delete |
-| `element_type` | string | OSM element type: node, way, or relation |
-| `element_id` | int64 | Unique OSM element identifier |
-| `version` | int32 | Element version number |
-| `timestamp` | datetime | UTC timestamp of the element version |
-| `changeset_id` | int64 | OSM changeset identifier |
-| `user_name` | string? | Display name of the editing user |
-| `user_id` | int64? | Numeric user identifier |
-| `latitude` | double? | WGS-84 latitude (nodes only) |
-| `longitude` | double? | WGS-84 longitude (nodes only) |
-| `tags` | string | JSON-encoded key-value tag pairs |
-| `sequence_number` | int64 | Replication sequence number |
+#### Schema:
+##### Object: MapChange
+*An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
+| `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
+| `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
+| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
+| `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
+| `user_name` | *string* (optional) | - | `False` | The display name of the OSM user who made this edit. May be null for redacted or anonymous edits. |
+| `user_id` | *int64* (optional) | - | `False` | The numeric user identifier of the OSM contributor. May be null for redacted or anonymous edits. |
+| `latitude` | *double* (optional) | - | `False` | The WGS-84 latitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `longitude` | *double* (optional) | - | `False` | The WGS-84 longitude of the node in decimal degrees. Present only when element_type is node; null for ways and relations. |
+| `tags` | *string* | - | `True` | JSON-encoded object of key-value tag pairs attached to this element. Tags describe the element's real-world features such as name, highway type, or building classification. Encoded as a JSON string because xreg does not natively support map types. |
+| `sequence_number` | *int64* | - | `True` | The replication sequence number of the minutely diff file that contained this change. Useful for correlating changes back to specific replication state. |
+---
+### Message: Org.OpenStreetMap.Diffs.mqtt.ReplicationState
+*Current replication state from the OpenStreetMap minutely diff feed. Emitted once per poll cycle to record which replication sequence was just processed. The state is read from https://planet.openstreetmap.org/replication/minute/state.txt.*
+#### CloudEvents Attributes:
+| **Name**    | **Description** | **Type**     | **Required** | **Value** |
+|-------------|-----------------|--------------|--------------|-----------|
+| `type` |  | `` | `False` | `Org.OpenStreetMap.Diffs.ReplicationState` |
+| `source` |  | `` | `False` | `https://planet.openstreetmap.org/replication/minute` |
+| `subject` |  | `uritemplate` | `False` | `replication-state` |
 
-#### Example
-
-```json
-{
-  "specversion": "1.0",
-  "type": "Org.OpenStreetMap.Diffs.MapChange",
-  "source": "https://planet.openstreetmap.org/replication/minute",
-  "subject": "node/317968498",
-  "data": {
-    "change_type": "delete",
-    "element_type": "node",
-    "element_id": 317968498,
-    "version": 5,
-    "timestamp": "2026-04-09T01:32:40+00:00",
-    "changeset_id": 181074839,
-    "user_name": "inserteunnombreaqui",
-    "user_id": 22579655,
-    "latitude": 21.0495463,
-    "longitude": 105.839612,
-    "tags": "{}",
-    "sequence_number": 7062480
-  }
-}
-```
+#### Schema:
+##### Object: ReplicationState
+*The current replication state of the OpenStreetMap minutely diff feed. Published once per poll cycle. The sequence_number and timestamp are parsed from the Java-properties-style state.txt file at https://planet.openstreetmap.org/replication/minute/state.txt.*
+| **Field Name** | **Type** | **Unit** | **Required** | **Description** |
+|----------------|----------|----------|--------------|-----------------|
+| `sequence_number` | *int64* | - | `True` | The monotonically increasing sequence number of the latest processed minutely diff file. Each diff file corresponds to exactly one sequence number. |
+| `timestamp` | *datetime* | - | `True` | The UTC timestamp associated with the replication state, indicating the point in time up to which the diff file covers OSM edits. |
+| `source_url` | *string* (optional) | - | `False` | The replication state document URL from which this snapshot was parsed. Useful so subscribers can re-derive the diff file URL or compare across mirror feeds. Null when the bridge does not record the URL. |

--- a/wikimedia-osm-diffs/README.md
+++ b/wikimedia-osm-diffs/README.md
@@ -4,7 +4,15 @@
 
 **OpenStreetMap Minutely Diffs Bridge** polls the OSM replication feed and
 forwards every element change (node, way, relation creates, modifies,
-deletes) to Kafka as [CloudEvents](https://cloudevents.io/).
+deletes) to Kafka or MQTT as [CloudEvents](https://cloudevents.io/).
+
+A second container variant (`Dockerfile.mqtt` / `wikimedia-osm-diffs-mqtt`)
+publishes the same stream to MQTT 5.0 as a non-retained QoS-0 firehose
+split into three topic families (`node`, `way`, `relation`) under
+`osm/intl/wikimedia/wikimedia-osm-diffs/{element_type}/{geohash5}/{element_id}/change`,
+plus a retained replication-state snapshot under
+`osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state`.
+See [CONTAINER.md](CONTAINER.md#mqttuns-variant-dockerfilemqtt) for details.
 
 ## Data Source
 

--- a/wikimedia-osm-diffs/generate_mqtt_producer.ps1
+++ b/wikimedia-osm-diffs/generate_mqtt_producer.ps1
@@ -1,0 +1,10 @@
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\wikimedia_osm_diffs.xreg.json `
+    --endpoint WikimediaOsmDiffs.Mqtt `
+    --projectname wikimedia_osm_diffs_mqtt_producer `
+    --output wikimedia_osm_diffs_mqtt_producer

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
@@ -86,6 +86,60 @@ def sequence_to_url(seq: int, base_url: str = DIFF_BASE_URL) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Geohash5 (mirrors aisstream_mqtt.enrichment.geohash5)
+# ---------------------------------------------------------------------------
+
+_GEOHASH_ALPHABET = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def _geohash5(latitude: Optional[float], longitude: Optional[float]) -> str:
+    """Return the 5-character base32 geohash, or 'nogeo' if unresolvable.
+
+    OSM ways and relations do not carry coordinates directly; nodes do.
+    We emit ``'nogeo'`` whenever a coordinate is missing so that downstream
+    MQTT topic placeholders always resolve to a fixed-shape lowercase ASCII
+    segment (never empty, never with a slash).
+    """
+    if latitude is None or longitude is None:
+        return "nogeo"
+    try:
+        lat = float(latitude)
+        lon = float(longitude)
+    except (TypeError, ValueError):
+        return "nogeo"
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return "nogeo"
+    precision = 5
+    lat_range = [-90.0, 90.0]
+    lon_range = [-180.0, 180.0]
+    bits: list[int] = []
+    even = True
+    while len(bits) < precision * 5:
+        if even:
+            mid = (lon_range[0] + lon_range[1]) / 2
+            if lon >= mid:
+                bits.append(1)
+                lon_range[0] = mid
+            else:
+                bits.append(0)
+                lon_range[1] = mid
+        else:
+            mid = (lat_range[0] + lat_range[1]) / 2
+            if lat >= mid:
+                bits.append(1)
+                lat_range[0] = mid
+            else:
+                bits.append(0)
+                lat_range[1] = mid
+        even = not even
+    out = []
+    for i in range(0, len(bits), 5):
+        idx = (bits[i] << 4) | (bits[i + 1] << 3) | (bits[i + 2] << 2) | (bits[i + 3] << 1) | bits[i + 4]
+        out.append(_GEOHASH_ALPHABET[idx])
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
 # OsmChange XML parsing
 # ---------------------------------------------------------------------------
 
@@ -132,6 +186,7 @@ def parse_osmchange_xml(xml_bytes: bytes, sequence_number: int) -> list[dict[str
                 "change_type": change_type,
                 "element_type": element_type,
                 "element_id": int(elem.get("id", "0")),
+                "geohash5": _geohash5(latitude, longitude),
                 "version": int(elem.get("version", "0")),
                 "timestamp": ts,
                 "changeset_id": int(elem.get("changeset", "0")),
@@ -288,6 +343,7 @@ class OsmDiffsBridge:
         state_data = ReplicationState(
             sequence_number=current_seq,
             timestamp=current_ts,
+            source_url=sequence_to_url(current_seq, self._diff_base_url),
         )
         self._state_producer.send_org_open_street_map_diffs_replication_state(
             data=state_data,

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/pyproject.toml
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "wikimedia-osm-diffs-mqtt"
+version = "0.1.0"
+description = "OpenStreetMap minutely diffs -> MQTT/UNS non-retained firehose bridge"
+authors = ["clemensv"]
+packages = [{include = "wikimedia_osm_diffs_mqtt"}]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.31.0"
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+wikimedia_osm_diffs_mqtt_producer_data = {path = "../wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data"}
+wikimedia_osm_diffs_mqtt_producer_mqtt_client = {path = "../wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client"}

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/__init__.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/__init__.py
@@ -1,0 +1,1 @@
+"""Wikimedia OSM Diffs firehose -> MQTT/UNS bridge."""

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/__main__.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
@@ -1,0 +1,475 @@
+"""OpenStreetMap minutely diffs -> MQTT/UNS bridge (firehose).
+
+Polls the OSM replication state at
+``https://planet.openstreetmap.org/replication/minute/state.txt``, fetches
+the ``.osc.gz`` diff per sequence, parses the OsmChange XML, and republishes
+each <node|way|relation> create/modify/delete as a non-retained QoS-0 MQTT 5
+binary-mode CloudEvent on the topic families::
+
+    osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change
+    osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change
+    osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change
+
+A retained side-channel summary of the last processed sequence is published to::
+
+    osm/intl/wikimedia/wikimedia-osm-diffs/replication-state
+
+Ways and relations carry no inline coordinates in OsmChange; the placeholder
+``geohash5`` for those elements is the fixed sentinel ``nogeo``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import gzip
+import io
+import json
+import logging
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+import requests
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from wikimedia_osm_diffs_mqtt_producer_data import MapChange, ReplicationState
+from wikimedia_osm_diffs_mqtt_producer_mqtt_client.client import (
+    OrgOpenStreetMapDiffsMqttMqttClient,
+)
+
+from wikimedia_osm_diffs_mqtt.enrichment import geohash5
+
+logger = logging.getLogger("wikimedia_osm_diffs_mqtt")
+
+STATE_URL = "https://planet.openstreetmap.org/replication/minute/state.txt"
+DIFF_BASE_URL = "https://planet.openstreetmap.org/replication/minute"
+DEFAULT_USER_AGENT = (
+    "real-time-sources-wikimedia-osm-diffs-mqtt/0.1 "
+    "(https://github.com/clemensv/real-time-sources)"
+)
+DEFAULT_STATE_FILE = os.path.expanduser("~/.wikimedia_osm_diffs_mqtt_state.json")
+
+
+# ---------------------------------------------------------------------------
+# OSM replication helpers (lifted from the Kafka bridge so the MQTT image
+# is self-contained; both share the same xreg-defined dataclasses).
+# ---------------------------------------------------------------------------
+
+
+def parse_state_txt(text: str) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key == "sequenceNumber":
+            result["sequence_number"] = int(value)
+        elif key == "timestamp":
+            ts_str = value.replace("\\:", ":")
+            if ts_str.endswith("Z"):
+                ts_str = ts_str[:-1] + "+00:00"
+            result["timestamp"] = datetime.datetime.fromisoformat(ts_str)
+    return result
+
+
+def sequence_to_path(seq: int) -> str:
+    a = seq // 1_000_000
+    b = (seq % 1_000_000) // 1_000
+    c = seq % 1_000
+    return f"{a:03d}/{b:03d}/{c:03d}"
+
+
+def sequence_to_url(seq: int, base_url: str = DIFF_BASE_URL) -> str:
+    return f"{base_url}/{sequence_to_path(seq)}.osc.gz"
+
+
+def parse_osmchange_xml(xml_bytes: bytes, sequence_number: int) -> List[Dict[str, Any]]:
+    """Parse an OsmChange XML payload into normalized change dicts."""
+    changes: List[Dict[str, Any]] = []
+    root = ET.fromstring(xml_bytes)
+    for action in root:
+        change_type = action.tag
+        if change_type not in ("create", "modify", "delete"):
+            continue
+        for elem in action:
+            element_type = elem.tag
+            if element_type not in ("node", "way", "relation"):
+                continue
+
+            tags: Dict[str, str] = {}
+            for child in elem:
+                if child.tag == "tag":
+                    k = child.get("k") or ""
+                    v = child.get("v") or ""
+                    tags[k] = v
+
+            ts_attr = elem.get("timestamp")
+            if ts_attr:
+                ts_str = ts_attr
+                if ts_str.endswith("Z"):
+                    ts_str = ts_str[:-1] + "+00:00"
+                ts = datetime.datetime.fromisoformat(ts_str)
+            else:
+                ts = datetime.datetime.now(datetime.timezone.utc)
+
+            uid_str = elem.get("uid")
+            user_id = int(uid_str) if uid_str else None
+            user_name = elem.get("user") or None
+
+            lat_str = elem.get("lat")
+            lon_str = elem.get("lon")
+            latitude = float(lat_str) if lat_str else None
+            longitude = float(lon_str) if lon_str else None
+
+            changes.append({
+                "change_type": change_type,
+                "element_type": element_type,
+                "element_id": int(elem.get("id", "0")),
+                "geohash5": _geohash5_for(element_type, latitude, longitude),
+                "version": int(elem.get("version", "0")),
+                "timestamp": ts,
+                "changeset_id": int(elem.get("changeset", "0")),
+                "user_name": user_name,
+                "user_id": user_id,
+                "latitude": latitude,
+                "longitude": longitude,
+                "tags": json.dumps(tags, separators=(",", ":"), ensure_ascii=False),
+                "sequence_number": sequence_number,
+            })
+    return changes
+
+
+def _geohash5_for(element_type: str, lat: Optional[float], lon: Optional[float]) -> str:
+    """Resolve the 5-character geohash placeholder for a UNS topic segment.
+
+    Nodes always have coordinates; ways and relations do not carry them in
+    OsmChange. We emit the fixed ``nogeo`` sentinel whenever the coordinate
+    pair cannot be resolved, so every topic placeholder has a non-empty
+    lowercase ASCII value (never blank, never containing a slash).
+    """
+    if lat is None or lon is None:
+        return "nogeo"
+    gh = geohash5(lat, lon)
+    return gh or "nogeo"
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+class StateStore:
+    def __init__(self, path: str) -> None:
+        self._path = Path(path)
+
+    def load(self) -> Optional[int]:
+        if not self._path.exists():
+            return None
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to load state file %s: %s", self._path, exc)
+            return None
+        return payload.get("last_sequence_number")
+
+    def save(self, last_sequence_number: int) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps({"last_sequence_number": last_sequence_number}, indent=2),
+            encoding="utf-8",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bridge
+# ---------------------------------------------------------------------------
+
+
+class OsmDiffsMqttBridge:
+    def __init__(
+        self,
+        client: OrgOpenStreetMapDiffsMqttMqttClient,
+        *,
+        state_store: Optional[StateStore] = None,
+        state_url: str = STATE_URL,
+        diff_base_url: str = DIFF_BASE_URL,
+        user_agent: str = DEFAULT_USER_AGENT,
+        poll_interval: int = 60,
+        max_retry_delay: int = 120,
+        once: bool = False,
+    ) -> None:
+        self.client = client
+        self._state_store = state_store
+        self._state_url = state_url
+        self._diff_base_url = diff_base_url
+        self._poll_interval = poll_interval
+        self._max_retry_delay = max_retry_delay
+        self._once = once
+        self._last_sequence = state_store.load() if state_store else None
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = user_agent
+        self._total_events = 0
+
+    async def run(self) -> None:
+        retry_delay = 1
+        while True:
+            try:
+                await self._poll_cycle()
+                retry_delay = 1
+                if self._once:
+                    return
+                await asyncio.sleep(self._poll_interval)
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                raise
+            except Exception as exc:
+                logger.warning("Poll cycle error: %s. Retrying in %ds.", exc, retry_delay)
+                if self._once:
+                    return
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, self._max_retry_delay)
+
+    async def _poll_cycle(self) -> None:
+        state = self._fetch_state()
+        if state is None:
+            return
+        current_seq = state["sequence_number"]
+        current_ts = state["timestamp"]
+
+        if self._last_sequence is not None and current_seq <= self._last_sequence:
+            return
+
+        start_seq = (self._last_sequence + 1) if self._last_sequence is not None else current_seq
+        start_seq = max(start_seq, current_seq - 4)
+
+        for seq in range(start_seq, current_seq + 1):
+            await self._process_sequence(seq)
+
+        await self._publish_replication_state(current_seq, current_ts)
+        self._last_sequence = current_seq
+        if self._state_store:
+            self._state_store.save(current_seq)
+        logger.info("Processed sequence %d (%d total events)", current_seq, self._total_events)
+
+    def _fetch_state(self) -> Optional[Dict[str, Any]]:
+        resp = self._session.get(self._state_url, timeout=30)
+        resp.raise_for_status()
+        return parse_state_txt(resp.text)
+
+    async def _process_sequence(self, seq: int) -> None:
+        url = sequence_to_url(seq, self._diff_base_url)
+        logger.debug("Fetching %s", url)
+        resp = self._session.get(url, timeout=60)
+        resp.raise_for_status()
+        xml_bytes = gzip.decompress(resp.content)
+        for change in parse_osmchange_xml(xml_bytes, seq):
+            await self._publish_change(change)
+
+    async def _publish_change(self, change: Dict[str, Any]) -> None:
+        data = MapChange(**change)
+        element_type = change["element_type"]
+        if element_type == "node":
+            await self.client.publish_org_open_street_map_diffs_mqtt_node(
+                geohash5=data.geohash5 or "nogeo",
+                element_id=str(data.element_id),
+                data=data,
+                qos=0,
+                retain=False,
+            )
+        elif element_type == "way":
+            await self.client.publish_org_open_street_map_diffs_mqtt_way(
+                geohash5=data.geohash5 or "nogeo",
+                element_id=str(data.element_id),
+                data=data,
+                qos=0,
+                retain=False,
+            )
+        elif element_type == "relation":
+            await self.client.publish_org_open_street_map_diffs_mqtt_relation(
+                geohash5=data.geohash5 or "nogeo",
+                element_id=str(data.element_id),
+                data=data,
+                qos=0,
+                retain=False,
+            )
+        else:
+            return
+        self._total_events += 1
+
+    async def _publish_replication_state(self, seq: int, ts: datetime.datetime) -> None:
+        state_data = ReplicationState(
+            sequence_number=seq,
+            timestamp=ts,
+            source_url=sequence_to_url(seq, self._diff_base_url),
+        )
+        await self.client.publish_org_open_street_map_diffs_mqtt_replication_state(
+            data=state_data, qos=0, retain=True,
+        )
+
+    async def emit_mock_corpus(self) -> None:
+        """Publish one synthetic change per family + a replication-state."""
+        seq = 6_500_000
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        node_change = {
+            "change_type": "create",
+            "element_type": "node",
+            "element_id": 1234567890,
+            "geohash5": _geohash5_for("node", 53.5511, 9.9937),
+            "version": 1,
+            "timestamp": now,
+            "changeset_id": 987654321,
+            "user_name": "mockuser",
+            "user_id": 42,
+            "latitude": 53.5511,
+            "longitude": 9.9937,
+            "tags": json.dumps({"amenity": "cafe", "name": "Mock Cafe"}, separators=(",", ":")),
+            "sequence_number": seq,
+        }
+        way_change = {
+            "change_type": "modify",
+            "element_type": "way",
+            "element_id": 222333444,
+            "geohash5": _geohash5_for("way", None, None),
+            "version": 7,
+            "timestamp": now,
+            "changeset_id": 987654322,
+            "user_name": "mockuser",
+            "user_id": 42,
+            "latitude": None,
+            "longitude": None,
+            "tags": json.dumps({"highway": "residential", "name": "Mock Street"}, separators=(",", ":")),
+            "sequence_number": seq,
+        }
+        relation_change = {
+            "change_type": "delete",
+            "element_type": "relation",
+            "element_id": 555666,
+            "geohash5": _geohash5_for("relation", None, None),
+            "version": 3,
+            "timestamp": now,
+            "changeset_id": 987654323,
+            "user_name": "mockuser",
+            "user_id": 42,
+            "latitude": None,
+            "longitude": None,
+            "tags": json.dumps({"type": "route", "route": "bus"}, separators=(",", ":")),
+            "sequence_number": seq,
+        }
+
+        for change in (node_change, way_change, relation_change):
+            await self._publish_change(change)
+        await self._publish_replication_state(seq, now)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_broker(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (8883 if scheme == "mqtts" else 1883)
+    return host, port, scheme == "mqtts"
+
+
+async def _run(args: argparse.Namespace) -> None:
+    broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
+    tls = tls or args.mqtt_enable_tls
+
+    paho_client = mqtt.Client(
+        callback_api_version=CallbackAPIVersion.VERSION2,
+        client_id=args.mqtt_client_id or "",
+        protocol=MQTTv5,
+    )
+    if args.mqtt_username:
+        paho_client.username_pw_set(args.mqtt_username, args.mqtt_password or "")
+    if tls:
+        paho_client.tls_set()
+
+    loop = asyncio.get_running_loop()
+    client = OrgOpenStreetMapDiffsMqttMqttClient(
+        client=paho_client,
+        content_mode="binary",
+        loop=loop,
+    )
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await client.connect(broker_host, broker_port)
+
+    state_store = StateStore(args.state_file) if args.state_file else None
+    bridge = OsmDiffsMqttBridge(
+        client,
+        state_store=state_store,
+        state_url=args.state_url,
+        diff_base_url=args.diff_base_url,
+        poll_interval=args.poll_interval,
+        once=args.once,
+    )
+
+    if args.mock:
+        logger.info("Mock mode: emitting synthetic OSM corpus and exiting")
+        await bridge.emit_mock_corpus()
+        await asyncio.sleep(1.0)
+        await client.disconnect()
+        return
+
+    try:
+        await bridge.run()
+    finally:
+        await client.disconnect()
+
+
+def main() -> None:
+    if sys.gettrace() is not None:
+        logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    else:
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    p = argparse.ArgumentParser(description="OSM minutely diffs -> MQTT/UNS bridge")
+    sub = p.add_subparsers(dest="command")
+
+    feed = sub.add_parser("feed", help="Stream OSM diffs to MQTT")
+    feed.add_argument("--mqtt-broker-url",
+                      default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    feed.add_argument("--mqtt-enable-tls", action="store_true",
+                      default=os.getenv("MQTT_ENABLE_TLS", "false").lower() in ("true", "1", "yes"))
+    feed.add_argument("--mqtt-username", default=os.getenv("MQTT_USERNAME"))
+    feed.add_argument("--mqtt-password", default=os.getenv("MQTT_PASSWORD"))
+    feed.add_argument("--mqtt-client-id", default=os.getenv("MQTT_CLIENT_ID"))
+    feed.add_argument("--state-url", default=os.getenv("OSM_DIFFS_STATE_URL", STATE_URL))
+    feed.add_argument("--diff-base-url",
+                      default=os.getenv("OSM_DIFFS_BASE_URL", DIFF_BASE_URL))
+    feed.add_argument("--state-file",
+                      default=os.getenv("OSM_DIFFS_STATE_FILE", DEFAULT_STATE_FILE))
+    feed.add_argument("--poll-interval", type=int,
+                      default=int(os.getenv("OSM_DIFFS_POLL_INTERVAL", "60")))
+    feed.add_argument("--once", action="store_true",
+                      default=os.getenv("OSM_DIFFS_ONCE", "false").lower() in ("true", "1", "yes"))
+    feed.add_argument("--mock", action="store_true",
+                      default=os.getenv("OSM_DIFFS_MOCK", "false").lower() in ("true", "1", "yes"),
+                      help="Skip OSM polling, emit one synthetic change per family + replication state, then exit")
+
+    args = p.parse_args()
+    if args.command != "feed":
+        p.print_help()
+        sys.exit(1)
+
+    try:
+        asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        logger.info("Shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/enrichment.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/enrichment.py
@@ -1,0 +1,56 @@
+"""Geohash-5 enrichment for OSM diff UNS topic placeholders."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_GEOHASH_ALPHABET = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def geohash5(latitude: Optional[float], longitude: Optional[float]) -> str:
+    """Return the 5-character base32 geohash for ``(latitude, longitude)``.
+
+    Returns ``"nogeo"`` when either coordinate is missing or out of range.
+    The returned string is always lowercase ASCII and exactly five
+    characters long, suitable for direct substitution into MQTT topic
+    placeholders.
+    """
+    if latitude is None or longitude is None:
+        return "nogeo"
+    try:
+        lat = float(latitude)
+        lon = float(longitude)
+    except (TypeError, ValueError):
+        return "nogeo"
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return "nogeo"
+
+    precision = 5
+    lat_range = [-90.0, 90.0]
+    lon_range = [-180.0, 180.0]
+    bits: list[int] = []
+    even = True
+    while len(bits) < precision * 5:
+        if even:
+            mid = (lon_range[0] + lon_range[1]) / 2.0
+            if lon >= mid:
+                bits.append(1)
+                lon_range[0] = mid
+            else:
+                bits.append(0)
+                lon_range[1] = mid
+        else:
+            mid = (lat_range[0] + lat_range[1]) / 2.0
+            if lat >= mid:
+                bits.append(1)
+                lat_range[0] = mid
+            else:
+                bits.append(0)
+                lat_range[1] = mid
+        even = not even
+
+    out = []
+    for i in range(0, len(bits), 5):
+        idx = (bits[i] << 4) | (bits[i + 1] << 3) | (bits[i + 2] << 2) | (bits[i + 3] << 1) | bits[i + 4]
+        out.append(_GEOHASH_ALPHABET[idx])
+    return "".join(out)

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/Makefile
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./wikimedia_osm_diffs_mqtt_producer_data ./wikimedia_osm_diffs_mqtt_producer_mqtt_client
+
+install: build
+	cd wikimedia_osm_diffs_mqtt_producer_data && poetry install
+	cd wikimedia_osm_diffs_mqtt_producer_mqtt_client && poetry install
+	pip install ./wikimedia_osm_diffs_mqtt_producer_data ./wikimedia_osm_diffs_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./wikimedia_osm_diffs_mqtt_producer_mqtt_client/tests ./wikimedia_osm_diffs_mqtt_producer_data/tests

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/README.md
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/README.md
@@ -1,0 +1,1180 @@
+# Wikimedia_osm_diffs_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the wikimedia_osm_diffs_mqtt_producer message definitions.
+
+# Wikimedia_osm_diffs_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - OrgOpenStreetMapDiffsMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from wikimedia_osm_diffs_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure
+Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = OrgOpenStreetMapDiffsMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### OrgOpenStreetMapDiffsMqttEventDispatcher
+
+
+
+# Publish message`OrgOpenStreetMapDiffsMqttEventDispatcher` handles events for the Org.OpenStreetMap.Diffs.mqtt message
+group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from wikimedia_osm_diffs_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = OrgOpenStreetMapDiffsMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the
+Event Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe OrgOpenStreetMapDiffsMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `org_open_street_map_diffs_mqtt_node_async`
+
+
+
+## Test```python
+
+org_open_street_map_diffs_mqtt_node_async:  Callable[[PartitionContext, EventData, CloudEvent, MapChange],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Node`: An individual element change from the
+OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a
+node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `wikimedia_osm_diffs_mqtt_producer_data.MapChange`.
+
+Example:
+
+```python
+async def org_open_street_map_diffs_mqtt_node_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: MapChange) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_node_async =
+org_open_street_map_diffs_mqtt_node_event
+```
+
+
+
+make build
+
+```##### `org_open_street_map_diffs_mqtt_way_async`
+
+
+
+## Test```python
+
+org_open_street_map_diffs_mqtt_way_async:  Callable[[PartitionContext, EventData, CloudEvent, MapChange],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Way`: An individual element change from the OpenStreetMap
+minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or
+relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `wikimedia_osm_diffs_mqtt_producer_data.MapChange`.
+
+Example:
+
+```python
+async def org_open_street_map_diffs_mqtt_way_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: MapChange) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_way_async =
+org_open_street_map_diffs_mqtt_way_event
+```
+
+
+
+make build
+
+```##### `org_open_street_map_diffs_mqtt_relation_async`
+
+
+
+## Test```python
+
+org_open_street_map_diffs_mqtt_relation_async:  Callable[[PartitionContext, EventData, CloudEvent, MapChange],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Relation`: An individual element change from the
+OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a
+node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `wikimedia_osm_diffs_mqtt_producer_data.MapChange`.
+
+Example:
+
+```python
+async def org_open_street_map_diffs_mqtt_relation_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: MapChange) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_relation_async =
+org_open_street_map_diffs_mqtt_relation_event
+```
+
+
+
+make build
+
+```##### `org_open_street_map_diffs_mqtt_replication_state_async`
+
+
+
+## Test```python
+
+org_open_street_map_diffs_mqtt_replication_state_async:  Callable[[PartitionContext, EventData, CloudEvent,
+ReplicationState], Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.ReplicationState`: Current replication state from the
+OpenStreetMap minutely diff feed. Emitted once per poll cycle to record which replication sequence was just processed.
+The state is read from https://planet.openstreetmap.org/replication/minute/state.txt.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `wikimedia_osm_diffs_mqtt_producer_data.ReplicationState`.
+
+Example:
+
+```python
+async def org_open_street_map_diffs_mqtt_replication_state_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: ReplicationState) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_replication_state_async =
+org_open_street_map_diffs_mqtt_replication_state_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/install.bat
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\wikimedia_osm_diffs_mqtt_producer_data
+pip install .\wikimedia_osm_diffs_mqtt_producer_mqtt_client

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/install.sh
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./wikimedia_osm_diffs_mqtt_producer_data
+pip install ./wikimedia_osm_diffs_mqtt_producer_mqtt_client

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/samples/sample.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/samples/sample.py
@@ -1,0 +1,101 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from wikimedia_osm_diffs_mqtt_producer_data import *
+from wikimedia_osm_diffs_mqtt_producer_mqtt_client.client import OrgOpenStreetMapDiffsMqttProducer, OrgOpenStreetMapDiffsMqttDispatcher
+
+async def handle_org_open_street_map_diffs_mqtt_node(mqtt_msg,cloud_event, org_open_street_map_diffs_mqtt_node_data):
+    """ Handles the Org.OpenStreetMap.Diffs.mqtt.Node message """
+    print(f"Received Org.OpenStreetMap.Diffs.mqtt.Node on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {org_open_street_map_diffs_mqtt_node_data}")
+
+async def handle_org_open_street_map_diffs_mqtt_way(mqtt_msg,cloud_event, org_open_street_map_diffs_mqtt_way_data):
+    """ Handles the Org.OpenStreetMap.Diffs.mqtt.Way message """
+    print(f"Received Org.OpenStreetMap.Diffs.mqtt.Way on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {org_open_street_map_diffs_mqtt_way_data}")
+
+async def handle_org_open_street_map_diffs_mqtt_relation(mqtt_msg,cloud_event, org_open_street_map_diffs_mqtt_relation_data):
+    """ Handles the Org.OpenStreetMap.Diffs.mqtt.Relation message """
+    print(f"Received Org.OpenStreetMap.Diffs.mqtt.Relation on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {org_open_street_map_diffs_mqtt_relation_data}")
+
+async def handle_org_open_street_map_diffs_mqtt_replication_state(mqtt_msg,cloud_event, org_open_street_map_diffs_mqtt_replication_state_data):
+    """ Handles the Org.OpenStreetMap.Diffs.mqtt.ReplicationState message """
+    print(f"Received Org.OpenStreetMap.Diffs.mqtt.ReplicationState on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {org_open_street_map_diffs_mqtt_replication_state_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/scripts/build.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["wikimedia_osm_diffs_mqtt_producer_mqtt_client", "wikimedia_osm_diffs_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/pyproject.toml
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "wikimedia-osm-diffs-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "wikimedia_osm_diffs_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/__init__.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .mapchange import MapChange
+from .replicationstate import ReplicationState
+
+__all__ = ["MapChange", "ReplicationState"]

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/mapchange.py
@@ -177,17 +177,17 @@ class MapChange:
             An instance of the dataclass.
         """
         return cls(
-            change_type='etszfwfpjecxalvkejsk',
-            element_type='udqmikpptqspjubfcrkg',
-            element_id=int(38),
-            geohash5='trihytyiamzwysoboodo',
-            version=int(88),
+            change_type='clghtpiadujfsggneetb',
+            element_type='uwuxdnmvyfedxxrriybq',
+            element_id=int(30),
+            geohash5='noxwbuqfnavfvmiqxzvx',
+            version=int(8),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(68),
-            user_name='iupminodrqjpbarcdsyh',
-            user_id=int(38),
-            latitude=float(79.79775288294415),
-            longitude=float(95.91527798692695),
-            tags='yslnqwxggghfcvyswion',
-            sequence_number=int(57)
+            changeset_id=int(88),
+            user_name='ltyzumsmnhdbromuptwj',
+            user_id=int(6),
+            latitude=float(13.905275865647514),
+            longitude=float(39.57107662278012),
+            tags='dcreyjsvbiojblfxitwq',
+            sequence_number=int(92)
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/replicationstate.py
@@ -1,4 +1,4 @@
-""" MapChange dataclass. """
+""" ReplicationState dataclass. """
 
 # pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
 from __future__ import annotations
@@ -17,43 +17,23 @@ import datetime
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
-class MapChange:
+class ReplicationState:
     """
-    An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.
+    The current replication state of the OpenStreetMap minutely diff feed. Published once per poll cycle. The sequence_number and timestamp are parsed from the Java-properties-style state.txt file at https://planet.openstreetmap.org/replication/minute/state.txt.
     
     Attributes:
-        change_type (str)
-        element_type (str)
-        element_id (int)
-        geohash5 (typing.Optional[str])
-        version (int)
-        timestamp (datetime.datetime)
-        changeset_id (int)
-        user_name (typing.Optional[str])
-        user_id (typing.Optional[int])
-        latitude (typing.Optional[float])
-        longitude (typing.Optional[float])
-        tags (str)
         sequence_number (int)
+        timestamp (datetime.datetime)
+        source_url (typing.Optional[str])
     """
     
     
-    change_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="change_type"))
-    element_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_type"))
-    element_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_id"))
-    geohash5: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash5"))
-    version: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="version"))
-    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
-    changeset_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="changeset_id"))
-    user_name: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="user_name"))
-    user_id: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="user_id"))
-    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
-    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
-    tags: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tags"))
     sequence_number: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sequence_number"))
+    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    source_url: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="source_url"))
 
     @classmethod
-    def from_serializer_dict(cls, data: dict) -> 'MapChange':
+    def from_serializer_dict(cls, data: dict) -> 'ReplicationState':
         """
         Converts a dictionary to a dataclass instance.
         
@@ -126,7 +106,7 @@ class MapChange:
         return result
 
     @classmethod
-    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['MapChange']:
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['ReplicationState']:
         """
         Converts the data to a dataclass based on the content type string.
         
@@ -163,13 +143,13 @@ class MapChange:
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
                 _record = json.loads(data_str)
-                return MapChange.from_serializer_dict(_record)
+                return ReplicationState.from_serializer_dict(_record)
             else:
                 raise NotImplementedError('Data is not of a supported type for JSON deserialization')
         raise NotImplementedError(f'Unsupported media type {content_type}')
 
     @classmethod
-    def create_instance(cls) -> 'MapChange':
+    def create_instance(cls) -> 'ReplicationState':
         """
         Creates an instance of the dataclass with test values.
         
@@ -177,17 +157,7 @@ class MapChange:
             An instance of the dataclass.
         """
         return cls(
-            change_type='etszfwfpjecxalvkejsk',
-            element_type='udqmikpptqspjubfcrkg',
-            element_id=int(38),
-            geohash5='trihytyiamzwysoboodo',
-            version=int(88),
+            sequence_number=int(57),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(68),
-            user_name='iupminodrqjpbarcdsyh',
-            user_id=int(38),
-            latitude=float(79.79775288294415),
-            longitude=float(95.91527798692695),
-            tags='yslnqwxggghfcvyswion',
-            sequence_number=int(57)
+            source_url='hsbvbiyenickwbhusvhm'
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_mapchange.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from wikimedia_osm_diffs_producer_data.mapchange import MapChange
+from wikimedia_osm_diffs_mqtt_producer_data.mapchange import MapChange
 import datetime
 
 
@@ -29,19 +29,19 @@ class Test_MapChange(unittest.TestCase):
         Create instance of MapChange for testing
         """
         instance = MapChange(
-            change_type='etszfwfpjecxalvkejsk',
-            element_type='udqmikpptqspjubfcrkg',
-            element_id=int(38),
-            geohash5='trihytyiamzwysoboodo',
-            version=int(88),
+            change_type='clghtpiadujfsggneetb',
+            element_type='uwuxdnmvyfedxxrriybq',
+            element_id=int(30),
+            geohash5='noxwbuqfnavfvmiqxzvx',
+            version=int(8),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(68),
-            user_name='iupminodrqjpbarcdsyh',
-            user_id=int(38),
-            latitude=float(79.79775288294415),
-            longitude=float(95.91527798692695),
-            tags='yslnqwxggghfcvyswion',
-            sequence_number=int(57)
+            changeset_id=int(88),
+            user_name='ltyzumsmnhdbromuptwj',
+            user_id=int(6),
+            latitude=float(13.905275865647514),
+            longitude=float(39.57107662278012),
+            tags='dcreyjsvbiojblfxitwq',
+            sequence_number=int(92)
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test change_type property
         """
-        test_value = 'etszfwfpjecxalvkejsk'
+        test_value = 'clghtpiadujfsggneetb'
         self.instance.change_type = test_value
         self.assertEqual(self.instance.change_type, test_value)
     
@@ -58,7 +58,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_type property
         """
-        test_value = 'udqmikpptqspjubfcrkg'
+        test_value = 'uwuxdnmvyfedxxrriybq'
         self.instance.element_type = test_value
         self.assertEqual(self.instance.element_type, test_value)
     
@@ -66,7 +66,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_id property
         """
-        test_value = int(38)
+        test_value = int(30)
         self.instance.element_id = test_value
         self.assertEqual(self.instance.element_id, test_value)
     
@@ -74,7 +74,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test geohash5 property
         """
-        test_value = 'trihytyiamzwysoboodo'
+        test_value = 'noxwbuqfnavfvmiqxzvx'
         self.instance.geohash5 = test_value
         self.assertEqual(self.instance.geohash5, test_value)
     
@@ -82,7 +82,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test version property
         """
-        test_value = int(88)
+        test_value = int(8)
         self.instance.version = test_value
         self.assertEqual(self.instance.version, test_value)
     
@@ -98,7 +98,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test changeset_id property
         """
-        test_value = int(68)
+        test_value = int(88)
         self.instance.changeset_id = test_value
         self.assertEqual(self.instance.changeset_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_name property
         """
-        test_value = 'iupminodrqjpbarcdsyh'
+        test_value = 'ltyzumsmnhdbromuptwj'
         self.instance.user_name = test_value
         self.assertEqual(self.instance.user_name, test_value)
     
@@ -114,7 +114,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_id property
         """
-        test_value = int(38)
+        test_value = int(6)
         self.instance.user_id = test_value
         self.assertEqual(self.instance.user_id, test_value)
     
@@ -122,7 +122,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(79.79775288294415)
+        test_value = float(13.905275865647514)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -130,7 +130,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(95.91527798692695)
+        test_value = float(39.57107662278012)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -138,7 +138,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test tags property
         """
-        test_value = 'yslnqwxggghfcvyswion'
+        test_value = 'dcreyjsvbiojblfxitwq'
         self.instance.tags = test_value
         self.assertEqual(self.instance.tags, test_value)
     
@@ -146,7 +146,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(57)
+        test_value = int(92)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_replicationstate.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from wikimedia_osm_diffs_producer_data.replicationstate import ReplicationState
+from wikimedia_osm_diffs_mqtt_producer_data.replicationstate import ReplicationState
 import datetime
 
 
@@ -29,9 +29,9 @@ class Test_ReplicationState(unittest.TestCase):
         Create instance of ReplicationState for testing
         """
         instance = ReplicationState(
-            sequence_number=int(24),
+            sequence_number=int(57),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            source_url='wjcdlgddtyzrynwsankg'
+            source_url='hsbvbiyenickwbhusvhm'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(24)
+        test_value = int(57)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test source_url property
         """
-        test_value = 'wjcdlgddtyzrynwsankg'
+        test_value = 'hsbvbiyenickwbhusvhm'
         self.instance.source_url = test_value
         self.assertEqual(self.instance.source_url, test_value)
     

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/pyproject.toml
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "wikimedia-osm-diffs-mqtt-producer-mqtt-client"
+description = "wikimedia_osm_diffs_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "wikimedia_osm_diffs_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+wikimedia-osm-diffs-mqtt-producer-data = {path = "../wikimedia_osm_diffs_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/__init__.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import OrgOpenStreetMapDiffsMqttMqttClient
+
+__all__ = [
+    "OrgOpenStreetMapDiffsMqttMqttClient",
+]

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/client.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,686 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import wikimedia_osm_diffs_mqtt_producer_data
+from wikimedia_osm_diffs_mqtt_producer_data import MapChange
+from wikimedia_osm_diffs_mqtt_producer_data import ReplicationState
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_org_openstreetmap_diffs_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the Org.OpenStreetMap.Diffs.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "Org.OpenStreetMap.Diffs.mqtt.Node": "osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change",
+        "Org.OpenStreetMap.Diffs.mqtt.Way": "osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change",
+        "Org.OpenStreetMap.Diffs.mqtt.Relation": "osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change",
+        "Org.OpenStreetMap.Diffs.mqtt.ReplicationState": "osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state",
+    }
+
+
+def get_subscription_topics_org_openstreetmap_diffs_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_org_openstreetmap_diffs_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class OrgOpenStreetMapDiffsMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the Org.OpenStreetMap.Diffs.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_org_openstreetmap_diffs_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.org_open_street_map_diffs_mqtt_node_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, wikimedia_osm_diffs_mqtt_producer_data.MapChange, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.org_open_street_map_diffs_mqtt_way_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, wikimedia_osm_diffs_mqtt_producer_data.MapChange, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.org_open_street_map_diffs_mqtt_relation_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, wikimedia_osm_diffs_mqtt_producer_data.MapChange, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.org_open_street_map_diffs_mqtt_replication_state_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, wikimedia_osm_diffs_mqtt_producer_data.ReplicationState, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "Org.OpenStreetMap.Diffs.MapChange":
+            if self.org_open_street_map_diffs_mqtt_node_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = wikimedia_osm_diffs_mqtt_producer_data.MapChange.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "Org.OpenStreetMap.Diffs.mqtt.Node")
+                    await self.org_open_street_map_diffs_mqtt_node_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in org_open_street_map_diffs_mqtt_node handler: {e}")
+            return
+        
+        if event_type == "Org.OpenStreetMap.Diffs.MapChange":
+            if self.org_open_street_map_diffs_mqtt_way_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = wikimedia_osm_diffs_mqtt_producer_data.MapChange.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "Org.OpenStreetMap.Diffs.mqtt.Way")
+                    await self.org_open_street_map_diffs_mqtt_way_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in org_open_street_map_diffs_mqtt_way handler: {e}")
+            return
+        
+        if event_type == "Org.OpenStreetMap.Diffs.MapChange":
+            if self.org_open_street_map_diffs_mqtt_relation_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = wikimedia_osm_diffs_mqtt_producer_data.MapChange.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "Org.OpenStreetMap.Diffs.mqtt.Relation")
+                    await self.org_open_street_map_diffs_mqtt_relation_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in org_open_street_map_diffs_mqtt_relation handler: {e}")
+            return
+        
+        if event_type == "Org.OpenStreetMap.Diffs.ReplicationState":
+            if self.org_open_street_map_diffs_mqtt_replication_state_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = wikimedia_osm_diffs_mqtt_producer_data.ReplicationState.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "Org.OpenStreetMap.Diffs.mqtt.ReplicationState")
+                    await self.org_open_street_map_diffs_mqtt_replication_state_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in org_open_street_map_diffs_mqtt_replication_state handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_org_openstreetmap_diffs_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_org_open_street_map_diffs_mqtt_node(self,
+        geohash5: str,
+        element_id: str,
+        data: wikimedia_osm_diffs_mqtt_producer_data.MapChange,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'Org.OpenStreetMap.Diffs.mqtt.Node' event to an MQTT topic.
+
+        Args:
+        
+            geohash5: URI template variable for 'geohash5'
+            element_id: URI template variable for 'element_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (0).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change"
+        _topic_template_values: Dict[str, str] = {
+            "geohash5": str(geohash5),
+            "element_id": str(element_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = geohash5,element_id = element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 0 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_org_open_street_map_diffs_mqtt_way(self,
+        geohash5: str,
+        element_id: str,
+        data: wikimedia_osm_diffs_mqtt_producer_data.MapChange,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'Org.OpenStreetMap.Diffs.mqtt.Way' event to an MQTT topic.
+
+        Args:
+        
+            geohash5: URI template variable for 'geohash5'
+            element_id: URI template variable for 'element_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (0).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change"
+        _topic_template_values: Dict[str, str] = {
+            "geohash5": str(geohash5),
+            "element_id": str(element_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = geohash5,element_id = element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 0 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_org_open_street_map_diffs_mqtt_relation(self,
+        geohash5: str,
+        element_id: str,
+        data: wikimedia_osm_diffs_mqtt_producer_data.MapChange,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'Org.OpenStreetMap.Diffs.mqtt.Relation' event to an MQTT topic.
+
+        Args:
+        
+            geohash5: URI template variable for 'geohash5'
+            element_id: URI template variable for 'element_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (0).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change"
+        _topic_template_values: Dict[str, str] = {
+            "geohash5": str(geohash5),
+            "element_id": str(element_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = geohash5,element_id = element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 0 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_org_open_street_map_diffs_mqtt_replication_state(self,
+        data: wikimedia_osm_diffs_mqtt_producer_data.ReplicationState,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'Org.OpenStreetMap.Diffs.mqtt.ReplicationState' event to an MQTT topic.
+
+        Args:
+        
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (0).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state"
+        _topic_template_values: Dict[str, str] = {
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.ReplicationState",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"replication-state"
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 0 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,308 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../wikimedia_osm_diffs_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../wikimedia_osm_diffs_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../wikimedia_osm_diffs_mqtt_producer_mqtt_client/src')))
+
+import wikimedia_osm_diffs_mqtt_producer_data
+from wikimedia_osm_diffs_mqtt_producer_data import MapChange
+from test_wikimedia_osm_diffs_mqtt_producer_data_mapchange import Test_MapChange
+from wikimedia_osm_diffs_mqtt_producer_data import ReplicationState
+from test_wikimedia_osm_diffs_mqtt_producer_data_replicationstate import Test_ReplicationState
+from wikimedia_osm_diffs_mqtt_producer_mqtt_client import OrgOpenStreetMapDiffsMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_org_openstreetmap_diffs_mqtt_org_open_street_map_diffs_mqtt_node_py(mosquitto_broker):
+    """Test publishing and receiving Org.OpenStreetMap.Diffs.mqtt.Node message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_MapChange.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = OrgOpenStreetMapDiffsMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = OrgOpenStreetMapDiffsMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_org_open_street_map_diffs_mqtt_node(mqtt_msg, cloud_event, data: wikimedia_osm_diffs_mqtt_producer_data.MapChange, topic_params: dict):
+        """Handler for Org.OpenStreetMap.Diffs.mqtt.Node messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "Org.OpenStreetMap.Diffs.MapChange"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.org_open_street_map_diffs_mqtt_node_async = on_org_open_street_map_diffs_mqtt_node
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/org_openstreetmap_diffs_mqtt/org_open_street_map_diffs_mqtt_node"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_org_open_street_map_diffs_mqtt_node(
+            topic=test_topic,
+            geohash5=f"test_geohash5_{i}",
+            element_id=f"test_element_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_org_openstreetmap_diffs_mqtt_org_open_street_map_diffs_mqtt_way_py(mosquitto_broker):
+    """Test publishing and receiving Org.OpenStreetMap.Diffs.mqtt.Way message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_MapChange.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = OrgOpenStreetMapDiffsMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = OrgOpenStreetMapDiffsMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_org_open_street_map_diffs_mqtt_way(mqtt_msg, cloud_event, data: wikimedia_osm_diffs_mqtt_producer_data.MapChange, topic_params: dict):
+        """Handler for Org.OpenStreetMap.Diffs.mqtt.Way messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "Org.OpenStreetMap.Diffs.MapChange"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.org_open_street_map_diffs_mqtt_way_async = on_org_open_street_map_diffs_mqtt_way
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/org_openstreetmap_diffs_mqtt/org_open_street_map_diffs_mqtt_way"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_org_open_street_map_diffs_mqtt_way(
+            topic=test_topic,
+            geohash5=f"test_geohash5_{i}",
+            element_id=f"test_element_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_org_openstreetmap_diffs_mqtt_org_open_street_map_diffs_mqtt_relation_py(mosquitto_broker):
+    """Test publishing and receiving Org.OpenStreetMap.Diffs.mqtt.Relation message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_MapChange.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = OrgOpenStreetMapDiffsMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = OrgOpenStreetMapDiffsMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_org_open_street_map_diffs_mqtt_relation(mqtt_msg, cloud_event, data: wikimedia_osm_diffs_mqtt_producer_data.MapChange, topic_params: dict):
+        """Handler for Org.OpenStreetMap.Diffs.mqtt.Relation messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "Org.OpenStreetMap.Diffs.MapChange"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.org_open_street_map_diffs_mqtt_relation_async = on_org_open_street_map_diffs_mqtt_relation
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/org_openstreetmap_diffs_mqtt/org_open_street_map_diffs_mqtt_relation"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_org_open_street_map_diffs_mqtt_relation(
+            topic=test_topic,
+            geohash5=f"test_geohash5_{i}",
+            element_id=f"test_element_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_org_openstreetmap_diffs_mqtt_org_open_street_map_diffs_mqtt_replication_state_py(mosquitto_broker):
+    """Test publishing and receiving Org.OpenStreetMap.Diffs.mqtt.ReplicationState message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_ReplicationState.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = OrgOpenStreetMapDiffsMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = OrgOpenStreetMapDiffsMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_org_open_street_map_diffs_mqtt_replication_state(mqtt_msg, cloud_event, data: wikimedia_osm_diffs_mqtt_producer_data.ReplicationState, topic_params: dict):
+        """Handler for Org.OpenStreetMap.Diffs.mqtt.ReplicationState messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "Org.OpenStreetMap.Diffs.ReplicationState"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.org_open_street_map_diffs_mqtt_replication_state_async = on_org_open_street_map_diffs_mqtt_replication_state
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/org_openstreetmap_diffs_mqtt/org_open_street_map_diffs_mqtt_replication_state"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_org_open_street_map_diffs_mqtt_replication_state(
+            topic=test_topic,
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/README.md
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/README.md
@@ -17,7 +17,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 3. [Quick Start](#quick-start)    - OrgOpenStreetMapDiffsEventDispatcher,
 
-4. [Generated Producer Classes](#generated-producer-classes)    OrgOpenStreetMapDiffsStateEventDispatcher
+4. [Generated Producer Classes](#generated-producer-classes)    OrgOpenStreetMapDiffsStateEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    OrgOpenStreetMapDiffsMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -45,6 +47,10 @@ It includes both plain Kafka messages and CloudEvents, offering a versatile
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - OrgOpenStreetMapDiffsStateProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- OrgOpenStreetMapDiffsMqttProducersolution for event-driven applications.
 
 
 
@@ -234,6 +240,45 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 org_open_street_map_diffs_state_dispatcher.org_open_street_map_diffs_map_change_async =
+org_open_street_map_diffs_map_change_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_map_change_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange)
+-> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_map_change_async =
 org_open_street_map_diffs_map_change_event
 
 **Parameters:**```
@@ -546,6 +591,46 @@ org_open_street_map_diffs_replication_state_event
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type
+`wikimedia_osm_diffs_producer_data.ReplicationState`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_replication_state_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ReplicationState) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_replication_state_async =
+org_open_street_map_diffs_replication_state_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -642,6 +727,1103 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_org_open_street_map_diffs_replication_state_batch(```
+
+    messages=[
+
+        ReplicationState(...),Initializes the runner with a Kafka consumer.
+
+        ReplicationState(...),
+
+        ReplicationState(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### OrgOpenStreetMapDiffsMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`OrgOpenStreetMapDiffsMqttEventDispatcher` handles events for the Org.OpenStreetMap.Diffs.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from wikimedia-osm-diffs-producer import OrgOpenStreetMapDiffsProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = OrgOpenStreetMapDiffsProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_org_open_street_map_diffs_map_change(```python
+
+    data=MapChange(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The OrgOpenStreetMapDiffsMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = OrgOpenStreetMapDiffsProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `org_open_street_map_diffs_mqtt_node_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'org_open_street_map_diffs_mqtt_node_async:  Callable[[ConsumerRecord, CloudEvent,
+MapChange], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Node`: An individual element change from the OpenStreetMap
+minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or
+relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_node_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_dispatcher.org_open_street_map_diffs_mqtt_node_async =
+org_open_street_map_diffs_mqtt_node_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsStateProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.State` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_node_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsStateProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_state_dispatcher.org_open_street_map_diffs_mqtt_node_async =
+org_open_street_map_diffs_mqtt_node_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_node_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_node_async =
+org_open_street_map_diffs_mqtt_node_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `org_open_street_map_diffs_mqtt_way_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'org_open_street_map_diffs_mqtt_way_async:  Callable[[ConsumerRecord, CloudEvent,
+MapChange], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Way`: An individual element change from the OpenStreetMap
+minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or
+relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_way_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_dispatcher.org_open_street_map_diffs_mqtt_way_async = org_open_street_map_diffs_mqtt_way_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsStateProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.State` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_way_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsStateProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_state_dispatcher.org_open_street_map_diffs_mqtt_way_async =
+org_open_street_map_diffs_mqtt_way_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_way_event(record: ConsumerRecord, cloud_event: CloudEvent, data: MapChange) ->
+None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_way_async =
+org_open_street_map_diffs_mqtt_way_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `org_open_street_map_diffs_mqtt_relation_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'org_open_street_map_diffs_mqtt_relation_async:  Callable[[ConsumerRecord, CloudEvent,
+MapChange], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.Relation`: An individual element change from the
+OpenStreetMap minutely replication diff feed. Each event represents a single create, modify, or delete operation on a
+node, way, or relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_relation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+MapChange) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_dispatcher.org_open_street_map_diffs_mqtt_relation_async =
+org_open_street_map_diffs_mqtt_relation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsStateProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.State` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_relation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+MapChange) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsStateProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_state_dispatcher.org_open_street_map_diffs_mqtt_relation_async =
+org_open_street_map_diffs_mqtt_relation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.MapChange`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_relation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+MapChange) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_relation_async =
+org_open_street_map_diffs_mqtt_relation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `org_open_street_map_diffs_mqtt_replication_state_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'org_open_street_map_diffs_mqtt_replication_state_async:  Callable[[ConsumerRecord,
+CloudEvent, ReplicationState], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `Org.OpenStreetMap.Diffs.mqtt.ReplicationState`: Current replication state from the
+OpenStreetMap minutely diff feed. Emitted once per poll cycle to record which replication sequence was just processed.
+The state is read from https://planet.openstreetmap.org/replication/minute/state.txt.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsProducer- `data`: The event data of type `wikimedia_osm_diffs_producer_data.ReplicationState`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_replication_state_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ReplicationState) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_dispatcher.org_open_street_map_diffs_mqtt_replication_state_async =
+org_open_street_map_diffs_mqtt_replication_state_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsStateProducer- `data`: The event data of type
+`wikimedia_osm_diffs_producer_data.ReplicationState`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.State` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_replication_state_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ReplicationState) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsStateProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_state_dispatcher.org_open_street_map_diffs_mqtt_replication_state_async =
+org_open_street_map_diffs_mqtt_replication_state_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### OrgOpenStreetMapDiffsMqttProducer- `data`: The event data of type
+`wikimedia_osm_diffs_producer_data.ReplicationState`.
+
+
+
+Producer for `Org.OpenStreetMap.Diffs.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def org_open_street_map_diffs_mqtt_replication_state_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ReplicationState) -> None:
+
+```python    # Process the event data
+
+OrgOpenStreetMapDiffsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+org_open_street_map_diffs_mqtt_dispatcher.org_open_street_map_diffs_mqtt_replication_state_async =
+org_open_street_map_diffs_mqtt_replication_state_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_org_open_street_map_diffs_mqtt_node`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_org_open_street_map_diffs_mqtt_node(
+
+    self,##### `_process_event`
+
+    data: MapChange,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `Org.OpenStreetMap.Diffs.mqtt.Node` message. An individual element change from the OpenStreetMap minutely
+replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in
+the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `MapChange`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_org_open_street_map_diffs_mqtt_node(
+
+    data=MapChange(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `Org.OpenStreetMap.Diffs.mqtt.Node` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_org_open_street_map_diffs_mqtt_node_batch(```
+
+    messages=[
+
+        MapChange(...),Initializes the runner with a Kafka consumer.
+
+        MapChange(...),
+
+        MapChange(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_org_open_street_map_diffs_mqtt_way`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_org_open_street_map_diffs_mqtt_way(
+
+    self,##### `_process_event`
+
+    data: MapChange,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `Org.OpenStreetMap.Diffs.mqtt.Way` message. An individual element change from the OpenStreetMap minutely
+replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or relation in
+the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `MapChange`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_org_open_street_map_diffs_mqtt_way(
+
+    data=MapChange(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `Org.OpenStreetMap.Diffs.mqtt.Way` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_org_open_street_map_diffs_mqtt_way_batch(```
+
+    messages=[
+
+        MapChange(...),Initializes the runner with a Kafka consumer.
+
+        MapChange(...),
+
+        MapChange(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_org_open_street_map_diffs_mqtt_relation`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_org_open_street_map_diffs_mqtt_relation(
+
+    self,##### `_process_event`
+
+    data: MapChange,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `Org.OpenStreetMap.Diffs.mqtt.Relation` message. An individual element change from the OpenStreetMap
+minutely replication diff feed. Each event represents a single create, modify, or delete operation on a node, way, or
+relation in the OSM database. The diff files are OsmChange XML documents published every 60 seconds at
+https://planet.openstreetmap.org/replication/minute/.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `MapChange`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_org_open_street_map_diffs_mqtt_relation(
+
+    data=MapChange(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `Org.OpenStreetMap.Diffs.mqtt.Relation` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_org_open_street_map_diffs_mqtt_relation_batch(```
+
+    messages=[
+
+        MapChange(...),Initializes the runner with a Kafka consumer.
+
+        MapChange(...),
+
+        MapChange(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_org_open_street_map_diffs_mqtt_replication_state`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_org_open_street_map_diffs_mqtt_replication_state(
+
+    self,##### `_process_event`
+
+    data: ReplicationState,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `Org.OpenStreetMap.Diffs.mqtt.ReplicationState` message. Current replication state from the OpenStreetMap
+minutely diff feed. Emitted once per poll cycle to record which replication sequence was just processed. The state is
+read from https://planet.openstreetmap.org/replication/minute/state.txt.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `ReplicationState`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_org_open_street_map_diffs_mqtt_replication_state(
+
+    data=ReplicationState(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `Org.OpenStreetMap.Diffs.mqtt.ReplicationState` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_org_open_street_map_diffs_mqtt_replication_state_batch(```
 
     messages=[
 

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/samples/sample.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/samples/sample.py
@@ -34,6 +34,7 @@ from confluent_kafka import Producer as KafkaProducer
 
 from wikimedia_osm_diffs_producer_kafka_producer.producer import OrgOpenStreetMapDiffsEventProducer
 from wikimedia_osm_diffs_producer_kafka_producer.producer import OrgOpenStreetMapDiffsStateEventProducer
+from wikimedia_osm_diffs_producer_kafka_producer.producer import OrgOpenStreetMapDiffsMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -81,6 +82,46 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'Org.OpenStreetMap.Diffs.ReplicationState' event to Kafka topic.
     await org_open_street_map_diffs_state_event_producer.send_org_open_street_map_diffs_replication_state(data = _replication_state)
     print(f"Sent 'Org.OpenStreetMap.Diffs.ReplicationState' event: {_replication_state.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        org_open_street_map_diffs_mqtt_event_producer = OrgOpenStreetMapDiffsMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        org_open_street_map_diffs_mqtt_event_producer = OrgOpenStreetMapDiffsMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- Org.OpenStreetMap.Diffs.mqtt.Node ----
+    # TODO: Supply event data for the Org.OpenStreetMap.Diffs.mqtt.Node event
+    _map_change = MapChange()
+
+    # sends the 'Org.OpenStreetMap.Diffs.mqtt.Node' event to Kafka topic.
+    await org_open_street_map_diffs_mqtt_event_producer.send_org_open_street_map_diffs_mqtt_node(_geohash5 = 'TODO: replace me', _element_id = 'TODO: replace me', data = _map_change)
+    print(f"Sent 'Org.OpenStreetMap.Diffs.mqtt.Node' event: {_map_change.to_json()}")
+
+    # ---- Org.OpenStreetMap.Diffs.mqtt.Way ----
+    # TODO: Supply event data for the Org.OpenStreetMap.Diffs.mqtt.Way event
+    _map_change = MapChange()
+
+    # sends the 'Org.OpenStreetMap.Diffs.mqtt.Way' event to Kafka topic.
+    await org_open_street_map_diffs_mqtt_event_producer.send_org_open_street_map_diffs_mqtt_way(_geohash5 = 'TODO: replace me', _element_id = 'TODO: replace me', data = _map_change)
+    print(f"Sent 'Org.OpenStreetMap.Diffs.mqtt.Way' event: {_map_change.to_json()}")
+
+    # ---- Org.OpenStreetMap.Diffs.mqtt.Relation ----
+    # TODO: Supply event data for the Org.OpenStreetMap.Diffs.mqtt.Relation event
+    _map_change = MapChange()
+
+    # sends the 'Org.OpenStreetMap.Diffs.mqtt.Relation' event to Kafka topic.
+    await org_open_street_map_diffs_mqtt_event_producer.send_org_open_street_map_diffs_mqtt_relation(_geohash5 = 'TODO: replace me', _element_id = 'TODO: replace me', data = _map_change)
+    print(f"Sent 'Org.OpenStreetMap.Diffs.mqtt.Relation' event: {_map_change.to_json()}")
+
+    # ---- Org.OpenStreetMap.Diffs.mqtt.ReplicationState ----
+    # TODO: Supply event data for the Org.OpenStreetMap.Diffs.mqtt.ReplicationState event
+    _replication_state = ReplicationState()
+
+    # sends the 'Org.OpenStreetMap.Diffs.mqtt.ReplicationState' event to Kafka topic.
+    await org_open_street_map_diffs_mqtt_event_producer.send_org_open_street_map_diffs_mqtt_replication_state(data = _replication_state)
+    print(f"Sent 'Org.OpenStreetMap.Diffs.mqtt.ReplicationState' event: {_replication_state.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/replicationstate.py
@@ -24,11 +24,13 @@ class ReplicationState:
     Attributes:
         sequence_number (int)
         timestamp (datetime.datetime)
+        source_url (typing.Optional[str])
     """
     
     
     sequence_number: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sequence_number"))
     timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    source_url: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="source_url"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'ReplicationState':
@@ -155,6 +157,7 @@ class ReplicationState:
             An instance of the dataclass.
         """
         return cls(
-            sequence_number=int(62),
-            timestamp=datetime.datetime.now(datetime.timezone.utc)
+            sequence_number=int(24),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            source_url='wjcdlgddtyzrynwsankg'
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_kafka_producer/src/wikimedia_osm_diffs_producer_kafka_producer/producer.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_kafka_producer/src/wikimedia_osm_diffs_producer_kafka_producer/producer.py
@@ -236,3 +236,211 @@ class OrgOpenStreetMapDiffsStateEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class OrgOpenStreetMapDiffsMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_org_open_street_map_diffs_mqtt_node(self,_geohash5 : str, _element_id : str, data: MapChange, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, MapChange], str]=None) -> None:
+        """
+        Sends the 'Org.OpenStreetMap.Diffs.mqtt.Node' event to the Kafka topic
+
+        Args:
+            _geohash5(str):  Value for placeholder geohash5 in attribute subject
+            _element_id(str):  Value for placeholder element_id in attribute subject
+            data: (MapChange): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, MapChange], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = _geohash5,element_id = _element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_org_open_street_map_diffs_mqtt_way(self,_geohash5 : str, _element_id : str, data: MapChange, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, MapChange], str]=None) -> None:
+        """
+        Sends the 'Org.OpenStreetMap.Diffs.mqtt.Way' event to the Kafka topic
+
+        Args:
+            _geohash5(str):  Value for placeholder geohash5 in attribute subject
+            _element_id(str):  Value for placeholder element_id in attribute subject
+            data: (MapChange): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, MapChange], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = _geohash5,element_id = _element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_org_open_street_map_diffs_mqtt_relation(self,_geohash5 : str, _element_id : str, data: MapChange, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, MapChange], str]=None) -> None:
+        """
+        Sends the 'Org.OpenStreetMap.Diffs.mqtt.Relation' event to the Kafka topic
+
+        Args:
+            _geohash5(str):  Value for placeholder geohash5 in attribute subject
+            _element_id(str):  Value for placeholder element_id in attribute subject
+            data: (MapChange): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, MapChange], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.MapChange",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"{geohash5}/{element_id}".format(geohash5 = _geohash5,element_id = _element_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_org_open_street_map_diffs_mqtt_replication_state(self,data: ReplicationState, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ReplicationState], str]=None) -> None:
+        """
+        Sends the 'Org.OpenStreetMap.Diffs.mqtt.ReplicationState' event to the Kafka topic
+
+        Args:
+            data: (ReplicationState): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, ReplicationState], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"Org.OpenStreetMap.Diffs.ReplicationState",
+             "source":"https://planet.openstreetmap.org/replication/minute",
+             "subject":"replication-state"
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'OrgOpenStreetMapDiffsMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_kafka_producer/tests/test_producer.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_kafka_producer/tests/test_producer.py
@@ -24,6 +24,7 @@ from test_wikimedia_osm_diffs_producer_data_mapchange import Test_MapChange
 from wikimedia_osm_diffs_producer_kafka_producer.producer import OrgOpenStreetMapDiffsStateEventProducer
 from wikimedia_osm_diffs_producer_data import ReplicationState
 from test_wikimedia_osm_diffs_producer_data_replicationstate import Test_ReplicationState
+from wikimedia_osm_diffs_producer_kafka_producer.producer import OrgOpenStreetMapDiffsMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -179,4 +180,248 @@ def test_org_openstreetmap_diffs_state_orgopenstreetmapdiffsreplicationstate(kaf
         received_key = on_event()
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         assert received_key == "replication_state", f"Expected Kafka key 'replication_state' but got '{received_key}'"
+    consumer.close()
+
+
+def test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttnode(kafka_emulator):
+    """Test the OrgOpenStreetMapDiffsMqttNode event from the Org.OpenStreetMap.Diffs.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttnode',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "Org.OpenStreetMap.Diffs.mqtt.Node":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = OrgOpenStreetMapDiffsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_MapChange.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_org_open_street_map_diffs_mqtt_node(_geohash5 = f'test_{i}', _element_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttway(kafka_emulator):
+    """Test the OrgOpenStreetMapDiffsMqttWay event from the Org.OpenStreetMap.Diffs.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttway',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "Org.OpenStreetMap.Diffs.mqtt.Way":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = OrgOpenStreetMapDiffsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_MapChange.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_org_open_street_map_diffs_mqtt_way(_geohash5 = f'test_{i}', _element_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttrelation(kafka_emulator):
+    """Test the OrgOpenStreetMapDiffsMqttRelation event from the Org.OpenStreetMap.Diffs.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttrelation',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "Org.OpenStreetMap.Diffs.mqtt.Relation":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = OrgOpenStreetMapDiffsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_MapChange.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_org_open_street_map_diffs_mqtt_relation(_geohash5 = f'test_{i}', _element_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttreplicationstate(kafka_emulator):
+    """Test the OrgOpenStreetMapDiffsMqttReplicationState event from the Org.OpenStreetMap.Diffs.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_org_openstreetmap_diffs_mqtt_orgopenstreetmapdiffsmqttreplicationstate',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "Org.OpenStreetMap.Diffs.mqtt.ReplicationState":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = OrgOpenStreetMapDiffsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_ReplicationState.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_org_open_street_map_diffs_mqtt_replication_state(data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()

--- a/wikimedia-osm-diffs/xreg/wikimedia_osm_diffs.xreg.json
+++ b/wikimedia-osm-diffs/xreg/wikimedia_osm_diffs.xreg.json
@@ -41,6 +41,27 @@
       "messagegroups": [
         "#/messagegroups/Org.OpenStreetMap.Diffs.State"
       ]
+    },
+    "WikimediaOsmDiffs.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/Org.OpenStreetMap.Diffs.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -89,6 +110,103 @@
           "dataschemauri": "#/schemagroups/Org.OpenStreetMap.Diffs.jstruct/schemas/Org.OpenStreetMap.Diffs.ReplicationState"
         }
       }
+    },
+    "Org.OpenStreetMap.Diffs.mqtt": {
+      "description": "MQTT/5.0 UNS variants of the Wikimedia OSM Diffs CloudEvents. The minutely diff stream is split into three non-retained firehose families (node, way, relation) under osm/intl/wikimedia/wikimedia-osm-diffs/<family>/{geohash5}/{element_id}/change with QoS 0 and retain=false, and one retained side-channel snapshot for the OSM replication sequence published to osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state with retain=true so late subscribers can see the most recent processed sequence number on connect.",
+      "messages": {
+        "Org.OpenStreetMap.Diffs.mqtt.Node": {
+          "name": "Node",
+          "basemessageurl": "/messagegroups/Org.OpenStreetMap.Diffs/messages/Org.OpenStreetMap.Diffs.MapChange",
+          "protocol": "MQTT/5.0",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "Org.OpenStreetMap.Diffs.MapChange"
+            },
+            "source": {
+              "value": "https://planet.openstreetmap.org/replication/minute"
+            },
+            "subject": {
+              "value": "{geohash5}/{element_id}",
+              "type": "uritemplate"
+            }
+          },
+          "protocoloptions": {
+            "topic_name": "osm/intl/wikimedia/wikimedia-osm-diffs/node/{geohash5}/{element_id}/change",
+            "qos": 0,
+            "retain": false
+          }
+        },
+        "Org.OpenStreetMap.Diffs.mqtt.Way": {
+          "name": "Way",
+          "basemessageurl": "/messagegroups/Org.OpenStreetMap.Diffs/messages/Org.OpenStreetMap.Diffs.MapChange",
+          "protocol": "MQTT/5.0",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "Org.OpenStreetMap.Diffs.MapChange"
+            },
+            "source": {
+              "value": "https://planet.openstreetmap.org/replication/minute"
+            },
+            "subject": {
+              "value": "{geohash5}/{element_id}",
+              "type": "uritemplate"
+            }
+          },
+          "protocoloptions": {
+            "topic_name": "osm/intl/wikimedia/wikimedia-osm-diffs/way/{geohash5}/{element_id}/change",
+            "qos": 0,
+            "retain": false
+          }
+        },
+        "Org.OpenStreetMap.Diffs.mqtt.Relation": {
+          "name": "Relation",
+          "basemessageurl": "/messagegroups/Org.OpenStreetMap.Diffs/messages/Org.OpenStreetMap.Diffs.MapChange",
+          "protocol": "MQTT/5.0",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "Org.OpenStreetMap.Diffs.MapChange"
+            },
+            "source": {
+              "value": "https://planet.openstreetmap.org/replication/minute"
+            },
+            "subject": {
+              "value": "{geohash5}/{element_id}",
+              "type": "uritemplate"
+            }
+          },
+          "protocoloptions": {
+            "topic_name": "osm/intl/wikimedia/wikimedia-osm-diffs/relation/{geohash5}/{element_id}/change",
+            "qos": 0,
+            "retain": false
+          }
+        },
+        "Org.OpenStreetMap.Diffs.mqtt.ReplicationState": {
+          "name": "ReplicationState",
+          "basemessageurl": "/messagegroups/Org.OpenStreetMap.Diffs.State/messages/Org.OpenStreetMap.Diffs.ReplicationState",
+          "protocol": "MQTT/5.0",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "Org.OpenStreetMap.Diffs.ReplicationState"
+            },
+            "source": {
+              "value": "https://planet.openstreetmap.org/replication/minute"
+            },
+            "subject": {
+              "value": "replication-state",
+              "type": "uritemplate"
+            }
+          },
+          "protocoloptions": {
+            "topic_name": "osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state",
+            "qos": 0,
+            "retain": true
+          }
+        }
+      }
     }
   },
   "schemagroups": {
@@ -106,7 +224,7 @@
                 "$id": "https://example.com/schemas/Org/OpenStreetMap/Diffs/MapChange",
                 "name": "MapChange",
                 "type": "object",
-                "description": "An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively.",
+                "description": "An individual element change from the OpenStreetMap minutely replication diff feed. Each event describes a create, modify, or delete of a node, way, or relation. Latitude and longitude are present only for node elements. Tags are JSON-encoded because xreg does not support map types natively. The geohash5 axis is the 5-character base32 geohash of the element's representative coordinate; relations without a derivable bounding box receive the sentinel 'nogeo' so they still publish onto the UNS tree.",
                 "properties": {
                   "change_type": {
                     "type": "string",
@@ -119,6 +237,13 @@
                   "element_id": {
                     "type": "int64",
                     "description": "The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity."
+                  },
+                  "geohash5": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis."
                   },
                   "version": {
                     "type": "int32",
@@ -204,6 +329,13 @@
                   "timestamp": {
                     "type": "datetime",
                     "description": "The UTC timestamp associated with the replication state, indicating the point in time up to which the diff file covers OSM edits."
+                  },
+                  "source_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The replication state document URL from which this snapshot was parsed. Useful so subscribers can re-derive the diff file URL or compare across mirror feeds. Null when the bridge does not record the URL."
                   }
                 },
                 "required": [


### PR DESCRIPTION
Adds the `wikimedia-osm-diffs-mqtt` sibling app/container that re-publishes the OpenStreetMap minutely diff stream as a non-retained MQTT 5 / UNS firehose split into three topic families (node/way/relation) under `osm/intl/wikimedia/wikimedia-osm-diffs/{element_type}/{geohash5}/{element_id}/change`, plus a retained `replication-state` side-channel.`r`n`r`n## What`r`n`r`n* New `wikimedia-osm-diffs/Dockerfile.mqtt` + `wikimedia_osm_diffs_mqtt/` package (mirrors the bluesky / aisstream pattern).`r`n* xreg manifest extended with an `Org.OpenStreetMap.Diffs.mqtt` messagegroup of 4 MQTT messages; `MapChange` schema gains an optional `geohash5` and `ReplicationState` gains an optional `source_url` (both nullable so the Kafka bridge keeps working).`r`n* Regenerated producer SDKs (Kafka + MQTT) via `xrcg 0.10.6`. The existing Kafka bridge now populates `geohash5`/`source_url` so the new schemas remain back-compatible.`r`n* Self-contained `app.py` lifts state.txt parsing / sequence URL helpers from the Kafka bridge and adds `emit_mock_corpus()` (one node + one way + one relation + one replication-state; ways/relations have no coords so `geohash5='nogeo'`).`r`n* `TestWikimediaOsmDiffsMqttDockerFlow` Docker E2E: subscriber attaches first inside `on_connect` (per the hard SUBSCRIBE-on-connect rule), feeder runs in `--mock`, assertions cover topic shape, CE binary-mode user properties (`id`/`source`/`type`/`subject`/`specversion`), subject ⊆ topic, `nogeo` sentinel; a follow-up subscriber on a fresh connection verifies the broker actually retained the replication-state and did NOT retain firehose messages.`r`n* `matrix.json` gains build + flow rows for `wikimedia-osm-diffs-mqtt`.`r`n* `CONTAINER.md` / `README.md` / `EVENTS.md` updated.`r`n`r`n## Verification`r`n`r`n* `docker build -f wikimedia-osm-diffs/Dockerfile.mqtt` succeeds (both kafka and mqtt images build green).`r`n* `pytest tests/docker_e2e/test_docker_mqtt_flow.py::TestWikimediaOsmDiffsMqttDockerFlow -xvs` -> passes locally (29s) with a real Mosquitto 2 broker.