### PR TITLE
fix(hongkong-epd): use air-quality root + kebab-case district axis

### DIFF
--- a/hongkong-epd/CONTAINER.md
+++ b/hongkong-epd/CONTAINER.md
@@ -75,8 +75,8 @@ events as **MQTT 5.0 binary-mode CloudEvents** into a Unified-Namespace
 topic tree:
 
 ```
-aq/hk/epd/hongkong-epd/{district}/{station_id}/info   # station reference
-aq/hk/epd/hongkong-epd/{district}/{station_id}/aqhi   # latest AQHI reading
+air-quality/hk/epd/hongkong-epd/{district}/{station_id}/info   # station reference
+air-quality/hk/epd/hongkong-epd/{district}/{station_id}/aqhi   # latest AQHI reading
 ```
 
 Every leaf is published with QoS 1 and `retain=true` so any subscriber
@@ -105,11 +105,11 @@ HTTP service is re-polled (default 3600 s).
 
 ```
 # Everything from this source
-aq/hk/epd/hongkong-epd/#
+air-quality/hk/epd/hongkong-epd/#
 
 # All AQHI readings for stations in the Central & Western district
-aq/hk/epd/hongkong-epd/central_and_western/+/aqhi
+air-quality/hk/epd/hongkong-epd/central-and-western/+/aqhi
 
 # Reference data for every station
-aq/hk/epd/hongkong-epd/+/+/info
+air-quality/hk/epd/hongkong-epd/+/+/info
 ```

--- a/hongkong-epd/Dockerfile.mqtt
+++ b/hongkong-epd/Dockerfile.mqtt
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 
 LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/hongkong-epd"
 LABEL org.opencontainers.image.title="Hong Kong EPD AQHI → MQTT/UNS bridge"
-LABEL org.opencontainers.image.description="Polls the Hong Kong EPD AQHI XML feed for air quality readings and publishes MQTT 5.0 binary-mode CloudEvents into a Unified-Namespace topic tree (aq/hk/epd/hongkong-epd/{district}/{station_id}/...)."
+LABEL org.opencontainers.image.description="Polls the Hong Kong EPD AQHI XML feed for air quality readings and publishes MQTT 5.0 binary-mode CloudEvents into a Unified-Namespace topic tree (air-quality/hk/epd/hongkong-epd/{district}/{station_id}/...)."
 LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/hongkong-epd/CONTAINER.md"
 LABEL org.opencontainers.image.license="MIT"
 LABEL source.transport="mqtt"

--- a/hongkong-epd/EVENTS.md
+++ b/hongkong-epd/EVENTS.md
@@ -15,7 +15,7 @@ Reference data for Hong Kong EPD AQHI monitoring stations.
 | `station_id` | string | — | Stable snake_case station identifier |
 | `station_name` | string | — | Station name from the EPD feed |
 | `station_type` | string | — | `General Stations` or `Roadside Stations` |
-| `district` | string | — | Hong Kong 18-district area (snake_case), e.g. `central_and_western` |
+| `district` | string | — | Hong Kong 18-district area (snake_case), e.g. `central-and-western` |
 | `latitude` | float | ° | WGS84 latitude |
 | `longitude` | float | ° | WGS84 longitude |
 
@@ -28,14 +28,14 @@ Latest AQHI reading emitted for each station from the 24-hour XML feed.
 | `station_id` | string | — | Stable snake_case station identifier |
 | `station_name` | string | — | Station name from the EPD feed |
 | `station_type` | string | — | `General Stations` or `Roadside Stations` |
-| `district` | string | — | Hong Kong 18-district area (snake_case), e.g. `central_and_western` |
+| `district` | string | — | Hong Kong 18-district area (snake_case), e.g. `central-and-western` |
 | `reading_time` | datetime | — | Observation timestamp in ISO 8601 |
 | `aqhi` | integer | — | AQHI value, where values above 10 mean `10+` |
 | `health_risk_category` | string | — | Derived risk category: Low, Moderate, High, Very High, or Serious |
 
 ## MQTT/UNS Topics
 
-Topic tree: `aq/hk/epd/hongkong-epd/{district}/{station_id}/{event}`
+Topic tree: `air-quality/hk/epd/hongkong-epd/{district}/{station_id}/{event}`
 
 | Leaf | CloudEvents Type | Description |
 |---|---|---|

--- a/hongkong-epd/hongkong_epd_mqtt/hongkong_epd_mqtt/app.py
+++ b/hongkong-epd/hongkong_epd_mqtt/hongkong_epd_mqtt/app.py
@@ -4,7 +4,7 @@ Reuses the upstream HTTP client and station catalog logic from the existing
 ``hongkong_epd`` Kafka bridge and pushes CloudEvents into MQTT 5.0 using the
 xrcg-generated :class:`HKGovEPDAQHIMqttMqttClient`.
 
-Topic tree: ``aq/hk/epd/hongkong-epd/{district}/{station_id}/{info|aqhi}``.
+Topic tree: ``air-quality/hk/epd/hongkong-epd/{district}/{station_id}/{info|aqhi}``.
 ``{district}`` is the Hong Kong 18-district administrative area where the
 station is located, normalized to lowercase snake_case.
 """
@@ -34,26 +34,27 @@ from hongkong_epd_mqtt_producer_mqtt_client.client import HKGovEPDAQHIMqttMqttCl
 
 logger = logging.getLogger(__name__)
 
-# Mapping from station_id to the Hong Kong 18-district administrative area.
+# Mapping from station_id to the Hong Kong 18-district administrative area
+# (kebab-case, matching the {district} MQTT topic axis).
 STATION_ID_TO_DISTRICT: Dict[str, str] = {
-    "central_western": "central_and_western",
+    "central_western": "central-and-western",
     "eastern": "eastern",
-    "kwai_chung": "kwai_tsing",
-    "kwun_tong": "kwun_tong",
+    "kwai_chung": "kwai-tsing",
+    "kwun_tong": "kwun-tong",
     "north": "north",
-    "sha_tin": "sha_tin",
-    "sham_shui_po": "sham_shui_po",
+    "sha_tin": "sha-tin",
+    "sham_shui_po": "sham-shui-po",
     "southern": "southern",
-    "tai_po": "tai_po",
+    "tai_po": "tai-po",
     "tap_mun": "islands",
-    "tseung_kwan_o": "sai_kung",
-    "tsuen_wan": "tsuen_wan",
-    "tuen_mun": "tuen_mun",
+    "tseung_kwan_o": "sai-kung",
+    "tsuen_wan": "tsuen-wan",
+    "tuen_mun": "tuen-mun",
     "tung_chung": "islands",
-    "yuen_long": "yuen_long",
-    "causeway_bay": "wan_chai",
-    "central": "central_and_western",
-    "mong_kok": "yau_tsim_mong",
+    "yuen_long": "yuen-long",
+    "causeway_bay": "wan-chai",
+    "central": "central-and-western",
+    "mong_kok": "yau-tsim-mong",
 }
 
 
@@ -151,7 +152,7 @@ async def feed(
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
     await mqtt_client.connect(broker_host, broker_port)
 
-    logger.info("Publishing station info events under aq/hk/epd/hongkong-epd/...")
+    logger.info("Publishing station info events under air-quality/hk/epd/hongkong-epd/...")
     await _publish_stations(mqtt_client, api)
     logger.info("Finished publishing station catalog")
 

--- a/hongkong-epd/xreg/hongkong_epd.xreg.json
+++ b/hongkong-epd/xreg/hongkong_epd.xreg.json
@@ -77,14 +77,14 @@
       }
     },
     "HK.Gov.EPD.AQHI.mqtt": {
-      "description": "MQTT/5.0 transport variants of the HK EPD AQHI CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under aq/hk/epd/hongkong-epd/{district}/{station_id}/... The {district} placeholder is the Hong Kong 18-district administrative area where the station is located, normalized to lowercase snake_case.",
+      "description": "MQTT/5.0 transport variants of the HK EPD AQHI CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under air-quality/hk/epd/hongkong-epd/{district}/{station_id}/... The {district} placeholder is the Hong Kong 18-district administrative area where the station is located, normalized to lowercase snake_case.",
       "messages": {
         "HK.Gov.EPD.AQHI.mqtt.Station": {
           "name": "Station",
           "basemessageurl": "/messagegroups/HK.Gov.EPD.AQHI/messages/HK.Gov.EPD.AQHI.Station",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "topic_name": "aq/hk/epd/hongkong-epd/{district}/{station_id}/info",
+            "topic_name": "air-quality/hk/epd/hongkong-epd/{district}/{station_id}/info",
             "qos": 1,
             "retain": true
           }
@@ -94,7 +94,7 @@
           "basemessageurl": "/messagegroups/HK.Gov.EPD.AQHI/messages/HK.Gov.EPD.AQHI.AQHIReading",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "topic_name": "aq/hk/epd/hongkong-epd/{district}/{station_id}/aqhi",
+            "topic_name": "air-quality/hk/epd/hongkong-epd/{district}/{station_id}/aqhi",
             "qos": 1,
             "retain": true
           }
@@ -143,7 +143,7 @@
                   },
                   "district": {
                     "type": "string",
-                    "description": "Hong Kong 18-district administrative area where the monitoring station is located, normalized to lowercase snake_case. Used as the {district} segment of the MQTT/UNS topic. Examples: central_and_western, wan_chai, yau_tsim_mong."
+                    "description": "Hong Kong 18-district administrative area where the monitoring station is located, normalized to lowercase snake_case. Used as the {district} segment of the MQTT/UNS topic. Examples: central-and-western, wan-chai, yau-tsim-mong."
                   },
                   "latitude": {
                     "type": [


### PR DESCRIPTION
Narrow review-driven fixup off main. Renames MQTT topic root from q/ to ir-quality/ (matching the canonical UNS family-root convention used by other air-quality feeders) and switches the {district} segment slugifier to kebab-case so the topic axis is consistent with kebab-case axes used elsewhere in the namespace. Updates xreg schemas, generated bridge code, EVENTS.md, CONTAINER.md, and Dockerfile.mqtt.