### PR TITLE
fix(wallonia-issep): air-quality root + {province} axis

### DIFF
--- a/wallonia-issep/CONTAINER.md
+++ b/wallonia-issep/CONTAINER.md
@@ -8,17 +8,17 @@ The **MQTT variant** (`Dockerfile.mqtt`) publishes retained, QoS-1,
 binary-mode CloudEvents into a Unified-Namespace topic tree:
 
 ```
-aq/be/wallonia/wallonia-issep/{configuration_id}/info
-aq/be/wallonia/wallonia-issep/{configuration_id}/observation
+air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/info
+air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/observation
 ```
 
 ### Wildcard subscriptions
 
 | Pattern | What it captures |
 |---------|-----------------|
-| `aq/be/wallonia/wallonia-issep/#` | All air-quality events for Wallonia ISSeP |
-| `aq/be/wallonia/wallonia-issep/+/info` | All sensor configuration info events |
-| `aq/be/wallonia/wallonia-issep/+/observation` | All observation events |
+| `air-quality/be/issep/wallonia-issep/#` | All air-quality events for Wallonia ISSeP |
+| `air-quality/be/issep/wallonia-issep/+/info` | All sensor configuration info events |
+| `air-quality/be/issep/wallonia-issep/+/observation` | All observation events |
 
 ### Environment variables (MQTT)
 

--- a/wallonia-issep/Dockerfile.mqtt
+++ b/wallonia-issep/Dockerfile.mqtt
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 
 LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/wallonia-issep"
 LABEL org.opencontainers.image.title="Wallonia ISSeP Air Quality → MQTT/UNS bridge"
-LABEL org.opencontainers.image.description="Polls the Wallonia ISSeP air quality sensor network (via ODWB Opendatasoft) and publishes MQTT 5.0 binary-mode CloudEvents into a Unified-Namespace topic tree (aq/be/wallonia/wallonia-issep/{configuration_id}/...)."
+LABEL org.opencontainers.image.description="Polls the Wallonia ISSeP air quality sensor network (via ODWB Opendatasoft) and publishes MQTT 5.0 binary-mode CloudEvents into a Unified-Namespace topic tree (air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/...)."
 LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/wallonia-issep/CONTAINER.md"
 LABEL org.opencontainers.image.license="MIT"
 LABEL source.transport="mqtt"

--- a/wallonia-issep/EVENTS.md
+++ b/wallonia-issep/EVENTS.md
@@ -1,6 +1,6 @@
-# Wallonia ISSeP Air Quality Bridge Events
+# Wallonia ISSEP Air Quality Bridge Events
 
-This document describes the events that are emitted by the Wallonia ISSeP Air Quality Bridge.
+Events emitted by the Wallonia ISSEP bridge.
 
 - [be.issep.airquality.Sensors](#message-group-beissepairqualitysensors)
   - [be.issep.airquality.SensorConfiguration](#message-beissepairqualitysensorconfiguration)
@@ -27,6 +27,7 @@ This document describes the events that are emitted by the Wallonia ISSeP Air Qu
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
 | `configuration_id` | *string* | - | `True` | Stable numeric identifier of the sensor configuration from the upstream id_configuration field. Converted to string because it serves as the CloudEvents subject and Kafka key. |
+| `province` | *string* | - | `True` | Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or "unknown" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis. |
 ---
 ### Message: be.issep.airquality.Observation
 #### CloudEvents Attributes:
@@ -42,6 +43,7 @@ This document describes the events that are emitted by the Wallonia ISSeP Air Qu
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
 | `configuration_id` | *string* | - | `True` | Stable numeric sensor configuration identifier from id_configuration. Matches the CloudEvents subject and Kafka key. |
+| `province` | *string* | - | `True` | Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or "unknown" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis. |
 | `moment` | *string* | - | `True` | ISO 8601 observation timestamp from the upstream moment field, e.g. '2026-04-08T09:09:13+02:00'. Preserved as-is from the API response. |
 | `co` | *int32* (optional) | - | `False` | Raw carbon monoxide electrochemical sensor reading in internal units. |
 | `no` | *int32* (optional) | - | `False` | Raw nitric oxide electrochemical sensor reading in internal units. |
@@ -99,6 +101,7 @@ This document describes the events that are emitted by the Wallonia ISSeP Air Qu
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
 | `configuration_id` | *string* | - | `True` | Stable numeric identifier of the sensor configuration from the upstream id_configuration field. Converted to string because it serves as the CloudEvents subject and Kafka key. |
+| `province` | *string* | - | `True` | Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or "unknown" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis. |
 ---
 ### Message: be.issep.airquality.Sensors.mqtt.Observation
 #### CloudEvents Attributes:
@@ -114,6 +117,7 @@ This document describes the events that are emitted by the Wallonia ISSeP Air Qu
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
 | `configuration_id` | *string* | - | `True` | Stable numeric sensor configuration identifier from id_configuration. Matches the CloudEvents subject and Kafka key. |
+| `province` | *string* | - | `True` | Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or "unknown" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis. |
 | `moment` | *string* | - | `True` | ISO 8601 observation timestamp from the upstream moment field, e.g. '2026-04-08T09:09:13+02:00'. Preserved as-is from the API response. |
 | `co` | *int32* (optional) | - | `False` | Raw carbon monoxide electrochemical sensor reading in internal units. |
 | `no` | *int32* (optional) | - | `False` | Raw nitric oxide electrochemical sensor reading in internal units. |

--- a/wallonia-issep/README.md
+++ b/wallonia-issep/README.md
@@ -64,7 +64,7 @@ Start the MQTT bridge:
 python -m wallonia_issep_mqtt feed --broker-url mqtt://localhost:1883
 ```
 
-Topic tree: `aq/be/wallonia/wallonia-issep/{configuration_id}/{info|observation}`
+Topic tree: `air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/{info|observation}`
 
 ## Upstream links
 

--- a/wallonia-issep/wallonia_issep_mqtt/wallonia_issep_mqtt/app.py
+++ b/wallonia-issep/wallonia_issep_mqtt/wallonia_issep_mqtt/app.py
@@ -4,7 +4,7 @@ Reuses the upstream HTTP client logic from the existing ``wallonia_issep``
 Kafka bridge and pushes CloudEvents into MQTT 5.0 using the xrcg-generated
 :class:`BeIssepAirqualitySensorsMqttMqttClient`.
 
-Topic tree: ``aq/be/wallonia/wallonia-issep/{configuration_id}/{info|observation}``.
+Topic tree: ``air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/{info|observation}``.
 """
 
 from __future__ import annotations
@@ -35,9 +35,14 @@ async def _publish_configurations(
     """Extract and publish sensor configuration reference events."""
     configs = WalloniaISsePAPI.extract_configurations(records)
     for config in configs:
-        data = SensorConfiguration(configuration_id=config.configuration_id)
+        province = getattr(config, "province", None) or "unknown"
+        data = SensorConfiguration(
+            configuration_id=config.configuration_id,
+            province=province,
+        )
         await mqtt_client.publish_be_issep_airquality_sensors_mqtt_sensor_configuration(
             configuration_id=config.configuration_id,
+            province=province,
             data=data,
         )
     logger.info("Published %d sensor configuration info events", len(configs))
@@ -48,6 +53,7 @@ def _build_observation_data(obs) -> Observation:
     """Build an MQTT Observation dataclass from a normalized upstream observation."""
     return Observation(
         configuration_id=obs.configuration_id,
+        province=getattr(obs, "province", None) or "unknown",
         moment=obs.moment,
         co=obs.co,
         no=obs.no,
@@ -107,6 +113,7 @@ async def _publish_observations(
             data = _build_observation_data(obs)
             await mqtt_client.publish_be_issep_airquality_sensors_mqtt_observation(
                 configuration_id=obs.configuration_id,
+                province=getattr(obs, "province", None) or "unknown",
                 data=data,
             )
             count += 1
@@ -158,7 +165,7 @@ async def feed(
 
     # Initial full fetch: publish both reference data and observations
     all_records = api.fetch_all_records()
-    logger.info("Publishing sensor configuration info events under aq/be/wallonia/wallonia-issep/...")
+    logger.info("Publishing sensor configuration info events under air-quality/be/issep/wallonia-issep/...")
     await _publish_configurations(mqtt_client, all_records)
 
     # Publish observations from the initial batch (treats all as new)
@@ -170,6 +177,7 @@ async def feed(
             data = _build_observation_data(obs)
             await mqtt_client.publish_be_issep_airquality_sensors_mqtt_observation(
                 configuration_id=obs.configuration_id,
+                province=getattr(obs, "province", None) or "unknown",
                 data=data,
             )
             init_count += 1

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/__init__.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/__init__.py
@@ -1,4 +1,4 @@
-from .sensorconfiguration import SensorConfiguration
 from .observation import Observation
+from .sensorconfiguration import SensorConfiguration
 
-__all__ = ["SensorConfiguration", "Observation"]
+__all__ = ["Observation", "SensorConfiguration"]

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/observation.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/observation.py
@@ -21,6 +21,7 @@ class Observation:
     
     Attributes:
         configuration_id (str)
+        province (str)
         moment (str)
         co (typing.Optional[int])
         no (typing.Optional[int])
@@ -66,6 +67,7 @@ class Observation:
     
     
     configuration_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="configuration_id"))
+    province: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="province"))
     moment: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="moment"))
     co: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="co"))
     no: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="no"))
@@ -233,46 +235,47 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            configuration_id='jwrrbcvhgmwnxfycaquk',
-            moment='chudtsmfqybmcivksxlq',
-            co=int(15),
-            no=int(28),
-            no2=int(28),
-            o3no2=int(16),
-            ppbno=float(24.16994733807941),
-            ppbno_statut=int(86),
-            ppbno2=float(0.03469932648516583),
-            ppbno2_statut=int(2),
-            ppbo3=float(43.53984489647272),
-            ppbo3_statut=int(44),
-            ugpcmno=float(79.7818732296871),
-            ugpcmno_statut=int(45),
-            ugpcmno2=float(69.83135022175607),
-            ugpcmno2_statut=int(94),
-            ugpcmo3=float(32.67851827613665),
-            ugpcmo3_statut=int(42),
-            bme_t=float(15.855151754298014),
-            bme_t_statut=int(89),
-            bme_pres=int(49),
-            bme_pres_statut=int(26),
-            bme_rh=float(0.7019100399006994),
-            bme_rh_statut=int(76),
-            pm1=float(10.857443760970732),
-            pm1_statut=int(56),
-            pm25=float(73.42415285430127),
-            pm25_statut=int(36),
-            pm4=float(58.49102337347398),
-            pm4_statut=int(14),
-            pm10=float(5.3560387400305),
-            pm10_statut=int(31),
-            vbat=float(70.55150465884368),
-            vbat_statut=int(91),
-            mwh_bat=float(62.37542059954579),
-            mwh_pv=float(68.32541406295078),
-            co_rf=float(64.32048673203494),
-            no_rf=float(89.30412982130048),
-            no2_rf=float(7.951076087324138),
-            o3no2_rf=float(19.0813988784979),
-            o3_rf=float(18.519047076504602),
-            pm10_rf=float(45.97927280117505)
+            configuration_id='wdbuhfvxuccchmwriiuk',
+            province='puvcjimmajjqdgiqsuaa',
+            moment='dwakvuxjbpohuteqdjsw',
+            co=int(4),
+            no=int(17),
+            no2=int(59),
+            o3no2=int(45),
+            ppbno=float(84.9479650831437),
+            ppbno_statut=int(18),
+            ppbno2=float(28.7116783250542),
+            ppbno2_statut=int(94),
+            ppbo3=float(7.1201512423551545),
+            ppbo3_statut=int(52),
+            ugpcmno=float(22.87867316064478),
+            ugpcmno_statut=int(19),
+            ugpcmno2=float(51.42337262228529),
+            ugpcmno2_statut=int(29),
+            ugpcmo3=float(41.507834755994885),
+            ugpcmo3_statut=int(74),
+            bme_t=float(82.24890251389802),
+            bme_t_statut=int(14),
+            bme_pres=int(94),
+            bme_pres_statut=int(90),
+            bme_rh=float(61.57551054821811),
+            bme_rh_statut=int(13),
+            pm1=float(41.927053408985884),
+            pm1_statut=int(38),
+            pm25=float(20.78993052546525),
+            pm25_statut=int(86),
+            pm4=float(1.8135991933360351),
+            pm4_statut=int(56),
+            pm10=float(18.931095942028975),
+            pm10_statut=int(89),
+            vbat=float(56.04872924639533),
+            vbat_statut=int(40),
+            mwh_bat=float(58.14062731516068),
+            mwh_pv=float(55.06309207267126),
+            co_rf=float(20.466768930176094),
+            no_rf=float(1.1975561159446757),
+            no2_rf=float(40.95696333046901),
+            o3no2_rf=float(62.84542271205182),
+            o3_rf=float(51.689186569297455),
+            pm10_rf=float(75.63828798435026)
         )

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/sensorconfiguration.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/src/wallonia_issep_mqtt_producer_data/sensorconfiguration.py
@@ -21,10 +21,12 @@ class SensorConfiguration:
     
     Attributes:
         configuration_id (str)
+        province (str)
     """
     
     
     configuration_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="configuration_id"))
+    province: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="province"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'SensorConfiguration':
@@ -151,5 +153,6 @@ class SensorConfiguration:
             An instance of the dataclass.
         """
         return cls(
-            configuration_id='vhthtbdrduaqmfhuzron'
+            configuration_id='yqpwvcwlsmtbxhvecwuo',
+            province='zowvrqhcsenfsijicsol'
         )

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/tests/test_observation.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/tests/test_observation.py
@@ -28,48 +28,49 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            configuration_id='jwrrbcvhgmwnxfycaquk',
-            moment='chudtsmfqybmcivksxlq',
-            co=int(15),
-            no=int(28),
-            no2=int(28),
-            o3no2=int(16),
-            ppbno=float(24.16994733807941),
-            ppbno_statut=int(86),
-            ppbno2=float(0.03469932648516583),
-            ppbno2_statut=int(2),
-            ppbo3=float(43.53984489647272),
-            ppbo3_statut=int(44),
-            ugpcmno=float(79.7818732296871),
-            ugpcmno_statut=int(45),
-            ugpcmno2=float(69.83135022175607),
-            ugpcmno2_statut=int(94),
-            ugpcmo3=float(32.67851827613665),
-            ugpcmo3_statut=int(42),
-            bme_t=float(15.855151754298014),
-            bme_t_statut=int(89),
-            bme_pres=int(49),
-            bme_pres_statut=int(26),
-            bme_rh=float(0.7019100399006994),
-            bme_rh_statut=int(76),
-            pm1=float(10.857443760970732),
-            pm1_statut=int(56),
-            pm25=float(73.42415285430127),
-            pm25_statut=int(36),
-            pm4=float(58.49102337347398),
-            pm4_statut=int(14),
-            pm10=float(5.3560387400305),
-            pm10_statut=int(31),
-            vbat=float(70.55150465884368),
-            vbat_statut=int(91),
-            mwh_bat=float(62.37542059954579),
-            mwh_pv=float(68.32541406295078),
-            co_rf=float(64.32048673203494),
-            no_rf=float(89.30412982130048),
-            no2_rf=float(7.951076087324138),
-            o3no2_rf=float(19.0813988784979),
-            o3_rf=float(18.519047076504602),
-            pm10_rf=float(45.97927280117505)
+            configuration_id='wdbuhfvxuccchmwriiuk',
+            province='puvcjimmajjqdgiqsuaa',
+            moment='dwakvuxjbpohuteqdjsw',
+            co=int(4),
+            no=int(17),
+            no2=int(59),
+            o3no2=int(45),
+            ppbno=float(84.9479650831437),
+            ppbno_statut=int(18),
+            ppbno2=float(28.7116783250542),
+            ppbno2_statut=int(94),
+            ppbo3=float(7.1201512423551545),
+            ppbo3_statut=int(52),
+            ugpcmno=float(22.87867316064478),
+            ugpcmno_statut=int(19),
+            ugpcmno2=float(51.42337262228529),
+            ugpcmno2_statut=int(29),
+            ugpcmo3=float(41.507834755994885),
+            ugpcmo3_statut=int(74),
+            bme_t=float(82.24890251389802),
+            bme_t_statut=int(14),
+            bme_pres=int(94),
+            bme_pres_statut=int(90),
+            bme_rh=float(61.57551054821811),
+            bme_rh_statut=int(13),
+            pm1=float(41.927053408985884),
+            pm1_statut=int(38),
+            pm25=float(20.78993052546525),
+            pm25_statut=int(86),
+            pm4=float(1.8135991933360351),
+            pm4_statut=int(56),
+            pm10=float(18.931095942028975),
+            pm10_statut=int(89),
+            vbat=float(56.04872924639533),
+            vbat_statut=int(40),
+            mwh_bat=float(58.14062731516068),
+            mwh_pv=float(55.06309207267126),
+            co_rf=float(20.466768930176094),
+            no_rf=float(1.1975561159446757),
+            no2_rf=float(40.95696333046901),
+            o3no2_rf=float(62.84542271205182),
+            o3_rf=float(51.689186569297455),
+            pm10_rf=float(75.63828798435026)
         )
         return instance
 
@@ -78,15 +79,23 @@ class Test_Observation(unittest.TestCase):
         """
         Test configuration_id property
         """
-        test_value = 'jwrrbcvhgmwnxfycaquk'
+        test_value = 'wdbuhfvxuccchmwriiuk'
         self.instance.configuration_id = test_value
         self.assertEqual(self.instance.configuration_id, test_value)
+    
+    def test_province_property(self):
+        """
+        Test province property
+        """
+        test_value = 'puvcjimmajjqdgiqsuaa'
+        self.instance.province = test_value
+        self.assertEqual(self.instance.province, test_value)
     
     def test_moment_property(self):
         """
         Test moment property
         """
-        test_value = 'chudtsmfqybmcivksxlq'
+        test_value = 'dwakvuxjbpohuteqdjsw'
         self.instance.moment = test_value
         self.assertEqual(self.instance.moment, test_value)
     
@@ -94,7 +103,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test co property
         """
-        test_value = int(15)
+        test_value = int(4)
         self.instance.co = test_value
         self.assertEqual(self.instance.co, test_value)
     
@@ -102,7 +111,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no property
         """
-        test_value = int(28)
+        test_value = int(17)
         self.instance.no = test_value
         self.assertEqual(self.instance.no, test_value)
     
@@ -110,7 +119,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no2 property
         """
-        test_value = int(28)
+        test_value = int(59)
         self.instance.no2 = test_value
         self.assertEqual(self.instance.no2, test_value)
     
@@ -118,7 +127,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test o3no2 property
         """
-        test_value = int(16)
+        test_value = int(45)
         self.instance.o3no2 = test_value
         self.assertEqual(self.instance.o3no2, test_value)
     
@@ -126,7 +135,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno property
         """
-        test_value = float(24.16994733807941)
+        test_value = float(84.9479650831437)
         self.instance.ppbno = test_value
         self.assertEqual(self.instance.ppbno, test_value)
     
@@ -134,7 +143,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno_statut property
         """
-        test_value = int(86)
+        test_value = int(18)
         self.instance.ppbno_statut = test_value
         self.assertEqual(self.instance.ppbno_statut, test_value)
     
@@ -142,7 +151,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno2 property
         """
-        test_value = float(0.03469932648516583)
+        test_value = float(28.7116783250542)
         self.instance.ppbno2 = test_value
         self.assertEqual(self.instance.ppbno2, test_value)
     
@@ -150,7 +159,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno2_statut property
         """
-        test_value = int(2)
+        test_value = int(94)
         self.instance.ppbno2_statut = test_value
         self.assertEqual(self.instance.ppbno2_statut, test_value)
     
@@ -158,7 +167,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbo3 property
         """
-        test_value = float(43.53984489647272)
+        test_value = float(7.1201512423551545)
         self.instance.ppbo3 = test_value
         self.assertEqual(self.instance.ppbo3, test_value)
     
@@ -166,7 +175,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbo3_statut property
         """
-        test_value = int(44)
+        test_value = int(52)
         self.instance.ppbo3_statut = test_value
         self.assertEqual(self.instance.ppbo3_statut, test_value)
     
@@ -174,7 +183,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno property
         """
-        test_value = float(79.7818732296871)
+        test_value = float(22.87867316064478)
         self.instance.ugpcmno = test_value
         self.assertEqual(self.instance.ugpcmno, test_value)
     
@@ -182,7 +191,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno_statut property
         """
-        test_value = int(45)
+        test_value = int(19)
         self.instance.ugpcmno_statut = test_value
         self.assertEqual(self.instance.ugpcmno_statut, test_value)
     
@@ -190,7 +199,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno2 property
         """
-        test_value = float(69.83135022175607)
+        test_value = float(51.42337262228529)
         self.instance.ugpcmno2 = test_value
         self.assertEqual(self.instance.ugpcmno2, test_value)
     
@@ -198,7 +207,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno2_statut property
         """
-        test_value = int(94)
+        test_value = int(29)
         self.instance.ugpcmno2_statut = test_value
         self.assertEqual(self.instance.ugpcmno2_statut, test_value)
     
@@ -206,7 +215,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmo3 property
         """
-        test_value = float(32.67851827613665)
+        test_value = float(41.507834755994885)
         self.instance.ugpcmo3 = test_value
         self.assertEqual(self.instance.ugpcmo3, test_value)
     
@@ -214,7 +223,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmo3_statut property
         """
-        test_value = int(42)
+        test_value = int(74)
         self.instance.ugpcmo3_statut = test_value
         self.assertEqual(self.instance.ugpcmo3_statut, test_value)
     
@@ -222,7 +231,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_t property
         """
-        test_value = float(15.855151754298014)
+        test_value = float(82.24890251389802)
         self.instance.bme_t = test_value
         self.assertEqual(self.instance.bme_t, test_value)
     
@@ -230,7 +239,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_t_statut property
         """
-        test_value = int(89)
+        test_value = int(14)
         self.instance.bme_t_statut = test_value
         self.assertEqual(self.instance.bme_t_statut, test_value)
     
@@ -238,7 +247,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_pres property
         """
-        test_value = int(49)
+        test_value = int(94)
         self.instance.bme_pres = test_value
         self.assertEqual(self.instance.bme_pres, test_value)
     
@@ -246,7 +255,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_pres_statut property
         """
-        test_value = int(26)
+        test_value = int(90)
         self.instance.bme_pres_statut = test_value
         self.assertEqual(self.instance.bme_pres_statut, test_value)
     
@@ -254,7 +263,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_rh property
         """
-        test_value = float(0.7019100399006994)
+        test_value = float(61.57551054821811)
         self.instance.bme_rh = test_value
         self.assertEqual(self.instance.bme_rh, test_value)
     
@@ -262,7 +271,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_rh_statut property
         """
-        test_value = int(76)
+        test_value = int(13)
         self.instance.bme_rh_statut = test_value
         self.assertEqual(self.instance.bme_rh_statut, test_value)
     
@@ -270,7 +279,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm1 property
         """
-        test_value = float(10.857443760970732)
+        test_value = float(41.927053408985884)
         self.instance.pm1 = test_value
         self.assertEqual(self.instance.pm1, test_value)
     
@@ -278,7 +287,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm1_statut property
         """
-        test_value = int(56)
+        test_value = int(38)
         self.instance.pm1_statut = test_value
         self.assertEqual(self.instance.pm1_statut, test_value)
     
@@ -286,7 +295,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm25 property
         """
-        test_value = float(73.42415285430127)
+        test_value = float(20.78993052546525)
         self.instance.pm25 = test_value
         self.assertEqual(self.instance.pm25, test_value)
     
@@ -294,7 +303,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm25_statut property
         """
-        test_value = int(36)
+        test_value = int(86)
         self.instance.pm25_statut = test_value
         self.assertEqual(self.instance.pm25_statut, test_value)
     
@@ -302,7 +311,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm4 property
         """
-        test_value = float(58.49102337347398)
+        test_value = float(1.8135991933360351)
         self.instance.pm4 = test_value
         self.assertEqual(self.instance.pm4, test_value)
     
@@ -310,7 +319,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm4_statut property
         """
-        test_value = int(14)
+        test_value = int(56)
         self.instance.pm4_statut = test_value
         self.assertEqual(self.instance.pm4_statut, test_value)
     
@@ -318,7 +327,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10 property
         """
-        test_value = float(5.3560387400305)
+        test_value = float(18.931095942028975)
         self.instance.pm10 = test_value
         self.assertEqual(self.instance.pm10, test_value)
     
@@ -326,7 +335,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10_statut property
         """
-        test_value = int(31)
+        test_value = int(89)
         self.instance.pm10_statut = test_value
         self.assertEqual(self.instance.pm10_statut, test_value)
     
@@ -334,7 +343,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test vbat property
         """
-        test_value = float(70.55150465884368)
+        test_value = float(56.04872924639533)
         self.instance.vbat = test_value
         self.assertEqual(self.instance.vbat, test_value)
     
@@ -342,7 +351,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test vbat_statut property
         """
-        test_value = int(91)
+        test_value = int(40)
         self.instance.vbat_statut = test_value
         self.assertEqual(self.instance.vbat_statut, test_value)
     
@@ -350,7 +359,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test mwh_bat property
         """
-        test_value = float(62.37542059954579)
+        test_value = float(58.14062731516068)
         self.instance.mwh_bat = test_value
         self.assertEqual(self.instance.mwh_bat, test_value)
     
@@ -358,7 +367,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test mwh_pv property
         """
-        test_value = float(68.32541406295078)
+        test_value = float(55.06309207267126)
         self.instance.mwh_pv = test_value
         self.assertEqual(self.instance.mwh_pv, test_value)
     
@@ -366,7 +375,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test co_rf property
         """
-        test_value = float(64.32048673203494)
+        test_value = float(20.466768930176094)
         self.instance.co_rf = test_value
         self.assertEqual(self.instance.co_rf, test_value)
     
@@ -374,7 +383,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no_rf property
         """
-        test_value = float(89.30412982130048)
+        test_value = float(1.1975561159446757)
         self.instance.no_rf = test_value
         self.assertEqual(self.instance.no_rf, test_value)
     
@@ -382,7 +391,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no2_rf property
         """
-        test_value = float(7.951076087324138)
+        test_value = float(40.95696333046901)
         self.instance.no2_rf = test_value
         self.assertEqual(self.instance.no2_rf, test_value)
     
@@ -390,7 +399,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test o3no2_rf property
         """
-        test_value = float(19.0813988784979)
+        test_value = float(62.84542271205182)
         self.instance.o3no2_rf = test_value
         self.assertEqual(self.instance.o3no2_rf, test_value)
     
@@ -398,7 +407,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test o3_rf property
         """
-        test_value = float(18.519047076504602)
+        test_value = float(51.689186569297455)
         self.instance.o3_rf = test_value
         self.assertEqual(self.instance.o3_rf, test_value)
     
@@ -406,7 +415,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10_rf property
         """
-        test_value = float(45.97927280117505)
+        test_value = float(75.63828798435026)
         self.instance.pm10_rf = test_value
         self.assertEqual(self.instance.pm10_rf, test_value)
     

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/tests/test_sensorconfiguration.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_data/tests/test_sensorconfiguration.py
@@ -28,7 +28,8 @@ class Test_SensorConfiguration(unittest.TestCase):
         Create instance of SensorConfiguration for testing
         """
         instance = SensorConfiguration(
-            configuration_id='vhthtbdrduaqmfhuzron'
+            configuration_id='yqpwvcwlsmtbxhvecwuo',
+            province='zowvrqhcsenfsijicsol'
         )
         return instance
 
@@ -37,9 +38,17 @@ class Test_SensorConfiguration(unittest.TestCase):
         """
         Test configuration_id property
         """
-        test_value = 'vhthtbdrduaqmfhuzron'
+        test_value = 'yqpwvcwlsmtbxhvecwuo'
         self.instance.configuration_id = test_value
         self.assertEqual(self.instance.configuration_id, test_value)
+    
+    def test_province_property(self):
+        """
+        Test province property
+        """
+        test_value = 'zowvrqhcsenfsijicsol'
+        self.instance.province = test_value
+        self.assertEqual(self.instance.province, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_mqtt_client/src/wallonia_issep_mqtt_producer_mqtt_client/client.py
+++ b/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_mqtt_client/src/wallonia_issep_mqtt_producer_mqtt_client/client.py
@@ -187,8 +187,8 @@ def get_default_topic_mappings_be_issep_airquality_sensors_mqtt() -> Dict[str, s
         Dictionary mapping message identifiers to their default topic patterns.
     """
     return {
-        "be.issep.airquality.Sensors.mqtt.SensorConfiguration": "aq/be/wallonia/wallonia-issep/{configuration_id}/info",
-        "be.issep.airquality.Sensors.mqtt.Observation": "aq/be/wallonia/wallonia-issep/{configuration_id}/observation",
+        "be.issep.airquality.Sensors.mqtt.SensorConfiguration": "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/info",
+        "be.issep.airquality.Sensors.mqtt.Observation": "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/observation",
     }
 
 
@@ -358,6 +358,7 @@ class BeIssepAirqualitySensorsMqttMqttClient(_ClientBase):
     
     async def publish_be_issep_airquality_sensors_mqtt_sensor_configuration(self,
         configuration_id: str,
+        province: str,
         data: wallonia_issep_mqtt_producer_data.SensorConfiguration,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
@@ -369,16 +370,18 @@ class BeIssepAirqualitySensorsMqttMqttClient(_ClientBase):
         Args:
         
             configuration_id: URI template variable for 'configuration_id'
+            province: URI template variable for 'province'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'aq/be/wallonia/wallonia-issep/{configuration_id}/info'
+            topic: Optional topic override. If not provided, uses default topic 'air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/info'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "aq/be/wallonia/wallonia-issep/{configuration_id}/info"
+        target_topic = topic if topic is not None else "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/info"
         _topic_template_values: Dict[str, str] = {
             "configuration_id": str(configuration_id),
+            "province": str(province),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)
@@ -431,6 +434,7 @@ class BeIssepAirqualitySensorsMqttMqttClient(_ClientBase):
     
     async def publish_be_issep_airquality_sensors_mqtt_observation(self,
         configuration_id: str,
+        province: str,
         data: wallonia_issep_mqtt_producer_data.Observation,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
@@ -442,16 +446,18 @@ class BeIssepAirqualitySensorsMqttMqttClient(_ClientBase):
         Args:
         
             configuration_id: URI template variable for 'configuration_id'
+            province: URI template variable for 'province'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'aq/be/wallonia/wallonia-issep/{configuration_id}/observation'
+            topic: Optional topic override. If not provided, uses default topic 'air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/observation'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "aq/be/wallonia/wallonia-issep/{configuration_id}/observation"
+        target_topic = topic if topic is not None else "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/observation"
         _topic_template_values: Dict[str, str] = {
             "configuration_id": str(configuration_id),
+            "province": str(province),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)

--- a/wallonia-issep/wallonia_issep_producer/README.md
+++ b/wallonia-issep/wallonia_issep_producer/README.md
@@ -15,7 +15,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 2. [What is Apache Kafka?](#what-is-apache-kafka)2. [Generated Event Dispatchers](#generated-event-dispatchers)
 
-3. [Quick Start](#quick-start)    - BeIssepAirqualitySensorsEventDispatcher
+3. [Quick Start](#quick-start)    - BeIssepAirqualitySensorsEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    BeIssepAirqualitySensorsMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -39,6 +41,10 @@ methods to handle various types of events.
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - BeIssepAirqualitySensorsProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- BeIssepAirqualitySensorsMqttProducersolution for event-driven applications.
 
 
 
@@ -192,6 +198,46 @@ be_issep_airquality_sensor_configuration_event
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsMqttProducer- `data`: The event data of type
+`wallonia_issep_producer_data.SensorConfiguration`.
+
+
+
+Producer for `be.issep.airquality.Sensors.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_sensor_configuration_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+SensorConfiguration) -> None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_mqtt_dispatcher.be_issep_airquality_sensor_configuration_async =
+be_issep_airquality_sensor_configuration_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -250,6 +296,45 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 be_issep_airquality_sensors_dispatcher.be_issep_airquality_observation_async = be_issep_airquality_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsMqttProducer- `data`: The event data of type `wallonia_issep_producer_data.Observation`.
+
+
+
+Producer for `be.issep.airquality.Sensors.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Observation) ->
+None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_mqtt_dispatcher.be_issep_airquality_observation_async =
+be_issep_airquality_observation_event
 
 **Parameters:**```
 
@@ -452,6 +537,513 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_be_issep_airquality_observation_batch(```
+
+    messages=[
+
+        Observation(...),Initializes the runner with a Kafka consumer.
+
+        Observation(...),
+
+        Observation(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### BeIssepAirqualitySensorsMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`BeIssepAirqualitySensorsMqttEventDispatcher` handles events for the be.issep.airquality.Sensors.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from wallonia_issep_producer import BeIssepAirqualitySensorsProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = BeIssepAirqualitySensorsProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_be_issep_airquality_sensor_configuration(```python
+
+    data=SensorConfiguration(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The BeIssepAirqualitySensorsMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = BeIssepAirqualitySensorsProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `be_issep_airquality_sensors_mqtt_sensor_configuration_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'be_issep_airquality_sensors_mqtt_sensor_configuration_async:  Callable[[ConsumerRecord,
+CloudEvent, SensorConfiguration], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `be.issep.airquality.Sensors.mqtt.SensorConfiguration`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsProducer- `data`: The event data of type `wallonia_issep_producer_data.SensorConfiguration`.
+
+
+
+Producer for `be.issep.airquality.Sensors` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_sensors_mqtt_sensor_configuration_event(record: ConsumerRecord, cloud_event: CloudEvent,
+data: SensorConfiguration) -> None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_dispatcher.be_issep_airquality_sensors_mqtt_sensor_configuration_async =
+be_issep_airquality_sensors_mqtt_sensor_configuration_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsMqttProducer- `data`: The event data of type
+`wallonia_issep_producer_data.SensorConfiguration`.
+
+
+
+Producer for `be.issep.airquality.Sensors.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_sensors_mqtt_sensor_configuration_event(record: ConsumerRecord, cloud_event: CloudEvent,
+data: SensorConfiguration) -> None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_mqtt_dispatcher.be_issep_airquality_sensors_mqtt_sensor_configuration_async =
+be_issep_airquality_sensors_mqtt_sensor_configuration_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `be_issep_airquality_sensors_mqtt_observation_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'be_issep_airquality_sensors_mqtt_observation_async:  Callable[[ConsumerRecord,
+CloudEvent, Observation], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `be.issep.airquality.Sensors.mqtt.Observation`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsProducer- `data`: The event data of type `wallonia_issep_producer_data.Observation`.
+
+
+
+Producer for `be.issep.airquality.Sensors` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_sensors_mqtt_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+Observation) -> None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_dispatcher.be_issep_airquality_sensors_mqtt_observation_async =
+be_issep_airquality_sensors_mqtt_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### BeIssepAirqualitySensorsMqttProducer- `data`: The event data of type `wallonia_issep_producer_data.Observation`.
+
+
+
+Producer for `be.issep.airquality.Sensors.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def be_issep_airquality_sensors_mqtt_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+Observation) -> None:
+
+```python    # Process the event data
+
+BeIssepAirqualitySensorsMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+be_issep_airquality_sensors_mqtt_dispatcher.be_issep_airquality_sensors_mqtt_observation_async =
+be_issep_airquality_sensors_mqtt_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_be_issep_airquality_sensors_mqtt_sensor_configuration`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_be_issep_airquality_sensors_mqtt_sensor_configuration(
+
+    self,##### `_process_event`
+
+    data: SensorConfiguration,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `be.issep.airquality.Sensors.mqtt.SensorConfiguration` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `SensorConfiguration`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_be_issep_airquality_sensors_mqtt_sensor_configuration(
+
+    data=SensorConfiguration(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `be.issep.airquality.Sensors.mqtt.SensorConfiguration` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_be_issep_airquality_sensors_mqtt_sensor_configuration_batch(```
+
+    messages=[
+
+        SensorConfiguration(...),Initializes the runner with a Kafka consumer.
+
+        SensorConfiguration(...),
+
+        SensorConfiguration(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_be_issep_airquality_sensors_mqtt_observation`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_be_issep_airquality_sensors_mqtt_observation(
+
+    self,##### `_process_event`
+
+    data: Observation,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `be.issep.airquality.Sensors.mqtt.Observation` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `Observation`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_be_issep_airquality_sensors_mqtt_observation(
+
+    data=Observation(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `be.issep.airquality.Sensors.mqtt.Observation` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_be_issep_airquality_sensors_mqtt_observation_batch(```
 
     messages=[
 

--- a/wallonia-issep/wallonia_issep_producer/samples/sample.py
+++ b/wallonia-issep/wallonia_issep_producer/samples/sample.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer as KafkaProducer
 # imports the producer clients for the message group(s)
 
 from wallonia_issep_producer_kafka_producer.producer import BeIssepAirqualitySensorsEventProducer
+from wallonia_issep_producer_kafka_producer.producer import BeIssepAirqualitySensorsMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -72,6 +73,30 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'be.issep.airquality.Observation' event to Kafka topic.
     await be_issep_airquality_sensors_event_producer.send_be_issep_airquality_observation(_configuration_id = 'TODO: replace me', data = _observation)
     print(f"Sent 'be.issep.airquality.Observation' event: {_observation.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        be_issep_airquality_sensors_mqtt_event_producer = BeIssepAirqualitySensorsMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        be_issep_airquality_sensors_mqtt_event_producer = BeIssepAirqualitySensorsMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- be.issep.airquality.Sensors.mqtt.SensorConfiguration ----
+    # TODO: Supply event data for the be.issep.airquality.Sensors.mqtt.SensorConfiguration event
+    _sensor_configuration = SensorConfiguration()
+
+    # sends the 'be.issep.airquality.Sensors.mqtt.SensorConfiguration' event to Kafka topic.
+    await be_issep_airquality_sensors_mqtt_event_producer.send_be_issep_airquality_sensors_mqtt_sensor_configuration(_configuration_id = 'TODO: replace me', data = _sensor_configuration)
+    print(f"Sent 'be.issep.airquality.Sensors.mqtt.SensorConfiguration' event: {_sensor_configuration.to_json()}")
+
+    # ---- be.issep.airquality.Sensors.mqtt.Observation ----
+    # TODO: Supply event data for the be.issep.airquality.Sensors.mqtt.Observation event
+    _observation = Observation()
+
+    # sends the 'be.issep.airquality.Sensors.mqtt.Observation' event to Kafka topic.
+    await be_issep_airquality_sensors_mqtt_event_producer.send_be_issep_airquality_sensors_mqtt_observation(_configuration_id = 'TODO: replace me', data = _observation)
+    print(f"Sent 'be.issep.airquality.Sensors.mqtt.Observation' event: {_observation.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/observation.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/observation.py
@@ -21,6 +21,7 @@ class Observation:
     
     Attributes:
         configuration_id (str)
+        province (str)
         moment (str)
         co (typing.Optional[int])
         no (typing.Optional[int])
@@ -66,6 +67,7 @@ class Observation:
     
     
     configuration_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="configuration_id"))
+    province: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="province"))
     moment: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="moment"))
     co: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="co"))
     no: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="no"))
@@ -233,46 +235,47 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            configuration_id='uixfcaqdjfvvnzvewodu',
-            moment='jecyjyjwyqohxnjmogtb',
-            co=int(52),
-            no=int(5),
-            no2=int(65),
+            configuration_id='gfulknwbzpfsgwfdytqa',
+            province='dmhbsjhpbitfuvekrvpl',
+            moment='vldnqtcsfjigoedxjlsm',
+            co=int(83),
+            no=int(31),
+            no2=int(88),
             o3no2=int(60),
-            ppbno=float(79.956649972886),
-            ppbno_statut=int(17),
-            ppbno2=float(94.11919558876022),
-            ppbno2_statut=int(85),
-            ppbo3=float(21.33356605375295),
-            ppbo3_statut=int(53),
-            ugpcmno=float(74.21210206407693),
-            ugpcmno_statut=int(27),
-            ugpcmno2=float(88.2004557205468),
-            ugpcmno2_statut=int(31),
-            ugpcmo3=float(88.63340488577101),
-            ugpcmo3_statut=int(97),
-            bme_t=float(97.46304059040543),
-            bme_t_statut=int(92),
-            bme_pres=int(36),
-            bme_pres_statut=int(90),
-            bme_rh=float(36.52698266088264),
-            bme_rh_statut=int(30),
-            pm1=float(58.18220156117552),
-            pm1_statut=int(93),
-            pm25=float(41.0223060292734),
-            pm25_statut=int(100),
-            pm4=float(58.53989368581607),
-            pm4_statut=int(59),
-            pm10=float(78.17333809168763),
-            pm10_statut=int(10),
-            vbat=float(92.70115078855189),
-            vbat_statut=int(36),
-            mwh_bat=float(81.17658722022883),
-            mwh_pv=float(61.01358538438968),
-            co_rf=float(21.88846915003254),
-            no_rf=float(2.7808634804511345),
-            no2_rf=float(6.979188514044099),
-            o3no2_rf=float(88.0150221249027),
-            o3_rf=float(82.8859582386486),
-            pm10_rf=float(80.89091760373559)
+            ppbno=float(38.88104499599242),
+            ppbno_statut=int(93),
+            ppbno2=float(61.155561549765125),
+            ppbno2_statut=int(22),
+            ppbo3=float(47.29630332223245),
+            ppbo3_statut=int(23),
+            ugpcmno=float(76.39859427920483),
+            ugpcmno_statut=int(63),
+            ugpcmno2=float(55.45350484640309),
+            ugpcmno2_statut=int(41),
+            ugpcmo3=float(74.16400076119484),
+            ugpcmo3_statut=int(37),
+            bme_t=float(85.53752025452533),
+            bme_t_statut=int(7),
+            bme_pres=int(28),
+            bme_pres_statut=int(61),
+            bme_rh=float(77.03445825672055),
+            bme_rh_statut=int(57),
+            pm1=float(16.129236434611492),
+            pm1_statut=int(8),
+            pm25=float(43.62485923221633),
+            pm25_statut=int(94),
+            pm4=float(69.19844505740777),
+            pm4_statut=int(84),
+            pm10=float(82.15620356870048),
+            pm10_statut=int(12),
+            vbat=float(66.23211266578703),
+            vbat_statut=int(91),
+            mwh_bat=float(40.04066080529497),
+            mwh_pv=float(95.24381597031412),
+            co_rf=float(95.68347655258395),
+            no_rf=float(62.38572091990584),
+            no2_rf=float(76.05566735261662),
+            o3no2_rf=float(69.69889161695323),
+            o3_rf=float(78.62969919594475),
+            pm10_rf=float(6.339080591731705)
         )

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/sensorconfiguration.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/sensorconfiguration.py
@@ -21,10 +21,12 @@ class SensorConfiguration:
     
     Attributes:
         configuration_id (str)
+        province (str)
     """
     
     
     configuration_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="configuration_id"))
+    province: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="province"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'SensorConfiguration':
@@ -151,5 +153,6 @@ class SensorConfiguration:
             An instance of the dataclass.
         """
         return cls(
-            configuration_id='vgqghiccoffedsmaxmfj'
+            configuration_id='rsjzqhoafxbclvknoyev',
+            province='ytpbzsjlmnehhtywlsjz'
         )

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/tests/test_observation.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/tests/test_observation.py
@@ -28,48 +28,49 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            configuration_id='uixfcaqdjfvvnzvewodu',
-            moment='jecyjyjwyqohxnjmogtb',
-            co=int(52),
-            no=int(5),
-            no2=int(65),
+            configuration_id='gfulknwbzpfsgwfdytqa',
+            province='dmhbsjhpbitfuvekrvpl',
+            moment='vldnqtcsfjigoedxjlsm',
+            co=int(83),
+            no=int(31),
+            no2=int(88),
             o3no2=int(60),
-            ppbno=float(79.956649972886),
-            ppbno_statut=int(17),
-            ppbno2=float(94.11919558876022),
-            ppbno2_statut=int(85),
-            ppbo3=float(21.33356605375295),
-            ppbo3_statut=int(53),
-            ugpcmno=float(74.21210206407693),
-            ugpcmno_statut=int(27),
-            ugpcmno2=float(88.2004557205468),
-            ugpcmno2_statut=int(31),
-            ugpcmo3=float(88.63340488577101),
-            ugpcmo3_statut=int(97),
-            bme_t=float(97.46304059040543),
-            bme_t_statut=int(92),
-            bme_pres=int(36),
-            bme_pres_statut=int(90),
-            bme_rh=float(36.52698266088264),
-            bme_rh_statut=int(30),
-            pm1=float(58.18220156117552),
-            pm1_statut=int(93),
-            pm25=float(41.0223060292734),
-            pm25_statut=int(100),
-            pm4=float(58.53989368581607),
-            pm4_statut=int(59),
-            pm10=float(78.17333809168763),
-            pm10_statut=int(10),
-            vbat=float(92.70115078855189),
-            vbat_statut=int(36),
-            mwh_bat=float(81.17658722022883),
-            mwh_pv=float(61.01358538438968),
-            co_rf=float(21.88846915003254),
-            no_rf=float(2.7808634804511345),
-            no2_rf=float(6.979188514044099),
-            o3no2_rf=float(88.0150221249027),
-            o3_rf=float(82.8859582386486),
-            pm10_rf=float(80.89091760373559)
+            ppbno=float(38.88104499599242),
+            ppbno_statut=int(93),
+            ppbno2=float(61.155561549765125),
+            ppbno2_statut=int(22),
+            ppbo3=float(47.29630332223245),
+            ppbo3_statut=int(23),
+            ugpcmno=float(76.39859427920483),
+            ugpcmno_statut=int(63),
+            ugpcmno2=float(55.45350484640309),
+            ugpcmno2_statut=int(41),
+            ugpcmo3=float(74.16400076119484),
+            ugpcmo3_statut=int(37),
+            bme_t=float(85.53752025452533),
+            bme_t_statut=int(7),
+            bme_pres=int(28),
+            bme_pres_statut=int(61),
+            bme_rh=float(77.03445825672055),
+            bme_rh_statut=int(57),
+            pm1=float(16.129236434611492),
+            pm1_statut=int(8),
+            pm25=float(43.62485923221633),
+            pm25_statut=int(94),
+            pm4=float(69.19844505740777),
+            pm4_statut=int(84),
+            pm10=float(82.15620356870048),
+            pm10_statut=int(12),
+            vbat=float(66.23211266578703),
+            vbat_statut=int(91),
+            mwh_bat=float(40.04066080529497),
+            mwh_pv=float(95.24381597031412),
+            co_rf=float(95.68347655258395),
+            no_rf=float(62.38572091990584),
+            no2_rf=float(76.05566735261662),
+            o3no2_rf=float(69.69889161695323),
+            o3_rf=float(78.62969919594475),
+            pm10_rf=float(6.339080591731705)
         )
         return instance
 
@@ -78,15 +79,23 @@ class Test_Observation(unittest.TestCase):
         """
         Test configuration_id property
         """
-        test_value = 'uixfcaqdjfvvnzvewodu'
+        test_value = 'gfulknwbzpfsgwfdytqa'
         self.instance.configuration_id = test_value
         self.assertEqual(self.instance.configuration_id, test_value)
+    
+    def test_province_property(self):
+        """
+        Test province property
+        """
+        test_value = 'dmhbsjhpbitfuvekrvpl'
+        self.instance.province = test_value
+        self.assertEqual(self.instance.province, test_value)
     
     def test_moment_property(self):
         """
         Test moment property
         """
-        test_value = 'jecyjyjwyqohxnjmogtb'
+        test_value = 'vldnqtcsfjigoedxjlsm'
         self.instance.moment = test_value
         self.assertEqual(self.instance.moment, test_value)
     
@@ -94,7 +103,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test co property
         """
-        test_value = int(52)
+        test_value = int(83)
         self.instance.co = test_value
         self.assertEqual(self.instance.co, test_value)
     
@@ -102,7 +111,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no property
         """
-        test_value = int(5)
+        test_value = int(31)
         self.instance.no = test_value
         self.assertEqual(self.instance.no, test_value)
     
@@ -110,7 +119,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no2 property
         """
-        test_value = int(65)
+        test_value = int(88)
         self.instance.no2 = test_value
         self.assertEqual(self.instance.no2, test_value)
     
@@ -126,7 +135,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno property
         """
-        test_value = float(79.956649972886)
+        test_value = float(38.88104499599242)
         self.instance.ppbno = test_value
         self.assertEqual(self.instance.ppbno, test_value)
     
@@ -134,7 +143,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno_statut property
         """
-        test_value = int(17)
+        test_value = int(93)
         self.instance.ppbno_statut = test_value
         self.assertEqual(self.instance.ppbno_statut, test_value)
     
@@ -142,7 +151,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno2 property
         """
-        test_value = float(94.11919558876022)
+        test_value = float(61.155561549765125)
         self.instance.ppbno2 = test_value
         self.assertEqual(self.instance.ppbno2, test_value)
     
@@ -150,7 +159,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbno2_statut property
         """
-        test_value = int(85)
+        test_value = int(22)
         self.instance.ppbno2_statut = test_value
         self.assertEqual(self.instance.ppbno2_statut, test_value)
     
@@ -158,7 +167,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbo3 property
         """
-        test_value = float(21.33356605375295)
+        test_value = float(47.29630332223245)
         self.instance.ppbo3 = test_value
         self.assertEqual(self.instance.ppbo3, test_value)
     
@@ -166,7 +175,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ppbo3_statut property
         """
-        test_value = int(53)
+        test_value = int(23)
         self.instance.ppbo3_statut = test_value
         self.assertEqual(self.instance.ppbo3_statut, test_value)
     
@@ -174,7 +183,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno property
         """
-        test_value = float(74.21210206407693)
+        test_value = float(76.39859427920483)
         self.instance.ugpcmno = test_value
         self.assertEqual(self.instance.ugpcmno, test_value)
     
@@ -182,7 +191,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno_statut property
         """
-        test_value = int(27)
+        test_value = int(63)
         self.instance.ugpcmno_statut = test_value
         self.assertEqual(self.instance.ugpcmno_statut, test_value)
     
@@ -190,7 +199,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno2 property
         """
-        test_value = float(88.2004557205468)
+        test_value = float(55.45350484640309)
         self.instance.ugpcmno2 = test_value
         self.assertEqual(self.instance.ugpcmno2, test_value)
     
@@ -198,7 +207,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmno2_statut property
         """
-        test_value = int(31)
+        test_value = int(41)
         self.instance.ugpcmno2_statut = test_value
         self.assertEqual(self.instance.ugpcmno2_statut, test_value)
     
@@ -206,7 +215,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmo3 property
         """
-        test_value = float(88.63340488577101)
+        test_value = float(74.16400076119484)
         self.instance.ugpcmo3 = test_value
         self.assertEqual(self.instance.ugpcmo3, test_value)
     
@@ -214,7 +223,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test ugpcmo3_statut property
         """
-        test_value = int(97)
+        test_value = int(37)
         self.instance.ugpcmo3_statut = test_value
         self.assertEqual(self.instance.ugpcmo3_statut, test_value)
     
@@ -222,7 +231,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_t property
         """
-        test_value = float(97.46304059040543)
+        test_value = float(85.53752025452533)
         self.instance.bme_t = test_value
         self.assertEqual(self.instance.bme_t, test_value)
     
@@ -230,7 +239,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_t_statut property
         """
-        test_value = int(92)
+        test_value = int(7)
         self.instance.bme_t_statut = test_value
         self.assertEqual(self.instance.bme_t_statut, test_value)
     
@@ -238,7 +247,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_pres property
         """
-        test_value = int(36)
+        test_value = int(28)
         self.instance.bme_pres = test_value
         self.assertEqual(self.instance.bme_pres, test_value)
     
@@ -246,7 +255,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_pres_statut property
         """
-        test_value = int(90)
+        test_value = int(61)
         self.instance.bme_pres_statut = test_value
         self.assertEqual(self.instance.bme_pres_statut, test_value)
     
@@ -254,7 +263,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_rh property
         """
-        test_value = float(36.52698266088264)
+        test_value = float(77.03445825672055)
         self.instance.bme_rh = test_value
         self.assertEqual(self.instance.bme_rh, test_value)
     
@@ -262,7 +271,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test bme_rh_statut property
         """
-        test_value = int(30)
+        test_value = int(57)
         self.instance.bme_rh_statut = test_value
         self.assertEqual(self.instance.bme_rh_statut, test_value)
     
@@ -270,7 +279,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm1 property
         """
-        test_value = float(58.18220156117552)
+        test_value = float(16.129236434611492)
         self.instance.pm1 = test_value
         self.assertEqual(self.instance.pm1, test_value)
     
@@ -278,7 +287,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm1_statut property
         """
-        test_value = int(93)
+        test_value = int(8)
         self.instance.pm1_statut = test_value
         self.assertEqual(self.instance.pm1_statut, test_value)
     
@@ -286,7 +295,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm25 property
         """
-        test_value = float(41.0223060292734)
+        test_value = float(43.62485923221633)
         self.instance.pm25 = test_value
         self.assertEqual(self.instance.pm25, test_value)
     
@@ -294,7 +303,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm25_statut property
         """
-        test_value = int(100)
+        test_value = int(94)
         self.instance.pm25_statut = test_value
         self.assertEqual(self.instance.pm25_statut, test_value)
     
@@ -302,7 +311,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm4 property
         """
-        test_value = float(58.53989368581607)
+        test_value = float(69.19844505740777)
         self.instance.pm4 = test_value
         self.assertEqual(self.instance.pm4, test_value)
     
@@ -310,7 +319,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm4_statut property
         """
-        test_value = int(59)
+        test_value = int(84)
         self.instance.pm4_statut = test_value
         self.assertEqual(self.instance.pm4_statut, test_value)
     
@@ -318,7 +327,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10 property
         """
-        test_value = float(78.17333809168763)
+        test_value = float(82.15620356870048)
         self.instance.pm10 = test_value
         self.assertEqual(self.instance.pm10, test_value)
     
@@ -326,7 +335,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10_statut property
         """
-        test_value = int(10)
+        test_value = int(12)
         self.instance.pm10_statut = test_value
         self.assertEqual(self.instance.pm10_statut, test_value)
     
@@ -334,7 +343,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test vbat property
         """
-        test_value = float(92.70115078855189)
+        test_value = float(66.23211266578703)
         self.instance.vbat = test_value
         self.assertEqual(self.instance.vbat, test_value)
     
@@ -342,7 +351,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test vbat_statut property
         """
-        test_value = int(36)
+        test_value = int(91)
         self.instance.vbat_statut = test_value
         self.assertEqual(self.instance.vbat_statut, test_value)
     
@@ -350,7 +359,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test mwh_bat property
         """
-        test_value = float(81.17658722022883)
+        test_value = float(40.04066080529497)
         self.instance.mwh_bat = test_value
         self.assertEqual(self.instance.mwh_bat, test_value)
     
@@ -358,7 +367,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test mwh_pv property
         """
-        test_value = float(61.01358538438968)
+        test_value = float(95.24381597031412)
         self.instance.mwh_pv = test_value
         self.assertEqual(self.instance.mwh_pv, test_value)
     
@@ -366,7 +375,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test co_rf property
         """
-        test_value = float(21.88846915003254)
+        test_value = float(95.68347655258395)
         self.instance.co_rf = test_value
         self.assertEqual(self.instance.co_rf, test_value)
     
@@ -374,7 +383,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no_rf property
         """
-        test_value = float(2.7808634804511345)
+        test_value = float(62.38572091990584)
         self.instance.no_rf = test_value
         self.assertEqual(self.instance.no_rf, test_value)
     
@@ -382,7 +391,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test no2_rf property
         """
-        test_value = float(6.979188514044099)
+        test_value = float(76.05566735261662)
         self.instance.no2_rf = test_value
         self.assertEqual(self.instance.no2_rf, test_value)
     
@@ -390,7 +399,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test o3no2_rf property
         """
-        test_value = float(88.0150221249027)
+        test_value = float(69.69889161695323)
         self.instance.o3no2_rf = test_value
         self.assertEqual(self.instance.o3no2_rf, test_value)
     
@@ -398,7 +407,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test o3_rf property
         """
-        test_value = float(82.8859582386486)
+        test_value = float(78.62969919594475)
         self.instance.o3_rf = test_value
         self.assertEqual(self.instance.o3_rf, test_value)
     
@@ -406,7 +415,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pm10_rf property
         """
-        test_value = float(80.89091760373559)
+        test_value = float(6.339080591731705)
         self.instance.pm10_rf = test_value
         self.assertEqual(self.instance.pm10_rf, test_value)
     

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/tests/test_sensorconfiguration.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/tests/test_sensorconfiguration.py
@@ -28,7 +28,8 @@ class Test_SensorConfiguration(unittest.TestCase):
         Create instance of SensorConfiguration for testing
         """
         instance = SensorConfiguration(
-            configuration_id='vgqghiccoffedsmaxmfj'
+            configuration_id='rsjzqhoafxbclvknoyev',
+            province='ytpbzsjlmnehhtywlsjz'
         )
         return instance
 
@@ -37,9 +38,17 @@ class Test_SensorConfiguration(unittest.TestCase):
         """
         Test configuration_id property
         """
-        test_value = 'vgqghiccoffedsmaxmfj'
+        test_value = 'rsjzqhoafxbclvknoyev'
         self.instance.configuration_id = test_value
         self.assertEqual(self.instance.configuration_id, test_value)
+    
+    def test_province_property(self):
+        """
+        Test province property
+        """
+        test_value = 'ytpbzsjlmnehhtywlsjz'
+        self.instance.province = test_value
+        self.assertEqual(self.instance.province, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_kafka_producer/src/wallonia_issep_producer_kafka_producer/producer.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_kafka_producer/src/wallonia_issep_producer_kafka_producer/producer.py
@@ -154,3 +154,147 @@ class BeIssepAirqualitySensorsEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class BeIssepAirqualitySensorsMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_be_issep_airquality_sensors_mqtt_sensor_configuration(self,_configuration_id : str, data: SensorConfiguration, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, SensorConfiguration], str]=None) -> None:
+        """
+        Sends the 'be.issep.airquality.Sensors.mqtt.SensorConfiguration' event to the Kafka topic
+
+        Args:
+            _configuration_id(str):  Value for placeholder configuration_id in attribute subject
+            data: (SensorConfiguration): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, SensorConfiguration], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"be.issep.airquality.SensorConfiguration",
+             "source":"https://www.odwb.be/api/explore/v2.1/catalog/datasets/last-data-capteurs-qualite-de-l-air-issep/records",
+             "subject":"{configuration_id}".format(configuration_id = _configuration_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_be_issep_airquality_sensors_mqtt_observation(self,_configuration_id : str, data: Observation, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Observation], str]=None) -> None:
+        """
+        Sends the 'be.issep.airquality.Sensors.mqtt.Observation' event to the Kafka topic
+
+        Args:
+            _configuration_id(str):  Value for placeholder configuration_id in attribute subject
+            data: (Observation): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Observation], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"be.issep.airquality.Observation",
+             "source":"https://www.odwb.be/api/explore/v2.1/catalog/datasets/last-data-capteurs-qualite-de-l-air-issep/records",
+             "subject":"{configuration_id}".format(configuration_id = _configuration_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'BeIssepAirqualitySensorsMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_kafka_producer/tests/test_producer.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_kafka_producer/tests/test_producer.py
@@ -23,6 +23,7 @@ from wallonia_issep_producer_data import SensorConfiguration
 from test_wallonia_issep_producer_data_sensorconfiguration import Test_SensorConfiguration
 from wallonia_issep_producer_data import Observation
 from test_wallonia_issep_producer_data_observation import Test_Observation
+from wallonia_issep_producer_kafka_producer.producer import BeIssepAirqualitySensorsMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -179,6 +180,128 @@ def test_be_issep_airquality_sensors_beissepairqualityobservation(kafka_emulator
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{configuration_id}".format(configuration_id=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_be_issep_airquality_sensors_mqtt_beissepairqualitysensorsmqttsensorconfiguration(kafka_emulator):
+    """Test the BeIssepAirqualitySensorsMqttSensorConfiguration event from the Be.Issep.Airquality.Sensors.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_be_issep_airquality_sensors_mqtt_beissepairqualitysensorsmqttsensorconfiguration',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "be.issep.airquality.Sensors.mqtt.SensorConfiguration":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = BeIssepAirqualitySensorsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_SensorConfiguration.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_be_issep_airquality_sensors_mqtt_sensor_configuration(_configuration_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_be_issep_airquality_sensors_mqtt_beissepairqualitysensorsmqttobservation(kafka_emulator):
+    """Test the BeIssepAirqualitySensorsMqttObservation event from the Be.Issep.Airquality.Sensors.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_be_issep_airquality_sensors_mqtt_beissepairqualitysensorsmqttobservation',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "be.issep.airquality.Sensors.mqtt.Observation":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = BeIssepAirqualitySensorsMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_Observation.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_be_issep_airquality_sensors_mqtt_observation(_configuration_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()
 
 

--- a/wallonia-issep/xreg/wallonia_issep.xreg.json
+++ b/wallonia-issep/xreg/wallonia_issep.xreg.json
@@ -92,7 +92,7 @@
           "basemessageurl": "/messagegroups/be.issep.airquality.Sensors/messages/be.issep.airquality.SensorConfiguration",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "topic_name": "aq/be/wallonia/wallonia-issep/{configuration_id}/info",
+            "topic_name": "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/info",
             "qos": 1,
             "retain": true
           }
@@ -102,7 +102,7 @@
           "basemessageurl": "/messagegroups/be.issep.airquality.Sensors/messages/be.issep.airquality.Observation",
           "protocol": "MQTT/5.0",
           "protocoloptions": {
-            "topic_name": "aq/be/wallonia/wallonia-issep/{configuration_id}/observation",
+            "topic_name": "air-quality/be/issep/wallonia-issep/{province}/{configuration_id}/observation",
             "qos": 1,
             "retain": true
           }
@@ -129,7 +129,8 @@
                 "additionalProperties": false,
                 "description": "Reference data for one ISSeP Wallonia air quality sensor configuration. Each id_configuration identifies a deployed sensor unit. The bridge emits this event at startup for each distinct configuration seen in the data records.",
                 "required": [
-                  "configuration_id"
+                  "configuration_id",
+                  "province"
                 ],
                 "properties": {
                   "configuration_id": {
@@ -139,6 +140,10 @@
                     "altnames": {
                       "issep": "id_configuration"
                     }
+                  },
+                  "province": {
+                    "type": "string",
+                    "description": "Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or \"unknown\" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis."
                   }
                 }
               }
@@ -162,7 +167,8 @@
                 "description": "Air quality observation from one ISSeP Wallonia sensor at a specific moment in time. Includes raw electrochemical gas readings, calibrated ppb and µg/m³ values, particulate matter concentrations, environmental parameters, reference station comparisons, and quality status flags. Negative raw values (e.g. no2=-4) are valid sensor readings and must not be filtered.",
                 "required": [
                   "configuration_id",
-                  "moment"
+                  "moment",
+                  "province"
                 ],
                 "properties": {
                   "configuration_id": {
@@ -172,6 +178,10 @@
                     "altnames": {
                       "issep": "id_configuration"
                     }
+                  },
+                  "province": {
+                    "type": "string",
+                    "description": "Slug of the Walloon province where the sensor is located (e.g. brabant-wallon, hainaut, liege, luxembourg, namur, or \"unknown\" sentinel if location is not yet mapped). Matches the {province} MQTT topic axis."
                   },
                   "moment": {
                     "type": "string",


### PR DESCRIPTION
Narrow review-driven fixup off main. Renames the MQTT topic root to the canonical 'air-quality/be/issep/wallonia-issep/...' shape and inserts a {province} topic axis between the feeder root and the configuration_id. Adds a required 'province' string field to SensorConfiguration and Observation; the bridge emits the literal sentinel 'unknown' for now (the upstream Opendatasoft API does not expose province). Updates xreg, generated MQTT producer, bridge, EVENTS.md, CONTAINER.md, Dockerfile.mqtt and README.