### PR TITLE
fix(wikimedia-osm-diffs): geohash5 required + ReplicationState QoS=1

### DIFF
--- a/wikimedia-osm-diffs/EVENTS.md
+++ b/wikimedia-osm-diffs/EVENTS.md
@@ -1,4 +1,6 @@
-# Table of Contents
+# Wikimedia OSM Diffs Bridge Events
+
+Events emitted by the Wikimedia OSM minutely diffs bridge.
 
 - [Org.OpenStreetMap.Diffs](#message-group-orgopenstreetmapdiffs)
   - [Org.OpenStreetMap.Diffs.MapChange](#message-orgopenstreetmapdiffsmapchange)
@@ -31,7 +33,7 @@
 | `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
 | `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
 | `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
-| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `geohash5` | *string* | - | `True` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. |
 | `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
 | `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
 | `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
@@ -79,7 +81,7 @@
 | `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
 | `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
 | `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
-| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `geohash5` | *string* | - | `True` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. |
 | `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
 | `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
 | `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
@@ -107,7 +109,7 @@
 | `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
 | `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
 | `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
-| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `geohash5` | *string* | - | `True` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. |
 | `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
 | `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
 | `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |
@@ -135,7 +137,7 @@
 | `change_type` | *string* | - | `True` | The type of change applied to the element in this replication diff: create, modify, or delete, corresponding to the OsmChange XML sections. |
 | `element_type` | *string* | - | `True` | The OSM element type: node, way, or relation. Nodes carry geographic coordinates; ways and relations reference other elements. |
 | `element_id` | *int64* | - | `True` | The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity. |
-| `geohash5` | *string* (optional) | - | `False` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis. |
+| `geohash5` | *string* | - | `True` | Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. |
 | `version` | *int32* | - | `True` | The version number of this element. Each edit to an element increments the version by one. |
 | `timestamp` | *datetime* | - | `True` | The UTC timestamp when this element version was created or last modified in the OSM database, as recorded in the OsmChange XML. |
 | `changeset_id` | *int64* | - | `True` | The numeric identifier of the OSM changeset that contains this element change. A changeset groups related edits by a single user. |

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/__init__.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/__init__.py
@@ -1,4 +1,4 @@
-from .mapchange import MapChange
 from .replicationstate import ReplicationState
+from .mapchange import MapChange
 
-__all__ = ["MapChange", "ReplicationState"]
+__all__ = ["ReplicationState", "MapChange"]

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/mapchange.py
@@ -25,7 +25,7 @@ class MapChange:
         change_type (str)
         element_type (str)
         element_id (int)
-        geohash5 (typing.Optional[str])
+        geohash5 (str)
         version (int)
         timestamp (datetime.datetime)
         changeset_id (int)
@@ -41,7 +41,7 @@ class MapChange:
     change_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="change_type"))
     element_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_type"))
     element_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_id"))
-    geohash5: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash5"))
+    geohash5: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash5"))
     version: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="version"))
     timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     changeset_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="changeset_id"))
@@ -177,17 +177,17 @@ class MapChange:
             An instance of the dataclass.
         """
         return cls(
-            change_type='clghtpiadujfsggneetb',
-            element_type='uwuxdnmvyfedxxrriybq',
-            element_id=int(30),
-            geohash5='noxwbuqfnavfvmiqxzvx',
-            version=int(8),
+            change_type='jldrfiemlelogzqfpmqk',
+            element_type='osgmzjavluqjlxsqcoct',
+            element_id=int(15),
+            geohash5='zkwfpmffxrypjsmcejto',
+            version=int(2),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(88),
-            user_name='ltyzumsmnhdbromuptwj',
-            user_id=int(6),
-            latitude=float(13.905275865647514),
-            longitude=float(39.57107662278012),
-            tags='dcreyjsvbiojblfxitwq',
-            sequence_number=int(92)
+            changeset_id=int(0),
+            user_name='jclntqgaabznwlcnckkm',
+            user_id=int(19),
+            latitude=float(35.639272025132904),
+            longitude=float(64.04351684568181),
+            tags='lmxrmazedazxluxkgvpz',
+            sequence_number=int(54)
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/src/wikimedia_osm_diffs_mqtt_producer_data/replicationstate.py
@@ -157,7 +157,7 @@ class ReplicationState:
             An instance of the dataclass.
         """
         return cls(
-            sequence_number=int(57),
+            sequence_number=int(7),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            source_url='hsbvbiyenickwbhusvhm'
+            source_url='upqqcqymzzglcayuryue'
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_mapchange.py
@@ -29,19 +29,19 @@ class Test_MapChange(unittest.TestCase):
         Create instance of MapChange for testing
         """
         instance = MapChange(
-            change_type='clghtpiadujfsggneetb',
-            element_type='uwuxdnmvyfedxxrriybq',
-            element_id=int(30),
-            geohash5='noxwbuqfnavfvmiqxzvx',
-            version=int(8),
+            change_type='jldrfiemlelogzqfpmqk',
+            element_type='osgmzjavluqjlxsqcoct',
+            element_id=int(15),
+            geohash5='zkwfpmffxrypjsmcejto',
+            version=int(2),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(88),
-            user_name='ltyzumsmnhdbromuptwj',
-            user_id=int(6),
-            latitude=float(13.905275865647514),
-            longitude=float(39.57107662278012),
-            tags='dcreyjsvbiojblfxitwq',
-            sequence_number=int(92)
+            changeset_id=int(0),
+            user_name='jclntqgaabznwlcnckkm',
+            user_id=int(19),
+            latitude=float(35.639272025132904),
+            longitude=float(64.04351684568181),
+            tags='lmxrmazedazxluxkgvpz',
+            sequence_number=int(54)
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test change_type property
         """
-        test_value = 'clghtpiadujfsggneetb'
+        test_value = 'jldrfiemlelogzqfpmqk'
         self.instance.change_type = test_value
         self.assertEqual(self.instance.change_type, test_value)
     
@@ -58,7 +58,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_type property
         """
-        test_value = 'uwuxdnmvyfedxxrriybq'
+        test_value = 'osgmzjavluqjlxsqcoct'
         self.instance.element_type = test_value
         self.assertEqual(self.instance.element_type, test_value)
     
@@ -66,7 +66,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_id property
         """
-        test_value = int(30)
+        test_value = int(15)
         self.instance.element_id = test_value
         self.assertEqual(self.instance.element_id, test_value)
     
@@ -74,7 +74,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test geohash5 property
         """
-        test_value = 'noxwbuqfnavfvmiqxzvx'
+        test_value = 'zkwfpmffxrypjsmcejto'
         self.instance.geohash5 = test_value
         self.assertEqual(self.instance.geohash5, test_value)
     
@@ -82,7 +82,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test version property
         """
-        test_value = int(8)
+        test_value = int(2)
         self.instance.version = test_value
         self.assertEqual(self.instance.version, test_value)
     
@@ -98,7 +98,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test changeset_id property
         """
-        test_value = int(88)
+        test_value = int(0)
         self.instance.changeset_id = test_value
         self.assertEqual(self.instance.changeset_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_name property
         """
-        test_value = 'ltyzumsmnhdbromuptwj'
+        test_value = 'jclntqgaabznwlcnckkm'
         self.instance.user_name = test_value
         self.assertEqual(self.instance.user_name, test_value)
     
@@ -114,7 +114,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_id property
         """
-        test_value = int(6)
+        test_value = int(19)
         self.instance.user_id = test_value
         self.assertEqual(self.instance.user_id, test_value)
     
@@ -122,7 +122,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(13.905275865647514)
+        test_value = float(35.639272025132904)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -130,7 +130,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(39.57107662278012)
+        test_value = float(64.04351684568181)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -138,7 +138,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test tags property
         """
-        test_value = 'dcreyjsvbiojblfxitwq'
+        test_value = 'lmxrmazedazxluxkgvpz'
         self.instance.tags = test_value
         self.assertEqual(self.instance.tags, test_value)
     
@@ -146,7 +146,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(92)
+        test_value = int(54)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_data/tests/test_replicationstate.py
@@ -29,9 +29,9 @@ class Test_ReplicationState(unittest.TestCase):
         Create instance of ReplicationState for testing
         """
         instance = ReplicationState(
-            sequence_number=int(57),
+            sequence_number=int(7),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            source_url='hsbvbiyenickwbhusvhm'
+            source_url='upqqcqymzzglcayuryue'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(57)
+        test_value = int(7)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test source_url property
         """
-        test_value = 'hsbvbiyenickwbhusvhm'
+        test_value = 'upqqcqymzzglcayuryue'
         self.instance.source_url = test_value
         self.assertEqual(self.instance.source_url, test_value)
     

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/client.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt_producer/wikimedia_osm_diffs_mqtt_producer_mqtt_client/src/wikimedia_osm_diffs_mqtt_producer_mqtt_client/client.py
@@ -628,7 +628,7 @@ class OrgOpenStreetMapDiffsMqttMqttClient(_ClientBase):
             data: The event data to be published.
             topic: Optional topic override. If not provided, uses default topic 'osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state'
                 with URI template placeholders substituted from the keyword arguments.
-            qos: Optional MQTT QoS override. If not provided, uses the message default (0).
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
             content_type: The content type for the event data.
         """
@@ -654,7 +654,7 @@ class OrgOpenStreetMapDiffsMqttMqttClient(_ClientBase):
             byte_data = byte_data.encode('utf-8')
         event = CloudEvent(attributes, byte_data)
 
-        _effective_qos = 0 if qos is None else qos
+        _effective_qos = 1 if qos is None else qos
         _effective_retain = True if retain is None else retain
 
         publish_kwargs: Dict[str, typing.Any] = {

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/README.md
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/README.md
@@ -1,6 +1,6 @@
 
 
-# Wikimedia-osm-diffs-producer Kafka Producer# Wikimedia-osm-diffs-producer Event Dispatcher for Apache Kafka
+# Wikimedia_osm_diffs_producer Kafka Producer# Wikimedia_osm_diffs_producer Event Dispatcher for Apache Kafka
 
 
 
@@ -98,7 +98,7 @@ Initializes the dispatcher.
 
 ```python
 
-from wikimedia-osm-diffs-producer import OrgOpenStreetMapDiffsProducer```python
+from wikimedia_osm_diffs_producer import OrgOpenStreetMapDiffsProducer```python
 
 create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
 
@@ -443,7 +443,7 @@ Initializes the dispatcher.
 
 ```python
 
-from wikimedia-osm-diffs-producer import OrgOpenStreetMapDiffsProducer```python
+from wikimedia_osm_diffs_producer import OrgOpenStreetMapDiffsProducer```python
 
 create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
 
@@ -788,7 +788,7 @@ Initializes the dispatcher.
 
 ```python
 
-from wikimedia-osm-diffs-producer import OrgOpenStreetMapDiffsProducer```python
+from wikimedia_osm_diffs_producer import OrgOpenStreetMapDiffsProducer```python
 
 create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
 

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/mapchange.py
@@ -25,7 +25,7 @@ class MapChange:
         change_type (str)
         element_type (str)
         element_id (int)
-        geohash5 (typing.Optional[str])
+        geohash5 (str)
         version (int)
         timestamp (datetime.datetime)
         changeset_id (int)
@@ -41,7 +41,7 @@ class MapChange:
     change_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="change_type"))
     element_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_type"))
     element_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="element_id"))
-    geohash5: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash5"))
+    geohash5: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash5"))
     version: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="version"))
     timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     changeset_id: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="changeset_id"))
@@ -177,17 +177,17 @@ class MapChange:
             An instance of the dataclass.
         """
         return cls(
-            change_type='etszfwfpjecxalvkejsk',
-            element_type='udqmikpptqspjubfcrkg',
-            element_id=int(38),
-            geohash5='trihytyiamzwysoboodo',
-            version=int(88),
+            change_type='fwkrldvfhqyasgmdbwka',
+            element_type='jgmfcxfvopsjvjlkuumo',
+            element_id=int(20),
+            geohash5='nqjzrhlhsmorjtxfevvq',
+            version=int(19),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(68),
-            user_name='iupminodrqjpbarcdsyh',
-            user_id=int(38),
-            latitude=float(79.79775288294415),
-            longitude=float(95.91527798692695),
-            tags='yslnqwxggghfcvyswion',
-            sequence_number=int(57)
+            changeset_id=int(46),
+            user_name='fpwvxmqrujiromacuegs',
+            user_id=int(97),
+            latitude=float(44.09570512288319),
+            longitude=float(71.30936994326764),
+            tags='msltapuulsnvxnmutyys',
+            sequence_number=int(87)
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/src/wikimedia_osm_diffs_producer_data/replicationstate.py
@@ -157,7 +157,7 @@ class ReplicationState:
             An instance of the dataclass.
         """
         return cls(
-            sequence_number=int(24),
+            sequence_number=int(6),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            source_url='wjcdlgddtyzrynwsankg'
+            source_url='ecebttoqqnvogideoexj'
         )

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/tests/test_mapchange.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/tests/test_mapchange.py
@@ -29,19 +29,19 @@ class Test_MapChange(unittest.TestCase):
         Create instance of MapChange for testing
         """
         instance = MapChange(
-            change_type='etszfwfpjecxalvkejsk',
-            element_type='udqmikpptqspjubfcrkg',
-            element_id=int(38),
-            geohash5='trihytyiamzwysoboodo',
-            version=int(88),
+            change_type='fwkrldvfhqyasgmdbwka',
+            element_type='jgmfcxfvopsjvjlkuumo',
+            element_id=int(20),
+            geohash5='nqjzrhlhsmorjtxfevvq',
+            version=int(19),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            changeset_id=int(68),
-            user_name='iupminodrqjpbarcdsyh',
-            user_id=int(38),
-            latitude=float(79.79775288294415),
-            longitude=float(95.91527798692695),
-            tags='yslnqwxggghfcvyswion',
-            sequence_number=int(57)
+            changeset_id=int(46),
+            user_name='fpwvxmqrujiromacuegs',
+            user_id=int(97),
+            latitude=float(44.09570512288319),
+            longitude=float(71.30936994326764),
+            tags='msltapuulsnvxnmutyys',
+            sequence_number=int(87)
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test change_type property
         """
-        test_value = 'etszfwfpjecxalvkejsk'
+        test_value = 'fwkrldvfhqyasgmdbwka'
         self.instance.change_type = test_value
         self.assertEqual(self.instance.change_type, test_value)
     
@@ -58,7 +58,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_type property
         """
-        test_value = 'udqmikpptqspjubfcrkg'
+        test_value = 'jgmfcxfvopsjvjlkuumo'
         self.instance.element_type = test_value
         self.assertEqual(self.instance.element_type, test_value)
     
@@ -66,7 +66,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test element_id property
         """
-        test_value = int(38)
+        test_value = int(20)
         self.instance.element_id = test_value
         self.assertEqual(self.instance.element_id, test_value)
     
@@ -74,7 +74,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test geohash5 property
         """
-        test_value = 'trihytyiamzwysoboodo'
+        test_value = 'nqjzrhlhsmorjtxfevvq'
         self.instance.geohash5 = test_value
         self.assertEqual(self.instance.geohash5, test_value)
     
@@ -82,7 +82,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test version property
         """
-        test_value = int(88)
+        test_value = int(19)
         self.instance.version = test_value
         self.assertEqual(self.instance.version, test_value)
     
@@ -98,7 +98,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test changeset_id property
         """
-        test_value = int(68)
+        test_value = int(46)
         self.instance.changeset_id = test_value
         self.assertEqual(self.instance.changeset_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_name property
         """
-        test_value = 'iupminodrqjpbarcdsyh'
+        test_value = 'fpwvxmqrujiromacuegs'
         self.instance.user_name = test_value
         self.assertEqual(self.instance.user_name, test_value)
     
@@ -114,7 +114,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test user_id property
         """
-        test_value = int(38)
+        test_value = int(97)
         self.instance.user_id = test_value
         self.assertEqual(self.instance.user_id, test_value)
     
@@ -122,7 +122,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(79.79775288294415)
+        test_value = float(44.09570512288319)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -130,7 +130,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(95.91527798692695)
+        test_value = float(71.30936994326764)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -138,7 +138,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test tags property
         """
-        test_value = 'yslnqwxggghfcvyswion'
+        test_value = 'msltapuulsnvxnmutyys'
         self.instance.tags = test_value
         self.assertEqual(self.instance.tags, test_value)
     
@@ -146,7 +146,7 @@ class Test_MapChange(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(57)
+        test_value = int(87)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     

--- a/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/tests/test_replicationstate.py
+++ b/wikimedia-osm-diffs/wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data/tests/test_replicationstate.py
@@ -29,9 +29,9 @@ class Test_ReplicationState(unittest.TestCase):
         Create instance of ReplicationState for testing
         """
         instance = ReplicationState(
-            sequence_number=int(24),
+            sequence_number=int(6),
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            source_url='wjcdlgddtyzrynwsankg'
+            source_url='ecebttoqqnvogideoexj'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test sequence_number property
         """
-        test_value = int(24)
+        test_value = int(6)
         self.instance.sequence_number = test_value
         self.assertEqual(self.instance.sequence_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_ReplicationState(unittest.TestCase):
         """
         Test source_url property
         """
-        test_value = 'wjcdlgddtyzrynwsankg'
+        test_value = 'ecebttoqqnvogideoexj'
         self.instance.source_url = test_value
         self.assertEqual(self.instance.source_url, test_value)
     

--- a/wikimedia-osm-diffs/xreg/wikimedia_osm_diffs.xreg.json
+++ b/wikimedia-osm-diffs/xreg/wikimedia_osm_diffs.xreg.json
@@ -202,7 +202,7 @@
           },
           "protocoloptions": {
             "topic_name": "osm/intl/wikimedia/wikimedia-osm-diffs/replication-state/replication-state",
-            "qos": 0,
+            "qos": 1,
             "retain": true
           }
         }
@@ -239,11 +239,8 @@
                     "description": "The unique numeric identifier of the OSM element within its element type namespace. Combined with element_type, this forms the globally unique OSM element identity."
                   },
                   "geohash5": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment. Null only on legacy payloads predating the MQTT axis."
+                    "type": "string",
+                    "description": "Five-character base32 geohash of the element's representative coordinate. For nodes, derived from latitude/longitude; for ways and relations, derived from the centroid of any embedded bbox. The sentinel 'nogeo' is emitted for elements with no resolvable coordinate (most relation deletes, member-only edits, etc.) so the UNS topic placeholder always resolves to a fixed-shape lowercase ASCII segment."
                   },
                   "version": {
                     "type": "int32",
@@ -298,6 +295,7 @@
                   "change_type",
                   "element_type",
                   "element_id",
+                  "geohash5",
                   "version",
                   "timestamp",
                   "changeset_id",


### PR DESCRIPTION
Narrow review-driven fixup off main. Two changes:

1. **MapChange.geohash5 is now required + non-null.** The bridge already substitutes the literal 'nogeo' sentinel before publish when no coordinate can be derived (most relation deletes / member-only edits), so the topic placeholder was always populated; the JSON Structure schema now matches that contract.
2. **ReplicationState MQTT message bumped to QoS 1.** This is a retained reference snapshot (retain=true). Retained messages must be published with QoS>=1 so the broker reliably re-delivers them to late subscribers; QoS 0 retained publishes can be dropped silently on flaky links.

Regenerates MQTT producer client, Kafka producer client, and EVENTS.md.