### PR TITLE
fix(german-waters): mirror water_body onto Avro WaterLevelObservation

### DIFF
--- a/german-waters/EVENTS.md
+++ b/german-waters/EVENTS.md
@@ -1,4 +1,6 @@
-# Table of Contents
+# German Waters Hydrology Bridge Events
+
+Events emitted by the German Waters hydrology bridge.
 
 - [DE.Waters.Hydrology](#message-group-dewatershydrology)
   - [DE.Waters.Hydrology.Station](#message-dewatershydrologystation)

--- a/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/src/german_waters_mqtt_producer_data/station.py
+++ b/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/src/german_waters_mqtt_producer_data/station.py
@@ -179,19 +179,19 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='fyifpkcphudipgpfkxra',
-            station_name='bwyyejhvnrtcvsgdqwvj',
-            water_body='uatcslbugtyvwjcekekb',
-            state='xxqrkaxgjkypmywnmyzf',
-            region='drkdlwdnrzputruubskp',
-            provider='oksnaqnwotdqxfutxqdl',
-            latitude=float(92.1469950263051),
-            longitude=float(35.262973336921945),
-            river_km=float(43.35035267656004),
-            altitude=float(27.668060216934975),
-            station_type='rbdpkdbhuwyeyjenalwe',
-            warn_level_cm=float(77.38871408818713),
-            alarm_level_cm=float(27.786740956447332),
-            warn_level_m3s=float(23.76137267055053),
-            alarm_level_m3s=float(80.34337205979571)
+            station_id='eakjxwnipngtqmluxwif',
+            station_name='pimgxeucxgrorhimhbrk',
+            water_body='rqifdaajrjonpbjejkyq',
+            state='sljtpyvodqpsjnywzrlj',
+            region='zsqhdogzuclflxhiphvz',
+            provider='asziziigzhnfbxdqcoko',
+            latitude=float(64.48818576212577),
+            longitude=float(20.34850513014034),
+            river_km=float(56.530640306623766),
+            altitude=float(98.8244265541659),
+            station_type='lpovzkudoegyfqeawhfs',
+            warn_level_cm=float(13.28843227366171),
+            alarm_level_cm=float(62.7120745244371),
+            warn_level_m3s=float(50.03185921009104),
+            alarm_level_m3s=float(3.810150209169272)
         )

--- a/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/src/german_waters_mqtt_producer_data/waterlevelobservation.py
+++ b/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/src/german_waters_mqtt_producer_data/waterlevelobservation.py
@@ -173,15 +173,15 @@ class WaterLevelObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='fmidqbfxrloltpgffzcf',
-            provider='julnehfatxpngcvedxpe',
-            water_body='toeeqpgqbvacfgckspxy',
-            water_level=float(39.004333009812456),
-            water_level_unit='veildprphsfgqtpjziud',
+            station_id='xrbynfabfhkrlxzizzvu',
+            provider='xzflntaveopiqmfkqytm',
+            water_body='msqjyoucxkiiehegfjmj',
+            water_level=float(12.579754363907746),
+            water_level_unit='cquplimhzbxdaizmikzs',
             water_level_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            discharge=float(69.38429399829452),
-            discharge_unit='imhaxhipklxfzqtfmjzk',
+            discharge=float(60.42593850990453),
+            discharge_unit='jhbppwqojjfcczmucyva',
             discharge_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            trend=int(1),
-            situation=int(95)
+            trend=int(29),
+            situation=int(11)
         )

--- a/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/tests/test_station.py
+++ b/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/tests/test_station.py
@@ -28,21 +28,21 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='fyifpkcphudipgpfkxra',
-            station_name='bwyyejhvnrtcvsgdqwvj',
-            water_body='uatcslbugtyvwjcekekb',
-            state='xxqrkaxgjkypmywnmyzf',
-            region='drkdlwdnrzputruubskp',
-            provider='oksnaqnwotdqxfutxqdl',
-            latitude=float(92.1469950263051),
-            longitude=float(35.262973336921945),
-            river_km=float(43.35035267656004),
-            altitude=float(27.668060216934975),
-            station_type='rbdpkdbhuwyeyjenalwe',
-            warn_level_cm=float(77.38871408818713),
-            alarm_level_cm=float(27.786740956447332),
-            warn_level_m3s=float(23.76137267055053),
-            alarm_level_m3s=float(80.34337205979571)
+            station_id='eakjxwnipngtqmluxwif',
+            station_name='pimgxeucxgrorhimhbrk',
+            water_body='rqifdaajrjonpbjejkyq',
+            state='sljtpyvodqpsjnywzrlj',
+            region='zsqhdogzuclflxhiphvz',
+            provider='asziziigzhnfbxdqcoko',
+            latitude=float(64.48818576212577),
+            longitude=float(20.34850513014034),
+            river_km=float(56.530640306623766),
+            altitude=float(98.8244265541659),
+            station_type='lpovzkudoegyfqeawhfs',
+            warn_level_cm=float(13.28843227366171),
+            alarm_level_cm=float(62.7120745244371),
+            warn_level_m3s=float(50.03185921009104),
+            alarm_level_m3s=float(3.810150209169272)
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'fyifpkcphudipgpfkxra'
+        test_value = 'eakjxwnipngtqmluxwif'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'bwyyejhvnrtcvsgdqwvj'
+        test_value = 'pimgxeucxgrorhimhbrk'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Station(unittest.TestCase):
         """
         Test water_body property
         """
-        test_value = 'uatcslbugtyvwjcekekb'
+        test_value = 'rqifdaajrjonpbjejkyq'
         self.instance.water_body = test_value
         self.assertEqual(self.instance.water_body, test_value)
     
@@ -75,7 +75,7 @@ class Test_Station(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'xxqrkaxgjkypmywnmyzf'
+        test_value = 'sljtpyvodqpsjnywzrlj'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -83,7 +83,7 @@ class Test_Station(unittest.TestCase):
         """
         Test region property
         """
-        test_value = 'drkdlwdnrzputruubskp'
+        test_value = 'zsqhdogzuclflxhiphvz'
         self.instance.region = test_value
         self.assertEqual(self.instance.region, test_value)
     
@@ -91,7 +91,7 @@ class Test_Station(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'oksnaqnwotdqxfutxqdl'
+        test_value = 'asziziigzhnfbxdqcoko'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
     
@@ -99,7 +99,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(92.1469950263051)
+        test_value = float(64.48818576212577)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -107,7 +107,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(35.262973336921945)
+        test_value = float(20.34850513014034)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -115,7 +115,7 @@ class Test_Station(unittest.TestCase):
         """
         Test river_km property
         """
-        test_value = float(43.35035267656004)
+        test_value = float(56.530640306623766)
         self.instance.river_km = test_value
         self.assertEqual(self.instance.river_km, test_value)
     
@@ -123,7 +123,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(27.668060216934975)
+        test_value = float(98.8244265541659)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -131,7 +131,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_type property
         """
-        test_value = 'rbdpkdbhuwyeyjenalwe'
+        test_value = 'lpovzkudoegyfqeawhfs'
         self.instance.station_type = test_value
         self.assertEqual(self.instance.station_type, test_value)
     
@@ -139,7 +139,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_cm property
         """
-        test_value = float(77.38871408818713)
+        test_value = float(13.28843227366171)
         self.instance.warn_level_cm = test_value
         self.assertEqual(self.instance.warn_level_cm, test_value)
     
@@ -147,7 +147,7 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_cm property
         """
-        test_value = float(27.786740956447332)
+        test_value = float(62.7120745244371)
         self.instance.alarm_level_cm = test_value
         self.assertEqual(self.instance.alarm_level_cm, test_value)
     
@@ -155,7 +155,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_m3s property
         """
-        test_value = float(23.76137267055053)
+        test_value = float(50.03185921009104)
         self.instance.warn_level_m3s = test_value
         self.assertEqual(self.instance.warn_level_m3s, test_value)
     
@@ -163,7 +163,7 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_m3s property
         """
-        test_value = float(80.34337205979571)
+        test_value = float(3.810150209169272)
         self.instance.alarm_level_m3s = test_value
         self.assertEqual(self.instance.alarm_level_m3s, test_value)
     

--- a/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/tests/test_waterlevelobservation.py
+++ b/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_data/tests/test_waterlevelobservation.py
@@ -29,17 +29,17 @@ class Test_WaterLevelObservation(unittest.TestCase):
         Create instance of WaterLevelObservation for testing
         """
         instance = WaterLevelObservation(
-            station_id='fmidqbfxrloltpgffzcf',
-            provider='julnehfatxpngcvedxpe',
-            water_body='toeeqpgqbvacfgckspxy',
-            water_level=float(39.004333009812456),
-            water_level_unit='veildprphsfgqtpjziud',
+            station_id='xrbynfabfhkrlxzizzvu',
+            provider='xzflntaveopiqmfkqytm',
+            water_body='msqjyoucxkiiehegfjmj',
+            water_level=float(12.579754363907746),
+            water_level_unit='cquplimhzbxdaizmikzs',
             water_level_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            discharge=float(69.38429399829452),
-            discharge_unit='imhaxhipklxfzqtfmjzk',
+            discharge=float(60.42593850990453),
+            discharge_unit='jhbppwqojjfcczmucyva',
             discharge_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            trend=int(1),
-            situation=int(95)
+            trend=int(29),
+            situation=int(11)
         )
         return instance
 
@@ -48,7 +48,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'fmidqbfxrloltpgffzcf'
+        test_value = 'xrbynfabfhkrlxzizzvu'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -56,7 +56,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'julnehfatxpngcvedxpe'
+        test_value = 'xzflntaveopiqmfkqytm'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
     
@@ -64,7 +64,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test water_body property
         """
-        test_value = 'toeeqpgqbvacfgckspxy'
+        test_value = 'msqjyoucxkiiehegfjmj'
         self.instance.water_body = test_value
         self.assertEqual(self.instance.water_body, test_value)
     
@@ -72,7 +72,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test water_level property
         """
-        test_value = float(39.004333009812456)
+        test_value = float(12.579754363907746)
         self.instance.water_level = test_value
         self.assertEqual(self.instance.water_level, test_value)
     
@@ -80,7 +80,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test water_level_unit property
         """
-        test_value = 'veildprphsfgqtpjziud'
+        test_value = 'cquplimhzbxdaizmikzs'
         self.instance.water_level_unit = test_value
         self.assertEqual(self.instance.water_level_unit, test_value)
     
@@ -96,7 +96,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge property
         """
-        test_value = float(69.38429399829452)
+        test_value = float(60.42593850990453)
         self.instance.discharge = test_value
         self.assertEqual(self.instance.discharge, test_value)
     
@@ -104,7 +104,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge_unit property
         """
-        test_value = 'imhaxhipklxfzqtfmjzk'
+        test_value = 'jhbppwqojjfcczmucyva'
         self.instance.discharge_unit = test_value
         self.assertEqual(self.instance.discharge_unit, test_value)
     
@@ -120,7 +120,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test trend property
         """
-        test_value = int(1)
+        test_value = int(29)
         self.instance.trend = test_value
         self.assertEqual(self.instance.trend, test_value)
     
@@ -128,7 +128,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test situation property
         """
-        test_value = int(95)
+        test_value = int(11)
         self.instance.situation = test_value
         self.assertEqual(self.instance.situation, test_value)
     

--- a/german-waters/german_waters_producer/README.md
+++ b/german-waters/german_waters_producer/README.md
@@ -15,7 +15,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 2. [What is Apache Kafka?](#what-is-apache-kafka)2. [Generated Event Dispatchers](#generated-event-dispatchers)
 
-3. [Quick Start](#quick-start)    - DEWatersHydrologyEventDispatcher
+3. [Quick Start](#quick-start)    - DEWatersHydrologyEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    DEWatersHydrologyMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -39,6 +41,10 @@ methods to handle various types of events.
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - DEWatersHydrologyProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- DEWatersHydrologyMqttProducersolution for event-driven applications.
 
 
 
@@ -190,6 +196,43 @@ de_waters_hydrology_dispatcher.de_waters_hydrology_station_async = de_waters_hyd
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyMqttProducer- `data`: The event data of type `german_waters_producer_data.Station`.
+
+
+
+Producer for `DE.Waters.Hydrology.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_station_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Station) -> None:
+
+```python    # Process the event data
+
+DEWatersHydrologyMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_mqtt_dispatcher.de_waters_hydrology_station_async = de_waters_hydrology_station_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -248,6 +291,45 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 de_waters_hydrology_dispatcher.de_waters_hydrology_water_level_observation_async =
+de_waters_hydrology_water_level_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyMqttProducer- `data`: The event data of type `german_waters_producer_data.WaterLevelObservation`.
+
+
+
+Producer for `DE.Waters.Hydrology.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_water_level_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WaterLevelObservation) -> None:
+
+```python    # Process the event data
+
+DEWatersHydrologyMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_mqtt_dispatcher.de_waters_hydrology_water_level_observation_async =
 de_waters_hydrology_water_level_observation_event
 
 **Parameters:**```
@@ -451,6 +533,510 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_de_waters_hydrology_water_level_observation_batch(```
+
+    messages=[
+
+        WaterLevelObservation(...),Initializes the runner with a Kafka consumer.
+
+        WaterLevelObservation(...),
+
+        WaterLevelObservation(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### DEWatersHydrologyMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`DEWatersHydrologyMqttEventDispatcher` handles events for the DE.Waters.Hydrology.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from german_waters_producer import DEWatersHydrologyProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = DEWatersHydrologyProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_de_waters_hydrology_station(```python
+
+    data=Station(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The DEWatersHydrologyMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = DEWatersHydrologyProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `de_waters_hydrology_mqtt_station_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'de_waters_hydrology_mqtt_station_async:  Callable[[ConsumerRecord, CloudEvent,
+Station], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `DE.Waters.Hydrology.mqtt.Station`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyProducer- `data`: The event data of type `german_waters_producer_data.Station`.
+
+
+
+Producer for `DE.Waters.Hydrology` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_mqtt_station_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Station) ->
+None:
+
+```python    # Process the event data
+
+DEWatersHydrologyProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_dispatcher.de_waters_hydrology_mqtt_station_async = de_waters_hydrology_mqtt_station_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyMqttProducer- `data`: The event data of type `german_waters_producer_data.Station`.
+
+
+
+Producer for `DE.Waters.Hydrology.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_mqtt_station_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Station) ->
+None:
+
+```python    # Process the event data
+
+DEWatersHydrologyMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_mqtt_dispatcher.de_waters_hydrology_mqtt_station_async = de_waters_hydrology_mqtt_station_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `de_waters_hydrology_mqtt_water_level_observation_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'de_waters_hydrology_mqtt_water_level_observation_async:  Callable[[ConsumerRecord,
+CloudEvent, WaterLevelObservation], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `DE.Waters.Hydrology.mqtt.WaterLevelObservation`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyProducer- `data`: The event data of type `german_waters_producer_data.WaterLevelObservation`.
+
+
+
+Producer for `DE.Waters.Hydrology` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_mqtt_water_level_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WaterLevelObservation) -> None:
+
+```python    # Process the event data
+
+DEWatersHydrologyProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_dispatcher.de_waters_hydrology_mqtt_water_level_observation_async =
+de_waters_hydrology_mqtt_water_level_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### DEWatersHydrologyMqttProducer- `data`: The event data of type `german_waters_producer_data.WaterLevelObservation`.
+
+
+
+Producer for `DE.Waters.Hydrology.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def de_waters_hydrology_mqtt_water_level_observation_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WaterLevelObservation) -> None:
+
+```python    # Process the event data
+
+DEWatersHydrologyMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+de_waters_hydrology_mqtt_dispatcher.de_waters_hydrology_mqtt_water_level_observation_async =
+de_waters_hydrology_mqtt_water_level_observation_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_de_waters_hydrology_mqtt_station`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_de_waters_hydrology_mqtt_station(
+
+    self,##### `_process_event`
+
+    data: Station,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `DE.Waters.Hydrology.mqtt.Station` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `Station`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_de_waters_hydrology_mqtt_station(
+
+    data=Station(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `DE.Waters.Hydrology.mqtt.Station` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_de_waters_hydrology_mqtt_station_batch(```
+
+    messages=[
+
+        Station(...),Initializes the runner with a Kafka consumer.
+
+        Station(...),
+
+        Station(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_de_waters_hydrology_mqtt_water_level_observation`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_de_waters_hydrology_mqtt_water_level_observation(
+
+    self,##### `_process_event`
+
+    data: WaterLevelObservation,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `DE.Waters.Hydrology.mqtt.WaterLevelObservation` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `WaterLevelObservation`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_de_waters_hydrology_mqtt_water_level_observation(
+
+    data=WaterLevelObservation(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `DE.Waters.Hydrology.mqtt.WaterLevelObservation` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_de_waters_hydrology_mqtt_water_level_observation_batch(```
 
     messages=[
 

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/__init__.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import Station, WaterLevelObservation
+from .de import WaterLevelObservation, Station
 
-__all__ = ["Station", "WaterLevelObservation"]
+__all__ = ["WaterLevelObservation", "Station"]

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/__init__.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .waters import Station, WaterLevelObservation
+from .waters import WaterLevelObservation, Station
 
-__all__ = ["Station", "WaterLevelObservation"]
+__all__ = ["WaterLevelObservation", "Station"]

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/__init__.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/__init__.py
@@ -1,3 +1,3 @@
-from .hydrology import Station, WaterLevelObservation
+from .hydrology import WaterLevelObservation, Station
 
-__all__ = ["Station", "WaterLevelObservation"]
+__all__ = ["WaterLevelObservation", "Station"]

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/hydrology/__init__.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/hydrology/__init__.py
@@ -1,4 +1,4 @@
-from .station import Station
 from .waterlevelobservation import WaterLevelObservation
+from .station import Station
 
-__all__ = ["Station", "WaterLevelObservation"]
+__all__ = ["WaterLevelObservation", "Station"]

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/hydrology/waterlevelobservation.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/de/waters/hydrology/waterlevelobservation.py
@@ -25,6 +25,7 @@ class WaterLevelObservation:
     Attributes:
         station_id (str): 
         provider (str): 
+        water_body (str): Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Mirrored from the JSON Structure WaterLevelObservation schema; sourced by the bridge from the per-provider station catalog and propagated onto every observation. Required non-null string.
         water_level (typing.Optional[float]): 
         water_level_unit (typing.Optional[str]): 
         water_level_timestamp (typing.Optional[datetime.datetime]): 
@@ -36,6 +37,7 @@ class WaterLevelObservation:
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
     provider: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="provider"))
+    water_body: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_body"))
     water_level: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level"))
     water_level_unit: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level_unit"))
     water_level_timestamp: typing.Optional[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level_timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -46,13 +48,14 @@ class WaterLevelObservation:
     situation: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="situation"))
     
     AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.make_avsc_object(
-        json.loads("{\"type\": \"record\", \"name\": \"WaterLevelObservation\", \"doc\": \"WaterLevelObservation\", \"fields\": [{\"name\": \"station_id\", \"type\": \"string\"}, {\"name\": \"provider\", \"type\": \"string\"}, {\"name\": \"water_level\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"water_level_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"water_level_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"discharge\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"discharge_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"discharge_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"trend\", \"type\": [\"null\", \"int\"], \"default\": null}, {\"name\": \"situation\", \"type\": [\"null\", \"int\"], \"default\": null}], \"namespace\": \"DE.Waters.Hydrology\"}"), avro.name.Names()
+        json.loads("{\"type\": \"record\", \"name\": \"WaterLevelObservation\", \"doc\": \"WaterLevelObservation\", \"fields\": [{\"name\": \"station_id\", \"type\": \"string\"}, {\"name\": \"provider\", \"type\": \"string\"}, {\"name\": \"water_body\", \"type\": \"string\", \"doc\": \"Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Mirrored from the JSON Structure WaterLevelObservation schema; sourced by the bridge from the per-provider station catalog and propagated onto every observation. Required non-null string.\"}, {\"name\": \"water_level\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"water_level_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"water_level_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"discharge\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"discharge_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"discharge_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"trend\", \"type\": [\"null\", \"int\"], \"default\": null}, {\"name\": \"situation\", \"type\": [\"null\", \"int\"], \"default\": null}], \"namespace\": \"DE.Waters.Hydrology\"}"), avro.name.Names()
     )
 
     def __post_init__(self):
         """ Initializes the dataclass with the provided keyword arguments."""
         self.station_id=str(self.station_id)
         self.provider=str(self.provider)
+        self.water_body=str(self.water_body)
         self.water_level=float(self.water_level) if self.water_level else None
         self.water_level_unit=str(self.water_level_unit) if self.water_level_unit else None
         self.water_level_timestamp=self.water_level_timestamp if self.water_level_timestamp else None

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/station.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/station.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
+import avro.schema
+import avro.io
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -36,6 +38,10 @@ class Station:
         warn_level_m3s (typing.Optional[float])
         alarm_level_m3s (typing.Optional[float])
     """
+    
+    AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.parse(
+        "{\"type\": \"record\", \"name\": \"Station\", \"doc\": \"Station\", \"fields\": [{\"name\": \"station_id\", \"type\": \"string\"}, {\"name\": \"station_name\", \"type\": \"string\"}, {\"name\": \"water_body\", \"type\": \"string\"}, {\"name\": \"state\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"region\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"provider\", \"type\": \"string\"}, {\"name\": \"latitude\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"longitude\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"river_km\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"altitude\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"station_type\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"warn_level_cm\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"alarm_level_cm\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"warn_level_m3s\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"alarm_level_m3s\", \"type\": [\"null\", \"double\"], \"default\": null}]}"
+    )
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
@@ -66,6 +72,53 @@ class Station:
             The dataclass representation of the dataclass.
         """
         return cls(**data)
+    @classmethod
+    def from_avro_dict(cls, data: dict) -> 'Station':
+        """
+        Converts a dictionary from Avro deserialization to a dataclass instance.
+        Handles conversion of string representations back to Python types for
+        extended logical types.
+        
+        Args:
+            data: The dictionary from Avro deserialization.
+        
+        Returns:
+            The dataclass representation.
+        """
+        # Convert string values back to Python types for Avro string-based logical types
+        converted = data.copy()
+        if 'station_id' in converted and converted['station_id'] is not None:
+            value = converted['station_id']
+        if 'station_name' in converted and converted['station_name'] is not None:
+            value = converted['station_name']
+        if 'water_body' in converted and converted['water_body'] is not None:
+            value = converted['water_body']
+        if 'state' in converted and converted['state'] is not None:
+            value = converted['state']
+        if 'region' in converted and converted['region'] is not None:
+            value = converted['region']
+        if 'provider' in converted and converted['provider'] is not None:
+            value = converted['provider']
+        if 'latitude' in converted and converted['latitude'] is not None:
+            value = converted['latitude']
+        if 'longitude' in converted and converted['longitude'] is not None:
+            value = converted['longitude']
+        if 'river_km' in converted and converted['river_km'] is not None:
+            value = converted['river_km']
+        if 'altitude' in converted and converted['altitude'] is not None:
+            value = converted['altitude']
+        if 'station_type' in converted and converted['station_type'] is not None:
+            value = converted['station_type']
+        if 'warn_level_cm' in converted and converted['warn_level_cm'] is not None:
+            value = converted['warn_level_cm']
+        if 'alarm_level_cm' in converted and converted['alarm_level_cm'] is not None:
+            value = converted['alarm_level_cm']
+        if 'warn_level_m3s' in converted and converted['warn_level_m3s'] is not None:
+            value = converted['warn_level_m3s']
+        if 'alarm_level_m3s' in converted and converted['alarm_level_m3s'] is not None:
+            value = converted['alarm_level_m3s']
+        
+        return cls(**converted)
 
     def to_serializer_dict(self) -> dict:
         """
@@ -89,6 +142,22 @@ class Station:
             return k[:-1] if k.endswith('_') else k
         return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
 
+    def to_avro_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary suitable for Avro serialization.
+        Handles conversion of Python types to Avro-compatible string representations
+        for extended logical types.
+
+        Returns:
+            The dictionary representation suitable for Avro serialization.
+        """
+        result = self.to_serializer_dict()
+        converted = result.copy()
+        
+        # Convert specific fields based on their source types
+        
+        return converted
+
     def to_byte_array(self, content_type_string: str) -> bytes:
         """
         Converts the dataclass to a byte array based on the content type string.
@@ -97,6 +166,8 @@ class Station:
             content_type_string: The content type string to convert the dataclass to.
                 Supported content types:
                     'application/json': Encodes the data to JSON format.
+                    'avro/binary': Encodes the data to Avro binary format.
+                    'application/vnd.apache.avro+avro': Encodes the data to Avro binary format.
                 Supported content type extensions:
                     '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
 
@@ -108,6 +179,13 @@ class Station:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
+        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
+            # Convert to Avro binary format using the embedded schema
+            writer = avro.io.DatumWriter(self.AvroType)
+            with io.BytesIO() as stream:
+                encoder = avro.io.BinaryEncoder(stream)
+                writer.write(self.to_avro_dict(), encoder)
+                result = stream.getvalue()
         if base_content_type == 'application/json':
             #pylint: disable=no-member
             result = self.to_json()
@@ -137,6 +215,8 @@ class Station:
             content_type_string: The content type string to convert the data to. 
                 Supported content types:
                     'application/json': Attempts to decode the data from JSON encoded format.
+                    'avro/binary': Attempts to decode the data from Avro binary format.
+                    'application/vnd.apache.avro+avro': Attempts to decode the data from Avro binary format.
                 Supported content type extensions:
                     '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
         Returns:
@@ -161,6 +241,16 @@ class Station:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
+        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
+            if isinstance(data, bytes):
+                # Decode from Avro binary format using the embedded schema
+                reader = avro.io.DatumReader(cls.AvroType)
+                with io.BytesIO(data) as stream:
+                    decoder = avro.io.BinaryDecoder(stream)
+                    _record = reader.read(decoder)
+                    return Station.from_avro_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for Avro deserialization')
         if base_content_type == 'application/json':
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
@@ -179,19 +269,19 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='rnzrhdwvwfpcygykryrw',
-            station_name='hiuctlpwvmzcrlilqdfe',
-            water_body='wtbafnfuarwtoadspjyb',
-            state='uvmycwblykojbtfdsvjh',
-            region='rvcetnyiejpxdsrrdcnl',
-            provider='srlbbqsxtrvtsaearwrg',
-            latitude=float(43.6581595257145),
-            longitude=float(49.83795689777193),
-            river_km=float(44.69247786336202),
-            altitude=float(26.37989497033977),
-            station_type='ftvhekvvfbrvjfmvikct',
-            warn_level_cm=float(9.296879119389867),
-            alarm_level_cm=float(43.30648059588951),
-            warn_level_m3s=float(66.82145473295586),
-            alarm_level_m3s=float(79.98576106579081)
+            station_id='qzpnpzonbqteubaosmmy',
+            station_name='agewzytsnmhvyfklphav',
+            water_body='dwiyqiuawdynxdzilrlj',
+            state='ozsdcxbyedeeznjccfbz',
+            region='akkxbbmougbwhjvoykps',
+            provider='ueyaxdporhvwnzaiqivk',
+            latitude=float(68.90349861976425),
+            longitude=float(87.51844962742975),
+            river_km=float(97.52917537581185),
+            altitude=float(66.24783751053795),
+            station_type='lhzskhdxlsjkavlwyvdh',
+            warn_level_cm=float(80.82965976388567),
+            alarm_level_cm=float(54.92113975744053),
+            warn_level_m3s=float(61.75023322032087),
+            alarm_level_m3s=float(86.44185070876027)
         )

--- a/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/waterlevelobservation.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/src/german_waters_producer_data/waterlevelobservation.py
@@ -12,6 +12,8 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
+import avro.schema
+import avro.io
 import datetime
 
 
@@ -24,6 +26,7 @@ class WaterLevelObservation:
     Attributes:
         station_id (str)
         provider (str)
+        water_body (str)
         water_level (typing.Optional[float])
         water_level_unit (typing.Optional[str])
         water_level_timestamp (typing.Optional[datetime.datetime])
@@ -34,9 +37,14 @@ class WaterLevelObservation:
         situation (typing.Optional[int])
     """
     
+    AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.parse(
+        "{\"type\": \"record\", \"name\": \"WaterLevelObservation\", \"doc\": \"WaterLevelObservation\", \"fields\": [{\"name\": \"station_id\", \"type\": \"string\"}, {\"name\": \"provider\", \"type\": \"string\"}, {\"name\": \"water_body\", \"type\": \"string\", \"doc\": \"Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Sourced by the bridge from the per-provider station catalog (Station.water_body field) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {water_body} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.\"}, {\"name\": \"water_level\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"water_level_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"water_level_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"discharge\", \"type\": [\"null\", \"double\"], \"default\": null}, {\"name\": \"discharge_unit\", \"type\": [\"null\", \"string\"], \"default\": null}, {\"name\": \"discharge_timestamp\", \"type\": [\"null\", {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}], \"default\": null}, {\"name\": \"trend\", \"type\": [\"null\", \"int\"], \"default\": null}, {\"name\": \"situation\", \"type\": [\"null\", \"int\"], \"default\": null}]}"
+    )
+    
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
     provider: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="provider"))
+    water_body: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_body"))
     water_level: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level"))
     water_level_unit: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level_unit"))
     water_level_timestamp: typing.Optional[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_level_timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -58,6 +66,49 @@ class WaterLevelObservation:
             The dataclass representation of the dataclass.
         """
         return cls(**data)
+    @classmethod
+    def from_avro_dict(cls, data: dict) -> 'WaterLevelObservation':
+        """
+        Converts a dictionary from Avro deserialization to a dataclass instance.
+        Handles conversion of string representations back to Python types for
+        extended logical types.
+        
+        Args:
+            data: The dictionary from Avro deserialization.
+        
+        Returns:
+            The dataclass representation.
+        """
+        # Convert string values back to Python types for Avro string-based logical types
+        converted = data.copy()
+        if 'station_id' in converted and converted['station_id'] is not None:
+            value = converted['station_id']
+        if 'provider' in converted and converted['provider'] is not None:
+            value = converted['provider']
+        if 'water_body' in converted and converted['water_body'] is not None:
+            value = converted['water_body']
+        if 'water_level' in converted and converted['water_level'] is not None:
+            value = converted['water_level']
+        if 'water_level_unit' in converted and converted['water_level_unit'] is not None:
+            value = converted['water_level_unit']
+        if 'water_level_timestamp' in converted and converted['water_level_timestamp'] is not None:
+            value = converted['water_level_timestamp']
+            if isinstance(value, str):
+                converted['water_level_timestamp'] = datetime.datetime.fromisoformat(value)
+        if 'discharge' in converted and converted['discharge'] is not None:
+            value = converted['discharge']
+        if 'discharge_unit' in converted and converted['discharge_unit'] is not None:
+            value = converted['discharge_unit']
+        if 'discharge_timestamp' in converted and converted['discharge_timestamp'] is not None:
+            value = converted['discharge_timestamp']
+            if isinstance(value, str):
+                converted['discharge_timestamp'] = datetime.datetime.fromisoformat(value)
+        if 'trend' in converted and converted['trend'] is not None:
+            value = converted['trend']
+        if 'situation' in converted and converted['situation'] is not None:
+            value = converted['situation']
+        
+        return cls(**converted)
 
     def to_serializer_dict(self) -> dict:
         """
@@ -81,6 +132,30 @@ class WaterLevelObservation:
             return k[:-1] if k.endswith('_') else k
         return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
 
+    def to_avro_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary suitable for Avro serialization.
+        Handles conversion of Python types to Avro-compatible string representations
+        for extended logical types.
+
+        Returns:
+            The dictionary representation suitable for Avro serialization.
+        """
+        result = self.to_serializer_dict()
+        converted = result.copy()
+        
+        # Convert specific fields based on their source types
+        if 'water_level_timestamp' in converted and converted['water_level_timestamp'] is not None:
+            value = converted['water_level_timestamp']
+            if isinstance(value, datetime.datetime):
+                converted['water_level_timestamp'] = value.isoformat()
+        if 'discharge_timestamp' in converted and converted['discharge_timestamp'] is not None:
+            value = converted['discharge_timestamp']
+            if isinstance(value, datetime.datetime):
+                converted['discharge_timestamp'] = value.isoformat()
+        
+        return converted
+
     def to_byte_array(self, content_type_string: str) -> bytes:
         """
         Converts the dataclass to a byte array based on the content type string.
@@ -89,6 +164,8 @@ class WaterLevelObservation:
             content_type_string: The content type string to convert the dataclass to.
                 Supported content types:
                     'application/json': Encodes the data to JSON format.
+                    'avro/binary': Encodes the data to Avro binary format.
+                    'application/vnd.apache.avro+avro': Encodes the data to Avro binary format.
                 Supported content type extensions:
                     '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
 
@@ -100,6 +177,13 @@ class WaterLevelObservation:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
+        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
+            # Convert to Avro binary format using the embedded schema
+            writer = avro.io.DatumWriter(self.AvroType)
+            with io.BytesIO() as stream:
+                encoder = avro.io.BinaryEncoder(stream)
+                writer.write(self.to_avro_dict(), encoder)
+                result = stream.getvalue()
         if base_content_type == 'application/json':
             #pylint: disable=no-member
             result = self.to_json()
@@ -129,6 +213,8 @@ class WaterLevelObservation:
             content_type_string: The content type string to convert the data to. 
                 Supported content types:
                     'application/json': Attempts to decode the data from JSON encoded format.
+                    'avro/binary': Attempts to decode the data from Avro binary format.
+                    'application/vnd.apache.avro+avro': Attempts to decode the data from Avro binary format.
                 Supported content type extensions:
                     '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
         Returns:
@@ -153,6 +239,16 @@ class WaterLevelObservation:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
+        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
+            if isinstance(data, bytes):
+                # Decode from Avro binary format using the embedded schema
+                reader = avro.io.DatumReader(cls.AvroType)
+                with io.BytesIO(data) as stream:
+                    decoder = avro.io.BinaryDecoder(stream)
+                    _record = reader.read(decoder)
+                    return WaterLevelObservation.from_avro_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for Avro deserialization')
         if base_content_type == 'application/json':
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
@@ -171,14 +267,15 @@ class WaterLevelObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='aehuuaatqlknyyxzccho',
-            provider='yiotmvpvifhddgdyrzer',
-            water_level=float(90.71112163779087),
-            water_level_unit='icolvuuiluaybadgxyai',
+            station_id='zourvmtveducfevobfef',
+            provider='ymjzldtgkkxuxycqgmgt',
+            water_body='pdsjibeqnremcdmhilmq',
+            water_level=float(99.00542845404094),
+            water_level_unit='kvisyvyapwtktrvinjzr',
             water_level_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            discharge=float(14.040679514173704),
-            discharge_unit='uuvccfeaxvgjswqgwkbc',
+            discharge=float(67.95379608627704),
+            discharge_unit='bdmxicirozvagiteabaq',
             discharge_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            trend=int(66),
-            situation=int(65)
+            trend=int(16),
+            situation=int(44)
         )

--- a/german-waters/german_waters_producer/german_waters_producer_data/tests/test_german_waters_producer_data_de_waters_hydrology_station.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/tests/test_german_waters_producer_data_de_waters_hydrology_station.py
@@ -28,21 +28,21 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='ecsycqjiwwylmzgvikqv',
-            station_name='ytsvjioogqzddgkpsunr',
-            water_body='awhjctaofblyvxfnmxtd',
-            state='mpwussboqwkemllatrgk',
-            region='mepdjizcpkwjoadkthrv',
-            provider='zwwowpejfddldmoucsvh',
-            latitude=float(12.79126010681615),
-            longitude=float(18.344025244442808),
-            river_km=float(23.436120265048576),
-            altitude=float(21.30856924480763),
-            station_type='bwavlzioiuiqaerbofkt',
-            warn_level_cm=float(26.39568092040594),
-            alarm_level_cm=float(55.24219018287061),
-            warn_level_m3s=float(88.00203104665732),
-            alarm_level_m3s=float(1.9139953650828212)
+            station_id='momdbyignjfqyntzhvpg',
+            station_name='gpbdryqlmcquiilkovrx',
+            water_body='jwzoclkqneuubltdvspi',
+            state='veoshaurtwhtbjcxrvge',
+            region='lsjbfpppweflduvhjnqi',
+            provider='sfscbkvfrzptlmjqpivg',
+            latitude=float(88.163029486018),
+            longitude=float(17.36368750604058),
+            river_km=float(45.02936915705735),
+            altitude=float(65.94691730184626),
+            station_type='udnlrkmdzemujvopdrcw',
+            warn_level_cm=float(81.08976877652698),
+            alarm_level_cm=float(58.866582420723525),
+            warn_level_m3s=float(17.03752997804344),
+            alarm_level_m3s=float(10.44652831344095)
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'ecsycqjiwwylmzgvikqv'
+        test_value = 'momdbyignjfqyntzhvpg'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'ytsvjioogqzddgkpsunr'
+        test_value = 'gpbdryqlmcquiilkovrx'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Station(unittest.TestCase):
         """
         Test water_body property
         """
-        test_value = 'awhjctaofblyvxfnmxtd'
+        test_value = 'jwzoclkqneuubltdvspi'
         self.instance.water_body = test_value
         self.assertEqual(self.instance.water_body, test_value)
     
@@ -75,7 +75,7 @@ class Test_Station(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'mpwussboqwkemllatrgk'
+        test_value = 'veoshaurtwhtbjcxrvge'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -83,7 +83,7 @@ class Test_Station(unittest.TestCase):
         """
         Test region property
         """
-        test_value = 'mepdjizcpkwjoadkthrv'
+        test_value = 'lsjbfpppweflduvhjnqi'
         self.instance.region = test_value
         self.assertEqual(self.instance.region, test_value)
     
@@ -91,7 +91,7 @@ class Test_Station(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'zwwowpejfddldmoucsvh'
+        test_value = 'sfscbkvfrzptlmjqpivg'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
     
@@ -99,7 +99,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(12.79126010681615)
+        test_value = float(88.163029486018)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -107,7 +107,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(18.344025244442808)
+        test_value = float(17.36368750604058)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -115,7 +115,7 @@ class Test_Station(unittest.TestCase):
         """
         Test river_km property
         """
-        test_value = float(23.436120265048576)
+        test_value = float(45.02936915705735)
         self.instance.river_km = test_value
         self.assertEqual(self.instance.river_km, test_value)
     
@@ -123,7 +123,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(21.30856924480763)
+        test_value = float(65.94691730184626)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -131,7 +131,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_type property
         """
-        test_value = 'bwavlzioiuiqaerbofkt'
+        test_value = 'udnlrkmdzemujvopdrcw'
         self.instance.station_type = test_value
         self.assertEqual(self.instance.station_type, test_value)
     
@@ -139,7 +139,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_cm property
         """
-        test_value = float(26.39568092040594)
+        test_value = float(81.08976877652698)
         self.instance.warn_level_cm = test_value
         self.assertEqual(self.instance.warn_level_cm, test_value)
     
@@ -147,7 +147,7 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_cm property
         """
-        test_value = float(55.24219018287061)
+        test_value = float(58.866582420723525)
         self.instance.alarm_level_cm = test_value
         self.assertEqual(self.instance.alarm_level_cm, test_value)
     
@@ -155,7 +155,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_m3s property
         """
-        test_value = float(88.00203104665732)
+        test_value = float(17.03752997804344)
         self.instance.warn_level_m3s = test_value
         self.assertEqual(self.instance.warn_level_m3s, test_value)
     
@@ -163,7 +163,7 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_m3s property
         """
-        test_value = float(1.9139953650828212)
+        test_value = float(10.44652831344095)
         self.instance.alarm_level_m3s = test_value
         self.assertEqual(self.instance.alarm_level_m3s, test_value)
     

--- a/german-waters/german_waters_producer/german_waters_producer_data/tests/test_german_waters_producer_data_de_waters_hydrology_waterlevelobservation.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/tests/test_german_waters_producer_data_de_waters_hydrology_waterlevelobservation.py
@@ -29,16 +29,17 @@ class Test_WaterLevelObservation(unittest.TestCase):
         Create instance of WaterLevelObservation for testing
         """
         instance = WaterLevelObservation(
-            station_id='moqjxqutquardqqgaflb',
-            provider='gakqnkpfaxaxlsiadshe',
-            water_level=float(59.649982729857484),
-            water_level_unit='dpmymwgmvsjdlxxajzqc',
+            station_id='iylbkjgnzbinipjbqfpv',
+            provider='pgfmubaptppqupiviolc',
+            water_body='eamrhnxvoejcmzoeucen',
+            water_level=float(21.555795150451964),
+            water_level_unit='khramdihektpzcudrxqd',
             water_level_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            discharge=float(28.65918097624469),
-            discharge_unit='knawnedidtsegrdtpzgf',
+            discharge=float(50.46359928296849),
+            discharge_unit='syafkfqokqwfylqgaaxh',
             discharge_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            trend=int(77),
-            situation=int(23)
+            trend=int(7),
+            situation=int(50)
         )
         return instance
 
@@ -47,7 +48,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'moqjxqutquardqqgaflb'
+        test_value = 'iylbkjgnzbinipjbqfpv'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -55,15 +56,23 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'gakqnkpfaxaxlsiadshe'
+        test_value = 'pgfmubaptppqupiviolc'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
+    
+    def test_water_body_property(self):
+        """
+        Test water_body property
+        """
+        test_value = 'eamrhnxvoejcmzoeucen'
+        self.instance.water_body = test_value
+        self.assertEqual(self.instance.water_body, test_value)
     
     def test_water_level_property(self):
         """
         Test water_level property
         """
-        test_value = float(59.649982729857484)
+        test_value = float(21.555795150451964)
         self.instance.water_level = test_value
         self.assertEqual(self.instance.water_level, test_value)
     
@@ -71,7 +80,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test water_level_unit property
         """
-        test_value = 'dpmymwgmvsjdlxxajzqc'
+        test_value = 'khramdihektpzcudrxqd'
         self.instance.water_level_unit = test_value
         self.assertEqual(self.instance.water_level_unit, test_value)
     
@@ -87,7 +96,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge property
         """
-        test_value = float(28.65918097624469)
+        test_value = float(50.46359928296849)
         self.instance.discharge = test_value
         self.assertEqual(self.instance.discharge, test_value)
     
@@ -95,7 +104,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge_unit property
         """
-        test_value = 'knawnedidtsegrdtpzgf'
+        test_value = 'syafkfqokqwfylqgaaxh'
         self.instance.discharge_unit = test_value
         self.assertEqual(self.instance.discharge_unit, test_value)
     
@@ -111,7 +120,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test trend property
         """
-        test_value = int(77)
+        test_value = int(7)
         self.instance.trend = test_value
         self.assertEqual(self.instance.trend, test_value)
     
@@ -119,7 +128,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test situation property
         """
-        test_value = int(23)
+        test_value = int(50)
         self.instance.situation = test_value
         self.assertEqual(self.instance.situation, test_value)
     

--- a/german-waters/german_waters_producer/german_waters_producer_data/tests/test_station.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/tests/test_station.py
@@ -28,21 +28,21 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='rnzrhdwvwfpcygykryrw',
-            station_name='hiuctlpwvmzcrlilqdfe',
-            water_body='wtbafnfuarwtoadspjyb',
-            state='uvmycwblykojbtfdsvjh',
-            region='rvcetnyiejpxdsrrdcnl',
-            provider='srlbbqsxtrvtsaearwrg',
-            latitude=float(43.6581595257145),
-            longitude=float(49.83795689777193),
-            river_km=float(44.69247786336202),
-            altitude=float(26.37989497033977),
-            station_type='ftvhekvvfbrvjfmvikct',
-            warn_level_cm=float(9.296879119389867),
-            alarm_level_cm=float(43.30648059588951),
-            warn_level_m3s=float(66.82145473295586),
-            alarm_level_m3s=float(79.98576106579081)
+            station_id='qzpnpzonbqteubaosmmy',
+            station_name='agewzytsnmhvyfklphav',
+            water_body='dwiyqiuawdynxdzilrlj',
+            state='ozsdcxbyedeeznjccfbz',
+            region='akkxbbmougbwhjvoykps',
+            provider='ueyaxdporhvwnzaiqivk',
+            latitude=float(68.90349861976425),
+            longitude=float(87.51844962742975),
+            river_km=float(97.52917537581185),
+            altitude=float(66.24783751053795),
+            station_type='lhzskhdxlsjkavlwyvdh',
+            warn_level_cm=float(80.82965976388567),
+            alarm_level_cm=float(54.92113975744053),
+            warn_level_m3s=float(61.75023322032087),
+            alarm_level_m3s=float(86.44185070876027)
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'rnzrhdwvwfpcygykryrw'
+        test_value = 'qzpnpzonbqteubaosmmy'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'hiuctlpwvmzcrlilqdfe'
+        test_value = 'agewzytsnmhvyfklphav'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Station(unittest.TestCase):
         """
         Test water_body property
         """
-        test_value = 'wtbafnfuarwtoadspjyb'
+        test_value = 'dwiyqiuawdynxdzilrlj'
         self.instance.water_body = test_value
         self.assertEqual(self.instance.water_body, test_value)
     
@@ -75,7 +75,7 @@ class Test_Station(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'uvmycwblykojbtfdsvjh'
+        test_value = 'ozsdcxbyedeeznjccfbz'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -83,7 +83,7 @@ class Test_Station(unittest.TestCase):
         """
         Test region property
         """
-        test_value = 'rvcetnyiejpxdsrrdcnl'
+        test_value = 'akkxbbmougbwhjvoykps'
         self.instance.region = test_value
         self.assertEqual(self.instance.region, test_value)
     
@@ -91,7 +91,7 @@ class Test_Station(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'srlbbqsxtrvtsaearwrg'
+        test_value = 'ueyaxdporhvwnzaiqivk'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
     
@@ -99,7 +99,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(43.6581595257145)
+        test_value = float(68.90349861976425)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -107,7 +107,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(49.83795689777193)
+        test_value = float(87.51844962742975)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -115,7 +115,7 @@ class Test_Station(unittest.TestCase):
         """
         Test river_km property
         """
-        test_value = float(44.69247786336202)
+        test_value = float(97.52917537581185)
         self.instance.river_km = test_value
         self.assertEqual(self.instance.river_km, test_value)
     
@@ -123,7 +123,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(26.37989497033977)
+        test_value = float(66.24783751053795)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -131,7 +131,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_type property
         """
-        test_value = 'ftvhekvvfbrvjfmvikct'
+        test_value = 'lhzskhdxlsjkavlwyvdh'
         self.instance.station_type = test_value
         self.assertEqual(self.instance.station_type, test_value)
     
@@ -139,7 +139,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_cm property
         """
-        test_value = float(9.296879119389867)
+        test_value = float(80.82965976388567)
         self.instance.warn_level_cm = test_value
         self.assertEqual(self.instance.warn_level_cm, test_value)
     
@@ -147,7 +147,7 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_cm property
         """
-        test_value = float(43.30648059588951)
+        test_value = float(54.92113975744053)
         self.instance.alarm_level_cm = test_value
         self.assertEqual(self.instance.alarm_level_cm, test_value)
     
@@ -155,7 +155,7 @@ class Test_Station(unittest.TestCase):
         """
         Test warn_level_m3s property
         """
-        test_value = float(66.82145473295586)
+        test_value = float(61.75023322032087)
         self.instance.warn_level_m3s = test_value
         self.assertEqual(self.instance.warn_level_m3s, test_value)
     
@@ -163,10 +163,19 @@ class Test_Station(unittest.TestCase):
         """
         Test alarm_level_m3s property
         """
-        test_value = float(79.98576106579081)
+        test_value = float(86.44185070876027)
         self.instance.alarm_level_m3s = test_value
         self.assertEqual(self.instance.alarm_level_m3s, test_value)
     
+    def test_to_byte_array_avro(self):
+        """
+        Test to_byte_array method with avro media type
+        """
+        media_type = "application/vnd.apache.avro+avro"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = Station.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
     def test_to_byte_array_json(self):
         """
         Test to_byte_array method with json media type

--- a/german-waters/german_waters_producer/german_waters_producer_data/tests/test_waterlevelobservation.py
+++ b/german-waters/german_waters_producer/german_waters_producer_data/tests/test_waterlevelobservation.py
@@ -29,16 +29,17 @@ class Test_WaterLevelObservation(unittest.TestCase):
         Create instance of WaterLevelObservation for testing
         """
         instance = WaterLevelObservation(
-            station_id='aehuuaatqlknyyxzccho',
-            provider='yiotmvpvifhddgdyrzer',
-            water_level=float(90.71112163779087),
-            water_level_unit='icolvuuiluaybadgxyai',
+            station_id='zourvmtveducfevobfef',
+            provider='ymjzldtgkkxuxycqgmgt',
+            water_body='pdsjibeqnremcdmhilmq',
+            water_level=float(99.00542845404094),
+            water_level_unit='kvisyvyapwtktrvinjzr',
             water_level_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            discharge=float(14.040679514173704),
-            discharge_unit='uuvccfeaxvgjswqgwkbc',
+            discharge=float(67.95379608627704),
+            discharge_unit='bdmxicirozvagiteabaq',
             discharge_timestamp=datetime.datetime.now(datetime.timezone.utc),
-            trend=int(66),
-            situation=int(65)
+            trend=int(16),
+            situation=int(44)
         )
         return instance
 
@@ -47,7 +48,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'aehuuaatqlknyyxzccho'
+        test_value = 'zourvmtveducfevobfef'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -55,15 +56,23 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test provider property
         """
-        test_value = 'yiotmvpvifhddgdyrzer'
+        test_value = 'ymjzldtgkkxuxycqgmgt'
         self.instance.provider = test_value
         self.assertEqual(self.instance.provider, test_value)
+    
+    def test_water_body_property(self):
+        """
+        Test water_body property
+        """
+        test_value = 'pdsjibeqnremcdmhilmq'
+        self.instance.water_body = test_value
+        self.assertEqual(self.instance.water_body, test_value)
     
     def test_water_level_property(self):
         """
         Test water_level property
         """
-        test_value = float(90.71112163779087)
+        test_value = float(99.00542845404094)
         self.instance.water_level = test_value
         self.assertEqual(self.instance.water_level, test_value)
     
@@ -71,7 +80,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test water_level_unit property
         """
-        test_value = 'icolvuuiluaybadgxyai'
+        test_value = 'kvisyvyapwtktrvinjzr'
         self.instance.water_level_unit = test_value
         self.assertEqual(self.instance.water_level_unit, test_value)
     
@@ -87,7 +96,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge property
         """
-        test_value = float(14.040679514173704)
+        test_value = float(67.95379608627704)
         self.instance.discharge = test_value
         self.assertEqual(self.instance.discharge, test_value)
     
@@ -95,7 +104,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test discharge_unit property
         """
-        test_value = 'uuvccfeaxvgjswqgwkbc'
+        test_value = 'bdmxicirozvagiteabaq'
         self.instance.discharge_unit = test_value
         self.assertEqual(self.instance.discharge_unit, test_value)
     
@@ -111,7 +120,7 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test trend property
         """
-        test_value = int(66)
+        test_value = int(16)
         self.instance.trend = test_value
         self.assertEqual(self.instance.trend, test_value)
     
@@ -119,10 +128,19 @@ class Test_WaterLevelObservation(unittest.TestCase):
         """
         Test situation property
         """
-        test_value = int(65)
+        test_value = int(44)
         self.instance.situation = test_value
         self.assertEqual(self.instance.situation, test_value)
     
+    def test_to_byte_array_avro(self):
+        """
+        Test to_byte_array method with avro media type
+        """
+        media_type = "application/vnd.apache.avro+avro"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = WaterLevelObservation.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
     def test_to_byte_array_json(self):
         """
         Test to_byte_array method with json media type

--- a/german-waters/german_waters_producer/german_waters_producer_kafka_producer/src/german_waters_producer_kafka_producer/producer.py
+++ b/german-waters/german_waters_producer/german_waters_producer_kafka_producer/src/german_waters_producer_kafka_producer/producer.py
@@ -154,3 +154,147 @@ class DEWatersHydrologyEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class DEWatersHydrologyMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_de_waters_hydrology_mqtt_station(self,_station_id : str, data: Station, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Station], str]=None) -> None:
+        """
+        Sends the 'DE.Waters.Hydrology.mqtt.Station' event to the Kafka topic
+
+        Args:
+            _station_id(str):  Value for placeholder station_id in attribute subject
+            data: (Station): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Station], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"DE.Waters.Hydrology.Station",
+             "source":"https://github.com/clemensv/real-time-sources/german-waters",
+             "subject":"{station_id}".format(station_id = _station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_de_waters_hydrology_mqtt_water_level_observation(self,_station_id : str, data: WaterLevelObservation, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, WaterLevelObservation], str]=None) -> None:
+        """
+        Sends the 'DE.Waters.Hydrology.mqtt.WaterLevelObservation' event to the Kafka topic
+
+        Args:
+            _station_id(str):  Value for placeholder station_id in attribute subject
+            data: (WaterLevelObservation): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, WaterLevelObservation], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"DE.Waters.Hydrology.WaterLevelObservation",
+             "source":"https://github.com/clemensv/real-time-sources/german-waters",
+             "subject":"{station_id}".format(station_id = _station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'DEWatersHydrologyMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/german-waters/german_waters_producer/german_waters_producer_kafka_producer/tests/test_producer.py
+++ b/german-waters/german_waters_producer/german_waters_producer_kafka_producer/tests/test_producer.py
@@ -23,6 +23,7 @@ from german_waters_producer_data import Station
 from test_german_waters_producer_data_station import Test_Station
 from german_waters_producer_data import WaterLevelObservation
 from test_german_waters_producer_data_waterlevelobservation import Test_WaterLevelObservation
+from german_waters_producer_kafka_producer.producer import DEWatersHydrologyMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -179,6 +180,128 @@ def test_de_waters_hydrology_dewatershydrologywaterlevelobservation(kafka_emulat
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{station_id}".format(station_id=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_de_waters_hydrology_mqtt_dewatershydrologymqttstation(kafka_emulator):
+    """Test the DEWatersHydrologyMqttStation event from the DE.Waters.Hydrology.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_de_waters_hydrology_mqtt_dewatershydrologymqttstation',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "DE.Waters.Hydrology.mqtt.Station":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = DEWatersHydrologyMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_Station.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_de_waters_hydrology_mqtt_station(_station_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_de_waters_hydrology_mqtt_dewatershydrologymqttwaterlevelobservation(kafka_emulator):
+    """Test the DEWatersHydrologyMqttWaterLevelObservation event from the DE.Waters.Hydrology.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_de_waters_hydrology_mqtt_dewatershydrologymqttwaterlevelobservation',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "DE.Waters.Hydrology.mqtt.WaterLevelObservation":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = DEWatersHydrologyMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_WaterLevelObservation.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_de_waters_hydrology_mqtt_water_level_observation(_station_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()
 
 

--- a/german-waters/german_waters_producer/samples/sample.py
+++ b/german-waters/german_waters_producer/samples/sample.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer as KafkaProducer
 # imports the producer clients for the message group(s)
 
 from german_waters_producer_kafka_producer.producer import DEWatersHydrologyEventProducer
+from german_waters_producer_kafka_producer.producer import DEWatersHydrologyMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -72,6 +73,30 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'DE.Waters.Hydrology.WaterLevelObservation' event to Kafka topic.
     await dewaters_hydrology_event_producer.send_de_waters_hydrology_water_level_observation(_station_id = 'TODO: replace me', data = _water_level_observation)
     print(f"Sent 'DE.Waters.Hydrology.WaterLevelObservation' event: {_water_level_observation.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        dewaters_hydrology_mqtt_event_producer = DEWatersHydrologyMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        dewaters_hydrology_mqtt_event_producer = DEWatersHydrologyMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- DE.Waters.Hydrology.mqtt.Station ----
+    # TODO: Supply event data for the DE.Waters.Hydrology.mqtt.Station event
+    _station = Station()
+
+    # sends the 'DE.Waters.Hydrology.mqtt.Station' event to Kafka topic.
+    await dewaters_hydrology_mqtt_event_producer.send_de_waters_hydrology_mqtt_station(_station_id = 'TODO: replace me', data = _station)
+    print(f"Sent 'DE.Waters.Hydrology.mqtt.Station' event: {_station.to_json()}")
+
+    # ---- DE.Waters.Hydrology.mqtt.WaterLevelObservation ----
+    # TODO: Supply event data for the DE.Waters.Hydrology.mqtt.WaterLevelObservation event
+    _water_level_observation = WaterLevelObservation()
+
+    # sends the 'DE.Waters.Hydrology.mqtt.WaterLevelObservation' event to Kafka topic.
+    await dewaters_hydrology_mqtt_event_producer.send_de_waters_hydrology_mqtt_water_level_observation(_station_id = 'TODO: replace me', data = _water_level_observation)
+    print(f"Sent 'DE.Waters.Hydrology.mqtt.WaterLevelObservation' event: {_water_level_observation.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/german-waters/xreg/german_waters.xreg.json
+++ b/german-waters/xreg/german_waters.xreg.json
@@ -394,6 +394,11 @@
                     "type": "string"
                   },
                   {
+                    "name": "water_body",
+                    "type": "string",
+                    "doc": "Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Mirrored from the JSON Structure WaterLevelObservation schema; sourced by the bridge from the per-provider station catalog and propagated onto every observation. Required non-null string."
+                  },
+                  {
                     "name": "water_level",
                     "type": [
                       "null",


### PR DESCRIPTION
Narrow review-driven fixup off main. The JSON Structure 'WaterLevelObservation' schema in 'DE.Waters.Hydrology.jstruct' requires a non-null 'water_body' field (same value as the {water_body} MQTT topic segment), but the parallel Avro schema in 'DE.Waters.Hydrology.avro' was missing it — leaving the two encodings out of sync. Adds 'water_body' as a required string field on the Avro WaterLevelObservation, positioned right after 'provider' to match the JSON Structure field order. Regenerates the Kafka and MQTT producer clients and EVENTS.md.