### PR TITLE
fix(wallonia-issep): default sensor config province

### DIFF
--- a/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/sensorconfiguration.py
+++ b/wallonia-issep/wallonia_issep_producer/wallonia_issep_producer_data/src/wallonia_issep_producer_data/sensorconfiguration.py
@@ -26,7 +26,7 @@ class SensorConfiguration:
     
     
     configuration_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="configuration_id"))
-    province: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="province"))
+    province: str=dataclasses.field(default="unknown", kw_only=True, metadata=dataclasses_json.config(field_name="province"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'SensorConfiguration':


### PR DESCRIPTION
## Summary
- default Wallonia SensorConfiguration province to unknown for legacy extraction compatibility
- fixes Docker E2E Wallonia MQTT crash after province became a required axis

## Validation
- python -c instantiate SensorConfiguration without province