### PR TITLE
ci: cancel superseded main workflow runs

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -1,5 +1,9 @@
 name: Build Containers
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
+
 on:
   push:
     branches: [ "main" ]
@@ -58,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 8
       matrix:
         container: ${{ fromJson(needs.find-dockerfiles.outputs.containers) }}
     permissions:

--- a/.github/workflows/publish-notebook-wheels.yml
+++ b/.github/workflows/publish-notebook-wheels.yml
@@ -1,5 +1,9 @@
 name: Publish Notebook Wheels
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
+
 # Build per-source wheel bundles for sources marked `notebook: true` in
 # catalog.json and publish them as assets on the `notebook-wheels` release
 # so deploy-feeder-notebook.ps1 can download them from Cloud Shell without

--- a/.github/workflows/test-docker-e2e.yml
+++ b/.github/workflows/test-docker-e2e.yml
@@ -1,5 +1,9 @@
 name: Docker E2E Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
+
 # Strategy: a `discover` job inspects the changed files and decides which
 # feeders to build + test. If only one feeder's files changed, only that
 # feeder's docker-build + docker-kafka-flow jobs run. If any infrastructure


### PR DESCRIPTION
## Summary
- add concurrency to Docker E2E, Publish Notebook Wheels, and Build Containers
- cancel superseded non-PR runs so rapid main merges do not compete for checkout/GHCR resources
- lower Build Containers push parallelism from 20 to 8

## Validation
- inspected workflow diff