### PR TITLE
mqtt(epa-uv): add MQTT/UNS feeder

### DIFF
--- a/epa-uv/Dockerfile.mqtt
+++ b/epa-uv/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/epa-uv"
+LABEL org.opencontainers.image.title="EPA UV Index → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls EPA Envirofacts UV hourly and daily forecast services and publishes MQTT 5.0 binary-mode CloudEvents into uv/us/epa/epa-uv/{state}/{location_id}/... topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/epa-uv/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./epa_uv_mqtt_producer/epa_uv_mqtt_producer_data \
+ && pip install --no-cache-dir ./epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./epa_uv_producer/epa_uv_producer_data \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./epa_uv_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "epa_uv_mqtt", "feed"]

--- a/epa-uv/epa_uv/epa_uv.py
+++ b/epa-uv/epa_uv/epa_uv.py
@@ -101,8 +101,10 @@ def parse_hourly_row(city: str, state: str, row: dict) -> HourlyForecast:
     return HourlyForecast(
         location_id=location_id,
         city=city,
-        state=state,
+        city_slug=slugify(city),
+        state=state.lower(),
         forecast_datetime=parsed_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+        forecast_hour=parsed_dt.strftime("%Y%m%dT%H"),
         uv_index=int(row["UV_VALUE"]),
     )
 
@@ -114,7 +116,8 @@ def parse_daily_row(city: str, state: str, row: dict) -> DailyForecast:
     return DailyForecast(
         location_id=location_id,
         city=city,
-        state=state,
+        city_slug=slugify(city),
+        state=state.lower(),
         forecast_date=parsed_date.strftime("%Y-%m-%d"),
         uv_index=int(row["UV_INDEX"]),
         uv_alert=str(row["UV_ALERT"]),

--- a/epa-uv/epa_uv_mqtt/epa_uv_mqtt/__init__.py
+++ b/epa-uv/epa_uv_mqtt/epa_uv_mqtt/__init__.py
@@ -1,0 +1,4 @@
+"""EPA UV MQTT feeder."""
+from .app import main
+
+__all__ = ["main"]

--- a/epa-uv/epa_uv_mqtt/epa_uv_mqtt/__main__.py
+++ b/epa-uv/epa_uv_mqtt/epa_uv_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/epa-uv/epa_uv_mqtt/epa_uv_mqtt/app.py
+++ b/epa-uv/epa_uv_mqtt/epa_uv_mqtt/app.py
@@ -1,0 +1,124 @@
+"""MQTT feeder application for EPA UV Index → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from epa_uv.epa_uv import DEFAULT_POLL_INTERVAL_SECONDS, EPAUVBridge, parse_locations
+from epa_uv_mqtt_producer_mqtt_client.client import USEPAUVIndexMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+async def feed(
+    bridge: EPAUVBridge,
+    broker_host: str,
+    broker_port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    once: bool = False,
+    content_mode: str = "binary",
+) -> None:
+    paho_client = mqtt.Client(
+        callback_api_version=CallbackAPIVersion.VERSION2,
+        client_id=client_id or "",
+        protocol=MQTTv5,
+    )
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+
+    mqtt_client = USEPAUVIndexMqttMqttClient(
+        client=paho_client,
+        content_mode=content_mode,  # type: ignore[arg-type]
+        loop=asyncio.get_running_loop(),
+    )
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await mqtt_client.connect(broker_host, broker_port)
+    try:
+        while True:
+            hourly_sent = 0
+            daily_sent = 0
+            for city, state in bridge.locations:
+                for hourly in bridge.fetch_hourly(city, state):
+                    event_id = f"{hourly.location_id}|{hourly.forecast_datetime}"
+                    if event_id in bridge.seen_hourly_ids:
+                        continue
+                    await mqtt_client.publish_us_epa_uvindex_mqtt_hourly_forecast(
+                        location_id=hourly.location_id,
+                        state=hourly.state,
+                        city_slug=hourly.city_slug,
+                        forecast_hour=hourly.forecast_hour,
+                        data=hourly,
+                    )
+                    bridge._remember(bridge.hourly_order, bridge.seen_hourly_ids, event_id)
+                    hourly_sent += 1
+                for daily in bridge.fetch_daily(city, state):
+                    event_id = f"{daily.location_id}|{daily.forecast_date}"
+                    if event_id in bridge.seen_daily_ids:
+                        continue
+                    await mqtt_client.publish_us_epa_uvindex_mqtt_daily_forecast(
+                        location_id=daily.location_id,
+                        state=daily.state,
+                        city_slug=daily.city_slug,
+                        forecast_date=daily.forecast_date,
+                        data=daily,
+                    )
+                    bridge._remember(bridge.daily_order, bridge.seen_daily_ids, event_id)
+                    daily_sent += 1
+            bridge.save_state()
+            logger.info("Published %d hourly forecasts and %d daily forecasts", hourly_sent, daily_sent)
+            if once:
+                break
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="EPA UV MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--locations", default=os.getenv("EPA_UV_LOCATIONS", "Seattle,WA"))
+    parser.add_argument("--state-file", default=os.getenv("EPA_UV_STATE_FILE", ""))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, tls = _parse_broker_url(args.broker_url)
+    bridge = EPAUVBridge(parse_locations(args.locations), state_file=args.state_file)
+    asyncio.run(feed(
+        bridge,
+        host,
+        port,
+        username=args.username or None,
+        password=args.password or None,
+        tls=tls,
+        client_id=args.client_id or None,
+        once=args.once,
+        content_mode=args.content_mode,
+    ))

--- a/epa-uv/epa_uv_mqtt/pyproject.toml
+++ b/epa-uv/epa_uv_mqtt/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "epa-uv-mqtt"
+version = "0.1.0"
+description = "EPA UV bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+epa_uv_mqtt_producer_data = {path = "../epa_uv_mqtt_producer/epa_uv_mqtt_producer_data"}
+epa_uv_mqtt_producer_mqtt_client = {path = "../epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+epa-uv-mqtt = "epa_uv_mqtt:main"

--- a/epa-uv/epa_uv_mqtt_producer/Makefile
+++ b/epa-uv/epa_uv_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./epa_uv_mqtt_producer_data ./epa_uv_mqtt_producer_mqtt_client
+
+install: build
+	cd epa_uv_mqtt_producer_data && poetry install
+	cd epa_uv_mqtt_producer_mqtt_client && poetry install
+	pip install ./epa_uv_mqtt_producer_data ./epa_uv_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./epa_uv_mqtt_producer_mqtt_client/tests ./epa_uv_mqtt_producer_data/tests

--- a/epa-uv/epa_uv_mqtt_producer/README.md
+++ b/epa-uv/epa_uv_mqtt_producer/README.md
@@ -1,0 +1,1077 @@
+# Epa_uv_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the epa_uv_mqtt_producer message definitions.
+
+# Epa_uv_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - USEPAUVIndexMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from epa_uv_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = USEPAUVIndexMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### USEPAUVIndexMqttEventDispatcher
+
+
+
+# Publish message`USEPAUVIndexMqttEventDispatcher` handles events for the US.EPA.UVIndex.mqtt message group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from epa_uv_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = USEPAUVIndexMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the Event
+Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe USEPAUVIndexMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `us_epa_uvindex_mqtt_hourly_forecast_async`
+
+
+
+## Test```python
+
+us_epa_uvindex_mqtt_hourly_forecast_async:  Callable[[PartitionContext, EventData, CloudEvent, HourlyForecast],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `US.EPA.UVIndex.mqtt.HourlyForecast`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `epa_uv_mqtt_producer_data.HourlyForecast`.
+
+Example:
+
+```python
+async def us_epa_uvindex_mqtt_hourly_forecast_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: HourlyForecast) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_mqtt_hourly_forecast_async = us_epa_uvindex_mqtt_hourly_forecast_event
+```
+
+
+
+make build
+
+```##### `us_epa_uvindex_mqtt_daily_forecast_async`
+
+
+
+## Test```python
+
+us_epa_uvindex_mqtt_daily_forecast_async:  Callable[[PartitionContext, EventData, CloudEvent, DailyForecast],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `US.EPA.UVIndex.mqtt.DailyForecast`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `epa_uv_mqtt_producer_data.DailyForecast`.
+
+Example:
+
+```python
+async def us_epa_uvindex_mqtt_daily_forecast_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: DailyForecast) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_mqtt_daily_forecast_async = us_epa_uvindex_mqtt_daily_forecast_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/pyproject.toml
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "epa-uv-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "epa_uv_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/__init__.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .hourlyforecast import HourlyForecast
+from .dailyforecast import DailyForecast
+
+__all__ = ["HourlyForecast", "DailyForecast"]

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/dailyforecast.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/dailyforecast.py
@@ -1,4 +1,4 @@
-""" HourlyForecast dataclass. """
+""" DailyForecast dataclass. """
 
 # pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
 from __future__ import annotations
@@ -15,31 +15,31 @@ import json
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
-class HourlyForecast:
+class DailyForecast:
     """
-    Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.
+    Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.
     
     Attributes:
         location_id (str)
         city (str)
         state (str)
-        forecast_datetime (str)
+        forecast_date (str)
         uv_index (int)
+        uv_alert (str)
         city_slug (str)
-        forecast_hour (str)
     """
     
     
     location_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="location_id"))
     city: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city"))
     state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
-    forecast_datetime: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_datetime"))
+    forecast_date: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_date"))
     uv_index: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_index"))
+    uv_alert: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_alert"))
     city_slug: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city_slug"))
-    forecast_hour: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_hour"))
 
     @classmethod
-    def from_serializer_dict(cls, data: dict) -> 'HourlyForecast':
+    def from_serializer_dict(cls, data: dict) -> 'DailyForecast':
         """
         Converts a dictionary to a dataclass instance.
         
@@ -112,7 +112,7 @@ class HourlyForecast:
         return result
 
     @classmethod
-    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['HourlyForecast']:
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['DailyForecast']:
         """
         Converts the data to a dataclass based on the content type string.
         
@@ -149,13 +149,13 @@ class HourlyForecast:
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
                 _record = json.loads(data_str)
-                return HourlyForecast.from_serializer_dict(_record)
+                return DailyForecast.from_serializer_dict(_record)
             else:
                 raise NotImplementedError('Data is not of a supported type for JSON deserialization')
         raise NotImplementedError(f'Unsupported media type {content_type}')
 
     @classmethod
-    def create_instance(cls) -> 'HourlyForecast':
+    def create_instance(cls) -> 'DailyForecast':
         """
         Creates an instance of the dataclass with test values.
         
@@ -163,11 +163,11 @@ class HourlyForecast:
             An instance of the dataclass.
         """
         return cls(
-            location_id='otzfaojtbagfodbrwjpk',
-            city='xndurnhipyfnpoewteik',
-            state='jfiilbgkznlunuhizprj',
-            forecast_datetime='wkiexiouqytxmmubukqz',
-            uv_index=int(75),
-            city_slug='sxzgxrefopedzhqrdekz',
-            forecast_hour='nwzbnckfqhjcysgpaxcf'
+            location_id='qsoujvqszlyyvxhqruqo',
+            city='jyuhjmmkhcemrwcxswvl',
+            state='txgizpyhrjwvvvayqwyg',
+            forecast_date='mjrhprgkwnbtmnxazpxu',
+            uv_index=int(35),
+            uv_alert='uowusuukktubnxfnwoub',
+            city_slug='vyxozgferrohlvndgepz'
         )

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/hourlyforecast.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/src/epa_uv_mqtt_producer_data/hourlyforecast.py
@@ -163,11 +163,11 @@ class HourlyForecast:
             An instance of the dataclass.
         """
         return cls(
-            location_id='otzfaojtbagfodbrwjpk',
-            city='xndurnhipyfnpoewteik',
-            state='jfiilbgkznlunuhizprj',
-            forecast_datetime='wkiexiouqytxmmubukqz',
-            uv_index=int(75),
-            city_slug='sxzgxrefopedzhqrdekz',
-            forecast_hour='nwzbnckfqhjcysgpaxcf'
+            location_id='jtkizmhvxlzycsqqzdxw',
+            city='pxrowkgybostpmnzbsxx',
+            state='zkgpscbnqwegepzgnpti',
+            forecast_datetime='jdjfwdcntpudfwqqtuzw',
+            uv_index=int(83),
+            city_slug='kkczggfnyirpgoteqggy',
+            forecast_hour='cqiyatbfnufixwqgkmzz'
         )

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/tests/test_dailyforecast.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/tests/test_dailyforecast.py
@@ -1,5 +1,5 @@
 """
-Test case for HourlyForecast
+Test case for DailyForecast
 """
 
 import os
@@ -8,33 +8,33 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from epa_uv_producer_data.hourlyforecast import HourlyForecast
+from epa_uv_mqtt_producer_data.dailyforecast import DailyForecast
 
 
-class Test_HourlyForecast(unittest.TestCase):
+class Test_DailyForecast(unittest.TestCase):
     """
-    Test case for HourlyForecast
+    Test case for DailyForecast
     """
 
     def setUp(self):
         """
         Set up test case
         """
-        self.instance = Test_HourlyForecast.create_instance()
+        self.instance = Test_DailyForecast.create_instance()
 
     @staticmethod
     def create_instance():
         """
-        Create instance of HourlyForecast for testing
+        Create instance of DailyForecast for testing
         """
-        instance = HourlyForecast(
-            location_id='otzfaojtbagfodbrwjpk',
-            city='xndurnhipyfnpoewteik',
-            state='jfiilbgkznlunuhizprj',
-            forecast_datetime='wkiexiouqytxmmubukqz',
-            uv_index=int(75),
-            city_slug='sxzgxrefopedzhqrdekz',
-            forecast_hour='nwzbnckfqhjcysgpaxcf'
+        instance = DailyForecast(
+            location_id='qsoujvqszlyyvxhqruqo',
+            city='jyuhjmmkhcemrwcxswvl',
+            state='txgizpyhrjwvvvayqwyg',
+            forecast_date='mjrhprgkwnbtmnxazpxu',
+            uv_index=int(35),
+            uv_alert='uowusuukktubnxfnwoub',
+            city_slug='vyxozgferrohlvndgepz'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test location_id property
         """
-        test_value = 'otzfaojtbagfodbrwjpk'
+        test_value = 'qsoujvqszlyyvxhqruqo'
         self.instance.location_id = test_value
         self.assertEqual(self.instance.location_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test city property
         """
-        test_value = 'xndurnhipyfnpoewteik'
+        test_value = 'jyuhjmmkhcemrwcxswvl'
         self.instance.city = test_value
         self.assertEqual(self.instance.city, test_value)
     
@@ -59,41 +59,41 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'jfiilbgkznlunuhizprj'
+        test_value = 'txgizpyhrjwvvvayqwyg'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
-    def test_forecast_datetime_property(self):
+    def test_forecast_date_property(self):
         """
-        Test forecast_datetime property
+        Test forecast_date property
         """
-        test_value = 'wkiexiouqytxmmubukqz'
-        self.instance.forecast_datetime = test_value
-        self.assertEqual(self.instance.forecast_datetime, test_value)
+        test_value = 'mjrhprgkwnbtmnxazpxu'
+        self.instance.forecast_date = test_value
+        self.assertEqual(self.instance.forecast_date, test_value)
     
     def test_uv_index_property(self):
         """
         Test uv_index property
         """
-        test_value = int(75)
+        test_value = int(35)
         self.instance.uv_index = test_value
         self.assertEqual(self.instance.uv_index, test_value)
+    
+    def test_uv_alert_property(self):
+        """
+        Test uv_alert property
+        """
+        test_value = 'uowusuukktubnxfnwoub'
+        self.instance.uv_alert = test_value
+        self.assertEqual(self.instance.uv_alert, test_value)
     
     def test_city_slug_property(self):
         """
         Test city_slug property
         """
-        test_value = 'sxzgxrefopedzhqrdekz'
+        test_value = 'vyxozgferrohlvndgepz'
         self.instance.city_slug = test_value
         self.assertEqual(self.instance.city_slug, test_value)
-    
-    def test_forecast_hour_property(self):
-        """
-        Test forecast_hour property
-        """
-        test_value = 'nwzbnckfqhjcysgpaxcf'
-        self.instance.forecast_hour = test_value
-        self.assertEqual(self.instance.forecast_hour, test_value)
     
     def test_to_byte_array_json(self):
         """
@@ -101,7 +101,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         media_type = "application/json"
         bytes_data = self.instance.to_byte_array(media_type)
-        new_instance = HourlyForecast.from_data(bytes_data, media_type)
+        new_instance = DailyForecast.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
 
@@ -110,7 +110,7 @@ class Test_HourlyForecast(unittest.TestCase):
         Test to_json method
         """
         json_data = self.instance.to_json()
-        new_instance = HourlyForecast.from_json(json_data)
+        new_instance = DailyForecast.from_json(json_data)
         json_data2 = new_instance.to_json()
         self.assertEqual(json_data, json_data2)
 

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/tests/test_hourlyforecast.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_data/tests/test_hourlyforecast.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from epa_uv_producer_data.hourlyforecast import HourlyForecast
+from epa_uv_mqtt_producer_data.hourlyforecast import HourlyForecast
 
 
 class Test_HourlyForecast(unittest.TestCase):
@@ -28,13 +28,13 @@ class Test_HourlyForecast(unittest.TestCase):
         Create instance of HourlyForecast for testing
         """
         instance = HourlyForecast(
-            location_id='otzfaojtbagfodbrwjpk',
-            city='xndurnhipyfnpoewteik',
-            state='jfiilbgkznlunuhizprj',
-            forecast_datetime='wkiexiouqytxmmubukqz',
-            uv_index=int(75),
-            city_slug='sxzgxrefopedzhqrdekz',
-            forecast_hour='nwzbnckfqhjcysgpaxcf'
+            location_id='jtkizmhvxlzycsqqzdxw',
+            city='pxrowkgybostpmnzbsxx',
+            state='zkgpscbnqwegepzgnpti',
+            forecast_datetime='jdjfwdcntpudfwqqtuzw',
+            uv_index=int(83),
+            city_slug='kkczggfnyirpgoteqggy',
+            forecast_hour='cqiyatbfnufixwqgkmzz'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test location_id property
         """
-        test_value = 'otzfaojtbagfodbrwjpk'
+        test_value = 'jtkizmhvxlzycsqqzdxw'
         self.instance.location_id = test_value
         self.assertEqual(self.instance.location_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test city property
         """
-        test_value = 'xndurnhipyfnpoewteik'
+        test_value = 'pxrowkgybostpmnzbsxx'
         self.instance.city = test_value
         self.assertEqual(self.instance.city, test_value)
     
@@ -59,7 +59,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'jfiilbgkznlunuhizprj'
+        test_value = 'zkgpscbnqwegepzgnpti'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -67,7 +67,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test forecast_datetime property
         """
-        test_value = 'wkiexiouqytxmmubukqz'
+        test_value = 'jdjfwdcntpudfwqqtuzw'
         self.instance.forecast_datetime = test_value
         self.assertEqual(self.instance.forecast_datetime, test_value)
     
@@ -75,7 +75,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test uv_index property
         """
-        test_value = int(75)
+        test_value = int(83)
         self.instance.uv_index = test_value
         self.assertEqual(self.instance.uv_index, test_value)
     
@@ -83,7 +83,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test city_slug property
         """
-        test_value = 'sxzgxrefopedzhqrdekz'
+        test_value = 'kkczggfnyirpgoteqggy'
         self.instance.city_slug = test_value
         self.assertEqual(self.instance.city_slug, test_value)
     
@@ -91,7 +91,7 @@ class Test_HourlyForecast(unittest.TestCase):
         """
         Test forecast_hour property
         """
-        test_value = 'nwzbnckfqhjcysgpaxcf'
+        test_value = 'cqiyatbfnufixwqgkmzz'
         self.instance.forecast_hour = test_value
         self.assertEqual(self.instance.forecast_hour, test_value)
     

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/pyproject.toml
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "epa-uv-mqtt-producer-mqtt-client"
+description = "epa_uv_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "epa_uv_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+epa-uv-mqtt-producer-data = {path = "../epa_uv_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/src/epa_uv_mqtt_producer_mqtt_client/__init__.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/src/epa_uv_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import USEPAUVIndexMqttMqttClient
+
+__all__ = [
+    "USEPAUVIndexMqttMqttClient",
+]

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/src/epa_uv_mqtt_producer_mqtt_client/client.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/src/epa_uv_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,522 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import epa_uv_mqtt_producer_data
+from epa_uv_mqtt_producer_data import HourlyForecast
+from epa_uv_mqtt_producer_data import DailyForecast
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_us_epa_uvindex_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the US.EPA.UVIndex.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "US.EPA.UVIndex.mqtt.HourlyForecast": "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}",
+        "US.EPA.UVIndex.mqtt.DailyForecast": "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}",
+    }
+
+
+def get_subscription_topics_us_epa_uvindex_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_us_epa_uvindex_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class USEPAUVIndexMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the US.EPA.UVIndex.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_us_epa_uvindex_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.us_epa_uvindex_mqtt_hourly_forecast_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, epa_uv_mqtt_producer_data.HourlyForecast, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.us_epa_uvindex_mqtt_daily_forecast_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, epa_uv_mqtt_producer_data.DailyForecast, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "US.EPA.UVIndex.HourlyForecast":
+            if self.us_epa_uvindex_mqtt_hourly_forecast_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = epa_uv_mqtt_producer_data.HourlyForecast.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "US.EPA.UVIndex.mqtt.HourlyForecast")
+                    await self.us_epa_uvindex_mqtt_hourly_forecast_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in us_epa_uvindex_mqtt_hourly_forecast handler: {e}")
+            return
+        
+        if event_type == "US.EPA.UVIndex.DailyForecast":
+            if self.us_epa_uvindex_mqtt_daily_forecast_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = epa_uv_mqtt_producer_data.DailyForecast.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "US.EPA.UVIndex.mqtt.DailyForecast")
+                    await self.us_epa_uvindex_mqtt_daily_forecast_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in us_epa_uvindex_mqtt_daily_forecast handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_us_epa_uvindex_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_us_epa_uvindex_mqtt_hourly_forecast(self,
+        location_id: str,
+        state: str,
+        city_slug: str,
+        forecast_hour: str,
+        data: epa_uv_mqtt_producer_data.HourlyForecast,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'US.EPA.UVIndex.mqtt.HourlyForecast' event to an MQTT topic.
+
+        Args:
+        
+            location_id: URI template variable for 'location_id'
+            state: URI template variable for 'state'
+            city_slug: URI template variable for 'city_slug'
+            forecast_hour: URI template variable for 'forecast_hour'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}"
+        _topic_template_values: Dict[str, str] = {
+            "location_id": str(location_id),
+            "state": str(state),
+            "city_slug": str(city_slug),
+            "forecast_hour": str(forecast_hour),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"US.EPA.UVIndex.HourlyForecast",
+             "source":"https://www.epa.gov/enviro/web-services",
+             "subject":"{location_id}".format(location_id = location_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_us_epa_uvindex_mqtt_daily_forecast(self,
+        location_id: str,
+        state: str,
+        city_slug: str,
+        forecast_date: str,
+        data: epa_uv_mqtt_producer_data.DailyForecast,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'US.EPA.UVIndex.mqtt.DailyForecast' event to an MQTT topic.
+
+        Args:
+        
+            location_id: URI template variable for 'location_id'
+            state: URI template variable for 'state'
+            city_slug: URI template variable for 'city_slug'
+            forecast_date: URI template variable for 'forecast_date'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}"
+        _topic_template_values: Dict[str, str] = {
+            "location_id": str(location_id),
+            "state": str(state),
+            "city_slug": str(city_slug),
+            "forecast_date": str(forecast_date),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"US.EPA.UVIndex.DailyForecast",
+             "source":"https://www.epa.gov/enviro/web-services",
+             "subject":"{location_id}".format(location_id = location_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,176 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_mqtt_producer_mqtt_client/src')))
+
+import epa_uv_mqtt_producer_data
+from epa_uv_mqtt_producer_data import HourlyForecast
+from test_epa_uv_mqtt_producer_data_hourlyforecast import Test_HourlyForecast
+from epa_uv_mqtt_producer_data import DailyForecast
+from test_epa_uv_mqtt_producer_data_dailyforecast import Test_DailyForecast
+from epa_uv_mqtt_producer_mqtt_client import USEPAUVIndexMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_us_epa_uvindex_mqtt_us_epa_uvindex_mqtt_hourly_forecast_py(mosquitto_broker):
+    """Test publishing and receiving US.EPA.UVIndex.mqtt.HourlyForecast message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_HourlyForecast.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = USEPAUVIndexMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = USEPAUVIndexMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_us_epa_uvindex_mqtt_hourly_forecast(mqtt_msg, cloud_event, data: epa_uv_mqtt_producer_data.HourlyForecast, topic_params: dict):
+        """Handler for US.EPA.UVIndex.mqtt.HourlyForecast messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "US.EPA.UVIndex.HourlyForecast"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.us_epa_uvindex_mqtt_hourly_forecast_async = on_us_epa_uvindex_mqtt_hourly_forecast
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/us_epa_uvindex_mqtt/us_epa_uvindex_mqtt_hourly_forecast"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_us_epa_uvindex_mqtt_hourly_forecast(
+            topic=test_topic,
+            location_id=f"test_location_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_us_epa_uvindex_mqtt_us_epa_uvindex_mqtt_daily_forecast_py(mosquitto_broker):
+    """Test publishing and receiving US.EPA.UVIndex.mqtt.DailyForecast message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_DailyForecast.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = USEPAUVIndexMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = USEPAUVIndexMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_us_epa_uvindex_mqtt_daily_forecast(mqtt_msg, cloud_event, data: epa_uv_mqtt_producer_data.DailyForecast, topic_params: dict):
+        """Handler for US.EPA.UVIndex.mqtt.DailyForecast messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "US.EPA.UVIndex.DailyForecast"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.us_epa_uvindex_mqtt_daily_forecast_async = on_us_epa_uvindex_mqtt_daily_forecast
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/us_epa_uvindex_mqtt/us_epa_uvindex_mqtt_daily_forecast"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_us_epa_uvindex_mqtt_daily_forecast(
+            topic=test_topic,
+            location_id=f"test_location_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/epa-uv/epa_uv_mqtt_producer/install.bat
+++ b/epa-uv/epa_uv_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\epa_uv_mqtt_producer_data
+pip install .\epa_uv_mqtt_producer_mqtt_client

--- a/epa-uv/epa_uv_mqtt_producer/install.sh
+++ b/epa-uv/epa_uv_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./epa_uv_mqtt_producer_data
+pip install ./epa_uv_mqtt_producer_mqtt_client

--- a/epa-uv/epa_uv_mqtt_producer/samples/sample.py
+++ b/epa-uv/epa_uv_mqtt_producer/samples/sample.py
@@ -1,0 +1,87 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from epa_uv_mqtt_producer_data import *
+from epa_uv_mqtt_producer_mqtt_client.client import USEPAUVIndexMqttProducer, USEPAUVIndexMqttDispatcher
+
+async def handle_us_epa_uvindex_mqtt_hourly_forecast(mqtt_msg,cloud_event, us_epa_uvindex_mqtt_hourly_forecast_data):
+    """ Handles the US.EPA.UVIndex.mqtt.HourlyForecast message """
+    print(f"Received US.EPA.UVIndex.mqtt.HourlyForecast on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {us_epa_uvindex_mqtt_hourly_forecast_data}")
+
+async def handle_us_epa_uvindex_mqtt_daily_forecast(mqtt_msg,cloud_event, us_epa_uvindex_mqtt_daily_forecast_data):
+    """ Handles the US.EPA.UVIndex.mqtt.DailyForecast message """
+    print(f"Received US.EPA.UVIndex.mqtt.DailyForecast on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {us_epa_uvindex_mqtt_daily_forecast_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/epa-uv/epa_uv_mqtt_producer/scripts/build.py
+++ b/epa-uv/epa_uv_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["epa_uv_mqtt_producer_mqtt_client", "epa_uv_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/epa-uv/epa_uv_producer/README.md
+++ b/epa-uv/epa_uv_producer/README.md
@@ -15,7 +15,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 2. [What is Apache Kafka?](#what-is-apache-kafka)2. [Generated Event Dispatchers](#generated-event-dispatchers)
 
-3. [Quick Start](#quick-start)    - USEPAUVIndexEventDispatcher
+3. [Quick Start](#quick-start)    - USEPAUVIndexEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    USEPAUVIndexMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -39,6 +41,10 @@ methods to handle various types of events.
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - USEPAUVIndexProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- USEPAUVIndexMqttProducersolution for event-driven applications.
 
 
 
@@ -191,6 +197,44 @@ us_epa_uvindex_dispatcher.us_epa_uvindex_hourly_forecast_async = us_epa_uvindex_
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexMqttProducer- `data`: The event data of type `epa_uv_producer_data.HourlyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_hourly_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data: HourlyForecast) ->
+None:
+
+```python    # Process the event data
+
+USEPAUVIndexMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_hourly_forecast_async = us_epa_uvindex_hourly_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -249,6 +293,44 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 us_epa_uvindex_dispatcher.us_epa_uvindex_daily_forecast_async = us_epa_uvindex_daily_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexMqttProducer- `data`: The event data of type `epa_uv_producer_data.DailyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_daily_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data: DailyForecast) ->
+None:
+
+```python    # Process the event data
+
+USEPAUVIndexMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_daily_forecast_async = us_epa_uvindex_daily_forecast_event
 
 **Parameters:**```
 
@@ -451,6 +533,508 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_us_epa_uvindex_daily_forecast_batch(```
+
+    messages=[
+
+        DailyForecast(...),Initializes the runner with a Kafka consumer.
+
+        DailyForecast(...),
+
+        DailyForecast(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### USEPAUVIndexMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`USEPAUVIndexMqttEventDispatcher` handles events for the US.EPA.UVIndex.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from epa-uv-producer import USEPAUVIndexProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = USEPAUVIndexProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_us_epa_uvindex_hourly_forecast(```python
+
+    data=HourlyForecast(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The USEPAUVIndexMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = USEPAUVIndexProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `us_epa_uvindex_mqtt_hourly_forecast_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'us_epa_uvindex_mqtt_hourly_forecast_async:  Callable[[ConsumerRecord, CloudEvent,
+HourlyForecast], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `US.EPA.UVIndex.mqtt.HourlyForecast`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexProducer- `data`: The event data of type `epa_uv_producer_data.HourlyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_mqtt_hourly_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+HourlyForecast) -> None:
+
+```python    # Process the event data
+
+USEPAUVIndexProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_dispatcher.us_epa_uvindex_mqtt_hourly_forecast_async = us_epa_uvindex_mqtt_hourly_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexMqttProducer- `data`: The event data of type `epa_uv_producer_data.HourlyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_mqtt_hourly_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+HourlyForecast) -> None:
+
+```python    # Process the event data
+
+USEPAUVIndexMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_mqtt_hourly_forecast_async = us_epa_uvindex_mqtt_hourly_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `us_epa_uvindex_mqtt_daily_forecast_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'us_epa_uvindex_mqtt_daily_forecast_async:  Callable[[ConsumerRecord, CloudEvent,
+DailyForecast], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `US.EPA.UVIndex.mqtt.DailyForecast`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexProducer- `data`: The event data of type `epa_uv_producer_data.DailyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_mqtt_daily_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data: DailyForecast)
+-> None:
+
+```python    # Process the event data
+
+USEPAUVIndexProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_dispatcher.us_epa_uvindex_mqtt_daily_forecast_async = us_epa_uvindex_mqtt_daily_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USEPAUVIndexMqttProducer- `data`: The event data of type `epa_uv_producer_data.DailyForecast`.
+
+
+
+Producer for `US.EPA.UVIndex.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_epa_uvindex_mqtt_daily_forecast_event(record: ConsumerRecord, cloud_event: CloudEvent, data: DailyForecast)
+-> None:
+
+```python    # Process the event data
+
+USEPAUVIndexMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_epa_uvindex_mqtt_dispatcher.us_epa_uvindex_mqtt_daily_forecast_async = us_epa_uvindex_mqtt_daily_forecast_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_us_epa_uvindex_mqtt_hourly_forecast`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_us_epa_uvindex_mqtt_hourly_forecast(
+
+    self,##### `_process_event`
+
+    data: HourlyForecast,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `US.EPA.UVIndex.mqtt.HourlyForecast` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `HourlyForecast`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_us_epa_uvindex_mqtt_hourly_forecast(
+
+    data=HourlyForecast(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `US.EPA.UVIndex.mqtt.HourlyForecast` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_us_epa_uvindex_mqtt_hourly_forecast_batch(```
+
+    messages=[
+
+        HourlyForecast(...),Initializes the runner with a Kafka consumer.
+
+        HourlyForecast(...),
+
+        HourlyForecast(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_us_epa_uvindex_mqtt_daily_forecast`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_us_epa_uvindex_mqtt_daily_forecast(
+
+    self,##### `_process_event`
+
+    data: DailyForecast,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `US.EPA.UVIndex.mqtt.DailyForecast` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `DailyForecast`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_us_epa_uvindex_mqtt_daily_forecast(
+
+    data=DailyForecast(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `US.EPA.UVIndex.mqtt.DailyForecast` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_us_epa_uvindex_mqtt_daily_forecast_batch(```
 
     messages=[
 

--- a/epa-uv/epa_uv_producer/epa_uv_producer_data/src/epa_uv_producer_data/dailyforecast.py
+++ b/epa-uv/epa_uv_producer/epa_uv_producer_data/src/epa_uv_producer_data/dailyforecast.py
@@ -26,6 +26,7 @@ class DailyForecast:
         forecast_date (str)
         uv_index (int)
         uv_alert (str)
+        city_slug (str)
     """
     
     
@@ -35,6 +36,7 @@ class DailyForecast:
     forecast_date: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_date"))
     uv_index: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_index"))
     uv_alert: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_alert"))
+    city_slug: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city_slug"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'DailyForecast':
@@ -161,10 +163,11 @@ class DailyForecast:
             An instance of the dataclass.
         """
         return cls(
-            location_id='tuimcyrnovsnxrxwmxsy',
-            city='sittjdlzwzcmusfybqfr',
-            state='aewrpavnyfxeftesfiib',
-            forecast_date='jfqtumcigicnamdznaci',
-            uv_index=int(71),
-            uv_alert='mldahjadlrxxgkdvbvna'
+            location_id='hrvicdklrugmbifvbpbp',
+            city='ksmyklxbeuvuzwinlujm',
+            state='xdexooviczhzklpwmmos',
+            forecast_date='fiznilmuurpztzgrusok',
+            uv_index=int(65),
+            uv_alert='ugjnxqcisgalgasxhvrt',
+            city_slug='mdmgrrnzuobzwxizadaj'
         )

--- a/epa-uv/epa_uv_producer/epa_uv_producer_data/tests/test_dailyforecast.py
+++ b/epa-uv/epa_uv_producer/epa_uv_producer_data/tests/test_dailyforecast.py
@@ -28,12 +28,13 @@ class Test_DailyForecast(unittest.TestCase):
         Create instance of DailyForecast for testing
         """
         instance = DailyForecast(
-            location_id='tuimcyrnovsnxrxwmxsy',
-            city='sittjdlzwzcmusfybqfr',
-            state='aewrpavnyfxeftesfiib',
-            forecast_date='jfqtumcigicnamdznaci',
-            uv_index=int(71),
-            uv_alert='mldahjadlrxxgkdvbvna'
+            location_id='hrvicdklrugmbifvbpbp',
+            city='ksmyklxbeuvuzwinlujm',
+            state='xdexooviczhzklpwmmos',
+            forecast_date='fiznilmuurpztzgrusok',
+            uv_index=int(65),
+            uv_alert='ugjnxqcisgalgasxhvrt',
+            city_slug='mdmgrrnzuobzwxizadaj'
         )
         return instance
 
@@ -42,7 +43,7 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test location_id property
         """
-        test_value = 'tuimcyrnovsnxrxwmxsy'
+        test_value = 'hrvicdklrugmbifvbpbp'
         self.instance.location_id = test_value
         self.assertEqual(self.instance.location_id, test_value)
     
@@ -50,7 +51,7 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test city property
         """
-        test_value = 'sittjdlzwzcmusfybqfr'
+        test_value = 'ksmyklxbeuvuzwinlujm'
         self.instance.city = test_value
         self.assertEqual(self.instance.city, test_value)
     
@@ -58,7 +59,7 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'aewrpavnyfxeftesfiib'
+        test_value = 'xdexooviczhzklpwmmos'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -66,7 +67,7 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test forecast_date property
         """
-        test_value = 'jfqtumcigicnamdznaci'
+        test_value = 'fiznilmuurpztzgrusok'
         self.instance.forecast_date = test_value
         self.assertEqual(self.instance.forecast_date, test_value)
     
@@ -74,7 +75,7 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test uv_index property
         """
-        test_value = int(71)
+        test_value = int(65)
         self.instance.uv_index = test_value
         self.assertEqual(self.instance.uv_index, test_value)
     
@@ -82,9 +83,17 @@ class Test_DailyForecast(unittest.TestCase):
         """
         Test uv_alert property
         """
-        test_value = 'mldahjadlrxxgkdvbvna'
+        test_value = 'ugjnxqcisgalgasxhvrt'
         self.instance.uv_alert = test_value
         self.assertEqual(self.instance.uv_alert, test_value)
+    
+    def test_city_slug_property(self):
+        """
+        Test city_slug property
+        """
+        test_value = 'mdmgrrnzuobzwxizadaj'
+        self.instance.city_slug = test_value
+        self.assertEqual(self.instance.city_slug, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/epa-uv/epa_uv_producer/epa_uv_producer_kafka_producer/src/epa_uv_producer_kafka_producer/producer.py
+++ b/epa-uv/epa_uv_producer/epa_uv_producer_kafka_producer/src/epa_uv_producer_kafka_producer/producer.py
@@ -154,3 +154,147 @@ class USEPAUVIndexEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class USEPAUVIndexMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_us_epa_uvindex_mqtt_hourly_forecast(self,_location_id : str, data: HourlyForecast, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyForecast], str]=None) -> None:
+        """
+        Sends the 'US.EPA.UVIndex.mqtt.HourlyForecast' event to the Kafka topic
+
+        Args:
+            _location_id(str):  Value for placeholder location_id in attribute subject
+            data: (HourlyForecast): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, HourlyForecast], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"US.EPA.UVIndex.HourlyForecast",
+             "source":"https://www.epa.gov/enviro/web-services",
+             "subject":"{location_id}".format(location_id = _location_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_us_epa_uvindex_mqtt_daily_forecast(self,_location_id : str, data: DailyForecast, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, DailyForecast], str]=None) -> None:
+        """
+        Sends the 'US.EPA.UVIndex.mqtt.DailyForecast' event to the Kafka topic
+
+        Args:
+            _location_id(str):  Value for placeholder location_id in attribute subject
+            data: (DailyForecast): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, DailyForecast], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"US.EPA.UVIndex.DailyForecast",
+             "source":"https://www.epa.gov/enviro/web-services",
+             "subject":"{location_id}".format(location_id = _location_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'USEPAUVIndexMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/epa-uv/epa_uv_producer/epa_uv_producer_kafka_producer/tests/test_producer.py
+++ b/epa-uv/epa_uv_producer/epa_uv_producer_kafka_producer/tests/test_producer.py
@@ -23,6 +23,7 @@ from epa_uv_producer_data import HourlyForecast
 from test_epa_uv_producer_data_hourlyforecast import Test_HourlyForecast
 from epa_uv_producer_data import DailyForecast
 from test_epa_uv_producer_data_dailyforecast import Test_DailyForecast
+from epa_uv_producer_kafka_producer.producer import USEPAUVIndexMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -179,6 +180,128 @@ def test_us_epa_uvindex_usepauvindexdailyforecast(kafka_emulator):
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{location_id}".format(location_id=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_us_epa_uvindex_mqtt_usepauvindexmqtthourlyforecast(kafka_emulator):
+    """Test the USEPAUVIndexMqttHourlyForecast event from the US.EPA.UVIndex.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_us_epa_uvindex_mqtt_usepauvindexmqtthourlyforecast',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "US.EPA.UVIndex.mqtt.HourlyForecast":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = USEPAUVIndexMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_HourlyForecast.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_us_epa_uvindex_mqtt_hourly_forecast(_location_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_us_epa_uvindex_mqtt_usepauvindexmqttdailyforecast(kafka_emulator):
+    """Test the USEPAUVIndexMqttDailyForecast event from the US.EPA.UVIndex.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_us_epa_uvindex_mqtt_usepauvindexmqttdailyforecast',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "US.EPA.UVIndex.mqtt.DailyForecast":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = USEPAUVIndexMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_DailyForecast.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_us_epa_uvindex_mqtt_daily_forecast(_location_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()
 
 

--- a/epa-uv/epa_uv_producer/samples/sample.py
+++ b/epa-uv/epa_uv_producer/samples/sample.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer as KafkaProducer
 # imports the producer clients for the message group(s)
 
 from epa_uv_producer_kafka_producer.producer import USEPAUVIndexEventProducer
+from epa_uv_producer_kafka_producer.producer import USEPAUVIndexMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -72,6 +73,30 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'US.EPA.UVIndex.DailyForecast' event to Kafka topic.
     await usepauvindex_event_producer.send_us_epa_uvindex_daily_forecast(_location_id = 'TODO: replace me', data = _daily_forecast)
     print(f"Sent 'US.EPA.UVIndex.DailyForecast' event: {_daily_forecast.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        usepauvindex_mqtt_event_producer = USEPAUVIndexMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        usepauvindex_mqtt_event_producer = USEPAUVIndexMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- US.EPA.UVIndex.mqtt.HourlyForecast ----
+    # TODO: Supply event data for the US.EPA.UVIndex.mqtt.HourlyForecast event
+    _hourly_forecast = HourlyForecast()
+
+    # sends the 'US.EPA.UVIndex.mqtt.HourlyForecast' event to Kafka topic.
+    await usepauvindex_mqtt_event_producer.send_us_epa_uvindex_mqtt_hourly_forecast(_location_id = 'TODO: replace me', data = _hourly_forecast)
+    print(f"Sent 'US.EPA.UVIndex.mqtt.HourlyForecast' event: {_hourly_forecast.to_json()}")
+
+    # ---- US.EPA.UVIndex.mqtt.DailyForecast ----
+    # TODO: Supply event data for the US.EPA.UVIndex.mqtt.DailyForecast event
+    _daily_forecast = DailyForecast()
+
+    # sends the 'US.EPA.UVIndex.mqtt.DailyForecast' event to Kafka topic.
+    await usepauvindex_mqtt_event_producer.send_us_epa_uvindex_mqtt_daily_forecast(_location_id = 'TODO: replace me', data = _daily_forecast)
+    print(f"Sent 'US.EPA.UVIndex.mqtt.DailyForecast' event: {_daily_forecast.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/epa-uv/generate_mqtt_producer.ps1
+++ b/epa-uv/generate_mqtt_producer.ps1
@@ -1,0 +1,11 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\epa_uv.xreg.json `
+    --endpoint US.EPA.UVIndex.Mqtt `
+    --projectname epa_uv_mqtt_producer `
+    --output epa_uv_mqtt_producer

--- a/epa-uv/xreg/epa_uv.xreg.json
+++ b/epa-uv/xreg/epa_uv.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "US.EPA.UVIndex.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,30 @@
           "key": "{location_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/US.EPA.UVIndex"]
+      "messagegroups": [
+        "#/messagegroups/US.EPA.UVIndex"
+      ]
+    },
+    "US.EPA.UVIndex.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/US.EPA.UVIndex.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -58,6 +83,33 @@
           "dataschemauri": "#/schemagroups/US.EPA.UVIndex.jstruct/schemas/US.EPA.UVIndex.DailyForecast"
         }
       }
+    },
+    "US.EPA.UVIndex.mqtt": {
+      "description": "MQTT/5.0 transport variants for EPA UV Index forecasts. Topics are retained QoS-1 UV forecast leaves under uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/..., where {state} is lowercase US state, {city_slug} is lowercase kebab-case city, and {location_id} preserves the existing Kafka/CloudEvents entity id intentionally for subject/key compatibility even though it is derivable from state+city. Hourly slots use topic-safe {forecast_hour}=YYYYMMDDTHH; daily slots use {forecast_date}=YYYY-MM-DD. Message expiry bounds retained forecast slots so stale forecasts age out.",
+      "messages": {
+        "US.EPA.UVIndex.mqtt.HourlyForecast": {
+          "name": "HourlyForecast",
+          "basemessageurl": "/messagegroups/US.EPA.UVIndex/messages/US.EPA.UVIndex.HourlyForecast",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}",
+            "qos": 1,
+            "retain": true,
+            "message_expiry_interval": 172800
+          }
+        },
+        "US.EPA.UVIndex.mqtt.DailyForecast": {
+          "name": "DailyForecast",
+          "basemessageurl": "/messagegroups/US.EPA.UVIndex/messages/US.EPA.UVIndex.DailyForecast",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}",
+            "qos": 1,
+            "retain": true,
+            "message_expiry_interval": 1209600
+          }
+        }
+      }
     }
   },
   "schemagroups": {
@@ -77,8 +129,10 @@
                 "required": [
                   "location_id",
                   "city",
+                  "city_slug",
                   "state",
                   "forecast_datetime",
+                  "forecast_hour",
                   "uv_index"
                 ],
                 "name": "HourlyForecast",
@@ -94,15 +148,23 @@
                   },
                   "state": {
                     "type": "string",
-                    "description": "Two-letter state abbreviation for the requested city."
+                    "description": "Lowercase two-letter US state segment used for MQTT/UNS routing; display/input state is normalized by the bridge."
                   },
                   "forecast_datetime": {
                     "type": "string",
-                    "description": "Forecast timestamp normalized to ISO local datetime form without an explicit UTC offset."
+                    "description": "Forecast timestamp normalized to ISO local datetime form without an explicit UTC offset. Used as the retained MQTT hourly slot with message expiry."
                   },
                   "uv_index": {
                     "type": "integer",
                     "description": "Hourly UV Index forecast value."
+                  },
+                  "city_slug": {
+                    "type": "string",
+                    "description": "Lowercase kebab-case city segment used for MQTT/UNS routing; derived from city without the state suffix."
+                  },
+                  "forecast_hour": {
+                    "type": "string",
+                    "description": "Topic-safe retained forecast slot in YYYYMMDDTHH form, derived from forecast_datetime with zero padding and no offset, colon, slash, plus, or hash characters."
                   }
                 }
               }
@@ -123,6 +185,7 @@
                 "required": [
                   "location_id",
                   "city",
+                  "city_slug",
                   "state",
                   "forecast_date",
                   "uv_index",
@@ -141,11 +204,11 @@
                   },
                   "state": {
                     "type": "string",
-                    "description": "Two-letter state abbreviation for the requested city."
+                    "description": "Lowercase two-letter US state segment used for MQTT/UNS routing; display/input state is normalized by the bridge."
                   },
                   "forecast_date": {
                     "type": "string",
-                    "description": "Forecast date normalized to YYYY-MM-DD."
+                    "description": "Topic-safe forecast date normalized to YYYY-MM-DD. Used as the retained MQTT daily slot with message expiry."
                   },
                   "uv_index": {
                     "type": "integer",
@@ -154,6 +217,10 @@
                   "uv_alert": {
                     "type": "string",
                     "description": "Character flag indicating whether a UV alert is issued for the forecast day."
+                  },
+                  "city_slug": {
+                    "type": "string",
+                    "description": "Lowercase kebab-case city segment used for MQTT/UNS routing; derived from city without the state suffix."
                   }
                 }
               }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -286,6 +286,12 @@
       "image": "rws-waterwebservices-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "rws_waterwebservices_mqtt"
+    },
+    {
+      "dir": "epa-uv",
+      "image": "epa-uv-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "epa_uv_mqtt"
     }
   ],
   "flow": [
@@ -537,6 +543,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestRWSWaterwebservicesMqttDockerFlow"
+    },
+    {
+      "dir": "epa-uv",
+      "image": "epa-uv-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestEPAUVMqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -3415,3 +3415,96 @@ class TestWikimediaOsmDiffsMqttDockerFlow:
         assert not retained_firehose, (
             f"firehose messages must not be retained, but broker replayed: {[m['topic'] for m in retained_firehose]}"
         )
+
+# ---- epa-uv -------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def epa_uv_mqtt_image():
+    return build_image('epa-uv', dockerfile='Dockerfile.mqtt', tag='test-epa-uv-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_epa_uv():
+    container, network, host_port = _generic_mosquitto(
+        'epa-uv-mqtt-e2e', 'epa-uv-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'epa-uv-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestEPAUVMqttDockerFlow:
+    """Verify the epa-uv-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_retained_uns_topics(self, mosquitto_epa_uv, epa_uv_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_epa_uv['internal_host']}:{mosquitto_epa_uv['internal_port']}"
+        feeder = client.containers.run(
+            epa_uv_mqtt_image.id,
+            detach=True,
+            remove=False,
+            network=mosquitto_epa_uv['network'],
+            environment={
+                'MQTT_BROKER_URL': broker_url,
+                'ONCE_MODE': 'true',
+                'EPA_UV_LOCATIONS': 'Seattle,WA',
+                'PYTHONUNBUFFERED': '1',
+            },
+        )
+        try:
+            result = feeder.wait(timeout=300)
+            logs = feeder.logs().decode('utf-8', errors='replace')
+            assert result.get('StatusCode') == 0, (
+                f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+            )
+        finally:
+            try:
+                feeder.remove(force=True)
+            except docker.errors.APIError:
+                pass
+
+        messages = _collect_messages_topic(
+            '127.0.0.1', mosquitto_epa_uv['host_port'], 'uv/us/epa/epa-uv/#',
+            timeout=30.0,
+        )
+        assert messages, 'No retained messages received from broker'
+        hourly_msgs = [m for m in messages if '/hourly/' in m['topic']]
+        daily_msgs = [m for m in messages if '/daily/' in m['topic']]
+        assert hourly_msgs, 'No /hourly forecast events published'
+        assert daily_msgs, 'No /daily forecast events published'
+
+        for sample in (hourly_msgs[0], daily_msgs[0]):
+            up = sample['user_properties']
+            for required in ('id', 'source', 'type', 'subject', 'time', 'specversion'):
+                assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+            assert sample['user_properties'].get('_contenttype') == 'application/json'
+            assert sample['retain'] is True
+            assert sample['qos'] == 1
+            parts = sample['topic'].split('/')
+            assert parts[:4] == ['uv', 'us', 'epa', 'epa-uv']
+            assert parts[4] == 'wa'
+            assert parts[5] == 'seattle'
+            assert parts[6] == sample['user_properties']['subject']
+
+        assert {m['user_properties'].get('type') for m in hourly_msgs} == {'US.EPA.UVIndex.HourlyForecast'}
+        assert {m['user_properties'].get('type') for m in daily_msgs} == {'US.EPA.UVIndex.DailyForecast'}
+        hourly_payload = _to_dict(hourly_msgs[0]['payload'])
+        daily_payload = _to_dict(daily_msgs[0]['payload'])
+        assert hourly_payload is not None and hourly_payload.get('state') == 'wa'
+        assert hourly_payload.get('city_slug') == 'seattle'
+        assert daily_payload is not None and daily_payload.get('state') == 'wa'
+        assert daily_payload.get('city_slug') == 'seattle'


### PR DESCRIPTION
## Summary
- Add EPA UV MQTT/UNS endpoint and generated MQTT producer
- Add `epa_uv_mqtt` feeder package and `Dockerfile.mqtt`
- Add Docker E2E matrix/build+flow coverage

## Topic tree
- `uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}` retained QoS 1, 48h expiry
- `uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}` retained QoS 1, 14d expiry

## Specialist review
- xRegistry Expert: no MUST-FIX; verified no schema fork, correct `basemessageurl`, all placeholders required/non-null, no `messageid`/`messagegroupid`, subject compatibility. SHOULD-FIX normalization docs addressed.
- UNS Catalog Architect: MUST-FIX retained forecast slot semantics, duplicated geography axis, and state casing. Fixed by adding `city_slug`, topic-safe hourly `forecast_hour`, forecast date/hour slots, lowercase state, message expiry, and documenting the intentional `{location_id}` compatibility segment.

## Validation
- `xrcg validate --definitions epa-uv/xreg/epa_uv.xreg.json` ✅
- `python -m pytest epa-uv/tests -q -x` with generated packages on `PYTHONPATH` ✅ (5 passed)
- `python -m pytest tests/docker_e2e/test_docker_mqtt_flow.py::TestEPAUVMqttDockerFlow -q -x` ✅ (1 passed)
