### PR TITLE
mqtt(usgs-geomag): add MQTT/UNS feeder

### DIFF
--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -292,6 +292,12 @@
       "image": "epa-uv-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "epa_uv_mqtt"
+    },
+    {
+      "dir": "usgs-geomag",
+      "image": "usgs-geomag-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "usgs_geomag_mqtt"
     }
   ],
   "flow": [
@@ -550,6 +556,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestEPAUVMqttDockerFlow"
+    },
+    {
+      "dir": "usgs-geomag",
+      "image": "usgs-geomag-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestUSGSGeomagMqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -3508,3 +3508,92 @@ class TestEPAUVMqttDockerFlow:
         assert hourly_payload.get('city_slug') == 'seattle'
         assert daily_payload is not None and daily_payload.get('state') == 'wa'
         assert daily_payload.get('city_slug') == 'seattle'
+
+# ---- usgs-geomag --------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def usgs_geomag_mqtt_image():
+    return build_image('usgs-geomag', dockerfile='Dockerfile.mqtt', tag='test-usgs-geomag-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_usgs_geomag():
+    container, network, host_port = _generic_mosquitto(
+        'usgs-geomag-mqtt-e2e', 'usgs-geomag-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'usgs-geomag-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestUSGSGeomagMqttDockerFlow:
+    """Verify the usgs-geomag-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_retained_uns_topics(self, mosquitto_usgs_geomag, usgs_geomag_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_usgs_geomag['internal_host']}:{mosquitto_usgs_geomag['internal_port']}"
+        feeder = client.containers.run(
+            usgs_geomag_mqtt_image.id,
+            detach=True,
+            remove=False,
+            network=mosquitto_usgs_geomag['network'],
+            environment={
+                'MQTT_BROKER_URL': broker_url,
+                'ONCE_MODE': 'true',
+                'GEOMAG_OBSERVATORIES': 'BOU',
+                'PYTHONUNBUFFERED': '1',
+            },
+        )
+        try:
+            result = feeder.wait(timeout=360)
+            logs = feeder.logs().decode('utf-8', errors='replace')
+            assert result.get('StatusCode') == 0, (
+                f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+            )
+        finally:
+            try:
+                feeder.remove(force=True)
+            except docker.errors.APIError:
+                pass
+
+        messages = _collect_messages_topic(
+            '127.0.0.1', mosquitto_usgs_geomag['host_port'], 'space-weather/us/usgs/usgs-geomag/#',
+            timeout=30.0,
+        )
+        assert messages, 'No retained messages received from broker'
+        info_msgs = [m for m in messages if m['topic'].endswith('/info')]
+        reading_msgs = [m for m in messages if m['topic'].endswith('/reading')]
+        assert info_msgs, 'No /info observatory events published'
+        assert reading_msgs, 'No /reading telemetry events published'
+
+        for sample in (info_msgs[0], reading_msgs[0]):
+            up = sample['user_properties']
+            for required in ('id', 'source', 'type', 'subject', 'time', 'specversion'):
+                assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+            assert sample['user_properties'].get('_contenttype') == 'application/json'
+            assert sample['retain'] is True
+            assert sample['qos'] == 1
+            parts = sample['topic'].split('/')
+            assert parts[:4] == ['space-weather', 'us', 'usgs', 'usgs-geomag']
+            assert parts[4] == sample['user_properties']['subject'].lower()
+
+        assert {m['user_properties'].get('type') for m in info_msgs} == {'gov.usgs.geomag.Observatory'}
+        assert {m['user_properties'].get('type') for m in reading_msgs} == {'gov.usgs.geomag.MagneticFieldReading'}
+        info_payload = _to_dict(info_msgs[0]['payload'])
+        reading_payload = _to_dict(reading_msgs[0]['payload'])
+        assert info_payload is not None and info_payload.get('iaga_code')
+        assert reading_payload is not None and reading_payload.get('iaga_code')

--- a/usgs-geomag/Dockerfile.mqtt
+++ b/usgs-geomag/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/usgs-geomag"
+LABEL org.opencontainers.image.title="USGS Geomagnetism → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls USGS Geomagnetism observatories and variation data and publishes MQTT 5.0 binary-mode CloudEvents into space-weather/us/usgs/usgs-geomag/{network}/{iaga_code}/... topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/usgs-geomag/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data \
+ && pip install --no-cache-dir ./usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./usgs_geomag_producer/usgs_geomag_producer_data \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./usgs_geomag_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "usgs_geomag_mqtt", "feed"]

--- a/usgs-geomag/generate_mqtt_producer.ps1
+++ b/usgs-geomag/generate_mqtt_producer.ps1
@@ -1,0 +1,11 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\usgs_geomag.xreg.json `
+    --endpoint gov.usgs.geomag.Mqtt `
+    --projectname usgs_geomag_mqtt_producer `
+    --output usgs_geomag_mqtt_producer

--- a/usgs-geomag/usgs_geomag/usgs_geomag.py
+++ b/usgs-geomag/usgs_geomag/usgs_geomag.py
@@ -87,7 +87,8 @@ class USGSGeomagPoller:
     def parse_observatory(feature: Dict) -> Observatory:
         """Convert a GeoJSON feature to an Observatory data class."""
         props = feature.get("properties", {})
-        coords = feature.get("geometry", {}).get("coordinates", [None, None, None])
+        geometry = feature.get("geometry") or {}
+        coords = geometry.get("coordinates", [None, None, None])
         longitude = coords[0] if len(coords) > 0 else None
         latitude = coords[1] if len(coords) > 1 else None
         elevation = coords[2] if len(coords) > 2 else None

--- a/usgs-geomag/usgs_geomag_mqtt/pyproject.toml
+++ b/usgs-geomag/usgs_geomag_mqtt/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "usgs-geomag-mqtt"
+version = "0.1.0"
+description = "USGS Geomagnetism bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+usgs_geomag_mqtt_producer_data = {path = "../usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data"}
+usgs_geomag_mqtt_producer_mqtt_client = {path = "../usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+usgs-geomag-mqtt = "usgs_geomag_mqtt:main"

--- a/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/__init__.py
+++ b/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/__init__.py
@@ -1,0 +1,4 @@
+"""USGS Geomagnetism MQTT feeder."""
+from .app import main
+
+__all__ = ["main"]

--- a/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/__main__.py
+++ b/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/app.py
+++ b/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/app.py
@@ -1,0 +1,161 @@
+"""MQTT feeder application for USGS Geomagnetism → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from usgs_geomag.usgs_geomag import DEFAULT_OBSERVATORIES, POLL_INTERVAL_SECONDS, USGSGeomagPoller
+from usgs_geomag_mqtt_producer_mqtt_client.client import GovUsgsGeomagMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+def _load_state(path: str) -> Dict:
+    try:
+        if path and os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    data.setdefault("last_timestamps", {})
+                    return data
+    except Exception as exc:
+        logger.warning("Could not load state %s: %s", path, exc)
+    return {"last_timestamps": {}}
+
+
+def _save_state(path: str, state: Dict) -> None:
+    if not path:
+        return
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+
+
+async def _publish_observatories(client: GovUsgsGeomagMqttMqttClient, observatories: List[str]) -> None:
+    features = USGSGeomagPoller.fetch_observatories()
+    wanted = {code.upper() for code in observatories}
+    for feature in features:
+        obs = USGSGeomagPoller.parse_observatory(feature)
+        if wanted and obs.iaga_code.upper() not in wanted:
+            continue
+        await client.publish_gov_usgs_geomag_mqtt_observatory(
+            iaga_code=obs.iaga_code.lower(),
+            data=obs,
+        )
+
+
+async def _publish_readings(
+    client: GovUsgsGeomagMqttMqttClient,
+    observatories: List[str],
+    state: Dict,
+) -> int:
+    last_timestamps = state.setdefault("last_timestamps", {})
+    now = datetime.now(timezone.utc)
+    end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    default_start = (now - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sent = 0
+    for code in observatories:
+        iaga_code = code.upper()
+        start_time = last_timestamps.get(iaga_code, default_start)
+        data = USGSGeomagPoller.fetch_variation_data(iaga_code, start_time, end_time)
+        if data is None:
+            continue
+        latest_ts = last_timestamps.get(iaga_code)
+        for reading in USGSGeomagPoller.parse_timeseries(iaga_code, data):
+            reading_ts = reading.timestamp.isoformat()
+            if latest_ts and reading_ts <= latest_ts:
+                continue
+            await client.publish_gov_usgs_geomag_mqtt_magnetic_field_reading(
+                iaga_code=reading.iaga_code.lower(),
+                data=reading,
+            )
+            latest_ts = reading_ts
+            sent += 1
+        if latest_ts:
+            last_timestamps[iaga_code] = latest_ts
+    return sent
+
+
+async def feed(
+    broker_host: str,
+    broker_port: int,
+    observatories: List[str],
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    state_file: str = "",
+    once: bool = False,
+    content_mode: str = "binary",
+) -> None:
+    paho_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, client_id=client_id or "", protocol=MQTTv5)
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+    mqtt_client = GovUsgsGeomagMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await mqtt_client.connect(broker_host, broker_port)
+    state = _load_state(state_file)
+    try:
+        await _publish_observatories(mqtt_client, observatories)
+        while True:
+            sent = await _publish_readings(mqtt_client, observatories, state)
+            _save_state(state_file, state)
+            logger.info("Published %d magnetic field readings", sent)
+            if once:
+                break
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    return parsed.hostname or "localhost", parsed.port or (8883 if scheme in ("mqtts", "ssl", "tls") else 1883), scheme in ("mqtts", "ssl", "tls")
+
+
+def _parse_observatories(raw: str) -> List[str]:
+    return [part.strip().upper() for part in raw.split(",") if part.strip()] or DEFAULT_OBSERVATORIES
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="USGS Geomagnetism MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--observatories", default=os.getenv("GEOMAG_OBSERVATORIES", ",".join(DEFAULT_OBSERVATORIES)))
+    parser.add_argument("--state-file", default=os.getenv("GEOMAG_LAST_POLLED_FILE", ""))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(
+        host,
+        port,
+        _parse_observatories(args.observatories),
+        username=args.username or None,
+        password=args.password or None,
+        tls=tls,
+        client_id=args.client_id or None,
+        state_file=args.state_file,
+        once=args.once,
+        content_mode=args.content_mode,
+    ))

--- a/usgs-geomag/usgs_geomag_mqtt_producer/Makefile
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./usgs_geomag_mqtt_producer_data ./usgs_geomag_mqtt_producer_mqtt_client
+
+install: build
+	cd usgs_geomag_mqtt_producer_data && poetry install
+	cd usgs_geomag_mqtt_producer_mqtt_client && poetry install
+	pip install ./usgs_geomag_mqtt_producer_data ./usgs_geomag_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./usgs_geomag_mqtt_producer_mqtt_client/tests ./usgs_geomag_mqtt_producer_data/tests

--- a/usgs-geomag/usgs_geomag_mqtt_producer/README.md
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/README.md
@@ -1,0 +1,1079 @@
+# Usgs_geomag_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the usgs_geomag_mqtt_producer message definitions.
+
+# Usgs_geomag_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - GovUsgsGeomagMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from usgs_geomag_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure Event
+Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = GovUsgsGeomagMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### GovUsgsGeomagMqttEventDispatcher
+
+
+
+# Publish message`GovUsgsGeomagMqttEventDispatcher` handles events for the gov.usgs.geomag.mqtt message group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from usgs_geomag_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = GovUsgsGeomagMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the Event
+Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe GovUsgsGeomagMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `gov_usgs_geomag_mqtt_observatory_async`
+
+
+
+## Test```python
+
+gov_usgs_geomag_mqtt_observatory_async:  Callable[[PartitionContext, EventData, CloudEvent, Observatory],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `gov.usgs.geomag.mqtt.Observatory`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `usgs_geomag_mqtt_producer_data.Observatory`.
+
+Example:
+
+```python
+async def gov_usgs_geomag_mqtt_observatory_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: Observatory) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+gov_usgs_geomag_mqtt_dispatcher.gov_usgs_geomag_mqtt_observatory_async = gov_usgs_geomag_mqtt_observatory_event
+```
+
+
+
+make build
+
+```##### `gov_usgs_geomag_mqtt_magnetic_field_reading_async`
+
+
+
+## Test```python
+
+gov_usgs_geomag_mqtt_magnetic_field_reading_async:  Callable[[PartitionContext, EventData, CloudEvent,
+MagneticFieldReading], Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `gov.usgs.geomag.mqtt.MagneticFieldReading`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `usgs_geomag_mqtt_producer_data.MagneticFieldReading`.
+
+Example:
+
+```python
+async def gov_usgs_geomag_mqtt_magnetic_field_reading_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: MagneticFieldReading) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+gov_usgs_geomag_mqtt_dispatcher.gov_usgs_geomag_mqtt_magnetic_field_reading_async =
+gov_usgs_geomag_mqtt_magnetic_field_reading_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/usgs-geomag/usgs_geomag_mqtt_producer/install.bat
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\usgs_geomag_mqtt_producer_data
+pip install .\usgs_geomag_mqtt_producer_mqtt_client

--- a/usgs-geomag/usgs_geomag_mqtt_producer/install.sh
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./usgs_geomag_mqtt_producer_data
+pip install ./usgs_geomag_mqtt_producer_mqtt_client

--- a/usgs-geomag/usgs_geomag_mqtt_producer/samples/sample.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/samples/sample.py
@@ -1,0 +1,87 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from usgs_geomag_mqtt_producer_data import *
+from usgs_geomag_mqtt_producer_mqtt_client.client import GovUsgsGeomagMqttProducer, GovUsgsGeomagMqttDispatcher
+
+async def handle_gov_usgs_geomag_mqtt_observatory(mqtt_msg,cloud_event, gov_usgs_geomag_mqtt_observatory_data):
+    """ Handles the gov.usgs.geomag.mqtt.Observatory message """
+    print(f"Received gov.usgs.geomag.mqtt.Observatory on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {gov_usgs_geomag_mqtt_observatory_data}")
+
+async def handle_gov_usgs_geomag_mqtt_magnetic_field_reading(mqtt_msg,cloud_event, gov_usgs_geomag_mqtt_magnetic_field_reading_data):
+    """ Handles the gov.usgs.geomag.mqtt.MagneticFieldReading message """
+    print(f"Received gov.usgs.geomag.mqtt.MagneticFieldReading on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {gov_usgs_geomag_mqtt_magnetic_field_reading_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/usgs-geomag/usgs_geomag_mqtt_producer/scripts/build.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["usgs_geomag_mqtt_producer_mqtt_client", "usgs_geomag_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/pyproject.toml
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "usgs-geomag-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "usgs_geomag_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/__init__.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .observatory import Observatory
+from .magneticfieldreading import MagneticFieldReading
+
+__all__ = ["Observatory", "MagneticFieldReading"]

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/magneticfieldreading.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/magneticfieldreading.py
@@ -1,0 +1,172 @@
+""" MagneticFieldReading dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
+import json
+import datetime
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class MagneticFieldReading:
+    """
+    One-minute resolution geomagnetic field variation reading from a USGS Geomagnetism Program observatory, sourced from the timeseries web-service at https://geomag.usgs.gov/ws/data/. The H, D, Z, and F elements correspond to the four standard INTERMAGNET variation data components. The timeseries API returns parallel arrays (times + per-element value arrays) which the bridge transforms into individual timestamped events.
+    
+    Attributes:
+        iaga_code (str)
+        timestamp (datetime.datetime)
+        h (typing.Optional[float])
+        d (typing.Optional[float])
+        z (typing.Optional[float])
+        f (typing.Optional[float])
+    """
+    
+    
+    iaga_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="iaga_code"))
+    timestamp: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="timestamp", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    h: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="h"))
+    d: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="d"))
+    z: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="z"))
+    f: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="f"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'MagneticFieldReading':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['MagneticFieldReading']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return MagneticFieldReading.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'MagneticFieldReading':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            iaga_code='rfyephueuruxjktlzcii',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            h=float(31.917443457587545),
+            d=float(84.80849969836828),
+            z=float(86.3781360772114),
+            f=float(94.57551044258747)
+        )

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/observatory.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/src/usgs_geomag_mqtt_producer_data/observatory.py
@@ -1,0 +1,182 @@
+""" Observatory dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Observatory:
+    """
+    Reference data for a USGS Geomagnetism Program observatory, sourced from the INTERMAGNET-compatible observatories GeoJSON endpoint at https://geomag.usgs.gov/ws/observatories/. Each feature represents a ground-based magnetometer station that continuously records geomagnetic field variations.
+    
+    Attributes:
+        iaga_code (str)
+        name (str)
+        agency (typing.Optional[str])
+        agency_name (typing.Optional[str])
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+        elevation (typing.Optional[float])
+        sensor_orientation (typing.Optional[str])
+        sensor_sampling_rate (typing.Optional[float])
+        declination_base (typing.Optional[float])
+    """
+    
+    
+    iaga_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="iaga_code"))
+    name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name"))
+    agency: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="agency"))
+    agency_name: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="agency_name"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    elevation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation"))
+    sensor_orientation: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sensor_orientation"))
+    sensor_sampling_rate: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sensor_sampling_rate"))
+    declination_base: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="declination_base"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Observatory':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['Observatory']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return Observatory.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'Observatory':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            iaga_code='nowykaioihnnadobmqsb',
+            name='wjmvjxdsiecnpcwqkycy',
+            agency='tbvqlvkkciyvhysgifwt',
+            agency_name='siqwdesbudwegtrynpjp',
+            latitude=float(41.62576511391492),
+            longitude=float(7.706016669556403),
+            elevation=float(43.623594593492165),
+            sensor_orientation='qsjcljbfuhtlyyadfwmg',
+            sensor_sampling_rate=float(24.29899627582488),
+            declination_base=float(28.80896204101643)
+        )

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/tests/test_magneticfieldreading.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/tests/test_magneticfieldreading.py
@@ -1,0 +1,108 @@
+"""
+Test case for MagneticFieldReading
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from usgs_geomag_mqtt_producer_data.magneticfieldreading import MagneticFieldReading
+import datetime
+
+
+class Test_MagneticFieldReading(unittest.TestCase):
+    """
+    Test case for MagneticFieldReading
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_MagneticFieldReading.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of MagneticFieldReading for testing
+        """
+        instance = MagneticFieldReading(
+            iaga_code='rfyephueuruxjktlzcii',
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            h=float(31.917443457587545),
+            d=float(84.80849969836828),
+            z=float(86.3781360772114),
+            f=float(94.57551044258747)
+        )
+        return instance
+
+    
+    def test_iaga_code_property(self):
+        """
+        Test iaga_code property
+        """
+        test_value = 'rfyephueuruxjktlzcii'
+        self.instance.iaga_code = test_value
+        self.assertEqual(self.instance.iaga_code, test_value)
+    
+    def test_timestamp_property(self):
+        """
+        Test timestamp property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.timestamp = test_value
+        self.assertEqual(self.instance.timestamp, test_value)
+    
+    def test_h_property(self):
+        """
+        Test h property
+        """
+        test_value = float(31.917443457587545)
+        self.instance.h = test_value
+        self.assertEqual(self.instance.h, test_value)
+    
+    def test_d_property(self):
+        """
+        Test d property
+        """
+        test_value = float(84.80849969836828)
+        self.instance.d = test_value
+        self.assertEqual(self.instance.d, test_value)
+    
+    def test_z_property(self):
+        """
+        Test z property
+        """
+        test_value = float(86.3781360772114)
+        self.instance.z = test_value
+        self.assertEqual(self.instance.z, test_value)
+    
+    def test_f_property(self):
+        """
+        Test f property
+        """
+        test_value = float(94.57551044258747)
+        self.instance.f = test_value
+        self.assertEqual(self.instance.f, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = MagneticFieldReading.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = MagneticFieldReading.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/tests/test_observatory.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_data/tests/test_observatory.py
@@ -1,0 +1,143 @@
+"""
+Test case for Observatory
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from usgs_geomag_mqtt_producer_data.observatory import Observatory
+
+
+class Test_Observatory(unittest.TestCase):
+    """
+    Test case for Observatory
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_Observatory.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of Observatory for testing
+        """
+        instance = Observatory(
+            iaga_code='nowykaioihnnadobmqsb',
+            name='wjmvjxdsiecnpcwqkycy',
+            agency='tbvqlvkkciyvhysgifwt',
+            agency_name='siqwdesbudwegtrynpjp',
+            latitude=float(41.62576511391492),
+            longitude=float(7.706016669556403),
+            elevation=float(43.623594593492165),
+            sensor_orientation='qsjcljbfuhtlyyadfwmg',
+            sensor_sampling_rate=float(24.29899627582488),
+            declination_base=float(28.80896204101643)
+        )
+        return instance
+
+    
+    def test_iaga_code_property(self):
+        """
+        Test iaga_code property
+        """
+        test_value = 'nowykaioihnnadobmqsb'
+        self.instance.iaga_code = test_value
+        self.assertEqual(self.instance.iaga_code, test_value)
+    
+    def test_name_property(self):
+        """
+        Test name property
+        """
+        test_value = 'wjmvjxdsiecnpcwqkycy'
+        self.instance.name = test_value
+        self.assertEqual(self.instance.name, test_value)
+    
+    def test_agency_property(self):
+        """
+        Test agency property
+        """
+        test_value = 'tbvqlvkkciyvhysgifwt'
+        self.instance.agency = test_value
+        self.assertEqual(self.instance.agency, test_value)
+    
+    def test_agency_name_property(self):
+        """
+        Test agency_name property
+        """
+        test_value = 'siqwdesbudwegtrynpjp'
+        self.instance.agency_name = test_value
+        self.assertEqual(self.instance.agency_name, test_value)
+    
+    def test_latitude_property(self):
+        """
+        Test latitude property
+        """
+        test_value = float(41.62576511391492)
+        self.instance.latitude = test_value
+        self.assertEqual(self.instance.latitude, test_value)
+    
+    def test_longitude_property(self):
+        """
+        Test longitude property
+        """
+        test_value = float(7.706016669556403)
+        self.instance.longitude = test_value
+        self.assertEqual(self.instance.longitude, test_value)
+    
+    def test_elevation_property(self):
+        """
+        Test elevation property
+        """
+        test_value = float(43.623594593492165)
+        self.instance.elevation = test_value
+        self.assertEqual(self.instance.elevation, test_value)
+    
+    def test_sensor_orientation_property(self):
+        """
+        Test sensor_orientation property
+        """
+        test_value = 'qsjcljbfuhtlyyadfwmg'
+        self.instance.sensor_orientation = test_value
+        self.assertEqual(self.instance.sensor_orientation, test_value)
+    
+    def test_sensor_sampling_rate_property(self):
+        """
+        Test sensor_sampling_rate property
+        """
+        test_value = float(24.29899627582488)
+        self.instance.sensor_sampling_rate = test_value
+        self.assertEqual(self.instance.sensor_sampling_rate, test_value)
+    
+    def test_declination_base_property(self):
+        """
+        Test declination_base property
+        """
+        test_value = float(28.80896204101643)
+        self.instance.declination_base = test_value
+        self.assertEqual(self.instance.declination_base, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = Observatory.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = Observatory.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/pyproject.toml
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "usgs-geomag-mqtt-producer-mqtt-client"
+description = "usgs_geomag_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "usgs_geomag_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+usgs-geomag-mqtt-producer-data = {path = "../usgs_geomag_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/src/usgs_geomag_mqtt_producer_mqtt_client/__init__.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/src/usgs_geomag_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import GovUsgsGeomagMqttMqttClient
+
+__all__ = [
+    "GovUsgsGeomagMqttMqttClient",
+]

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/src/usgs_geomag_mqtt_producer_mqtt_client/client.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/src/usgs_geomag_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,504 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import usgs_geomag_mqtt_producer_data
+from usgs_geomag_mqtt_producer_data import Observatory
+from usgs_geomag_mqtt_producer_data import MagneticFieldReading
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_gov_usgs_geomag_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the gov.usgs.geomag.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "gov.usgs.geomag.mqtt.Observatory": "space-weather/us/usgs/usgs-geomag/{iaga_code}/info",
+        "gov.usgs.geomag.mqtt.MagneticFieldReading": "space-weather/us/usgs/usgs-geomag/{iaga_code}/reading",
+    }
+
+
+def get_subscription_topics_gov_usgs_geomag_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_gov_usgs_geomag_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class GovUsgsGeomagMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the gov.usgs.geomag.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_gov_usgs_geomag_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.gov_usgs_geomag_mqtt_observatory_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, usgs_geomag_mqtt_producer_data.Observatory, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.gov_usgs_geomag_mqtt_magnetic_field_reading_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, usgs_geomag_mqtt_producer_data.MagneticFieldReading, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "gov.usgs.geomag.Observatory":
+            if self.gov_usgs_geomag_mqtt_observatory_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = usgs_geomag_mqtt_producer_data.Observatory.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "gov.usgs.geomag.mqtt.Observatory")
+                    await self.gov_usgs_geomag_mqtt_observatory_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in gov_usgs_geomag_mqtt_observatory handler: {e}")
+            return
+        
+        if event_type == "gov.usgs.geomag.MagneticFieldReading":
+            if self.gov_usgs_geomag_mqtt_magnetic_field_reading_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = usgs_geomag_mqtt_producer_data.MagneticFieldReading.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "gov.usgs.geomag.mqtt.MagneticFieldReading")
+                    await self.gov_usgs_geomag_mqtt_magnetic_field_reading_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in gov_usgs_geomag_mqtt_magnetic_field_reading handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_gov_usgs_geomag_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_gov_usgs_geomag_mqtt_observatory(self,
+        iaga_code: str,
+        data: usgs_geomag_mqtt_producer_data.Observatory,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'gov.usgs.geomag.mqtt.Observatory' event to an MQTT topic.
+
+        Args:
+        
+            iaga_code: URI template variable for 'iaga_code'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'space-weather/us/usgs/usgs-geomag/{iaga_code}/info'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "space-weather/us/usgs/usgs-geomag/{iaga_code}/info"
+        _topic_template_values: Dict[str, str] = {
+            "iaga_code": str(iaga_code),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"gov.usgs.geomag.Observatory",
+             "source":"https://geomag.usgs.gov",
+             "subject":"{iaga_code}".format(iaga_code = iaga_code)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_gov_usgs_geomag_mqtt_magnetic_field_reading(self,
+        iaga_code: str,
+        data: usgs_geomag_mqtt_producer_data.MagneticFieldReading,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'gov.usgs.geomag.mqtt.MagneticFieldReading' event to an MQTT topic.
+
+        Args:
+        
+            iaga_code: URI template variable for 'iaga_code'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'space-weather/us/usgs/usgs-geomag/{iaga_code}/reading'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "space-weather/us/usgs/usgs-geomag/{iaga_code}/reading"
+        _topic_template_values: Dict[str, str] = {
+            "iaga_code": str(iaga_code),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"gov.usgs.geomag.MagneticFieldReading",
+             "source":"https://geomag.usgs.gov",
+             "subject":"{iaga_code}".format(iaga_code = iaga_code)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/usgs-geomag/usgs_geomag_mqtt_producer/usgs_geomag_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,176 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../usgs_geomag_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../usgs_geomag_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../usgs_geomag_mqtt_producer_mqtt_client/src')))
+
+import usgs_geomag_mqtt_producer_data
+from usgs_geomag_mqtt_producer_data import Observatory
+from test_usgs_geomag_mqtt_producer_data_observatory import Test_Observatory
+from usgs_geomag_mqtt_producer_data import MagneticFieldReading
+from test_usgs_geomag_mqtt_producer_data_magneticfieldreading import Test_MagneticFieldReading
+from usgs_geomag_mqtt_producer_mqtt_client import GovUsgsGeomagMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_gov_usgs_geomag_mqtt_gov_usgs_geomag_mqtt_observatory_py(mosquitto_broker):
+    """Test publishing and receiving gov.usgs.geomag.mqtt.Observatory message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Observatory.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = GovUsgsGeomagMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = GovUsgsGeomagMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_gov_usgs_geomag_mqtt_observatory(mqtt_msg, cloud_event, data: usgs_geomag_mqtt_producer_data.Observatory, topic_params: dict):
+        """Handler for gov.usgs.geomag.mqtt.Observatory messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "gov.usgs.geomag.Observatory"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.gov_usgs_geomag_mqtt_observatory_async = on_gov_usgs_geomag_mqtt_observatory
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/gov_usgs_geomag_mqtt/gov_usgs_geomag_mqtt_observatory"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_gov_usgs_geomag_mqtt_observatory(
+            topic=test_topic,
+            iaga_code=f"test_iaga_code_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_gov_usgs_geomag_mqtt_gov_usgs_geomag_mqtt_magnetic_field_reading_py(mosquitto_broker):
+    """Test publishing and receiving gov.usgs.geomag.mqtt.MagneticFieldReading message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_MagneticFieldReading.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = GovUsgsGeomagMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = GovUsgsGeomagMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_gov_usgs_geomag_mqtt_magnetic_field_reading(mqtt_msg, cloud_event, data: usgs_geomag_mqtt_producer_data.MagneticFieldReading, topic_params: dict):
+        """Handler for gov.usgs.geomag.mqtt.MagneticFieldReading messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "gov.usgs.geomag.MagneticFieldReading"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.gov_usgs_geomag_mqtt_magnetic_field_reading_async = on_gov_usgs_geomag_mqtt_magnetic_field_reading
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/gov_usgs_geomag_mqtt/gov_usgs_geomag_mqtt_magnetic_field_reading"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_gov_usgs_geomag_mqtt_magnetic_field_reading(
+            topic=test_topic,
+            iaga_code=f"test_iaga_code_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/usgs-geomag/xreg/usgs_geomag.xreg.json
+++ b/usgs-geomag/xreg/usgs_geomag.xreg.json
@@ -20,6 +20,27 @@
       "messagegroups": [
         "#/messagegroups/gov.usgs.geomag"
       ]
+    },
+    "gov.usgs.geomag.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/gov.usgs.geomag.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -62,6 +83,32 @@
           "dataschemauri": "#/schemagroups/gov.usgs.geomag.jstruct/schemas/gov.usgs.geomag.MagneticFieldReading"
         }
       }
+    },
+    "gov.usgs.geomag.mqtt": {
+      "description": "MQTT/5.0 transport variants for USGS geomagnetic observatory reference data and one-minute readings. Topics are retained QoS-1 leaves under space-weather/us/usgs/usgs-geomag/{iaga_code}/..., where {iaga_code} in the topic is the lowercased IAGA observatory code; the payload field may carry the canonical upstream code. Producers MUST lowercase {iaga_code} for the topic and consumers MUST treat topic filters as case-sensitive. The info leaf is retained reference metadata with no expiry. The reading leaf is a latched current 1-minute observation with Message Expiry Interval 7200 seconds; if the retained value expires, interpret the empty topic as observatory or bridge silence for at least two hours, not a zero magnetic-field reading. The iaga_code is the join key between retained info and readings.",
+      "messages": {
+        "gov.usgs.geomag.mqtt.Observatory": {
+          "name": "Observatory",
+          "basemessageurl": "/messagegroups/gov.usgs.geomag/messages/gov.usgs.geomag.Observatory",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "space-weather/us/usgs/usgs-geomag/{iaga_code}/info",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "gov.usgs.geomag.mqtt.MagneticFieldReading": {
+          "name": "MagneticFieldReading",
+          "basemessageurl": "/messagegroups/gov.usgs.geomag/messages/gov.usgs.geomag.MagneticFieldReading",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "space-weather/us/usgs/usgs-geomag/{iaga_code}/reading",
+            "qos": 1,
+            "retain": true,
+            "message_expiry_interval": 7200
+          }
+        }
+      }
     }
   },
   "schemagroups": {
@@ -92,43 +139,67 @@
                     "description": "Human-readable name of the observatory, e.g. 'Boulder', 'Barrow', 'College'."
                   },
                   "agency": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Short identifier of the operating agency, e.g. 'USGS' for United States Geological Survey."
                   },
                   "agency_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Full name of the operating agency, e.g. 'United States Geological Survey (USGS)'."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geodetic latitude of the observatory in decimal degrees. Positive values indicate north of the equator.",
                     "unit": "deg",
-                    "symbol": "°"
+                    "symbol": "\u00b0"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geodetic longitude of the observatory in decimal degrees east. Values above 180 represent west longitudes expressed as 360 minus the west longitude (e.g. 254.763 = -105.237 W).",
                     "unit": "deg",
-                    "symbol": "°"
+                    "symbol": "\u00b0"
                   },
                   "elevation": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Elevation of the observatory above mean sea level in meters.",
                     "unit": "m",
                     "symbol": "m"
                   },
                   "sensor_orientation": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Orientation of the magnetometer sensor, e.g. 'HDZ' indicating sensors measure horizontal intensity (H), declination (D), and vertical intensity (Z)."
                   },
                   "sensor_sampling_rate": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Native sampling rate of the magnetometer sensor in hertz.",
                     "unit": "Hz",
                     "symbol": "Hz"
                   },
                   "declination_base": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Declination baseline value in minutes of arc. Used as a reference for variation measurements of the D element."
                   }
                 },
@@ -163,26 +234,38 @@
                     "description": "UTC timestamp of the 1-minute magnetic field sample, in ISO 8601 format. Derived from the 'times' array in the USGS Geomagnetism web-service timeseries response."
                   },
                   "h": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Horizontal intensity component of the geomagnetic field vector. Represents the magnitude of the horizontal projection of the total field vector. Null when the observatory does not report this element or the value is missing for this minute.",
                     "unit": "nT",
                     "symbol": "nT"
                   },
                   "d": {
-                    "type": ["double", "null"],
-                    "description": "Declination angle — the angular difference between magnetic north and geographic north. Positive values indicate east declination. Null when the observatory does not report this element or the value is missing for this minute.",
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Declination angle \u2014 the angular difference between magnetic north and geographic north. Positive values indicate east declination. Null when the observatory does not report this element or the value is missing for this minute.",
                     "unit": "'",
-                    "symbol": "′"
+                    "symbol": "\u2032"
                   },
                   "z": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Vertical intensity component of the geomagnetic field vector. Positive values indicate downward (into the Earth in the northern hemisphere). Null when the observatory does not report this element or the value is missing for this minute.",
                     "unit": "nT",
                     "symbol": "nT"
                   },
                   "f": {
-                    "type": ["double", "null"],
-                    "description": "Total field intensity — the scalar magnitude of the full geomagnetic field vector. Measured by an independent proton or Overhauser magnetometer. Null when the observatory does not report this element or the value is missing for this minute.",
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Total field intensity \u2014 the scalar magnitude of the full geomagnetic field vector. Measured by an independent proton or Overhauser magnetometer. Null when the observatory does not report this element or the value is missing for this minute.",
                     "unit": "nT",
                     "symbol": "nT"
                   }


### PR DESCRIPTION
## Summary
- Add USGS Geomagnetism MQTT/UNS endpoint and generated MQTT producer
- Add `usgs_geomag_mqtt` feeder package and `Dockerfile.mqtt`
- Add Docker E2E matrix/build+flow coverage

## Topic tree
- `space-weather/us/usgs/usgs-geomag/{iaga_code}/info` retained QoS 1
- `space-weather/us/usgs/usgs-geomag/{iaga_code}/reading` retained QoS 1, 2h expiry

## Specialist review
- xRegistry Expert: no MUST-FIX; verified no schema fork, correct `basemessageurl`, placeholders required/non-null, no `messageid`/`messagegroupid`, subject compatibility. SHOULD-FIX redundant network axis addressed by dropping it.
- UNS Catalog Architect: MUST-FIX IAGA case rule and retained reading expiry semantics. Fixed in messagegroup description; topic uses lowercase IAGA while payload keeps upstream code, and reading is documented as a latched current sample that expires after 7200s.

## Validation
- `xrcg validate --definitions usgs-geomag/xreg/usgs_geomag.xreg.json` ✅
- `python -m pytest usgs-geomag/tests -q -x` with generated packages on `PYTHONPATH` ✅ (41 passed)
- `python -m pytest tests/docker_e2e/test_docker_mqtt_flow.py::TestUSGSGeomagMqttDockerFlow -q -x` ✅ (1 passed)
