### PR TITLE
mqtt(seattle-911): add MQTT/UNS feeder

### DIFF
--- a/seattle-911/Dockerfile.mqtt
+++ b/seattle-911/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/seattle-911"
+LABEL org.opencontainers.image.title="Seattle Fire 911 → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls Seattle Fire real-time 911 dispatch records and publishes MQTT 5.0 binary-mode CloudEvents into civic-events/us/seattle/seattle-911/{incident_type}/{incident_number}/incident topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/seattle-911/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./seattle_911_mqtt_producer/seattle_911_mqtt_producer_data \
+ && pip install --no-cache-dir ./seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./seattle_911_producer/seattle_911_producer_data \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./seattle_911_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "seattle_911_mqtt", "feed"]

--- a/seattle-911/generate_mqtt_producer.ps1
+++ b/seattle-911/generate_mqtt_producer.ps1
@@ -1,0 +1,11 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\seattle_911.xreg.json `
+    --endpoint US.WA.Seattle.Fire911.Mqtt `
+    --projectname seattle_911_mqtt_producer `
+    --output seattle_911_mqtt_producer

--- a/seattle-911/seattle_911/seattle_911.py
+++ b/seattle-911/seattle_911/seattle_911.py
@@ -7,8 +7,9 @@ import json
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
+from zoneinfo import ZoneInfo
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -111,12 +112,39 @@ def _save_state(state_file: str, data: dict) -> None:
         json.dump(data, handle, ensure_ascii=False, indent=2)
 
 
+def _incident_type_slug(value: str) -> str:
+    """Normalize an incident type into a deterministic MQTT topic segment."""
+    raw = (value or "unknown").lower().strip()
+    out: List[str] = []
+    previous_dash = False
+    for ch in raw:
+        if ch.isalnum():
+            out.append(ch)
+            previous_dash = False
+        elif not previous_dash:
+            out.append("-")
+            previous_dash = True
+    return "".join(out).strip("-") or "unknown"
+
+
+def _incident_datetime_utc(value: str) -> datetime:
+    """Convert the upstream Seattle local timestamp into UTC."""
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo("America/Los_Angeles"))
+    return parsed.astimezone(timezone.utc)
+
+
 def parse_incident(record: dict) -> Incident:
     """Map a Socrata row into the generated Incident data class."""
+    incident_type = record.get("type", "")
+    incident_datetime = record.get("datetime", "")
     return Incident(
         incident_number=str(record.get("incident_number", "")),
-        incident_type=record.get("type", ""),
-        incident_datetime=record.get("datetime", ""),
+        incident_type=incident_type,
+        incident_type_slug=_incident_type_slug(incident_type),
+        incident_datetime=incident_datetime,
+        incident_datetime_utc=_incident_datetime_utc(incident_datetime),
         address=record.get("address"),
         latitude=float(record["latitude"]) if record.get("latitude") not in (None, "") else None,
         longitude=float(record["longitude"]) if record.get("longitude") not in (None, "") else None,
@@ -207,6 +235,7 @@ class SeattleFire911Bridge:
                         continue
                     producer.send_us_wa_seattle_fire911_incident(
                         incident.incident_number,
+                        incident.incident_datetime_utc.isoformat(),
                         incident,
                         flush_producer=False,
                     )

--- a/seattle-911/seattle_911_mqtt/pyproject.toml
+++ b/seattle-911/seattle_911_mqtt/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "seattle-911-mqtt"
+version = "0.1.0"
+description = "Seattle Fire 911 bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+seattle_911_mqtt_producer_data = {path = "../seattle_911_mqtt_producer/seattle_911_mqtt_producer_data"}
+seattle_911_mqtt_producer_mqtt_client = {path = "../seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+seattle-911-mqtt = "seattle_911_mqtt:main"

--- a/seattle-911/seattle_911_mqtt/seattle_911_mqtt/__init__.py
+++ b/seattle-911/seattle_911_mqtt/seattle_911_mqtt/__init__.py
@@ -1,0 +1,4 @@
+"""Seattle Fire 911 MQTT feeder."""
+from .app import main
+
+__all__ = ["main"]

--- a/seattle-911/seattle_911_mqtt/seattle_911_mqtt/__main__.py
+++ b/seattle-911/seattle_911_mqtt/seattle_911_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/seattle-911/seattle_911_mqtt/seattle_911_mqtt/app.py
+++ b/seattle-911/seattle_911_mqtt/seattle_911_mqtt/app.py
@@ -1,0 +1,124 @@
+"""MQTT feeder application for Seattle Fire 911 → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from seattle_911.seattle_911 import DEFAULT_LOOKBACK_HOURS, DEFAULT_OVERLAP_MINUTES, DEFAULT_POLL_INTERVAL_SECONDS, SeattleFire911Bridge
+from seattle_911_mqtt_producer_mqtt_client.client import USWASeattleFire911MqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+def _uns_slug(value: str) -> str:
+    raw = (value or "unknown").lower().strip()
+    out = []
+    for ch in raw:
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in ("-", "_"):
+            out.append(ch)
+        else:
+            out.append("-")
+    slug = "".join(out).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "unknown"
+
+
+async def feed(
+    bridge: SeattleFire911Bridge,
+    broker_host: str,
+    broker_port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    once: bool = False,
+    content_mode: str = "binary",
+) -> None:
+    paho_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, client_id=client_id or "", protocol=MQTTv5)
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+    mqtt_client = USWASeattleFire911MqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await mqtt_client.connect(broker_host, broker_port)
+    try:
+        while True:
+            if bridge.last_seen_datetime:
+                since = datetime.fromisoformat(bridge.last_seen_datetime) - timedelta(minutes=DEFAULT_OVERLAP_MINUTES)
+            else:
+                since = datetime.utcnow() - timedelta(hours=DEFAULT_LOOKBACK_HOURS)
+            incidents = bridge.fetch_incidents(since=since)
+            sent = 0
+            newest: Optional[str] = bridge.last_seen_datetime
+            sent_ids: list[str] = []
+            for incident in incidents:
+                if incident.incident_number in bridge.sent_incident_numbers:
+                    newest = max(newest or "", incident.incident_datetime)
+                    continue
+                await mqtt_client.publish_us_wa_seattle_fire911_mqtt_incident(
+                    incident_number=incident.incident_number,
+                    incident_datetime_utc=incident.incident_datetime_utc.isoformat(),
+                    incident_type_slug=incident.incident_type_slug,
+                    data=incident,
+                )
+                sent_ids.append(incident.incident_number)
+                newest = max(newest or "", incident.incident_datetime)
+                sent += 1
+            bridge._remember_incidents(sent_ids)
+            if newest:
+                bridge.last_seen_datetime = newest
+            bridge.save_state()
+            logger.info("Fetched %d incidents and published %d new MQTT incidents", len(incidents), sent)
+            if once:
+                break
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    return parsed.hostname or "localhost", parsed.port or (8883 if scheme in ("mqtts", "ssl", "tls") else 1883), scheme in ("mqtts", "ssl", "tls")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Seattle Fire 911 MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--state-file", default=os.getenv("SEATTLE_911_LAST_POLLED_FILE", ""))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(
+        SeattleFire911Bridge(state_file=args.state_file),
+        host,
+        port,
+        username=args.username or None,
+        password=args.password or None,
+        tls=tls,
+        client_id=args.client_id or None,
+        once=args.once,
+        content_mode=args.content_mode,
+    ))

--- a/seattle-911/seattle_911_mqtt_producer/Makefile
+++ b/seattle-911/seattle_911_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./seattle_911_mqtt_producer_data ./seattle_911_mqtt_producer_mqtt_client
+
+install: build
+	cd seattle_911_mqtt_producer_data && poetry install
+	cd seattle_911_mqtt_producer_mqtt_client && poetry install
+	pip install ./seattle_911_mqtt_producer_data ./seattle_911_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./seattle_911_mqtt_producer_mqtt_client/tests ./seattle_911_mqtt_producer_data/tests

--- a/seattle-911/seattle_911_mqtt_producer/README.md
+++ b/seattle-911/seattle_911_mqtt_producer/README.md
@@ -1,0 +1,1037 @@
+# Seattle_911_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the seattle_911_mqtt_producer message definitions.
+
+# Seattle_911_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - USWASeattleFire911MqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from seattle_911_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure Event
+Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = USWASeattleFire911MqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### USWASeattleFire911MqttEventDispatcher
+
+
+
+# Publish message`USWASeattleFire911MqttEventDispatcher` handles events for the US.WA.Seattle.Fire911.mqtt message
+group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from seattle_911_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = USWASeattleFire911MqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the
+Event Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe USWASeattleFire911MqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `us_wa_seattle_fire911_mqtt_incident_async`
+
+
+
+## Test```python
+
+us_wa_seattle_fire911_mqtt_incident_async:  Callable[[PartitionContext, EventData, CloudEvent, Incident],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `US.WA.Seattle.Fire911.mqtt.Incident`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `seattle_911_mqtt_producer_data.Incident`.
+
+Example:
+
+```python
+async def us_wa_seattle_fire911_mqtt_incident_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: Incident) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+us_wa_seattle_fire911_mqtt_dispatcher.us_wa_seattle_fire911_mqtt_incident_async =
+us_wa_seattle_fire911_mqtt_incident_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/seattle-911/seattle_911_mqtt_producer/install.bat
+++ b/seattle-911/seattle_911_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\seattle_911_mqtt_producer_data
+pip install .\seattle_911_mqtt_producer_mqtt_client

--- a/seattle-911/seattle_911_mqtt_producer/install.sh
+++ b/seattle-911/seattle_911_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./seattle_911_mqtt_producer_data
+pip install ./seattle_911_mqtt_producer_mqtt_client

--- a/seattle-911/seattle_911_mqtt_producer/samples/sample.py
+++ b/seattle-911/seattle_911_mqtt_producer/samples/sample.py
@@ -1,0 +1,80 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from seattle_911_mqtt_producer_data import *
+from seattle_911_mqtt_producer_mqtt_client.client import USWASeattleFire911MqttProducer, USWASeattleFire911MqttDispatcher
+
+async def handle_us_wa_seattle_fire911_mqtt_incident(mqtt_msg,cloud_event, us_wa_seattle_fire911_mqtt_incident_data):
+    """ Handles the US.WA.Seattle.Fire911.mqtt.Incident message """
+    print(f"Received US.WA.Seattle.Fire911.mqtt.Incident on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {us_wa_seattle_fire911_mqtt_incident_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/seattle-911/seattle_911_mqtt_producer/scripts/build.py
+++ b/seattle-911/seattle_911_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["seattle_911_mqtt_producer_mqtt_client", "seattle_911_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/pyproject.toml
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "seattle-911-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "seattle_911_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/src/seattle_911_mqtt_producer_data/__init__.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/src/seattle_911_mqtt_producer_data/__init__.py
@@ -1,0 +1,3 @@
+from .incident import Incident
+
+__all__ = ["Incident"]

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/src/seattle_911_mqtt_producer_data/incident.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/src/seattle_911_mqtt_producer_data/incident.py
@@ -167,12 +167,12 @@ class Incident:
             An instance of the dataclass.
         """
         return cls(
-            incident_number='arpmjkrbanxcofsfbvcy',
-            incident_type='qanwdgbumskzeiodpita',
-            incident_datetime='mhnelyhpiwtpdsnhulpd',
-            address='joxebduhektwfuqzoopl',
-            latitude=float(39.326202307634226),
-            longitude=float(70.61534969291277),
-            incident_type_slug='abxfwrffgykbneybnljd',
+            incident_number='yhmfeqrvnvgtxeqqvygn',
+            incident_type='rtvixnujpuejdicplvjc',
+            incident_datetime='pirjplqowexucmdzqnfc',
+            address='wogpjngtehjuxnckljdj',
+            latitude=float(56.92861567732885),
+            longitude=float(56.22043047487445),
+            incident_type_slug='ittagfogaprtboawpwak',
             incident_datetime_utc=datetime.datetime.now(datetime.timezone.utc)
         )

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/tests/test_incident.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_data/tests/test_incident.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from seattle_911_producer_data.incident import Incident
+from seattle_911_mqtt_producer_data.incident import Incident
 import datetime
 
 
@@ -29,13 +29,13 @@ class Test_Incident(unittest.TestCase):
         Create instance of Incident for testing
         """
         instance = Incident(
-            incident_number='arpmjkrbanxcofsfbvcy',
-            incident_type='qanwdgbumskzeiodpita',
-            incident_datetime='mhnelyhpiwtpdsnhulpd',
-            address='joxebduhektwfuqzoopl',
-            latitude=float(39.326202307634226),
-            longitude=float(70.61534969291277),
-            incident_type_slug='abxfwrffgykbneybnljd',
+            incident_number='yhmfeqrvnvgtxeqqvygn',
+            incident_type='rtvixnujpuejdicplvjc',
+            incident_datetime='pirjplqowexucmdzqnfc',
+            address='wogpjngtehjuxnckljdj',
+            latitude=float(56.92861567732885),
+            longitude=float(56.22043047487445),
+            incident_type_slug='ittagfogaprtboawpwak',
             incident_datetime_utc=datetime.datetime.now(datetime.timezone.utc)
         )
         return instance
@@ -45,7 +45,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test incident_number property
         """
-        test_value = 'arpmjkrbanxcofsfbvcy'
+        test_value = 'yhmfeqrvnvgtxeqqvygn'
         self.instance.incident_number = test_value
         self.assertEqual(self.instance.incident_number, test_value)
     
@@ -53,7 +53,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test incident_type property
         """
-        test_value = 'qanwdgbumskzeiodpita'
+        test_value = 'rtvixnujpuejdicplvjc'
         self.instance.incident_type = test_value
         self.assertEqual(self.instance.incident_type, test_value)
     
@@ -61,7 +61,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test incident_datetime property
         """
-        test_value = 'mhnelyhpiwtpdsnhulpd'
+        test_value = 'pirjplqowexucmdzqnfc'
         self.instance.incident_datetime = test_value
         self.assertEqual(self.instance.incident_datetime, test_value)
     
@@ -69,7 +69,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test address property
         """
-        test_value = 'joxebduhektwfuqzoopl'
+        test_value = 'wogpjngtehjuxnckljdj'
         self.instance.address = test_value
         self.assertEqual(self.instance.address, test_value)
     
@@ -77,7 +77,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(39.326202307634226)
+        test_value = float(56.92861567732885)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -85,7 +85,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(70.61534969291277)
+        test_value = float(56.22043047487445)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -93,7 +93,7 @@ class Test_Incident(unittest.TestCase):
         """
         Test incident_type_slug property
         """
-        test_value = 'abxfwrffgykbneybnljd'
+        test_value = 'ittagfogaprtboawpwak'
         self.instance.incident_type_slug = test_value
         self.assertEqual(self.instance.incident_type_slug, test_value)
     

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/pyproject.toml
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "seattle-911-mqtt-producer-mqtt-client"
+description = "seattle_911_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "seattle_911_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+seattle-911-mqtt-producer-data = {path = "../seattle_911_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/src/seattle_911_mqtt_producer_mqtt_client/__init__.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/src/seattle_911_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import USWASeattleFire911MqttMqttClient
+
+__all__ = [
+    "USWASeattleFire911MqttMqttClient",
+]

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/src/seattle_911_mqtt_producer_mqtt_client/client.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/src/seattle_911_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,422 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import seattle_911_mqtt_producer_data
+from seattle_911_mqtt_producer_data import Incident
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_us_wa_seattle_fire911_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the US.WA.Seattle.Fire911.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "US.WA.Seattle.Fire911.mqtt.Incident": "civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}",
+    }
+
+
+def get_subscription_topics_us_wa_seattle_fire911_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_us_wa_seattle_fire911_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class USWASeattleFire911MqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the US.WA.Seattle.Fire911.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_us_wa_seattle_fire911_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.us_wa_seattle_fire911_mqtt_incident_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, seattle_911_mqtt_producer_data.Incident, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "US.WA.Seattle.Fire911.Incident":
+            if self.us_wa_seattle_fire911_mqtt_incident_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = seattle_911_mqtt_producer_data.Incident.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "US.WA.Seattle.Fire911.mqtt.Incident")
+                    await self.us_wa_seattle_fire911_mqtt_incident_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in us_wa_seattle_fire911_mqtt_incident handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_us_wa_seattle_fire911_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_us_wa_seattle_fire911_mqtt_incident(self,
+        incident_number: str,
+        incident_datetime_utc: str,
+        incident_type_slug: str,
+        data: seattle_911_mqtt_producer_data.Incident,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'US.WA.Seattle.Fire911.mqtt.Incident' event to an MQTT topic.
+
+        Args:
+        
+            incident_number: URI template variable for 'incident_number'
+            incident_datetime_utc: URI template variable for 'incident_datetime_utc'
+            incident_type_slug: URI template variable for 'incident_type_slug'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}"
+        _topic_template_values: Dict[str, str] = {
+            "incident_number": str(incident_number),
+            "incident_datetime_utc": str(incident_datetime_utc),
+            "incident_type_slug": str(incident_type_slug),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"US.WA.Seattle.Fire911.Incident",
+             "source":"https://data.seattle.gov/Public-Safety/Seattle-Real-Time-Fire-911-Calls/kzjm-xkqj",
+             "subject":"{incident_number}".format(incident_number = incident_number),
+             "time":"{incident_datetime_utc}".format(incident_datetime_utc = incident_datetime_utc)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,110 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../seattle_911_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../seattle_911_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../seattle_911_mqtt_producer_mqtt_client/src')))
+
+import seattle_911_mqtt_producer_data
+from seattle_911_mqtt_producer_data import Incident
+from test_seattle_911_mqtt_producer_data_incident import Test_Incident
+from seattle_911_mqtt_producer_mqtt_client import USWASeattleFire911MqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_us_wa_seattle_fire911_mqtt_us_wa_seattle_fire911_mqtt_incident_py(mosquitto_broker):
+    """Test publishing and receiving US.WA.Seattle.Fire911.mqtt.Incident message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Incident.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = USWASeattleFire911MqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = USWASeattleFire911MqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_us_wa_seattle_fire911_mqtt_incident(mqtt_msg, cloud_event, data: seattle_911_mqtt_producer_data.Incident, topic_params: dict):
+        """Handler for US.WA.Seattle.Fire911.mqtt.Incident messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "US.WA.Seattle.Fire911.Incident"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.us_wa_seattle_fire911_mqtt_incident_async = on_us_wa_seattle_fire911_mqtt_incident
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/us_wa_seattle_fire911_mqtt/us_wa_seattle_fire911_mqtt_incident"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_us_wa_seattle_fire911_mqtt_incident(
+            topic=test_topic,
+            incident_number=f"test_incident_number_{i}",
+            incident_datetime_utc=f"test_incident_datetime_utc_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/seattle-911/seattle_911_producer/README.md
+++ b/seattle-911/seattle_911_producer/README.md
@@ -15,7 +15,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 2. [What is Apache Kafka?](#what-is-apache-kafka)2. [Generated Event Dispatchers](#generated-event-dispatchers)
 
-3. [Quick Start](#quick-start)    - USWASeattleFire911EventDispatcher
+3. [Quick Start](#quick-start)    - USWASeattleFire911EventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    USWASeattleFire911MqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -39,6 +41,10 @@ methods to handle various types of events.
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - USWASeattleFire911Producersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- USWASeattleFire911MqttProducersolution for event-driven applications.
 
 
 
@@ -190,6 +196,43 @@ us_wa_seattle_fire911_dispatcher.us_wa_seattle_fire911_incident_async = us_wa_se
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USWASeattleFire911MqttProducer- `data`: The event data of type `seattle_911_producer_data.Incident`.
+
+
+
+Producer for `US.WA.Seattle.Fire911.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_wa_seattle_fire911_incident_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Incident) -> None:
+
+```python    # Process the event data
+
+USWASeattleFire911MqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_wa_seattle_fire911_mqtt_dispatcher.us_wa_seattle_fire911_incident_async = us_wa_seattle_fire911_incident_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -284,6 +327,305 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_us_wa_seattle_fire911_incident_batch(```
+
+    messages=[
+
+        Incident(...),Initializes the runner with a Kafka consumer.
+
+        Incident(...),
+
+        Incident(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### USWASeattleFire911MqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`USWASeattleFire911MqttEventDispatcher` handles events for the US.WA.Seattle.Fire911.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from seattle-911-producer import USWASeattleFire911Producer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = USWASeattleFire911Producer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_us_wa_seattle_fire911_incident(```python
+
+    data=Incident(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The USWASeattleFire911MqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = USWASeattleFire911Producer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `us_wa_seattle_fire911_mqtt_incident_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'us_wa_seattle_fire911_mqtt_incident_async:  Callable[[ConsumerRecord, CloudEvent,
+Incident], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `US.WA.Seattle.Fire911.mqtt.Incident`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USWASeattleFire911Producer- `data`: The event data of type `seattle_911_producer_data.Incident`.
+
+
+
+Producer for `US.WA.Seattle.Fire911` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_wa_seattle_fire911_mqtt_incident_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Incident) ->
+None:
+
+```python    # Process the event data
+
+USWASeattleFire911Producer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_wa_seattle_fire911_dispatcher.us_wa_seattle_fire911_mqtt_incident_async = us_wa_seattle_fire911_mqtt_incident_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### USWASeattleFire911MqttProducer- `data`: The event data of type `seattle_911_producer_data.Incident`.
+
+
+
+Producer for `US.WA.Seattle.Fire911.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def us_wa_seattle_fire911_mqtt_incident_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Incident) ->
+None:
+
+```python    # Process the event data
+
+USWASeattleFire911MqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+us_wa_seattle_fire911_mqtt_dispatcher.us_wa_seattle_fire911_mqtt_incident_async =
+us_wa_seattle_fire911_mqtt_incident_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_us_wa_seattle_fire911_mqtt_incident`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_us_wa_seattle_fire911_mqtt_incident(
+
+    self,##### `_process_event`
+
+    data: Incident,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `US.WA.Seattle.Fire911.mqtt.Incident` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `Incident`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_us_wa_seattle_fire911_mqtt_incident(
+
+    data=Incident(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `US.WA.Seattle.Fire911.mqtt.Incident` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_us_wa_seattle_fire911_mqtt_incident_batch(```
 
     messages=[
 

--- a/seattle-911/seattle_911_producer/samples/sample.py
+++ b/seattle-911/seattle_911_producer/samples/sample.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer as KafkaProducer
 # imports the producer clients for the message group(s)
 
 from seattle_911_producer_kafka_producer.producer import USWASeattleFire911EventProducer
+from seattle_911_producer_kafka_producer.producer import USWASeattleFire911MqttEventProducer
 
 # imports for the data classes for each event
 
@@ -61,8 +62,24 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     _incident = Incident()
 
     # sends the 'US.WA.Seattle.Fire911.Incident' event to Kafka topic.
-    await uswaseattle_fire911_event_producer.send_us_wa_seattle_fire911_incident(_incident_number = 'TODO: replace me', data = _incident)
+    await uswaseattle_fire911_event_producer.send_us_wa_seattle_fire911_incident(_incident_number = 'TODO: replace me', _incident_datetime_utc = 'TODO: replace me', data = _incident)
     print(f"Sent 'US.WA.Seattle.Fire911.Incident' event: {_incident.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        uswaseattle_fire911_mqtt_event_producer = USWASeattleFire911MqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        uswaseattle_fire911_mqtt_event_producer = USWASeattleFire911MqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- US.WA.Seattle.Fire911.mqtt.Incident ----
+    # TODO: Supply event data for the US.WA.Seattle.Fire911.mqtt.Incident event
+    _incident = Incident()
+
+    # sends the 'US.WA.Seattle.Fire911.mqtt.Incident' event to Kafka topic.
+    await uswaseattle_fire911_mqtt_event_producer.send_us_wa_seattle_fire911_mqtt_incident(_incident_number = 'TODO: replace me', _incident_datetime_utc = 'TODO: replace me', data = _incident)
+    print(f"Sent 'US.WA.Seattle.Fire911.mqtt.Incident' event: {_incident.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/seattle-911/seattle_911_producer/seattle_911_producer_kafka_producer/src/seattle_911_producer_kafka_producer/producer.py
+++ b/seattle-911/seattle_911_producer/seattle_911_producer_kafka_producer/src/seattle_911_producer_kafka_producer/producer.py
@@ -40,12 +40,13 @@ class USWASeattleFire911EventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_us_wa_seattle_fire911_incident(self,_incident_number : str, data: Incident, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Incident], str]=None) -> None:
+    def send_us_wa_seattle_fire911_incident(self,_incident_number : str, _incident_datetime_utc : str, data: Incident, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Incident], str]=None) -> None:
         """
         Sends the 'US.WA.Seattle.Fire911.Incident' event to the Kafka topic
 
         Args:
             _incident_number(str):  Value for placeholder incident_number in attribute subject
+            _incident_datetime_utc(str):  Value for placeholder incident_datetime_utc in attribute time
             data: (Incident): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
@@ -56,7 +57,8 @@ class USWASeattleFire911EventProducer:
         attributes = {
              "type":"US.WA.Seattle.Fire911.Incident",
              "source":"https://data.seattle.gov/Public-Safety/Seattle-Real-Time-Fire-911-Calls/kzjm-xkqj",
-             "subject":"{incident_number}".format(incident_number = _incident_number)
+             "subject":"{incident_number}".format(incident_number = _incident_number),
+             "time":"{incident_datetime_utc}".format(incident_datetime_utc = _incident_datetime_utc)
         }
         attributes["datacontenttype"] = content_type
         event = CloudEvent.create(attributes, data)
@@ -103,6 +105,121 @@ class USWASeattleFire911EventProducer:
 
     @classmethod
     def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'USWASeattleFire911EventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+
+
+
+class USWASeattleFire911MqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_us_wa_seattle_fire911_mqtt_incident(self,_incident_number : str, _incident_datetime_utc : str, data: Incident, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Incident], str]=None) -> None:
+        """
+        Sends the 'US.WA.Seattle.Fire911.mqtt.Incident' event to the Kafka topic
+
+        Args:
+            _incident_number(str):  Value for placeholder incident_number in attribute subject
+            _incident_datetime_utc(str):  Value for placeholder incident_datetime_utc in attribute time
+            data: (Incident): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Incident], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"US.WA.Seattle.Fire911.Incident",
+             "source":"https://data.seattle.gov/Public-Safety/Seattle-Real-Time-Fire-911-Calls/kzjm-xkqj",
+             "subject":"{incident_number}".format(incident_number = _incident_number),
+             "time":"{incident_datetime_utc}".format(incident_datetime_utc = _incident_datetime_utc)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'USWASeattleFire911MqttEventProducer':
         """
         Create a Kafka producer from a connection string and a topic name.
 

--- a/seattle-911/seattle_911_producer/seattle_911_producer_kafka_producer/tests/test_producer.py
+++ b/seattle-911/seattle_911_producer/seattle_911_producer_kafka_producer/tests/test_producer.py
@@ -21,6 +21,7 @@ from testcontainers.kafka import KafkaContainer
 from seattle_911_producer_kafka_producer.producer import USWASeattleFire911EventProducer
 from seattle_911_producer_data import Incident
 from test_seattle_911_producer_data_incident import Test_Incident
+from seattle_911_producer_kafka_producer.producer import USWASeattleFire911MqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -103,7 +104,7 @@ def test_us_wa_seattle_fire911_uswaseattlefire911incident(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_us_wa_seattle_fire911_incident(_incident_number = f'test_{i}', data = event_data)
+        producer_instance.send_us_wa_seattle_fire911_incident(_incident_number = f'test_{i}', _incident_datetime_utc = f'test_{i}', data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -114,4 +115,65 @@ def test_us_wa_seattle_fire911_uswaseattlefire911incident(kafka_emulator):
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{incident_number}".format(incident_number=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_us_wa_seattle_fire911_mqtt_uswaseattlefire911mqttincident(kafka_emulator):
+    """Test the USWASeattleFire911MqttIncident event from the US.WA.Seattle.Fire911.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_us_wa_seattle_fire911_mqtt_uswaseattlefire911mqttincident',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "US.WA.Seattle.Fire911.mqtt.Incident":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = USWASeattleFire911MqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_Incident.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_us_wa_seattle_fire911_mqtt_incident(_incident_number = f'test_{i}', _incident_datetime_utc = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()

--- a/seattle-911/tests/test_seattle_911_unit.py
+++ b/seattle-911/tests/test_seattle_911_unit.py
@@ -60,6 +60,8 @@ class TestIncidentParsing:
         incident = parse_incident(SAMPLE_ROWS[0])
         assert incident.incident_number == "F260046986"
         assert incident.incident_type == "Aid Response"
+        assert incident.incident_type_slug == "aid-response"
+        assert incident.incident_datetime_utc.isoformat() == "2026-04-09T10:52:00+00:00"
         assert incident.latitude == pytest.approx(47.666481)
         assert incident.longitude == pytest.approx(-122.284803)
 
@@ -100,9 +102,11 @@ class TestPolling:
         bridge.poll_and_send(producer, once=True)
 
         assert producer.send_us_wa_seattle_fire911_incident.call_count == 2
+        first_incident = parse_incident(SAMPLE_ROWS[0])
         producer.send_us_wa_seattle_fire911_incident.assert_any_call(
             "F260046986",
-            parse_incident(SAMPLE_ROWS[0]),
+            first_incident.incident_datetime_utc.isoformat(),
+            first_incident,
             flush_producer=False,
         )
 

--- a/seattle-911/xreg/seattle_911.xreg.json
+++ b/seattle-911/xreg/seattle_911.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "US.WA.Seattle.Fire911.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,30 @@
           "key": "{incident_number}"
         }
       },
-      "messagegroups": ["#/messagegroups/US.WA.Seattle.Fire911"]
+      "messagegroups": [
+        "#/messagegroups/US.WA.Seattle.Fire911"
+      ]
+    },
+    "US.WA.Seattle.Fire911.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/US.WA.Seattle.Fire911.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -34,10 +59,30 @@
             "subject": {
               "value": "{incident_number}",
               "type": "uritemplate"
+            },
+            "time": {
+              "value": "{incident_datetime_utc}",
+              "type": "uritemplate"
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/US.WA.Seattle.Fire911.jstruct/schemas/US.WA.Seattle.Fire911.Incident"
+        }
+      }
+    },
+    "US.WA.Seattle.Fire911.mqtt": {
+      "description": "MQTT/5.0 transport variant for Seattle Fire 911 dispatch incidents. Topics are non-retained QoS-1 event messages under civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}. The incident_type_slug field is the deterministic lowercase kebab-case routing key derived from the display incident_type; incident_number preserves the CloudEvents subject/Kafka key for per-incident subscriptions. Message expiry is 86400 seconds for queued/offline delivery only; this event stream does not use retained MQTT state.",
+      "messages": {
+        "US.WA.Seattle.Fire911.mqtt.Incident": {
+          "name": "Incident",
+          "basemessageurl": "/messagegroups/US.WA.Seattle.Fire911/messages/US.WA.Seattle.Fire911.Incident",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}",
+            "qos": 1,
+            "retain": false,
+            "message_expiry_interval": 86400
+          }
         }
       }
     }
@@ -59,7 +104,9 @@
                 "required": [
                   "incident_number",
                   "incident_type",
-                  "incident_datetime"
+                  "incident_type_slug",
+                  "incident_datetime",
+                  "incident_datetime_utc"
                 ],
                 "name": "Incident",
                 "description": "Seattle Fire Department 911 dispatch record from the City of Seattle real-time fire calls dataset.",
@@ -76,7 +123,7 @@
                   },
                   "incident_type": {
                     "type": "string",
-                    "description": "Seattle Fire Department response type for the incident, such as Aid Response or Medic Response.",
+                    "description": "Seattle Fire Department response type display string for the incident, such as Aid Response or Medic Response.",
                     "alternates": [
                       {
                         "name": "type",
@@ -95,7 +142,10 @@
                     ]
                   },
                   "address": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Incident location text as published by the dataset.",
                     "alternates": [
                       {
@@ -105,7 +155,10 @@
                     ]
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Latitude of the incident location in decimal degrees north.",
                     "alternates": [
                       {
@@ -115,7 +168,10 @@
                     ]
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Longitude of the incident location in decimal degrees east of Greenwich; Seattle values are negative because they lie west of Greenwich.",
                     "alternates": [
                       {
@@ -123,6 +179,15 @@
                         "description": "Original field name in the Seattle Open Data dataset."
                       }
                     ]
+                  },
+                  "incident_type_slug": {
+                    "type": "string",
+                    "description": "Deterministic lowercase kebab-case routing slug derived from incident_type by lowercasing ASCII alphanumerics, replacing every run of non-alphanumeric characters with a single hyphen, and trimming leading/trailing hyphens (example: Aid Response - 7 per Unit -> aid-response-7-per-unit).",
+                    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+                  },
+                  "incident_datetime_utc": {
+                    "type": "datetime",
+                    "description": "Incident timestamp normalized to RFC 3339 UTC using America/Los_Angeles for the upstream local dataset timestamp."
                   }
                 }
               }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -298,6 +298,12 @@
       "image": "usgs-geomag-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "usgs_geomag_mqtt"
+    },
+    {
+      "dir": "seattle-911",
+      "image": "seattle-911-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "seattle_911_mqtt"
     }
   ],
   "flow": [
@@ -563,6 +569,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestUSGSGeomagMqttDockerFlow"
+    },
+    {
+      "dir": "seattle-911",
+      "image": "seattle-911-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestSeattle911MqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -3597,3 +3597,114 @@ class TestUSGSGeomagMqttDockerFlow:
         reading_payload = _to_dict(reading_msgs[0]['payload'])
         assert info_payload is not None and info_payload.get('iaga_code')
         assert reading_payload is not None and reading_payload.get('iaga_code')
+
+# ---- seattle-911 --------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def seattle_911_mqtt_image():
+    return build_image('seattle-911', dockerfile='Dockerfile.mqtt', tag='test-seattle-911-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_seattle_911():
+    container, network, host_port = _generic_mosquitto(
+        'seattle-911-mqtt-e2e', 'seattle-911-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'seattle-911-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestSeattle911MqttDockerFlow:
+    """Verify the seattle-911-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_uns_event_topics(self, mosquitto_seattle_911, seattle_911_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_seattle_911['internal_host']}:{mosquitto_seattle_911['internal_port']}"
+        messages = []
+
+        def on_message(_client, _userdata, msg):
+            props = {}
+            if msg.properties is not None:
+                for k, v in getattr(msg.properties, 'UserProperty', []) or []:
+                    props[k] = v
+                ct = getattr(msg.properties, 'ContentType', None)
+                if ct:
+                    props['_contenttype'] = ct
+            try:
+                payload = json.loads(msg.payload)
+            except (TypeError, ValueError):
+                payload = None
+            messages.append({
+                'topic': msg.topic,
+                'retain': bool(msg.retain),
+                'qos': msg.qos,
+                'user_properties': props,
+                'payload': payload,
+            })
+
+        sub = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
+        sub.on_message = on_message
+        sub.connect('127.0.0.1', mosquitto_seattle_911['host_port'], 30)
+        sub.subscribe('civic-events/us/wa/seattle/public-safety/fire-dispatch/#', qos=1)
+        sub.loop_start()
+        try:
+            feeder = client.containers.run(
+                seattle_911_mqtt_image.id,
+                detach=True,
+                remove=False,
+                network=mosquitto_seattle_911['network'],
+                environment={
+                    'MQTT_BROKER_URL': broker_url,
+                    'ONCE_MODE': 'true',
+                    'PYTHONUNBUFFERED': '1',
+                },
+            )
+            try:
+                result = feeder.wait(timeout=360)
+                logs = feeder.logs().decode('utf-8', errors='replace')
+                assert result.get('StatusCode') == 0, (
+                    f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+                )
+            finally:
+                try:
+                    feeder.remove(force=True)
+                except docker.errors.APIError:
+                    pass
+            deadline = time.time() + 10
+            while not messages and time.time() < deadline:
+                time.sleep(0.5)
+        finally:
+            sub.loop_stop()
+            sub.disconnect()
+
+        assert messages, 'No live messages received from broker'
+        sample = messages[0]
+        up = sample['user_properties']
+        for required in ('id', 'source', 'type', 'subject', 'time', 'specversion'):
+            assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+        assert sample['user_properties'].get('_contenttype') == 'application/json'
+        assert sample['retain'] is False
+        assert sample['qos'] == 1
+        assert up.get('type') == 'US.WA.Seattle.Fire911.Incident'
+        parts = sample['topic'].split('/')
+        assert parts[:6] == ['civic-events', 'us', 'wa', 'seattle', 'public-safety', 'fire-dispatch']
+        assert parts[7] == up['subject']
+        payload = _to_dict(sample['payload'])
+        assert payload is not None and payload.get('incident_number') == up['subject']
+        assert payload.get('incident_type_slug') == parts[6]
+        assert payload.get('incident_datetime_utc')


### PR DESCRIPTION
## Summary
- Add Seattle Fire 911 MQTT/UNS endpoint and generated MQTT producer
- Add `seattle_911_mqtt` feeder package and `Dockerfile.mqtt`
- Add deterministic `incident_type_slug` and UTC incident time for routing/CE time
- Add Docker E2E matrix/build+flow coverage

## Topic tree
- `civic-events/us/wa/seattle/public-safety/fire-dispatch/{incident_type_slug}/{incident_number}`
- QoS 1, non-retained event stream, 24h message-expiry for queued/offline delivery

## Specialist review
- xRegistry Expert: no MUST-FIX; verified no schema fork, correct `basemessageurl`, required/non-null placeholders, no `messageid`/`messagegroupid`, subject compatibility. SHOULD-FIX field docs/time typing addressed.
- UNS Catalog Architect: MUST-FIX retain semantics, slug determinism, region axis/taxonomy, and UTC timestamp. Fixed by making incident events non-retained, adding required `incident_type_slug`, moving to `civic-events/us/wa/seattle/public-safety/fire-dispatch/...`, and adding `incident_datetime_utc` as CE time.

## Validation
- `xrcg validate --definitions seattle-911/xreg/seattle_911.xreg.json` ✅
- `python -m pytest seattle-911/tests -q -x` with generated packages on `PYTHONPATH` ✅ (7 passed)
- `python -m pytest tests/docker_e2e/test_docker_mqtt_flow.py::TestSeattle911MqttDockerFlow -q -x` ✅ (1 passed)
