### PR TITLE
mqtt(paris-bicycle-counters): add MQTT UNS feeder

### DIFF
--- a/paris-bicycle-counters/CONTAINER.md
+++ b/paris-bicycle-counters/CONTAINER.md
@@ -10,6 +10,8 @@ The City of Paris provides publicly available bicycle counting data through the 
 
 The bridge polls the Paris Open Data bicycle counter API and writes new observations to a Kafka topic as [CloudEvents](https://cloudevents.io/) in JSON format, documented in [EVENTS.md](EVENTS.md). Previously seen counter_id + date pairs are tracked in a state file to prevent duplicates.
 
+An MQTT/UNS variant is available via `Dockerfile.mqtt`. It publishes MQTT 5.0 binary-mode CloudEvents under `traffic/fr/paris/paris-bicycle-counters/{counter_id}/{event}`: retained QoS 1 counter `info` records and non-retained QoS 1 hourly `count` events.
+
 ## Database Schemas and Handling
 
 If you want to build a full data pipeline with all events ingested into a
@@ -56,6 +58,20 @@ $ docker run --rm \
     -e CONNECTION_STRING='<connection-string>' \
     ghcr.io/clemensv/real-time-sources-paris-bicycle-counters:latest
 ```
+
+### With an MQTT Broker
+
+Build or pull the MQTT image and provide an MQTT broker URL:
+
+```shell
+$ docker build -f Dockerfile.mqtt -t paris-bicycle-counters-mqtt .
+$ docker run --rm \
+    -e MQTT_BROKER_URL='mqtt://broker:1883' \
+    -e ONCE_MODE='true' \
+    paris-bicycle-counters-mqtt
+```
+
+Optional MQTT environment variables are `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_CLIENT_ID`, `MQTT_CONTENT_MODE` (`binary` or `structured`), and `PARIS_BICYCLE_COUNTERS_MQTT_STATE_FILE`.
 
 ### Preserving State Between Restarts
 

--- a/paris-bicycle-counters/Dockerfile.mqtt
+++ b/paris-bicycle-counters/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/paris-bicycle-counters"
+LABEL org.opencontainers.image.title="Paris bicycle counters → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls Paris Open Data bicycle counters and publishes MQTT 5.0 binary-mode CloudEvents into traffic/fr/paris/paris-bicycle-counters/{counter_id}/... topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/paris-bicycle-counters/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data \
+ && pip install --no-cache-dir ./paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./paris_bicycle_counters_producer/paris_bicycle_counters_producer_data \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./paris_bicycle_counters_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "paris_bicycle_counters_mqtt", "feed"]

--- a/paris-bicycle-counters/EVENTS.md
+++ b/paris-bicycle-counters/EVENTS.md
@@ -1,5 +1,14 @@
 # Table of Contents
 
+## MQTT/UNS topics
+
+The MQTT feeder publishes binary-mode CloudEvents under `traffic/fr/paris/paris-bicycle-counters/{counter_id}/{event}`:
+
+- `traffic/fr/paris/paris-bicycle-counters/{counter_id}/info` — retained QoS 1 counter reference records.
+- `traffic/fr/paris/paris-bicycle-counters/{counter_id}/count` — non-retained QoS 1 hourly bicycle count events.
+
+Recommended bootstrap flow: subscribe to `traffic/fr/paris/paris-bicycle-counters/+/info` first to populate a retained counter cache, then subscribe to `traffic/fr/paris/paris-bicycle-counters/+/count` for live count events. Example subscriptions: all Paris bicycle counter events: `traffic/fr/paris/paris-bicycle-counters/#`; one counter: `traffic/fr/paris/paris-bicycle-counters/{counter_id}/#`; live count events only: `traffic/fr/paris/paris-bicycle-counters/+/count`.
+
 - [FR.Paris.OpenData.Velo](#message-group-frparisopendatavelo)
   - [FR.Paris.OpenData.Velo.Counter](#message-frparisopendatavelocounter)
   - [FR.Paris.OpenData.Velo.BicycleCount](#message-frparisopendatavelobicyclecount)
@@ -21,6 +30,7 @@
 *Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.*
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
+| `ce_id` | *string* | - | `True` | Deterministic CloudEvents id for the retained counter reference record. |
 | `counter_id` | *string* | - | `True` | Unique identifier for the counting channel, combining the site ID and channel ID (mapped from 'id_compteur'). |
 | `counter_name` | *string* | - | `True` | Human-readable name of the counter including street name and direction (mapped from 'nom_compteur'). |
 | `channel_name` | *string* (optional) | - | `False` | Directional channel label for the counter, e.g. 'SE-NO' or 'E-O' (mapped from 'channel_name'). |
@@ -41,6 +51,7 @@
 *Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.*
 | **Field Name** | **Type** | **Unit** | **Required** | **Description** |
 |----------------|----------|----------|--------------|-----------------|
+| `ce_id` | *string* | - | `True` | Deterministic CloudEvents id composed from counter_id and hourly count date. |
 | `counter_id` | *string* | - | `True` | Unique identifier for the counting channel (mapped from 'id_compteur'). |
 | `counter_name` | *string* | - | `True` | Human-readable name of the counter including street name and direction (mapped from 'nom_compteur'). |
 | `count` | *integer* (optional) | - | `False` | Number of bicycles counted during the one-hour window (mapped from 'sum_counts'). |

--- a/paris-bicycle-counters/README.md
+++ b/paris-bicycle-counters/README.md
@@ -10,6 +10,7 @@
 - **Counter Reference Data**: Fetch counter location metadata from `https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/comptage-velo-compteurs/records`.
 - **Deduplication**: Tracks seen counter_id + date pairs in a state file to avoid reprocessing.
 - **Kafka Integration**: Send bicycle counts to a Kafka topic using SASL PLAIN authentication.
+- **MQTT/UNS Integration**: The MQTT variant publishes to `traffic/fr/paris/paris-bicycle-counters/{counter_id}/{info|count}` with retained counter info and non-retained count events.
 - **CloudEvents**: All events are formatted as CloudEvents, documented in [EVENTS.md](EVENTS.md).
 - **Fabric notebook hosting**: deploy as a scheduled Fabric notebook via [`tools/deploy-fabric/deploy-feeder-notebook.ps1`](../tools/deploy-fabric/deploy-feeder-notebook.ps1) using [`notebook/paris-bicycle-counters-feed.ipynb`](notebook/paris-bicycle-counters-feed.ipynb).
 

--- a/paris-bicycle-counters/generate_mqtt_producer.ps1
+++ b/paris-bicycle-counters/generate_mqtt_producer.ps1
@@ -1,0 +1,11 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\paris_bicycle_counters.xreg.json `
+    --endpoint FR.Paris.OpenData.Velo.Mqtt `
+    --projectname paris_bicycle_counters_mqtt_producer `
+    --output paris_bicycle_counters_mqtt_producer

--- a/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
+++ b/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
@@ -10,6 +10,7 @@ import os
 import json
 import sys
 import time
+import hashlib
 from typing import Dict, List, Optional, Set, Tuple
 from datetime import datetime, timezone, timedelta
 import argparse
@@ -21,6 +22,21 @@ from paris_bicycle_counters_producer_kafka_producer.producer import FRParisOpenD
 
 COUNTER_DATA_URL = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/comptage-velo-donnees-compteurs/records"
 COUNTER_LOCATIONS_URL = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/comptage-velo-compteurs/records"
+
+
+def ce_datetime(value: datetime) -> str:
+    """Return a stable UTC-ish timestamp string for CloudEvents ids."""
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def is_topic_safe_segment(value: str) -> bool:
+    return bool(value) and not any(ch in value for ch in ('/', '+', '#', '\x00'))
+
+
+def counter_info_ce_id(counter_id: str, fields: Dict[str, object]) -> str:
+    encoded = json.dumps(fields, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+    return f"{counter_id}/info/{digest}"
 
 
 class ParisBicycleCounterPoller:
@@ -92,13 +108,21 @@ class ParisBicycleCounterPoller:
                 break
             for record in results:
                 coords = record.get("coordinates") or {}
+                counter_id = record.get("id_compteur", "")
+                if not is_topic_safe_segment(counter_id):
+                    print(f"Skipping counter with MQTT-unsafe id_compteur={counter_id!r}", file=sys.stderr)
+                    continue
+                fields = {
+                    "counter_name": record.get("nom_compteur", ""),
+                    "channel_name": record.get("channel_name"),
+                    "installation_date": record.get("installation_date"),
+                    "longitude": coords.get("lon"),
+                    "latitude": coords.get("lat"),
+                }
                 counter = Counter(
-                    counter_id=record.get("id_compteur", ""),
-                    counter_name=record.get("nom_compteur", ""),
-                    channel_name=record.get("channel_name"),
-                    installation_date=record.get("installation_date"),
-                    longitude=coords.get("lon"),
-                    latitude=coords.get("lat"),
+                    ce_id=counter_info_ce_id(counter_id, fields),
+                    counter_id=counter_id,
+                    **fields,
                 )
                 counters.append(counter)
             if len(results) < limit:
@@ -149,8 +173,13 @@ class ParisBicycleCounterPoller:
                     date_val = datetime.fromisoformat(date_str)
                 except (ValueError, TypeError):
                     continue
+                counter_id = record.get("id_compteur", "")
+                if not is_topic_safe_segment(counter_id):
+                    print(f"Skipping count with MQTT-unsafe id_compteur={counter_id!r}", file=sys.stderr)
+                    continue
                 bc = BicycleCount(
-                    counter_id=record.get("id_compteur", ""),
+                    ce_id=f"{counter_id}/{ce_datetime(date_val)}/count",
+                    counter_id=counter_id,
                     counter_name=record.get("nom_compteur", ""),
                     count=record.get("sum_counts"),
                     date=date_val,
@@ -205,7 +234,7 @@ class ParisBicycleCounterPoller:
         counters = self.fetch_counter_locations()
         for counter in counters:
             self.producer.send_fr_paris_open_data_velo_counter(
-                counter.counter_id, counter, flush_producer=False)
+                counter.counter_id, counter.ce_id, counter, flush_producer=False)
         self.producer.producer.flush()
         print(f"Sent {len(counters)} counter locations as reference data")
 
@@ -223,7 +252,7 @@ class ParisBicycleCounterPoller:
 
                 for bc in new_counts:
                     self.producer.send_fr_paris_open_data_velo_bicycle_count(
-                        bc.counter_id, bc, flush_producer=False)
+                        bc.counter_id, bc.ce_id, ce_datetime(bc.date), bc, flush_producer=False)
                 self.producer.producer.flush()
 
                 # Trim seen_keys to last 48h worth of keys to avoid unbounded growth

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/__init__.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/__init__.py
@@ -1,0 +1,5 @@
+"""MQTT/UNS bridge for Paris bicycle counters."""
+
+from .app import main
+
+__all__ = ["main"]

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/__main__.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/app.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/app.py
@@ -1,0 +1,145 @@
+"""MQTT feeder application for Paris bicycle counters → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Set
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from paris_bicycle_counters.paris_bicycle_counters import ParisBicycleCounterPoller
+from paris_bicycle_counters_mqtt_producer_mqtt_client.client import FRParisOpenDataVeloMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+class ParisBicycleCounterMqttPoller(ParisBicycleCounterPoller):
+    def __init__(self, mqtt_client: FRParisOpenDataVeloMqttMqttClient, last_polled_file: str):
+        self.kafka_topic = ""
+        self.last_polled_file = last_polled_file
+        self.producer = mqtt_client
+
+    async def poll_and_send_async(self, once: bool = False) -> None:
+        logger.info("Starting Paris Bicycle Counter MQTT poller (once=%s)", once)
+        while True:
+            counters = self.fetch_counter_locations()
+            for counter in counters:
+                await self.producer.publish_fr_paris_open_data_velo_mqtt_counter(
+                    counter_id=counter.counter_id,
+                    ce_id=counter.ce_id,
+                    data=counter,
+                )
+            logger.info("Published %d retained counter info records", len(counters))
+
+            state = self.load_state()
+            seen_keys: Set[str] = set(state.get("seen_keys", []))
+            since = datetime.now(timezone.utc) - timedelta(days=7)
+            counts = self.fetch_bicycle_counts(since=since)
+            new_counts, seen_keys = self.dedup_counts(counts, seen_keys)
+            for count in new_counts:
+                await self.producer.publish_fr_paris_open_data_velo_mqtt_bicycle_count(
+                    counter_id=count.counter_id,
+                    ce_id=count.ce_id,
+                    date=count.date.isoformat().replace("+00:00", "Z") if hasattr(count.date, "isoformat") else str(count.date),
+                    data=count,
+                )
+
+            cutoff = datetime.now(timezone.utc) - timedelta(days=14)
+            trimmed_keys: Set[str] = set()
+            for key in seen_keys:
+                try:
+                    date_part = key.split("|", 1)[1]
+                    dt = datetime.fromisoformat(date_part)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    if dt >= cutoff:
+                        trimmed_keys.add(key)
+                except (IndexError, ValueError):
+                    trimmed_keys.add(key)
+            state["seen_keys"] = list(trimmed_keys)
+            self.save_state(state)
+            logger.info("Polled %d count records, published %d new count events", len(counts), len(new_counts))
+
+            if once:
+                return
+            await asyncio.sleep(self.POLL_INTERVAL_SECONDS)
+
+
+async def feed(
+    broker_host: str,
+    broker_port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    state_file: str = "",
+    once: bool = False,
+    content_mode: str = "binary",
+) -> None:
+    paho_client = mqtt.Client(
+        callback_api_version=CallbackAPIVersion.VERSION2,
+        client_id=client_id or "",
+        protocol=MQTTv5,
+    )
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+
+    mqtt_client = FRParisOpenDataVeloMqttMqttClient(
+        client=paho_client,
+        content_mode=content_mode,  # type: ignore[arg-type]
+        loop=asyncio.get_running_loop(),
+    )
+    await mqtt_client.connect(broker_host, broker_port)
+    try:
+        poller = ParisBicycleCounterMqttPoller(
+            mqtt_client,
+            state_file or os.path.expanduser("~/.paris_bicycle_counters_mqtt_state.json"),
+        )
+        await poller.poll_and_send_async(once=once)
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Paris bicycle counters MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--state-file", default=os.getenv("PARIS_BICYCLE_COUNTERS_MQTT_STATE_FILE", os.getenv("STATE_FILE", "")))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(
+        host,
+        port,
+        username=args.username or None,
+        password=args.password or None,
+        tls=tls,
+        client_id=args.client_id or None,
+        state_file=args.state_file,
+        once=args.once,
+        content_mode=args.content_mode,
+    ))

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt/pyproject.toml
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "paris-bicycle-counters-mqtt"
+version = "0.1.0"
+description = "Paris bicycle counters bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+paris_bicycle_counters_mqtt_producer_data = {path = "../paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data"}
+paris_bicycle_counters_mqtt_producer_mqtt_client = {path = "../paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+paris-bicycle-counters-mqtt = "paris_bicycle_counters_mqtt:main"

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/Makefile
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./paris_bicycle_counters_mqtt_producer_data ./paris_bicycle_counters_mqtt_producer_mqtt_client
+
+install: build
+	cd paris_bicycle_counters_mqtt_producer_data && poetry install
+	cd paris_bicycle_counters_mqtt_producer_mqtt_client && poetry install
+	pip install ./paris_bicycle_counters_mqtt_producer_data ./paris_bicycle_counters_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./paris_bicycle_counters_mqtt_producer_mqtt_client/tests ./paris_bicycle_counters_mqtt_producer_data/tests

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/README.md
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/README.md
@@ -1,0 +1,1081 @@
+# Paris_bicycle_counters_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the paris_bicycle_counters_mqtt_producer message definitions.
+
+# Paris_bicycle_counters_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - FRParisOpenDataVeloMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from paris_bicycle_counters_mqtt_producer_mqtt_client import *This module defines an event processing framework for
+Azure Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = FRParisOpenDataVeloMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### FRParisOpenDataVeloMqttEventDispatcher
+
+
+
+# Publish message`FRParisOpenDataVeloMqttEventDispatcher` handles events for the FR.Paris.OpenData.Velo.mqtt message
+group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from paris_bicycle_counters_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = FRParisOpenDataVeloMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the
+Event Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe FRParisOpenDataVeloMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `fr_paris_open_data_velo_mqtt_counter_async`
+
+
+
+## Test```python
+
+fr_paris_open_data_velo_mqtt_counter_async:  Callable[[PartitionContext, EventData, CloudEvent, Counter],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `FR.Paris.OpenData.Velo.mqtt.Counter`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `paris_bicycle_counters_mqtt_producer_data.Counter`.
+
+Example:
+
+```python
+async def fr_paris_open_data_velo_mqtt_counter_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: Counter) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_mqtt_counter_async =
+fr_paris_open_data_velo_mqtt_counter_event
+```
+
+
+
+make build
+
+```##### `fr_paris_open_data_velo_mqtt_bicycle_count_async`
+
+
+
+## Test```python
+
+fr_paris_open_data_velo_mqtt_bicycle_count_async:  Callable[[PartitionContext, EventData, CloudEvent, BicycleCount],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `FR.Paris.OpenData.Velo.mqtt.BicycleCount`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `paris_bicycle_counters_mqtt_producer_data.BicycleCount`.
+
+Example:
+
+```python
+async def fr_paris_open_data_velo_mqtt_bicycle_count_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: BicycleCount) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_mqtt_bicycle_count_async =
+fr_paris_open_data_velo_mqtt_bicycle_count_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/install.bat
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\paris_bicycle_counters_mqtt_producer_data
+pip install .\paris_bicycle_counters_mqtt_producer_mqtt_client

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/install.sh
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./paris_bicycle_counters_mqtt_producer_data
+pip install ./paris_bicycle_counters_mqtt_producer_mqtt_client

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/pyproject.toml
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "paris-bicycle-counters-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "paris_bicycle_counters_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/__init__.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .counter import Counter
+from .bicyclecount import BicycleCount
+
+__all__ = ["Counter", "BicycleCount"]

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/bicyclecount.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/bicyclecount.py
@@ -1,4 +1,4 @@
-""" Counter dataclass. """
+""" BicycleCount dataclass. """
 
 # pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
 from __future__ import annotations
@@ -10,20 +10,22 @@ import dataclasses
 from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
 import json
+import datetime
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
-class Counter:
+class BicycleCount:
     """
-    Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.
+    Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.
     
     Attributes:
         counter_id (str)
         counter_name (str)
-        channel_name (typing.Optional[str])
-        installation_date (typing.Optional[str])
+        count (typing.Optional[int])
+        date (datetime.datetime)
         longitude (typing.Optional[float])
         latitude (typing.Optional[float])
         ce_id (str)
@@ -32,14 +34,14 @@ class Counter:
     
     counter_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="counter_id"))
     counter_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="counter_name"))
-    channel_name: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="channel_name"))
-    installation_date: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="installation_date"))
+    count: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="count"))
+    date: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="date", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
     ce_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ce_id"))
 
     @classmethod
-    def from_serializer_dict(cls, data: dict) -> 'Counter':
+    def from_serializer_dict(cls, data: dict) -> 'BicycleCount':
         """
         Converts a dictionary to a dataclass instance.
         
@@ -112,7 +114,7 @@ class Counter:
         return result
 
     @classmethod
-    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['Counter']:
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['BicycleCount']:
         """
         Converts the data to a dataclass based on the content type string.
         
@@ -149,13 +151,13 @@ class Counter:
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
                 _record = json.loads(data_str)
-                return Counter.from_serializer_dict(_record)
+                return BicycleCount.from_serializer_dict(_record)
             else:
                 raise NotImplementedError('Data is not of a supported type for JSON deserialization')
         raise NotImplementedError(f'Unsupported media type {content_type}')
 
     @classmethod
-    def create_instance(cls) -> 'Counter':
+    def create_instance(cls) -> 'BicycleCount':
         """
         Creates an instance of the dataclass with test values.
         
@@ -163,11 +165,11 @@ class Counter:
             An instance of the dataclass.
         """
         return cls(
-            counter_id='calenwkulyhdiqztweae',
-            counter_name='sndpxhkutaruqtilujxi',
-            channel_name='yvrfxujkcujxbapaaxka',
-            installation_date='qtypxthvuhgoisznxotg',
-            longitude=float(71.2167451470225),
-            latitude=float(13.712512642205986),
-            ce_id='eflsyyzzhstvorwptpfx'
+            counter_id='clmiyfivbfqopvtrwtxs',
+            counter_name='qrzqmsqqhpawxlqpyozw',
+            count=int(13),
+            date=datetime.datetime.now(datetime.timezone.utc),
+            longitude=float(95.62318596124648),
+            latitude=float(41.19340357462205),
+            ce_id='nrteytgvuaydqfiqmxup'
         )

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/counter.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/src/paris_bicycle_counters_mqtt_producer_data/counter.py
@@ -163,11 +163,11 @@ class Counter:
             An instance of the dataclass.
         """
         return cls(
-            counter_id='calenwkulyhdiqztweae',
-            counter_name='sndpxhkutaruqtilujxi',
-            channel_name='yvrfxujkcujxbapaaxka',
-            installation_date='qtypxthvuhgoisznxotg',
-            longitude=float(71.2167451470225),
-            latitude=float(13.712512642205986),
-            ce_id='eflsyyzzhstvorwptpfx'
+            counter_id='qtojhzqfgitklimlfrvk',
+            counter_name='fhnsfarhbuiyegdwptgk',
+            channel_name='pttvepgtkhcxfbkxqesg',
+            installation_date='ublkmnjtxqszumspgheg',
+            longitude=float(86.69705413883321),
+            latitude=float(71.09077304312967),
+            ce_id='dqikvwoumjjpmcjkqjdj'
         )

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/tests/test_bicyclecount.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/tests/test_bicyclecount.py
@@ -1,5 +1,5 @@
 """
-Test case for Counter
+Test case for BicycleCount
 """
 
 import os
@@ -8,33 +8,34 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from paris_bicycle_counters_producer_data.counter import Counter
+from paris_bicycle_counters_mqtt_producer_data.bicyclecount import BicycleCount
+import datetime
 
 
-class Test_Counter(unittest.TestCase):
+class Test_BicycleCount(unittest.TestCase):
     """
-    Test case for Counter
+    Test case for BicycleCount
     """
 
     def setUp(self):
         """
         Set up test case
         """
-        self.instance = Test_Counter.create_instance()
+        self.instance = Test_BicycleCount.create_instance()
 
     @staticmethod
     def create_instance():
         """
-        Create instance of Counter for testing
+        Create instance of BicycleCount for testing
         """
-        instance = Counter(
-            counter_id='calenwkulyhdiqztweae',
-            counter_name='sndpxhkutaruqtilujxi',
-            channel_name='yvrfxujkcujxbapaaxka',
-            installation_date='qtypxthvuhgoisznxotg',
-            longitude=float(71.2167451470225),
-            latitude=float(13.712512642205986),
-            ce_id='eflsyyzzhstvorwptpfx'
+        instance = BicycleCount(
+            counter_id='clmiyfivbfqopvtrwtxs',
+            counter_name='qrzqmsqqhpawxlqpyozw',
+            count=int(13),
+            date=datetime.datetime.now(datetime.timezone.utc),
+            longitude=float(95.62318596124648),
+            latitude=float(41.19340357462205),
+            ce_id='nrteytgvuaydqfiqmxup'
         )
         return instance
 
@@ -43,7 +44,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test counter_id property
         """
-        test_value = 'calenwkulyhdiqztweae'
+        test_value = 'clmiyfivbfqopvtrwtxs'
         self.instance.counter_id = test_value
         self.assertEqual(self.instance.counter_id, test_value)
     
@@ -51,31 +52,31 @@ class Test_Counter(unittest.TestCase):
         """
         Test counter_name property
         """
-        test_value = 'sndpxhkutaruqtilujxi'
+        test_value = 'qrzqmsqqhpawxlqpyozw'
         self.instance.counter_name = test_value
         self.assertEqual(self.instance.counter_name, test_value)
     
-    def test_channel_name_property(self):
+    def test_count_property(self):
         """
-        Test channel_name property
+        Test count property
         """
-        test_value = 'yvrfxujkcujxbapaaxka'
-        self.instance.channel_name = test_value
-        self.assertEqual(self.instance.channel_name, test_value)
+        test_value = int(13)
+        self.instance.count = test_value
+        self.assertEqual(self.instance.count, test_value)
     
-    def test_installation_date_property(self):
+    def test_date_property(self):
         """
-        Test installation_date property
+        Test date property
         """
-        test_value = 'qtypxthvuhgoisznxotg'
-        self.instance.installation_date = test_value
-        self.assertEqual(self.instance.installation_date, test_value)
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.date = test_value
+        self.assertEqual(self.instance.date, test_value)
     
     def test_longitude_property(self):
         """
         Test longitude property
         """
-        test_value = float(71.2167451470225)
+        test_value = float(95.62318596124648)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -83,7 +84,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(13.712512642205986)
+        test_value = float(41.19340357462205)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -91,7 +92,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test ce_id property
         """
-        test_value = 'eflsyyzzhstvorwptpfx'
+        test_value = 'nrteytgvuaydqfiqmxup'
         self.instance.ce_id = test_value
         self.assertEqual(self.instance.ce_id, test_value)
     
@@ -101,7 +102,7 @@ class Test_Counter(unittest.TestCase):
         """
         media_type = "application/json"
         bytes_data = self.instance.to_byte_array(media_type)
-        new_instance = Counter.from_data(bytes_data, media_type)
+        new_instance = BicycleCount.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
 
@@ -110,7 +111,7 @@ class Test_Counter(unittest.TestCase):
         Test to_json method
         """
         json_data = self.instance.to_json()
-        new_instance = Counter.from_json(json_data)
+        new_instance = BicycleCount.from_json(json_data)
         json_data2 = new_instance.to_json()
         self.assertEqual(json_data, json_data2)
 

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/tests/test_counter.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_data/tests/test_counter.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from paris_bicycle_counters_producer_data.counter import Counter
+from paris_bicycle_counters_mqtt_producer_data.counter import Counter
 
 
 class Test_Counter(unittest.TestCase):
@@ -28,13 +28,13 @@ class Test_Counter(unittest.TestCase):
         Create instance of Counter for testing
         """
         instance = Counter(
-            counter_id='calenwkulyhdiqztweae',
-            counter_name='sndpxhkutaruqtilujxi',
-            channel_name='yvrfxujkcujxbapaaxka',
-            installation_date='qtypxthvuhgoisznxotg',
-            longitude=float(71.2167451470225),
-            latitude=float(13.712512642205986),
-            ce_id='eflsyyzzhstvorwptpfx'
+            counter_id='qtojhzqfgitklimlfrvk',
+            counter_name='fhnsfarhbuiyegdwptgk',
+            channel_name='pttvepgtkhcxfbkxqesg',
+            installation_date='ublkmnjtxqszumspgheg',
+            longitude=float(86.69705413883321),
+            latitude=float(71.09077304312967),
+            ce_id='dqikvwoumjjpmcjkqjdj'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test counter_id property
         """
-        test_value = 'calenwkulyhdiqztweae'
+        test_value = 'qtojhzqfgitklimlfrvk'
         self.instance.counter_id = test_value
         self.assertEqual(self.instance.counter_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test counter_name property
         """
-        test_value = 'sndpxhkutaruqtilujxi'
+        test_value = 'fhnsfarhbuiyegdwptgk'
         self.instance.counter_name = test_value
         self.assertEqual(self.instance.counter_name, test_value)
     
@@ -59,7 +59,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test channel_name property
         """
-        test_value = 'yvrfxujkcujxbapaaxka'
+        test_value = 'pttvepgtkhcxfbkxqesg'
         self.instance.channel_name = test_value
         self.assertEqual(self.instance.channel_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test installation_date property
         """
-        test_value = 'qtypxthvuhgoisznxotg'
+        test_value = 'ublkmnjtxqszumspgheg'
         self.instance.installation_date = test_value
         self.assertEqual(self.instance.installation_date, test_value)
     
@@ -75,7 +75,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(71.2167451470225)
+        test_value = float(86.69705413883321)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -83,7 +83,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(13.712512642205986)
+        test_value = float(71.09077304312967)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -91,7 +91,7 @@ class Test_Counter(unittest.TestCase):
         """
         Test ce_id property
         """
-        test_value = 'eflsyyzzhstvorwptpfx'
+        test_value = 'dqikvwoumjjpmcjkqjdj'
         self.instance.ce_id = test_value
         self.assertEqual(self.instance.ce_id, test_value)
     

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/pyproject.toml
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "paris-bicycle-counters-mqtt-producer-mqtt-client"
+description = "paris_bicycle_counters_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "paris_bicycle_counters_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+paris-bicycle-counters-mqtt-producer-data = {path = "../paris_bicycle_counters_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/src/paris_bicycle_counters_mqtt_producer_mqtt_client/__init__.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/src/paris_bicycle_counters_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import FRParisOpenDataVeloMqttMqttClient
+
+__all__ = [
+    "FRParisOpenDataVeloMqttMqttClient",
+]

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/src/paris_bicycle_counters_mqtt_producer_mqtt_client/client.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/src/paris_bicycle_counters_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,516 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import paris_bicycle_counters_mqtt_producer_data
+from paris_bicycle_counters_mqtt_producer_data import Counter
+from paris_bicycle_counters_mqtt_producer_data import BicycleCount
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_fr_paris_opendata_velo_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the FR.Paris.OpenData.Velo.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "FR.Paris.OpenData.Velo.mqtt.Counter": "traffic/fr/paris/paris-bicycle-counters/{counter_id}/info",
+        "FR.Paris.OpenData.Velo.mqtt.BicycleCount": "traffic/fr/paris/paris-bicycle-counters/{counter_id}/count",
+    }
+
+
+def get_subscription_topics_fr_paris_opendata_velo_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_fr_paris_opendata_velo_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class FRParisOpenDataVeloMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the FR.Paris.OpenData.Velo.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_fr_paris_opendata_velo_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.fr_paris_open_data_velo_mqtt_counter_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, paris_bicycle_counters_mqtt_producer_data.Counter, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.fr_paris_open_data_velo_mqtt_bicycle_count_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, paris_bicycle_counters_mqtt_producer_data.BicycleCount, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "FR.Paris.OpenData.Velo.Counter":
+            if self.fr_paris_open_data_velo_mqtt_counter_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = paris_bicycle_counters_mqtt_producer_data.Counter.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "FR.Paris.OpenData.Velo.mqtt.Counter")
+                    await self.fr_paris_open_data_velo_mqtt_counter_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in fr_paris_open_data_velo_mqtt_counter handler: {e}")
+            return
+        
+        if event_type == "FR.Paris.OpenData.Velo.BicycleCount":
+            if self.fr_paris_open_data_velo_mqtt_bicycle_count_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = paris_bicycle_counters_mqtt_producer_data.BicycleCount.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "FR.Paris.OpenData.Velo.mqtt.BicycleCount")
+                    await self.fr_paris_open_data_velo_mqtt_bicycle_count_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in fr_paris_open_data_velo_mqtt_bicycle_count handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_fr_paris_opendata_velo_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_fr_paris_open_data_velo_mqtt_counter(self,
+        counter_id: str,
+        ce_id: str,
+        data: paris_bicycle_counters_mqtt_producer_data.Counter,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'FR.Paris.OpenData.Velo.mqtt.Counter' event to an MQTT topic.
+
+        Args:
+        
+            counter_id: URI template variable for 'counter_id'
+            ce_id: URI template variable for 'ce_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'traffic/fr/paris/paris-bicycle-counters/{counter_id}/info'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "traffic/fr/paris/paris-bicycle-counters/{counter_id}/info"
+        _topic_template_values: Dict[str, str] = {
+            "counter_id": str(counter_id),
+            "ce_id": str(ce_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"FR.Paris.OpenData.Velo.Counter",
+             "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-compteurs",
+             "subject":"{counter_id}".format(counter_id = counter_id),
+             "id":"{ce_id}".format(ce_id = ce_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_fr_paris_open_data_velo_mqtt_bicycle_count(self,
+        counter_id: str,
+        ce_id: str,
+        date: str,
+        data: paris_bicycle_counters_mqtt_producer_data.BicycleCount,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'FR.Paris.OpenData.Velo.mqtt.BicycleCount' event to an MQTT topic.
+
+        Args:
+        
+            counter_id: URI template variable for 'counter_id'
+            ce_id: URI template variable for 'ce_id'
+            date: URI template variable for 'date'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'traffic/fr/paris/paris-bicycle-counters/{counter_id}/count'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "traffic/fr/paris/paris-bicycle-counters/{counter_id}/count"
+        _topic_template_values: Dict[str, str] = {
+            "counter_id": str(counter_id),
+            "ce_id": str(ce_id),
+            "date": str(date),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"FR.Paris.OpenData.Velo.BicycleCount",
+             "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-donnees-compteurs",
+             "subject":"{counter_id}".format(counter_id = counter_id),
+             "id":"{ce_id}".format(ce_id = ce_id),
+             "time":"{date}".format(date = date)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/paris_bicycle_counters_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,179 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../paris_bicycle_counters_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../paris_bicycle_counters_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../paris_bicycle_counters_mqtt_producer_mqtt_client/src')))
+
+import paris_bicycle_counters_mqtt_producer_data
+from paris_bicycle_counters_mqtt_producer_data import Counter
+from test_paris_bicycle_counters_mqtt_producer_data_counter import Test_Counter
+from paris_bicycle_counters_mqtt_producer_data import BicycleCount
+from test_paris_bicycle_counters_mqtt_producer_data_bicyclecount import Test_BicycleCount
+from paris_bicycle_counters_mqtt_producer_mqtt_client import FRParisOpenDataVeloMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_fr_paris_opendata_velo_mqtt_fr_paris_open_data_velo_mqtt_counter_py(mosquitto_broker):
+    """Test publishing and receiving FR.Paris.OpenData.Velo.mqtt.Counter message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Counter.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = FRParisOpenDataVeloMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = FRParisOpenDataVeloMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_fr_paris_open_data_velo_mqtt_counter(mqtt_msg, cloud_event, data: paris_bicycle_counters_mqtt_producer_data.Counter, topic_params: dict):
+        """Handler for FR.Paris.OpenData.Velo.mqtt.Counter messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "FR.Paris.OpenData.Velo.Counter"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.fr_paris_open_data_velo_mqtt_counter_async = on_fr_paris_open_data_velo_mqtt_counter
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/fr_paris_opendata_velo_mqtt/fr_paris_open_data_velo_mqtt_counter"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_fr_paris_open_data_velo_mqtt_counter(
+            topic=test_topic,
+            counter_id=f"test_counter_id_{i}",
+            ce_id=f"test_ce_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_fr_paris_opendata_velo_mqtt_fr_paris_open_data_velo_mqtt_bicycle_count_py(mosquitto_broker):
+    """Test publishing and receiving FR.Paris.OpenData.Velo.mqtt.BicycleCount message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_BicycleCount.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = FRParisOpenDataVeloMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = FRParisOpenDataVeloMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_fr_paris_open_data_velo_mqtt_bicycle_count(mqtt_msg, cloud_event, data: paris_bicycle_counters_mqtt_producer_data.BicycleCount, topic_params: dict):
+        """Handler for FR.Paris.OpenData.Velo.mqtt.BicycleCount messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "FR.Paris.OpenData.Velo.BicycleCount"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.fr_paris_open_data_velo_mqtt_bicycle_count_async = on_fr_paris_open_data_velo_mqtt_bicycle_count
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/fr_paris_opendata_velo_mqtt/fr_paris_open_data_velo_mqtt_bicycle_count"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_fr_paris_open_data_velo_mqtt_bicycle_count(
+            topic=test_topic,
+            counter_id=f"test_counter_id_{i}",
+            ce_id=f"test_ce_id_{i}",
+            date=f"test_date_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/samples/sample.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/samples/sample.py
@@ -1,0 +1,87 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from paris_bicycle_counters_mqtt_producer_data import *
+from paris_bicycle_counters_mqtt_producer_mqtt_client.client import FRParisOpenDataVeloMqttProducer, FRParisOpenDataVeloMqttDispatcher
+
+async def handle_fr_paris_open_data_velo_mqtt_counter(mqtt_msg,cloud_event, fr_paris_open_data_velo_mqtt_counter_data):
+    """ Handles the FR.Paris.OpenData.Velo.mqtt.Counter message """
+    print(f"Received FR.Paris.OpenData.Velo.mqtt.Counter on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {fr_paris_open_data_velo_mqtt_counter_data}")
+
+async def handle_fr_paris_open_data_velo_mqtt_bicycle_count(mqtt_msg,cloud_event, fr_paris_open_data_velo_mqtt_bicycle_count_data):
+    """ Handles the FR.Paris.OpenData.Velo.mqtt.BicycleCount message """
+    print(f"Received FR.Paris.OpenData.Velo.mqtt.BicycleCount on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {fr_paris_open_data_velo_mqtt_bicycle_count_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/scripts/build.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["paris_bicycle_counters_mqtt_producer_mqtt_client", "paris_bicycle_counters_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/README.md
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/README.md
@@ -15,7 +15,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 2. [What is Apache Kafka?](#what-is-apache-kafka)2. [Generated Event Dispatchers](#generated-event-dispatchers)
 
-3. [Quick Start](#quick-start)    - FRParisOpenDataVeloEventDispatcher
+3. [Quick Start](#quick-start)    - FRParisOpenDataVeloEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    FRParisOpenDataVeloMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -39,6 +41,10 @@ methods to handle various types of events.
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - FRParisOpenDataVeloProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- FRParisOpenDataVeloMqttProducersolution for event-driven applications.
 
 
 
@@ -190,6 +196,43 @@ fr_paris_open_data_velo_dispatcher.fr_paris_open_data_velo_counter_async = fr_pa
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloMqttProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.Counter`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_counter_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Counter) -> None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_counter_async = fr_paris_open_data_velo_counter_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -248,6 +291,45 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 fr_paris_open_data_velo_dispatcher.fr_paris_open_data_velo_bicycle_count_async =
+fr_paris_open_data_velo_bicycle_count_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloMqttProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.BicycleCount`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_bicycle_count_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+BicycleCount) -> None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_bicycle_count_async =
 fr_paris_open_data_velo_bicycle_count_event
 
 **Parameters:**```
@@ -451,6 +533,512 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_fr_paris_open_data_velo_bicycle_count_batch(```
+
+    messages=[
+
+        BicycleCount(...),Initializes the runner with a Kafka consumer.
+
+        BicycleCount(...),
+
+        BicycleCount(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### FRParisOpenDataVeloMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`FRParisOpenDataVeloMqttEventDispatcher` handles events for the FR.Paris.OpenData.Velo.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from paris-bicycle-counters-producer import FRParisOpenDataVeloProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = FRParisOpenDataVeloProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_fr_paris_open_data_velo_counter(```python
+
+    data=Counter(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The FRParisOpenDataVeloMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = FRParisOpenDataVeloProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `fr_paris_open_data_velo_mqtt_counter_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'fr_paris_open_data_velo_mqtt_counter_async:  Callable[[ConsumerRecord, CloudEvent,
+Counter], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `FR.Paris.OpenData.Velo.mqtt.Counter`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.Counter`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_mqtt_counter_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Counter) ->
+None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_dispatcher.fr_paris_open_data_velo_mqtt_counter_async =
+fr_paris_open_data_velo_mqtt_counter_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloMqttProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.Counter`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_mqtt_counter_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Counter) ->
+None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_mqtt_counter_async =
+fr_paris_open_data_velo_mqtt_counter_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `fr_paris_open_data_velo_mqtt_bicycle_count_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'fr_paris_open_data_velo_mqtt_bicycle_count_async:  Callable[[ConsumerRecord,
+CloudEvent, BicycleCount], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `FR.Paris.OpenData.Velo.mqtt.BicycleCount`:
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.BicycleCount`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_mqtt_bicycle_count_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+BicycleCount) -> None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_dispatcher.fr_paris_open_data_velo_mqtt_bicycle_count_async =
+fr_paris_open_data_velo_mqtt_bicycle_count_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### FRParisOpenDataVeloMqttProducer- `data`: The event data of type `paris_bicycle_counters_producer_data.BicycleCount`.
+
+
+
+Producer for `FR.Paris.OpenData.Velo.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def fr_paris_open_data_velo_mqtt_bicycle_count_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+BicycleCount) -> None:
+
+```python    # Process the event data
+
+FRParisOpenDataVeloMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+fr_paris_open_data_velo_mqtt_dispatcher.fr_paris_open_data_velo_mqtt_bicycle_count_async =
+fr_paris_open_data_velo_mqtt_bicycle_count_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_fr_paris_open_data_velo_mqtt_counter`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_fr_paris_open_data_velo_mqtt_counter(
+
+    self,##### `_process_event`
+
+    data: Counter,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `FR.Paris.OpenData.Velo.mqtt.Counter` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `Counter`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_fr_paris_open_data_velo_mqtt_counter(
+
+    data=Counter(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `FR.Paris.OpenData.Velo.mqtt.Counter` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_fr_paris_open_data_velo_mqtt_counter_batch(```
+
+    messages=[
+
+        Counter(...),Initializes the runner with a Kafka consumer.
+
+        Counter(...),
+
+        Counter(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_fr_paris_open_data_velo_mqtt_bicycle_count`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_fr_paris_open_data_velo_mqtt_bicycle_count(
+
+    self,##### `_process_event`
+
+    data: BicycleCount,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `FR.Paris.OpenData.Velo.mqtt.BicycleCount` message.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `BicycleCount`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_fr_paris_open_data_velo_mqtt_bicycle_count(
+
+    data=BicycleCount(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `FR.Paris.OpenData.Velo.mqtt.BicycleCount` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_fr_paris_open_data_velo_mqtt_bicycle_count_batch(```
 
     messages=[
 

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_data/src/paris_bicycle_counters_producer_data/bicyclecount.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_data/src/paris_bicycle_counters_producer_data/bicyclecount.py
@@ -28,6 +28,7 @@ class BicycleCount:
         date (datetime.datetime)
         longitude (typing.Optional[float])
         latitude (typing.Optional[float])
+        ce_id (str)
     """
     
     
@@ -37,6 +38,7 @@ class BicycleCount:
     date: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="date", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    ce_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ce_id"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'BicycleCount':
@@ -163,10 +165,11 @@ class BicycleCount:
             An instance of the dataclass.
         """
         return cls(
-            counter_id='hkivgivgzzedokfofbaj',
-            counter_name='hgllbjnpjxbhswbuikxt',
-            count=int(56),
+            counter_id='vfprdhkmwkfbftldiacq',
+            counter_name='mtpuvweukyvqxviasuko',
+            count=int(40),
             date=datetime.datetime.now(datetime.timezone.utc),
-            longitude=float(69.61782005974942),
-            latitude=float(16.70452305549611)
+            longitude=float(96.83450034853813),
+            latitude=float(9.275390082703494),
+            ce_id='edoeqyyhdrfsyhidftvs'
         )

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_data/tests/test_bicyclecount.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_data/tests/test_bicyclecount.py
@@ -29,12 +29,13 @@ class Test_BicycleCount(unittest.TestCase):
         Create instance of BicycleCount for testing
         """
         instance = BicycleCount(
-            counter_id='hkivgivgzzedokfofbaj',
-            counter_name='hgllbjnpjxbhswbuikxt',
-            count=int(56),
+            counter_id='vfprdhkmwkfbftldiacq',
+            counter_name='mtpuvweukyvqxviasuko',
+            count=int(40),
             date=datetime.datetime.now(datetime.timezone.utc),
-            longitude=float(69.61782005974942),
-            latitude=float(16.70452305549611)
+            longitude=float(96.83450034853813),
+            latitude=float(9.275390082703494),
+            ce_id='edoeqyyhdrfsyhidftvs'
         )
         return instance
 
@@ -43,7 +44,7 @@ class Test_BicycleCount(unittest.TestCase):
         """
         Test counter_id property
         """
-        test_value = 'hkivgivgzzedokfofbaj'
+        test_value = 'vfprdhkmwkfbftldiacq'
         self.instance.counter_id = test_value
         self.assertEqual(self.instance.counter_id, test_value)
     
@@ -51,7 +52,7 @@ class Test_BicycleCount(unittest.TestCase):
         """
         Test counter_name property
         """
-        test_value = 'hgllbjnpjxbhswbuikxt'
+        test_value = 'mtpuvweukyvqxviasuko'
         self.instance.counter_name = test_value
         self.assertEqual(self.instance.counter_name, test_value)
     
@@ -59,7 +60,7 @@ class Test_BicycleCount(unittest.TestCase):
         """
         Test count property
         """
-        test_value = int(56)
+        test_value = int(40)
         self.instance.count = test_value
         self.assertEqual(self.instance.count, test_value)
     
@@ -75,7 +76,7 @@ class Test_BicycleCount(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(69.61782005974942)
+        test_value = float(96.83450034853813)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -83,9 +84,17 @@ class Test_BicycleCount(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(16.70452305549611)
+        test_value = float(9.275390082703494)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
+    
+    def test_ce_id_property(self):
+        """
+        Test ce_id property
+        """
+        test_value = 'edoeqyyhdrfsyhidftvs'
+        self.instance.ce_id = test_value
+        self.assertEqual(self.instance.ce_id, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_kafka_producer/src/paris_bicycle_counters_producer_kafka_producer/producer.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_kafka_producer/src/paris_bicycle_counters_producer_kafka_producer/producer.py
@@ -41,12 +41,13 @@ class FRParisOpenDataVeloEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_fr_paris_open_data_velo_counter(self,_counter_id : str, data: Counter, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Counter], str]=None) -> None:
+    def send_fr_paris_open_data_velo_counter(self,_counter_id : str, _ce_id : str, data: Counter, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Counter], str]=None) -> None:
         """
         Sends the 'FR.Paris.OpenData.Velo.Counter' event to the Kafka topic
 
         Args:
             _counter_id(str):  Value for placeholder counter_id in attribute subject
+            _ce_id(str):  Value for placeholder ce_id in attribute id
             data: (Counter): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
@@ -57,7 +58,8 @@ class FRParisOpenDataVeloEventProducer:
         attributes = {
              "type":"FR.Paris.OpenData.Velo.Counter",
              "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-compteurs",
-             "subject":"{counter_id}".format(counter_id = _counter_id)
+             "subject":"{counter_id}".format(counter_id = _counter_id),
+             "id":"{ce_id}".format(ce_id = _ce_id)
         }
         attributes["datacontenttype"] = content_type
         event = CloudEvent.create(attributes, data)
@@ -73,12 +75,14 @@ class FRParisOpenDataVeloEventProducer:
             self.producer.flush()
 
 
-    def send_fr_paris_open_data_velo_bicycle_count(self,_counter_id : str, data: BicycleCount, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, BicycleCount], str]=None) -> None:
+    def send_fr_paris_open_data_velo_bicycle_count(self,_counter_id : str, _ce_id : str, _date : str, data: BicycleCount, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, BicycleCount], str]=None) -> None:
         """
         Sends the 'FR.Paris.OpenData.Velo.BicycleCount' event to the Kafka topic
 
         Args:
             _counter_id(str):  Value for placeholder counter_id in attribute subject
+            _ce_id(str):  Value for placeholder ce_id in attribute id
+            _date(str):  Value for placeholder date in attribute time
             data: (BicycleCount): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
@@ -89,7 +93,9 @@ class FRParisOpenDataVeloEventProducer:
         attributes = {
              "type":"FR.Paris.OpenData.Velo.BicycleCount",
              "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-donnees-compteurs",
-             "subject":"{counter_id}".format(counter_id = _counter_id)
+             "subject":"{counter_id}".format(counter_id = _counter_id),
+             "id":"{ce_id}".format(ce_id = _ce_id),
+             "time":"{date}".format(date = _date)
         }
         attributes["datacontenttype"] = content_type
         event = CloudEvent.create(attributes, data)
@@ -136,6 +142,156 @@ class FRParisOpenDataVeloEventProducer:
 
     @classmethod
     def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'FRParisOpenDataVeloEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+
+
+
+class FRParisOpenDataVeloMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_fr_paris_open_data_velo_mqtt_counter(self,_counter_id : str, _ce_id : str, data: Counter, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Counter], str]=None) -> None:
+        """
+        Sends the 'FR.Paris.OpenData.Velo.mqtt.Counter' event to the Kafka topic
+
+        Args:
+            _counter_id(str):  Value for placeholder counter_id in attribute subject
+            _ce_id(str):  Value for placeholder ce_id in attribute id
+            data: (Counter): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Counter], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"FR.Paris.OpenData.Velo.Counter",
+             "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-compteurs",
+             "subject":"{counter_id}".format(counter_id = _counter_id),
+             "id":"{ce_id}".format(ce_id = _ce_id)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_fr_paris_open_data_velo_mqtt_bicycle_count(self,_counter_id : str, _ce_id : str, _date : str, data: BicycleCount, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, BicycleCount], str]=None) -> None:
+        """
+        Sends the 'FR.Paris.OpenData.Velo.mqtt.BicycleCount' event to the Kafka topic
+
+        Args:
+            _counter_id(str):  Value for placeholder counter_id in attribute subject
+            _ce_id(str):  Value for placeholder ce_id in attribute id
+            _date(str):  Value for placeholder date in attribute time
+            data: (BicycleCount): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, BicycleCount], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"FR.Paris.OpenData.Velo.BicycleCount",
+             "source":"https://opendata.paris.fr/explore/dataset/comptage-velo-donnees-compteurs",
+             "subject":"{counter_id}".format(counter_id = _counter_id),
+             "id":"{ce_id}".format(ce_id = _ce_id),
+             "time":"{date}".format(date = _date)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'FRParisOpenDataVeloMqttEventProducer':
         """
         Create a Kafka producer from a connection string and a topic name.
 

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_kafka_producer/tests/test_producer.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/paris_bicycle_counters_producer_kafka_producer/tests/test_producer.py
@@ -23,6 +23,7 @@ from paris_bicycle_counters_producer_data import Counter
 from test_paris_bicycle_counters_producer_data_counter import Test_Counter
 from paris_bicycle_counters_producer_data import BicycleCount
 from test_paris_bicycle_counters_producer_data_bicyclecount import Test_BicycleCount
+from paris_bicycle_counters_producer_kafka_producer.producer import FRParisOpenDataVeloMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -105,7 +106,7 @@ def test_fr_paris_opendata_velo_frparisopendatavelocounter(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_fr_paris_open_data_velo_counter(_counter_id = f'test_{i}', data = event_data)
+        producer_instance.send_fr_paris_open_data_velo_counter(_counter_id = f'test_{i}', _ce_id = f'test_{i}', data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -168,7 +169,7 @@ def test_fr_paris_opendata_velo_frparisopendatavelobicyclecount(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_fr_paris_open_data_velo_bicycle_count(_counter_id = f'test_{i}', data = event_data)
+        producer_instance.send_fr_paris_open_data_velo_bicycle_count(_counter_id = f'test_{i}', _ce_id = f'test_{i}', _date = f'test_{i}', data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -179,6 +180,128 @@ def test_fr_paris_opendata_velo_frparisopendatavelobicyclecount(kafka_emulator):
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{counter_id}".format(counter_id=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_fr_paris_opendata_velo_mqtt_frparisopendatavelomqttcounter(kafka_emulator):
+    """Test the FRParisOpenDataVeloMqttCounter event from the FR.Paris.OpenData.Velo.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_fr_paris_opendata_velo_mqtt_frparisopendatavelomqttcounter',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "FR.Paris.OpenData.Velo.mqtt.Counter":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = FRParisOpenDataVeloMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_Counter.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_fr_paris_open_data_velo_mqtt_counter(_counter_id = f'test_{i}', _ce_id = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_fr_paris_opendata_velo_mqtt_frparisopendatavelomqttbicyclecount(kafka_emulator):
+    """Test the FRParisOpenDataVeloMqttBicycleCount event from the FR.Paris.OpenData.Velo.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_fr_paris_opendata_velo_mqtt_frparisopendatavelomqttbicyclecount',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "FR.Paris.OpenData.Velo.mqtt.BicycleCount":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = FRParisOpenDataVeloMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_BicycleCount.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_fr_paris_open_data_velo_mqtt_bicycle_count(_counter_id = f'test_{i}', _ce_id = f'test_{i}', _date = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()
 
 
@@ -214,8 +337,8 @@ def test_fr_paris_opendata_velo_cross_event_type_kafka_key(kafka_emulator):
     data1 = Test_Counter.create_instance()
     data2 = Test_BicycleCount.create_instance()
 
-    producer_instance.send_fr_paris_open_data_velo_counter(_counter_id = shared_key_value, data = data1)
-    producer_instance.send_fr_paris_open_data_velo_bicycle_count(_counter_id = shared_key_value, data = data2)
+    producer_instance.send_fr_paris_open_data_velo_counter(_counter_id = shared_key_value, _ce_id = shared_key_value, data = data1)
+    producer_instance.send_fr_paris_open_data_velo_bicycle_count(_counter_id = shared_key_value, _ce_id = shared_key_value, _date = shared_key_value, data = data2)
     kafka_producer.flush(timeout=5.0)
 
     # Collect keys from both messages

--- a/paris-bicycle-counters/paris_bicycle_counters_producer/samples/sample.py
+++ b/paris-bicycle-counters/paris_bicycle_counters_producer/samples/sample.py
@@ -33,6 +33,7 @@ from confluent_kafka import Producer as KafkaProducer
 # imports the producer clients for the message group(s)
 
 from paris_bicycle_counters_producer_kafka_producer.producer import FRParisOpenDataVeloEventProducer
+from paris_bicycle_counters_producer_kafka_producer.producer import FRParisOpenDataVeloMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -62,7 +63,7 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     _counter = Counter()
 
     # sends the 'FR.Paris.OpenData.Velo.Counter' event to Kafka topic.
-    await frparis_open_data_velo_event_producer.send_fr_paris_open_data_velo_counter(_counter_id = 'TODO: replace me', data = _counter)
+    await frparis_open_data_velo_event_producer.send_fr_paris_open_data_velo_counter(_counter_id = 'TODO: replace me', _ce_id = 'TODO: replace me', data = _counter)
     print(f"Sent 'FR.Paris.OpenData.Velo.Counter' event: {_counter.to_json()}")
 
     # ---- FR.Paris.OpenData.Velo.BicycleCount ----
@@ -70,8 +71,32 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     _bicycle_count = BicycleCount()
 
     # sends the 'FR.Paris.OpenData.Velo.BicycleCount' event to Kafka topic.
-    await frparis_open_data_velo_event_producer.send_fr_paris_open_data_velo_bicycle_count(_counter_id = 'TODO: replace me', data = _bicycle_count)
+    await frparis_open_data_velo_event_producer.send_fr_paris_open_data_velo_bicycle_count(_counter_id = 'TODO: replace me', _ce_id = 'TODO: replace me', _date = 'TODO: replace me', data = _bicycle_count)
     print(f"Sent 'FR.Paris.OpenData.Velo.BicycleCount' event: {_bicycle_count.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        frparis_open_data_velo_mqtt_event_producer = FRParisOpenDataVeloMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        frparis_open_data_velo_mqtt_event_producer = FRParisOpenDataVeloMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- FR.Paris.OpenData.Velo.mqtt.Counter ----
+    # TODO: Supply event data for the FR.Paris.OpenData.Velo.mqtt.Counter event
+    _counter = Counter()
+
+    # sends the 'FR.Paris.OpenData.Velo.mqtt.Counter' event to Kafka topic.
+    await frparis_open_data_velo_mqtt_event_producer.send_fr_paris_open_data_velo_mqtt_counter(_counter_id = 'TODO: replace me', _ce_id = 'TODO: replace me', data = _counter)
+    print(f"Sent 'FR.Paris.OpenData.Velo.mqtt.Counter' event: {_counter.to_json()}")
+
+    # ---- FR.Paris.OpenData.Velo.mqtt.BicycleCount ----
+    # TODO: Supply event data for the FR.Paris.OpenData.Velo.mqtt.BicycleCount event
+    _bicycle_count = BicycleCount()
+
+    # sends the 'FR.Paris.OpenData.Velo.mqtt.BicycleCount' event to Kafka topic.
+    await frparis_open_data_velo_mqtt_event_producer.send_fr_paris_open_data_velo_mqtt_bicycle_count(_counter_id = 'TODO: replace me', _ce_id = 'TODO: replace me', _date = 'TODO: replace me', data = _bicycle_count)
+    print(f"Sent 'FR.Paris.OpenData.Velo.mqtt.BicycleCount' event: {_bicycle_count.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/paris-bicycle-counters/tests/test_paris_bicycle_counters_unit.py
+++ b/paris-bicycle-counters/tests/test_paris_bicycle_counters_unit.py
@@ -127,6 +127,7 @@ class TestCounterDataclass:
 
     def test_create_counter(self):
         counter = Counter(
+            ce_id="counter-1/info",
             counter_id="100047537-101047537",
             counter_name="26 boulevard de Ménilmontant SE-NO",
             channel_name="SE-NO",
@@ -143,6 +144,7 @@ class TestCounterDataclass:
 
     def test_counter_nullable_fields(self):
         counter = Counter(
+            ce_id="counter-1/info",
             counter_id="test-id",
             counter_name="Test Counter",
             channel_name=None,
@@ -157,6 +159,7 @@ class TestCounterDataclass:
 
     def test_counter_to_json(self):
         counter = Counter(
+            ce_id="counter-1/info",
             counter_id="test-id",
             counter_name="Test Counter",
             channel_name="SE-NO",
@@ -171,6 +174,7 @@ class TestCounterDataclass:
 
     def test_counter_from_dict(self):
         data = {
+            "ce_id": "abc-123/info",
             "counter_id": "abc-123",
             "counter_name": "Test",
             "channel_name": "N-S",
@@ -195,6 +199,7 @@ class TestBicycleCountDataclass:
     def test_create_bicycle_count(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         bc = BicycleCount(
+            ce_id="counter-1/2026-04-06T09:00Z/count",
             counter_id="100036719-103036719",
             counter_name="18 quai de l'Hôtel de Ville SE-NO",
             count=79,
@@ -209,6 +214,7 @@ class TestBicycleCountDataclass:
     def test_bicycle_count_nullable_count(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         bc = BicycleCount(
+            ce_id="counter-1/2026-04-06T09:00Z/count",
             counter_id="test-id",
             counter_name="Test Counter",
             count=None,
@@ -221,6 +227,7 @@ class TestBicycleCountDataclass:
     def test_bicycle_count_to_json(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         bc = BicycleCount(
+            ce_id="counter-1/2026-04-06T09:00Z/count",
             counter_id="test-id",
             counter_name="Test Counter",
             count=42,
@@ -242,6 +249,7 @@ class TestBicycleCountDataclass:
     def test_bicycle_count_zero_count(self):
         dt = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         bc = BicycleCount(
+            ce_id="counter-1/2026-04-06T09:00Z/count",
             counter_id="test-id",
             counter_name="Test Counter",
             count=0,
@@ -408,9 +416,9 @@ class TestDedupCounts:
         dt1 = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         dt2 = datetime(2025, 12, 6, 16, 0, 0, tzinfo=timezone.utc)
         counts = [
-            BicycleCount(counter_id="c1", counter_name="C1", count=10, date=dt1,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=10, date=dt1,
                          longitude=2.0, latitude=48.0),
-            BicycleCount(counter_id="c2", counter_name="C2", count=20, date=dt2,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c2", counter_name="C2", count=20, date=dt2,
                          longitude=2.1, latitude=48.1),
         ]
         new_counts, seen = ParisBicycleCounterPoller.dedup_counts(counts, set())
@@ -420,9 +428,9 @@ class TestDedupCounts:
     def test_dedup_with_duplicates(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         counts = [
-            BicycleCount(counter_id="c1", counter_name="C1", count=10, date=dt,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=10, date=dt,
                          longitude=2.0, latitude=48.0),
-            BicycleCount(counter_id="c1", counter_name="C1", count=10, date=dt,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=10, date=dt,
                          longitude=2.0, latitude=48.0),
         ]
         new_counts, seen = ParisBicycleCounterPoller.dedup_counts(counts, set())
@@ -431,7 +439,7 @@ class TestDedupCounts:
     def test_dedup_with_seen_keys(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         counts = [
-            BicycleCount(counter_id="c1", counter_name="C1", count=10, date=dt,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=10, date=dt,
                          longitude=2.0, latitude=48.0),
         ]
         seen = {f"c1|{dt.isoformat()}"}
@@ -443,9 +451,9 @@ class TestDedupCounts:
         dt1 = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         dt2 = datetime(2025, 12, 6, 16, 0, 0, tzinfo=timezone.utc)
         counts = [
-            BicycleCount(counter_id="c1", counter_name="C1", count=10, date=dt1,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=10, date=dt1,
                          longitude=2.0, latitude=48.0),
-            BicycleCount(counter_id="c1", counter_name="C1", count=20, date=dt2,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="C1", count=20, date=dt2,
                          longitude=2.0, latitude=48.0),
         ]
         new_counts, seen = ParisBicycleCounterPoller.dedup_counts(counts, set())
@@ -499,12 +507,12 @@ class TestPollAndSend:
     @patch('paris_bicycle_counters.paris_bicycle_counters.ParisBicycleCounterPoller.fetch_counter_locations')
     def test_poll_and_send_once(self, mock_locations, mock_counts, tmp_path):
         mock_locations.return_value = [
-            Counter(counter_id="c1", counter_name="Counter 1", channel_name="SE-NO",
+            Counter(ce_id="counter/info", counter_id="c1", counter_name="Counter 1", channel_name="SE-NO",
                     installation_date="2020-01-01", longitude=2.0, latitude=48.0)
         ]
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         mock_counts.return_value = [
-            BicycleCount(counter_id="c1", counter_name="Counter 1", count=42,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="Counter 1", count=42,
                          date=dt, longitude=2.0, latitude=48.0)
         ]
 
@@ -528,7 +536,7 @@ class TestPollAndSend:
         mock_locations.return_value = []
         dt = datetime.now(timezone.utc) - timedelta(hours=1)
         mock_counts.return_value = [
-            BicycleCount(counter_id="c1", counter_name="Counter 1", count=42,
+            BicycleCount(ce_id="c1/2026-01-01T00:00Z/count", counter_id="c1", counter_name="Counter 1", count=42,
                          date=dt, longitude=2.0, latitude=48.0)
         ]
 
@@ -627,6 +635,7 @@ class TestEdgeCases:
 
     def test_counter_byte_array_json(self):
         counter = Counter(
+            ce_id="counter-1/info",
             counter_id="test-id", counter_name="Test",
             channel_name=None, installation_date=None,
             longitude=2.0, latitude=48.0,
@@ -639,6 +648,7 @@ class TestEdgeCases:
     def test_bicycle_count_byte_array_json(self):
         dt = datetime(2025, 12, 6, 15, 0, 0, tzinfo=timezone.utc)
         bc = BicycleCount(
+            ce_id="counter-1/2026-04-06T09:00Z/count",
             counter_id="test-id", counter_name="Test",
             count=42, date=dt, longitude=2.0, latitude=48.0,
         )
@@ -649,6 +659,7 @@ class TestEdgeCases:
 
     def test_counter_from_data_dict(self):
         data = {
+            "ce_id": "test-id/info",
             "counter_id": "test-id", "counter_name": "Test",
             "channel_name": None, "installation_date": None,
             "longitude": 2.0, "latitude": 48.0,

--- a/paris-bicycle-counters/xreg/paris_bicycle_counters.xreg.json
+++ b/paris-bicycle-counters/xreg/paris_bicycle_counters.xreg.json
@@ -20,6 +20,27 @@
       "messagegroups": [
         "#/messagegroups/FR.Paris.OpenData.Velo"
       ]
+    },
+    "FR.Paris.OpenData.Velo.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/FR.Paris.OpenData.Velo.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -37,6 +58,10 @@
             },
             "subject": {
               "value": "{counter_id}",
+              "type": "uritemplate"
+            },
+            "id": {
+              "value": "{ce_id}",
               "type": "uritemplate"
             }
           },
@@ -56,10 +81,43 @@
             "subject": {
               "value": "{counter_id}",
               "type": "uritemplate"
+            },
+            "id": {
+              "value": "{ce_id}",
+              "type": "uritemplate"
+            },
+            "time": {
+              "value": "{date}",
+              "type": "uritemplate"
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/FR.Paris.OpenData.Velo.jstruct/schemas/FR.Paris.OpenData.Velo.BicycleCount"
+        }
+      }
+    },
+    "FR.Paris.OpenData.Velo.mqtt": {
+      "description": "MQTT/5.0 transport variants for Paris bicycle counters. Topics route by stable MQTT-safe counter_id (upstream id_compteur; values containing /, +, #, or NUL are dropped) under traffic/fr/paris/paris-bicycle-counters/{counter_id}/... . Counter reference records are retained QoS 1; hourly bicycle counts are non-retained QoS 1 events.",
+      "messages": {
+        "FR.Paris.OpenData.Velo.mqtt.Counter": {
+          "name": "Counter",
+          "basemessageurl": "/messagegroups/FR.Paris.OpenData.Velo/messages/FR.Paris.OpenData.Velo.Counter",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/fr/paris/paris-bicycle-counters/{counter_id}/info",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "FR.Paris.OpenData.Velo.mqtt.BicycleCount": {
+          "name": "BicycleCount",
+          "basemessageurl": "/messagegroups/FR.Paris.OpenData.Velo/messages/FR.Paris.OpenData.Velo.BicycleCount",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/fr/paris/paris-bicycle-counters/{counter_id}/count",
+            "qos": 1,
+            "retain": false
+          }
         }
       }
     }
@@ -79,6 +137,7 @@
                 "$id": "https://schemas.real-time-sources.io/paris-bicycle-counters/Counter/v1",
                 "type": "object",
                 "required": [
+                  "ce_id",
                   "counter_id",
                   "counter_name"
                 ],
@@ -138,6 +197,10 @@
                       "null"
                     ],
                     "description": "Latitude of the counter location in decimal degrees (WGS 84)."
+                  },
+                  "ce_id": {
+                    "type": "string",
+                    "description": "Deterministic CloudEvents id for the retained counter reference record."
                   }
                 }
               }
@@ -156,6 +219,7 @@
                 "$id": "https://schemas.real-time-sources.io/paris-bicycle-counters/BicycleCount/v1",
                 "type": "object",
                 "required": [
+                  "ce_id",
                   "counter_id",
                   "counter_name",
                   "date"
@@ -219,6 +283,10 @@
                       "null"
                     ],
                     "description": "Latitude of the counter location in decimal degrees (WGS 84)."
+                  },
+                  "ce_id": {
+                    "type": "string",
+                    "description": "Deterministic CloudEvents id composed from counter_id and hourly count date for subscriber deduplication."
                   }
                 }
               }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -322,6 +322,12 @@
       "image": "carbon-intensity-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "carbon_intensity_mqtt"
+    },
+    {
+      "dir": "paris-bicycle-counters",
+      "image": "paris-bicycle-counters-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "paris_bicycle_counters_mqtt"
     }
   ],
   "flow": [
@@ -615,6 +621,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestCarbonIntensityMqttDockerFlow"
+    },
+    {
+      "dir": "paris-bicycle-counters",
+      "image": "paris-bicycle-counters-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestParisBicycleCountersMqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -4046,3 +4046,119 @@ class TestCarbonIntensityMqttDockerFlow:
                 assert payload.get('region_id') is not None
             else:
                 assert parts[4] == 'national'
+
+# ---- paris-bicycle-counters ---------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def paris_bicycle_counters_mqtt_image():
+    return build_image('paris-bicycle-counters', dockerfile='Dockerfile.mqtt', tag='test-paris-bicycle-counters-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_paris_bicycle_counters():
+    container, network, host_port = _generic_mosquitto(
+        'paris-bicycle-counters-mqtt-e2e', 'paris-bicycle-counters-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'paris-bicycle-counters-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestParisBicycleCountersMqttDockerFlow:
+    """Verify the paris-bicycle-counters-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_uns_topics(self, mosquitto_paris_bicycle_counters, paris_bicycle_counters_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_paris_bicycle_counters['internal_host']}:{mosquitto_paris_bicycle_counters['internal_port']}"
+        messages = []
+
+        def on_message(_client, _userdata, msg):
+            props = {}
+            if msg.properties is not None:
+                for k, v in getattr(msg.properties, 'UserProperty', []) or []:
+                    props[k] = v
+                ct = getattr(msg.properties, 'ContentType', None)
+                if ct:
+                    props['_contenttype'] = ct
+            try:
+                payload = json.loads(msg.payload)
+            except (TypeError, ValueError):
+                payload = None
+            messages.append({'topic': msg.topic, 'retain': bool(msg.retain), 'qos': msg.qos, 'user_properties': props, 'payload': payload})
+
+        sub = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
+        sub.on_message = on_message
+        sub.connect('127.0.0.1', mosquitto_paris_bicycle_counters['host_port'], 30)
+        sub.subscribe('traffic/fr/paris/paris-bicycle-counters/#', qos=1)
+        sub.loop_start()
+        try:
+            feeder = client.containers.run(
+                paris_bicycle_counters_mqtt_image.id,
+                detach=True,
+                remove=False,
+                network=mosquitto_paris_bicycle_counters['network'],
+                environment={
+                    'MQTT_BROKER_URL': broker_url,
+                    'ONCE_MODE': 'true',
+                    'PYTHONUNBUFFERED': '1',
+                },
+            )
+            try:
+                result = feeder.wait(timeout=420)
+                logs = feeder.logs().decode('utf-8', errors='replace')
+                assert result.get('StatusCode') == 0, f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+            finally:
+                try:
+                    feeder.remove(force=True)
+                except docker.errors.APIError:
+                    pass
+            deadline = time.time() + 20
+            while len(messages) < 2 and time.time() < deadline:
+                time.sleep(0.5)
+        finally:
+            sub.loop_stop()
+            sub.disconnect()
+
+        assert messages, 'No MQTT messages received from broker'
+        info = [m for m in messages if m['topic'].endswith('/info')]
+        counts = [m for m in messages if m['topic'].endswith('/count')]
+        assert info, 'No counter info messages published'
+        assert counts, 'No count event messages published'
+        retained_info = _collect_messages_topic(
+            '127.0.0.1', mosquitto_paris_bicycle_counters['host_port'],
+            'traffic/fr/paris/paris-bicycle-counters/+/info', timeout=20.0,
+        )
+        assert retained_info and all(m['retain'] is True for m in retained_info), 'No retained /info messages for late subscribers'
+        for sample in messages:
+            up = sample['user_properties']
+            for required in ('id', 'source', 'type', 'subject', 'specversion'):
+                assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+            assert up.get('_contenttype') == 'application/json'
+            assert sample['qos'] == 1
+            parts = sample['topic'].split('/')
+            assert parts[:4] == ['traffic', 'fr', 'paris', 'paris-bicycle-counters']
+            assert len(parts) == 6
+            payload = _to_dict(sample['payload'])
+            assert payload is not None
+            assert payload.get('counter_id') == parts[4] == up['subject']
+            if parts[5] == 'info':
+                assert up.get('type') == 'FR.Paris.OpenData.Velo.Counter'
+            else:
+                assert parts[5] == 'count'
+                assert sample['retain'] is False
+                assert up.get('type') == 'FR.Paris.OpenData.Velo.BicycleCount'
+                assert payload.get('date')


### PR DESCRIPTION
## Summary
- Adds MQTT/UNS endpoint and generated MQTT client for `paris-bicycle-counters`
- Publishes `traffic/fr/paris/paris-bicycle-counters/{counter_id}/info` retained QoS 1 and `/count` non-retained QoS 1
- Adds deterministic `ce_id`, MQTT-safe `counter_id` validation, MQTT Docker app, docs, and docker-e2e coverage

## Topic tree
- `traffic/fr/paris/paris-bicycle-counters/{counter_id}/info` (retained counter reference)
- `traffic/fr/paris/paris-bicycle-counters/{counter_id}/count` (non-retained hourly count event)

## Specialist review
- xRegistry Expert: no MUST-FIX; suggested CE time and routing-key docs, both addressed.
- UNS Catalog Architect: initial MUST-FIX for retained info CE id uniqueness, topic-segment validation, and runtime e2e coverage. Fixed with content-hash `ce_id`, unsafe id drop/log, and docker e2e live + late-retained checks. Final review: no MUST-FIX remaining.

## Validation
- `xrcg validate --definitions paris-bicycle-counters\\xreg\\paris_bicycle_counters.xreg.json`
- `python -m pytest paris-bicycle-counters\\tests -q -x` (46 passed)
- `python -m pytest paris-bicycle-counters\\paris_bicycle_counters_mqtt_producer\\paris_bicycle_counters_mqtt_producer_data\\tests -q -x` (18 passed)
- `docker build -f paris-bicycle-counters\\Dockerfile.mqtt -t test-paris-bicycle-counters-mqtt paris-bicycle-counters`
- `python -m pytest tests\\docker_e2e\\test_docker_mqtt_flow.py::TestParisBicycleCountersMqttDockerFlow -q -x` (1 passed)