### PR TITLE
mqtt(australia-wildfires): add MQTT UNS feeder

### DIFF
--- a/australia-wildfires/CONTAINER.md
+++ b/australia-wildfires/CONTAINER.md
@@ -16,6 +16,10 @@ JSON content mode. See [EVENTS.md](EVENTS.md) for the full event catalog.
 | `POLLING_INTERVAL` | No | Polling interval in seconds (default: `300`) |
 | `STATE_FILE` | No | Path for dedup state persistence (default: `~/.australia_wildfires_state.json`) |
 | `KAFKA_ENABLE_TLS` | No | Enable TLS for Kafka connections (default: `true`) |
+| `MQTT_BROKER_URL` | MQTT only | MQTT broker URL such as `mqtt://broker:1883` or `mqtts://broker:8883` |
+| `MQTT_USERNAME` / `MQTT_PASSWORD` | MQTT only | Optional MQTT credentials |
+| `MQTT_CONTENT_MODE` | MQTT only | CloudEvents MQTT content mode (`binary`, default, or `structured`) |
+| `AUSTRALIA_WILDFIRES_SAMPLE_MODE` | MQTT test only | Publish one deterministic sample incident instead of polling live feeds |
 
 ## Connection Strings
 
@@ -50,6 +54,18 @@ docker run --rm \
   -e CONNECTION_STRING="BootstrapServer=host.docker.internal:9092;EntityPath=australia-wildfires" \
   ghcr.io/clemensv/real-time-sources/australia-wildfires:latest
 ```
+
+### MQTT/UNS image
+
+```bash
+docker build -f Dockerfile.mqtt -t australia-wildfires-mqtt .
+docker run --rm \
+  -e MQTT_BROKER_URL="mqtt://host.docker.internal:1883" \
+  ghcr.io/clemensv/real-time-sources/australia-wildfires-mqtt:latest
+```
+
+The MQTT image publishes QoS 1, non-retained binary CloudEvents under
+`wildfire/au/{state}/{status}/{incident_id}/incident`.
 
 ## Azure Container Instance
 

--- a/australia-wildfires/Dockerfile.mqtt
+++ b/australia-wildfires/Dockerfile.mqtt
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires"
+LABEL org.opencontainers.image.title="Australian Wildfires → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls Australian state bushfire incident feeds and publishes MQTT 5.0 binary-mode CloudEvents into wildfire/au/{state}/{status}/{incident_id}/incident topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/australia-wildfires/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data \
+ && pip install --no-cache-dir ./australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./australia_wildfires_producer/australia_wildfires_producer_data \
+ && pip install --no-cache-dir ./australia_wildfires_producer/australia_wildfires_producer_kafka_producer \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./australia_wildfires_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "australia_wildfires_mqtt", "feed"]

--- a/australia-wildfires/EVENTS.md
+++ b/australia-wildfires/EVENTS.md
@@ -13,6 +13,17 @@ Wildfires bridge, derived from the xreg manifest at
 | Envelope | CloudEvents/1.0 structured JSON |
 | Key | `{state}/{incident_id}` |
 
+## MQTT Endpoint
+
+| Property | Value |
+|----------|-------|
+| Protocol | MQTT/5.0 |
+| Topic | `wildfire/au/{state}/{status}/{incident_id}/incident` |
+| Envelope | CloudEvents/1.0 binary mode |
+| QoS / retain | QoS 1, non-retained |
+| Message expiry | 7 days (`604800` seconds) |
+| Retention rationale | Incident updates are time-varying events; only true reference data is retained. |
+
 ## Message Group: `AU.Gov.Emergency.Wildfires`
 
 ### `AU.Gov.Emergency.Wildfires.FireIncident`
@@ -26,6 +37,15 @@ Australian state emergency services.
 | `source` | `https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires` |
 | `subject` | `{state}/{incident_id}` |
 
+### MQTT subscription patterns
+
+- All current wildfire incident updates: `wildfire/au/+/+/+/incident`
+- All NSW incident updates: `wildfire/au/nsw/+/+/incident`
+- All incidents with an under-control status: `wildfire/au/+/under-control/+/incident`
+- One incident across status changes: `wildfire/au/+/+/sample-incident-001/incident`
+
+`{state}` and `{status}` are normalized to lowercase kebab-case for MQTT. Missing upstream status values publish as `unknown`.
+
 #### Schema: `FireIncident`
 
 | Field | Type | Required | Description |
@@ -34,7 +54,7 @@ Australian state emergency services.
 | `state` | string | ✅ | Australian state abbreviation (NSW, VIC, QLD) |
 | `title` | string | ✅ | Human-readable title or headline |
 | `alert_level` | string | ✅ | Alert level (Advice, Watch and Act, Emergency Warning) |
-| `status` | string \| null | | Operational status of the incident |
+| `status` | string | ✅ | Topic-safe operational status; missing upstream values are normalized to `unknown` before MQTT publish, never null or empty |
 | `location` | string \| null | | Human-readable location description |
 | `latitude` | double \| null | | Latitude of incident centroid (WGS84, °) |
 | `longitude` | double \| null | | Longitude of incident centroid (WGS84, °) |

--- a/australia-wildfires/README.md
+++ b/australia-wildfires/README.md
@@ -44,6 +44,9 @@ python -m australia_wildfires list
 
 # Feed to Kafka
 python -m australia_wildfires --connection-string "BootstrapServer=localhost:9092;EntityPath=australia-wildfires" feed
+
+# Feed to MQTT/UNS
+MQTT_BROKER_URL=mqtt://localhost:1883 python -m australia_wildfires_mqtt feed
 ```
 
 ## Container

--- a/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/__init__.py
+++ b/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/__init__.py
@@ -1,0 +1,1 @@
+"""MQTT/UNS feeder for Australian state wildfire incidents."""

--- a/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/__main__.py
+++ b/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
+++ b/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
@@ -1,0 +1,158 @@
+"""MQTT feeder application for Australian wildfires → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import logging
+import os
+import re
+import unicodedata
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from australia_wildfires.australia_wildfires import AustraliaWildfiresAPI
+from australia_wildfires_mqtt_producer_data import FireIncident as MqttFireIncident
+from australia_wildfires_mqtt_producer_mqtt_client.client import AUGovEmergencyWildfiresMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def topic_slug(value: object, default: str = "unknown") -> str:
+    text = str(value or "").strip()
+    if not text:
+        return default
+    normalized = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+    return slug or default
+
+
+def topic_safe_id(value: object, default: str = "unknown") -> str:
+    text = str(value or "").strip()
+    if not text:
+        return default
+    normalized = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized).strip("-._")
+    return safe or default
+
+
+def _to_mqtt_incident(incident) -> MqttFireIncident:
+    payload = dataclasses.asdict(incident)
+    payload["state"] = topic_slug(payload.get("state"))
+    payload["status"] = topic_slug(payload.get("status"))
+    payload["incident_id"] = topic_safe_id(payload.get("incident_id"))
+    return MqttFireIncident(**payload)
+
+
+async def feed(
+    broker_host: str,
+    broker_port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    once: bool = False,
+    content_mode: str = "binary",
+    polling_interval: int = 300,
+) -> None:
+    paho_client = mqtt.Client(
+        callback_api_version=CallbackAPIVersion.VERSION2,
+        client_id=client_id or "",
+        protocol=MQTTv5,
+    )
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+
+    mqtt_client = AUGovEmergencyWildfiresMqttMqttClient(
+        client=paho_client,
+        content_mode=content_mode,  # type: ignore[arg-type]
+        loop=asyncio.get_running_loop(),
+    )
+    api = AustraliaWildfiresAPI(polling_interval=polling_interval)
+
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await mqtt_client.connect(broker_host, broker_port)
+    try:
+        while True:
+            if os.getenv("AUSTRALIA_WILDFIRES_SAMPLE_MODE", "").lower() in ("1", "true", "yes"):
+                incidents = [MqttFireIncident(
+                    incident_id="sample-incident-001",
+                    state="nsw",
+                    title="Sample Fire Incident",
+                    alert_level="Advice",
+                    status="under-control",
+                    location="Sample Location, NSW",
+                    latitude=-33.0,
+                    longitude=151.0,
+                    size_hectares=10.5,
+                    type="Bush Fire",
+                    responsible_agency="Rural Fire Service",
+                    updated="2026-01-01T00:00:00+00:00",
+                    source_url="https://www.rfs.nsw.gov.au/feeds/majorIncidents.json",
+                )]
+            else:
+                incidents = []
+                incidents.extend(_to_mqtt_incident(item) for item in api.fetch_nsw_incidents())
+                incidents.extend(_to_mqtt_incident(item) for item in api.fetch_vic_incidents())
+                incidents.extend(_to_mqtt_incident(item) for item in api.fetch_qld_incidents())
+            published = 0
+            for mqtt_incident in incidents:
+                await mqtt_client.publish_au_gov_emergency_wildfires_mqtt_fire_incident(
+                    state=mqtt_incident.state,
+                    incident_id=mqtt_incident.incident_id,
+                    status=mqtt_incident.status,
+                    data=mqtt_incident,
+                )
+                published += 1
+            logger.info("Published %d Australian wildfire incidents to MQTT", published)
+            if once:
+                break
+            await asyncio.sleep(max(1, polling_interval))
+    finally:
+        await mqtt_client.disconnect()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Australian wildfires MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--polling-interval", type=int, default=int(os.getenv("POLLING_INTERVAL", "300")))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, parsed_tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(
+        host,
+        port,
+        username=args.username or None,
+        password=args.password or None,
+        tls=parsed_tls,
+        client_id=args.client_id or None,
+        once=args.once,
+        content_mode=args.content_mode,
+        polling_interval=args.polling_interval,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/australia-wildfires/australia_wildfires_mqtt/pyproject.toml
+++ b/australia-wildfires/australia_wildfires_mqtt/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "australia-wildfires-mqtt"
+version = "0.1.0"
+description = "Australian wildfires MQTT/UNS feeder"
+requires-python = ">=3.10"
+dependencies = [
+    "paho-mqtt",
+    "dataclasses_json",
+    "cloudevents",
+    "australia-wildfires",
+    "australia_wildfires_mqtt_producer_data",
+    "australia_wildfires_mqtt_producer_mqtt_client",
+]
+
+[project.scripts]
+australia-wildfires-mqtt = "australia_wildfires_mqtt.app:main"
+
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["australia_wildfires_mqtt*"]

--- a/australia-wildfires/australia_wildfires_mqtt_producer/Makefile
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./australia_wildfires_mqtt_producer_data ./australia_wildfires_mqtt_producer_mqtt_client
+
+install: build
+	cd australia_wildfires_mqtt_producer_data && poetry install
+	cd australia_wildfires_mqtt_producer_mqtt_client && poetry install
+	pip install ./australia_wildfires_mqtt_producer_data ./australia_wildfires_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./australia_wildfires_mqtt_producer_mqtt_client/tests ./australia_wildfires_mqtt_producer_data/tests

--- a/australia-wildfires/australia_wildfires_mqtt_producer/README.md
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/README.md
@@ -1,0 +1,1037 @@
+# Australia_wildfires_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the australia_wildfires_mqtt_producer message definitions.
+
+# Australia_wildfires_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - AUGovEmergencyWildfiresMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from australia_wildfires_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure
+Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = AUGovEmergencyWildfiresMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### AUGovEmergencyWildfiresMqttEventDispatcher
+
+
+
+# Publish message`AUGovEmergencyWildfiresMqttEventDispatcher` handles events for the AU.Gov.Emergency.Wildfires.mqtt
+message group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from australia_wildfires_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = AUGovEmergencyWildfiresMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the
+Event Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe AUGovEmergencyWildfiresMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `au_gov_emergency_wildfires_mqtt_fire_incident_async`
+
+
+
+## Test```python
+
+au_gov_emergency_wildfires_mqtt_fire_incident_async:  Callable[[PartitionContext, EventData, CloudEvent, FireIncident],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `AU.Gov.Emergency.Wildfires.mqtt.FireIncident`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `australia_wildfires_mqtt_producer_data.FireIncident`.
+
+Example:
+
+```python
+async def au_gov_emergency_wildfires_mqtt_fire_incident_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: FireIncident) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+au_gov_emergency_wildfires_mqtt_dispatcher.au_gov_emergency_wildfires_mqtt_fire_incident_async =
+au_gov_emergency_wildfires_mqtt_fire_incident_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/pyproject.toml
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "australia-wildfires-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "australia_wildfires_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/src/australia_wildfires_mqtt_producer_data/__init__.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/src/australia_wildfires_mqtt_producer_data/__init__.py
@@ -1,0 +1,3 @@
+from .fireincident import FireIncident
+
+__all__ = ["FireIncident"]

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/src/australia_wildfires_mqtt_producer_data/fireincident.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/src/australia_wildfires_mqtt_producer_data/fireincident.py
@@ -1,0 +1,193 @@
+""" FireIncident dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
+import json
+import datetime
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class FireIncident:
+    """
+    Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.
+    
+    Attributes:
+        incident_id (str)
+        state (str)
+        title (str)
+        alert_level (str)
+        status (str)
+        location (typing.Optional[str])
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+        size_hectares (typing.Optional[float])
+        type (typing.Optional[str])
+        responsible_agency (typing.Optional[str])
+        updated (datetime.datetime)
+        source_url (str)
+    """
+    
+    
+    incident_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="incident_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
+    title: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="title"))
+    alert_level: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="alert_level"))
+    status: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="status"))
+    location: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="location"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    size_hectares: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_hectares"))
+    type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="type"))
+    responsible_agency: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="responsible_agency"))
+    updated: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="updated", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    source_url: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="source_url"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'FireIncident':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['FireIncident']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return FireIncident.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'FireIncident':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            incident_id='qfswdcbxnlfbiwqavrxp',
+            state='ggjeuhlfqcpwwbtzabsy',
+            title='lhncjnoznfiqmlaxgjfd',
+            alert_level='wzeimsrjtvivznuxxbfq',
+            status='nmvckjyozqphxyidzgte',
+            location='cyxhjcdsrwlvntpjvbsc',
+            latitude=float(77.23411198588978),
+            longitude=float(43.655104617444884),
+            size_hectares=float(97.54792733834306),
+            type='eechprvjlpybfacetjcz',
+            responsible_agency='ehrufaciwojtqpuvmpxz',
+            updated=datetime.datetime.now(datetime.timezone.utc),
+            source_url='qosvtimvbvtukijpemyk'
+        )

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/tests/test_fireincident.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_data/tests/test_fireincident.py
@@ -1,0 +1,171 @@
+"""
+Test case for FireIncident
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from australia_wildfires_mqtt_producer_data.fireincident import FireIncident
+import datetime
+
+
+class Test_FireIncident(unittest.TestCase):
+    """
+    Test case for FireIncident
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_FireIncident.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of FireIncident for testing
+        """
+        instance = FireIncident(
+            incident_id='qfswdcbxnlfbiwqavrxp',
+            state='ggjeuhlfqcpwwbtzabsy',
+            title='lhncjnoznfiqmlaxgjfd',
+            alert_level='wzeimsrjtvivznuxxbfq',
+            status='nmvckjyozqphxyidzgte',
+            location='cyxhjcdsrwlvntpjvbsc',
+            latitude=float(77.23411198588978),
+            longitude=float(43.655104617444884),
+            size_hectares=float(97.54792733834306),
+            type='eechprvjlpybfacetjcz',
+            responsible_agency='ehrufaciwojtqpuvmpxz',
+            updated=datetime.datetime.now(datetime.timezone.utc),
+            source_url='qosvtimvbvtukijpemyk'
+        )
+        return instance
+
+    
+    def test_incident_id_property(self):
+        """
+        Test incident_id property
+        """
+        test_value = 'qfswdcbxnlfbiwqavrxp'
+        self.instance.incident_id = test_value
+        self.assertEqual(self.instance.incident_id, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'ggjeuhlfqcpwwbtzabsy'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
+    
+    def test_title_property(self):
+        """
+        Test title property
+        """
+        test_value = 'lhncjnoznfiqmlaxgjfd'
+        self.instance.title = test_value
+        self.assertEqual(self.instance.title, test_value)
+    
+    def test_alert_level_property(self):
+        """
+        Test alert_level property
+        """
+        test_value = 'wzeimsrjtvivznuxxbfq'
+        self.instance.alert_level = test_value
+        self.assertEqual(self.instance.alert_level, test_value)
+    
+    def test_status_property(self):
+        """
+        Test status property
+        """
+        test_value = 'nmvckjyozqphxyidzgte'
+        self.instance.status = test_value
+        self.assertEqual(self.instance.status, test_value)
+    
+    def test_location_property(self):
+        """
+        Test location property
+        """
+        test_value = 'cyxhjcdsrwlvntpjvbsc'
+        self.instance.location = test_value
+        self.assertEqual(self.instance.location, test_value)
+    
+    def test_latitude_property(self):
+        """
+        Test latitude property
+        """
+        test_value = float(77.23411198588978)
+        self.instance.latitude = test_value
+        self.assertEqual(self.instance.latitude, test_value)
+    
+    def test_longitude_property(self):
+        """
+        Test longitude property
+        """
+        test_value = float(43.655104617444884)
+        self.instance.longitude = test_value
+        self.assertEqual(self.instance.longitude, test_value)
+    
+    def test_size_hectares_property(self):
+        """
+        Test size_hectares property
+        """
+        test_value = float(97.54792733834306)
+        self.instance.size_hectares = test_value
+        self.assertEqual(self.instance.size_hectares, test_value)
+    
+    def test_type_property(self):
+        """
+        Test type property
+        """
+        test_value = 'eechprvjlpybfacetjcz'
+        self.instance.type = test_value
+        self.assertEqual(self.instance.type, test_value)
+    
+    def test_responsible_agency_property(self):
+        """
+        Test responsible_agency property
+        """
+        test_value = 'ehrufaciwojtqpuvmpxz'
+        self.instance.responsible_agency = test_value
+        self.assertEqual(self.instance.responsible_agency, test_value)
+    
+    def test_updated_property(self):
+        """
+        Test updated property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.updated = test_value
+        self.assertEqual(self.instance.updated, test_value)
+    
+    def test_source_url_property(self):
+        """
+        Test source_url property
+        """
+        test_value = 'qosvtimvbvtukijpemyk'
+        self.instance.source_url = test_value
+        self.assertEqual(self.instance.source_url, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = FireIncident.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = FireIncident.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/pyproject.toml
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "australia-wildfires-mqtt-producer-mqtt-client"
+description = "australia_wildfires_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "australia_wildfires_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+australia-wildfires-mqtt-producer-data = {path = "../australia_wildfires_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/__init__.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import AUGovEmergencyWildfiresMqttMqttClient
+
+__all__ = [
+    "AUGovEmergencyWildfiresMqttMqttClient",
+]

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/client.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,426 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import australia_wildfires_mqtt_producer_data
+from australia_wildfires_mqtt_producer_data import FireIncident
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_au_gov_emergency_wildfires_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the AU.Gov.Emergency.Wildfires.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "AU.Gov.Emergency.Wildfires.mqtt.FireIncident": "wildfire/au/{state}/{status}/{incident_id}/incident",
+    }
+
+
+def get_subscription_topics_au_gov_emergency_wildfires_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_au_gov_emergency_wildfires_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class AUGovEmergencyWildfiresMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the AU.Gov.Emergency.Wildfires.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_au_gov_emergency_wildfires_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.au_gov_emergency_wildfires_mqtt_fire_incident_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, australia_wildfires_mqtt_producer_data.FireIncident, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "AU.Gov.Emergency.Wildfires.FireIncident":
+            if self.au_gov_emergency_wildfires_mqtt_fire_incident_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = australia_wildfires_mqtt_producer_data.FireIncident.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "AU.Gov.Emergency.Wildfires.mqtt.FireIncident")
+                    await self.au_gov_emergency_wildfires_mqtt_fire_incident_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in au_gov_emergency_wildfires_mqtt_fire_incident handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_au_gov_emergency_wildfires_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_au_gov_emergency_wildfires_mqtt_fire_incident(self,
+        state: str,
+        incident_id: str,
+        status: str,
+        data: australia_wildfires_mqtt_producer_data.FireIncident,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'AU.Gov.Emergency.Wildfires.mqtt.FireIncident' event to an MQTT topic.
+
+        Args:
+        
+            state: URI template variable for 'state'
+            incident_id: URI template variable for 'incident_id'
+            status: URI template variable for 'status'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'wildfire/au/{state}/{status}/{incident_id}/incident'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "wildfire/au/{state}/{status}/{incident_id}/incident"
+        _topic_template_values: Dict[str, str] = {
+            "state": str(state),
+            "incident_id": str(incident_id),
+            "status": str(status),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"AU.Gov.Emergency.Wildfires.FireIncident",
+             "source":"https://github.com/clemensv/real-time-sources/tree/main/australia-wildfires",
+             "subject":"{state}/{incident_id}".format(state = state,incident_id = incident_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+        if _MQTT5_AVAILABLE and _MqttProperties is not None and _MqttPacketTypes is not None:
+            props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+            props.MessageExpiryInterval = 604800
+            publish_kwargs["properties"] = props
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                mqtt5_props.MessageExpiryInterval = 604800
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,111 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../australia_wildfires_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../australia_wildfires_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../australia_wildfires_mqtt_producer_mqtt_client/src')))
+
+import australia_wildfires_mqtt_producer_data
+from australia_wildfires_mqtt_producer_data import FireIncident
+from test_fireincident import Test_FireIncident
+from australia_wildfires_mqtt_producer_mqtt_client import AUGovEmergencyWildfiresMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_au_gov_emergency_wildfires_mqtt_au_gov_emergency_wildfires_mqtt_fire_incident_py(mosquitto_broker):
+    """Test publishing and receiving AU.Gov.Emergency.Wildfires.mqtt.FireIncident message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_FireIncident.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = AUGovEmergencyWildfiresMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = AUGovEmergencyWildfiresMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_au_gov_emergency_wildfires_mqtt_fire_incident(mqtt_msg, cloud_event, data: australia_wildfires_mqtt_producer_data.FireIncident, topic_params: dict):
+        """Handler for AU.Gov.Emergency.Wildfires.mqtt.FireIncident messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "AU.Gov.Emergency.Wildfires.FireIncident"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.au_gov_emergency_wildfires_mqtt_fire_incident_async = on_au_gov_emergency_wildfires_mqtt_fire_incident
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/au_gov_emergency_wildfires_mqtt/au_gov_emergency_wildfires_mqtt_fire_incident"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_au_gov_emergency_wildfires_mqtt_fire_incident(
+            topic=test_topic,
+            state=f"test_state_{i}",
+            incident_id=f"test_incident_id_{i}",
+            status=f"test_status_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/australia-wildfires/australia_wildfires_mqtt_producer/install.bat
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\australia_wildfires_mqtt_producer_data
+pip install .\australia_wildfires_mqtt_producer_mqtt_client

--- a/australia-wildfires/australia_wildfires_mqtt_producer/install.sh
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./australia_wildfires_mqtt_producer_data
+pip install ./australia_wildfires_mqtt_producer_mqtt_client

--- a/australia-wildfires/australia_wildfires_mqtt_producer/samples/sample.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/samples/sample.py
@@ -1,0 +1,80 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from australia_wildfires_mqtt_producer_data import *
+from australia_wildfires_mqtt_producer_mqtt_client.client import AUGovEmergencyWildfiresMqttProducer, AUGovEmergencyWildfiresMqttDispatcher
+
+async def handle_au_gov_emergency_wildfires_mqtt_fire_incident(mqtt_msg,cloud_event, au_gov_emergency_wildfires_mqtt_fire_incident_data):
+    """ Handles the AU.Gov.Emergency.Wildfires.mqtt.FireIncident message """
+    print(f"Received AU.Gov.Emergency.Wildfires.mqtt.FireIncident on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {au_gov_emergency_wildfires_mqtt_fire_incident_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/australia-wildfires/australia_wildfires_mqtt_producer/scripts/build.py
+++ b/australia-wildfires/australia_wildfires_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["australia_wildfires_mqtt_producer_mqtt_client", "australia_wildfires_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/australia-wildfires/xreg/australia_wildfires.xreg.json
+++ b/australia-wildfires/xreg/australia_wildfires.xreg.json
@@ -20,6 +20,28 @@
       "messagegroups": [
         "#/messagegroups/AU.Gov.Emergency.Wildfires"
       ]
+    },
+    "AU.Gov.Emergency.Wildfires.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/AU.Gov.Emergency.Wildfires.mqtt"
+      ],
+      "description": "MQTT/5.0 binary-mode CloudEvents producer for the Australian wildfires UNS topic tree."
     }
   },
   "messagegroups": {
@@ -42,6 +64,22 @@
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/AU.Gov.Emergency.Wildfires.jstruct/schemas/AU.Gov.Emergency.Wildfires.FireIncident"
+        }
+      }
+    },
+    "AU.Gov.Emergency.Wildfires.mqtt": {
+      "description": "MQTT/5.0 transport variant for Australian bushfire incidents. The UNS topic tree is wildfire/au/{state}/{status}/{incident_id}/incident. QoS 1 and retain=false are used because incident updates are time-varying event updates rather than static reference data; consumers deduplicate by {state}/{incident_id} and CloudEvents id.",
+      "messages": {
+        "AU.Gov.Emergency.Wildfires.mqtt.FireIncident": {
+          "name": "FireIncident",
+          "basemessageurl": "/messagegroups/AU.Gov.Emergency.Wildfires/messages/AU.Gov.Emergency.Wildfires.FireIncident",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "wildfire/au/{state}/{status}/{incident_id}/incident",
+            "qos": 1,
+            "retain": false,
+            "message_expiry_interval": 604800
+          }
         }
       }
     }
@@ -68,7 +106,8 @@
                   "title",
                   "alert_level",
                   "updated",
-                  "source_url"
+                  "source_url",
+                  "status"
                 ],
                 "properties": {
                   "incident_id": {
@@ -88,11 +127,9 @@
                     "description": "Fire danger alert level as classified by the issuing agency. Common values across states: 'Advice' (fire is under control or low threat), 'Watch and Act' (conditions are changing, prepare to leave), 'Emergency Warning' (immediate danger, take action now). NSW uses 'category' field, VIC uses 'action' or category1, QLD uses 'WarningLevel'."
                   },
                   "status": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Current operational status of the incident as reported by the source agency. NSW: extracted from the HTML description field (e.g. 'Under control', 'Being controlled', 'Out of control'). VIC: status field from VicEmergency (e.g. 'Unknown', 'Safe'). QLD: not typically provided, may be null."
+                    "type": "string",
+                    "description": "Topic-safe lowercase-kebab operational status for the incident (e.g. under-control, being-controlled, out-of-control, unknown). The MQTT feeder maps missing upstream status values to unknown so the {status} topic segment is never null or empty.",
+                    "pattern": "^[a-z0-9][a-z0-9-]*$"
                   },
                   "location": {
                     "type": [
@@ -108,7 +145,7 @@
                     ],
                     "description": "Latitude of the incident centroid in decimal degrees (WGS84). Extracted from the GeoJSON Point geometry where available, or computed as the centroid of a Polygon geometry. Negative values indicate Southern Hemisphere.",
                     "unit": "degree",
-                    "symbol": "°"
+                    "symbol": "\\u00b0"
                   },
                   "longitude": {
                     "type": [
@@ -117,7 +154,7 @@
                     ],
                     "description": "Longitude of the incident centroid in decimal degrees (WGS84). Extracted from the GeoJSON Point geometry where available, or computed as the centroid of a Polygon geometry.",
                     "unit": "degree",
-                    "symbol": "°"
+                    "symbol": "\\u00b0"
                   },
                   "size_hectares": {
                     "type": [
@@ -159,3 +196,4 @@
     }
   }
 }
+

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -328,6 +328,12 @@
       "image": "paris-bicycle-counters-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "paris_bicycle_counters_mqtt"
+    },
+    {
+      "dir": "australia-wildfires",
+      "image": "australia-wildfires-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "australia_wildfires_mqtt"
     }
   ],
   "flow": [
@@ -628,6 +634,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestParisBicycleCountersMqttDockerFlow"
+    },
+    {
+      "dir": "australia-wildfires",
+      "image": "australia-wildfires-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestAustraliaWildfiresMqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -4162,3 +4162,107 @@ class TestParisBicycleCountersMqttDockerFlow:
                 assert sample['retain'] is False
                 assert up.get('type') == 'FR.Paris.OpenData.Velo.BicycleCount'
                 assert payload.get('date')
+
+# ---- australia-wildfires --------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def australia_wildfires_mqtt_image():
+    return build_image('australia-wildfires', dockerfile='Dockerfile.mqtt', tag='test-australia-wildfires-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_australia_wildfires():
+    container, network, host_port = _generic_mosquitto(
+        'australia-wildfires-mqtt-e2e', 'australia-wildfires-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'australia-wildfires-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestAustraliaWildfiresMqttDockerFlow:
+    """Verify the australia-wildfires-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_non_retained_uns_topic(self, mosquitto_australia_wildfires, australia_wildfires_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_australia_wildfires['internal_host']}:{mosquitto_australia_wildfires['internal_port']}"
+        messages = []
+
+        def on_message(_client, _userdata, msg):
+            props = {}
+            if msg.properties is not None:
+                for k, v in getattr(msg.properties, 'UserProperty', []) or []:
+                    props[k] = v
+                ct = getattr(msg.properties, 'ContentType', None)
+                if ct:
+                    props['_contenttype'] = ct
+            try:
+                payload = json.loads(msg.payload)
+            except (TypeError, ValueError):
+                payload = None
+            messages.append({'topic': msg.topic, 'retain': bool(msg.retain), 'qos': msg.qos, 'user_properties': props, 'payload': payload})
+
+        sub = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
+        sub.on_message = on_message
+        sub.connect('127.0.0.1', mosquitto_australia_wildfires['host_port'], 30)
+        sub.subscribe('wildfire/au/#', qos=1)
+        sub.loop_start()
+        try:
+            feeder = client.containers.run(
+                australia_wildfires_mqtt_image.id,
+                detach=True,
+                remove=False,
+                network=mosquitto_australia_wildfires['network'],
+                environment={
+                    'MQTT_BROKER_URL': broker_url,
+                    'ONCE_MODE': 'true',
+                    'AUSTRALIA_WILDFIRES_SAMPLE_MODE': 'true',
+                    'PYTHONUNBUFFERED': '1',
+                },
+            )
+            try:
+                result = feeder.wait(timeout=180)
+                logs = feeder.logs().decode('utf-8', errors='replace')
+                assert result.get('StatusCode') == 0, f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+            finally:
+                try:
+                    feeder.remove(force=True)
+                except docker.errors.APIError:
+                    pass
+            deadline = time.time() + 15
+            while not messages and time.time() < deadline:
+                time.sleep(0.5)
+        finally:
+            sub.loop_stop()
+            sub.disconnect()
+
+        assert messages, 'No MQTT messages received from broker'
+        sample = messages[0]
+        assert sample['topic'] == 'wildfire/au/nsw/under-control/sample-incident-001/incident'
+        assert sample['retain'] is False
+        assert sample['qos'] == 1
+        up = sample['user_properties']
+        for required in ('id', 'source', 'type', 'subject', 'specversion'):
+            assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+        assert up.get('_contenttype') == 'application/json'
+        assert up.get('type') == 'AU.Gov.Emergency.Wildfires.FireIncident'
+        assert up.get('subject') == 'nsw/sample-incident-001'
+        payload = _to_dict(sample['payload'])
+        assert payload is not None
+        assert payload.get('state') == 'nsw'
+        assert payload.get('status') == 'under-control'
+        assert payload.get('incident_id') == 'sample-incident-001'


### PR DESCRIPTION
## Topic tree

- `wildfire/au/{state}/{status}/{incident_id}/incident`
- QoS 1, `retain=false`, 7-day MQTT message expiry for time-varying incident updates.

## Specialist review

- xRegistry Expert: no MUST-FIX. SHOULD-FIX items reviewed; fixed defensive incident-id topic safety and documented/implemented expiry semantics. Retained canonical `basemessageurl` style used elsewhere in repo.
- UNS Catalog Architect: MUST-FIX `EVENTS.md` status contract drift fixed. SHOULD-FIXes addressed: message expiry emitted, incident IDs sanitized, retention/expiry documented, sample-mode documented.

## Validation

- `xrcg validate --definitions australia-wildfires\xreg\australia_wildfires.xreg.json`
- `python -m pytest australia-wildfires\tests -q -x` (61 passed)
- `python -m pytest australia-wildfires\australia_wildfires_mqtt_producer\australia_wildfires_mqtt_producer_data\tests australia-wildfires\australia_wildfires_mqtt_producer\australia_wildfires_mqtt_producer_mqtt_client\tests -q -x` (31 passed)
- `docker build -f australia-wildfires\Dockerfile.mqtt -t test-australia-wildfires-mqtt australia-wildfires`
- `python -m pytest tests\docker_e2e\test_docker_mqtt_flow.py::TestAustraliaWildfiresMqttDockerFlow -q -x` (1 passed)