### PR TITLE
mqtt(king-county-marine): add MQTT UNS feeder

### DIFF
--- a/king-county-marine/CONTAINER.md
+++ b/king-county-marine/CONTAINER.md
@@ -35,13 +35,30 @@ docker run --rm \
   ghcr.io/clemensv/real-time-sources-king-county-marine:latest
 ```
 
+### MQTT/UNS image
+
+```bash
+docker build -f Dockerfile.mqtt -t king-county-marine-mqtt .
+docker run --rm \
+  -e MQTT_BROKER_URL="mqtt://host.docker.internal:1883" \
+  ghcr.io/clemensv/real-time-sources/king-county-marine-mqtt:latest
+```
+
+The MQTT image publishes retained QoS 1 binary CloudEvents under
+`maritime/us/wa/king-county/king-county-marine/{station_id}/{event}`. Mount
+`/var/lib/king-county-marine` to persist de-duplication state across restarts.
+
 ## Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
 | `CONNECTION_STRING` | Yes | Kafka/Event Hubs/Fabric connection string |
 | `KAFKA_ENABLE_TLS` | No | Set `false` for plain Kafka in local and Docker E2E runs |
-| `KING_COUNTY_MARINE_STATE_FILE` | No | Path to dedupe state; default `/mnt/fileshare/king_county_marine_state.json` |
+| `KING_COUNTY_MARINE_STATE_FILE` | No | Path to dedupe state; default `/mnt/fileshare/king_county_marine_state.json` for Kafka and `/var/lib/king-county-marine/state.json` for MQTT |
+| `MQTT_BROKER_URL` | MQTT only | MQTT broker URL such as `mqtt://broker:1883` or `mqtts://broker:8883` |
+| `MQTT_USERNAME` / `MQTT_PASSWORD` | MQTT only | Optional MQTT credentials |
+| `MQTT_CONTENT_MODE` | MQTT only | CloudEvents MQTT content mode (`binary`, default, or `structured`) |
+| `KING_COUNTY_MARINE_SAMPLE_MODE` | MQTT test only | Publish one deterministic sample station and reading instead of polling live Socrata feeds |
 
 ## Deploying into Azure Container Instances
 

--- a/king-county-marine/Dockerfile.mqtt
+++ b/king-county-marine/Dockerfile.mqtt
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/king-county-marine"
+LABEL org.opencontainers.image.title="King County Marine → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Publishes MQTT 5.0 binary-mode CloudEvents into maritime/us/wa/king-county/king-county-marine/{station_id}/{event} topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/king-county-marine/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data \
+ && pip install --no-cache-dir ./king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./king_county_marine_producer/king_county_marine_producer_data \
+ && pip install --no-cache-dir ./king_county_marine_producer/king_county_marine_producer_kafka_producer \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./king_county_marine_mqtt
+
+ENV MQTT_BROKER_URL=""
+VOLUME ["/var/lib/king-county-marine"]
+
+CMD ["python", "-m", "king_county_marine_mqtt", "feed"]

--- a/king-county-marine/EVENTS.md
+++ b/king-county-marine/EVENTS.md
@@ -2,6 +2,24 @@
 
 This document describes the events emitted by the King County Marine bridge.
 
+## MQTT Endpoint
+
+| Property | Value |
+|----------|-------|
+| Protocol | MQTT/5.0 |
+| Topic | `maritime/us/wa/king-county/king-county-marine/{station_id}/{event}` |
+| Events | `info`, `water-quality` |
+| QoS / retain | QoS 1, retained |
+| Retention rationale | Station metadata and latest station readings are useful last-known-value state for late subscribers. |
+| Message expiry | `water-quality` retained readings expire after 1 hour; `info` station metadata does not expire. |
+
+### MQTT subscription patterns
+
+- All King County marine events: `maritime/us/wa/king-county/king-county-marine/#`
+- All station metadata: `maritime/us/wa/king-county/king-county-marine/+/info`
+- All latest water-quality readings: `maritime/us/wa/king-county/king-county-marine/+/water-quality`
+- One station: `maritime/us/wa/king-county/king-county-marine/{station_id}/#`
+
 - [US.WA.KingCounty.Marine](#message-group-uswakingcountymarine)
   - [US.WA.KingCounty.Marine.Station](#message-uswakingcountymarinestation)
   - [US.WA.KingCounty.Marine.WaterQualityReading](#message-uswakingcountymarinewaterqualityreading)

--- a/king-county-marine/README.md
+++ b/king-county-marine/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**King County Marine Bridge** polls the current King County marine buoy and mooring raw-data datasets and emits station reference events plus normalized water-quality readings to Kafka as CloudEvents.
+**King County Marine Bridge** polls the current King County marine buoy and mooring raw-data datasets and emits station reference events plus normalized water-quality readings to Kafka as CloudEvents. The MQTT/UNS variant publishes retained QoS 1 binary CloudEvents under `maritime/us/wa/king-county/king-county-marine/{station_id}/{event}`.
 
 The source focuses on near-real-time raw buoy and mooring telemetry published on `data.kingcounty.gov`. It excludes periodic laboratory programs and historical backfill datasets that are not part of the current operational feed.
 

--- a/king-county-marine/king_county_marine/king_county_marine.py
+++ b/king-county-marine/king_county_marine/king_county_marine.py
@@ -231,8 +231,8 @@ class KingCountyMarineBridge:
         """Build station reference metadata from a Socrata view."""
         latitude, longitude = parse_station_location(view.get("description", ""))
         station_name = view.get("name", "")
-        station_id = infer_station_id(station_name)
         dataset_id = view["id"]
+        station_id = infer_station_id(station_name) or slugify(dataset_id)
         dataset_url = f"https://data.kingcounty.gov/d/{dataset_id}"
         sensor_level = infer_sensor_level(station_name)
         return Station(

--- a/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/__init__.py
+++ b/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/__init__.py
@@ -1,0 +1,1 @@
+"""MQTT/UNS feeder for King County Marine."""

--- a/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/__main__.py
+++ b/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/app.py
+++ b/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/app.py
@@ -1,0 +1,177 @@
+"""MQTT feeder application for King County Marine → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from king_county_marine.king_county_marine import KingCountyMarineBridge, REFERENCE_REFRESH_SECONDS
+from king_county_marine_mqtt_producer_data import Station, WaterQualityReading
+from king_county_marine_mqtt_producer_mqtt_client.client import USWAKingCountyMarineMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def _sample_events() -> tuple[list[Station], list[WaterQualityReading]]:
+    station = Station(
+        station_id="sample-station",
+        station_name="Sample Marine Station",
+        dataset_id="sample-dataset",
+        dataset_name="Sample Marine Raw Data Output",
+        dataset_url="https://data.kingcounty.gov/d/sample-dataset",
+        sensor_level="surface",
+        latitude=47.6,
+        longitude=-122.3,
+    )
+    reading = WaterQualityReading(
+        station_id="sample-station",
+        station_name="Sample Marine Station",
+        observation_time="2026-01-01T00:00:00Z",
+        water_temperature_c=10.5,
+        conductivity_s_m=None,
+        pressure_dbar=None,
+        dissolved_oxygen_mg_l=8.1,
+        ph=7.8,
+        chlorophyll_ug_l=None,
+        turbidity_ntu=1.2,
+        chlorophyll_stddev_ug_l=None,
+        turbidity_stddev_ntu=None,
+        salinity_psu=28.0,
+        specific_conductivity_s_m=None,
+        dissolved_oxygen_saturation_pct=95.0,
+        nitrate_umol=None,
+        nitrate_mg_l=None,
+        wind_direction_deg=None,
+        wind_speed_m_s=None,
+        photosynthetically_active_radiation_umol_s_m2=None,
+        air_temperature_f=None,
+        air_humidity_pct=None,
+        air_pressure_in_hg=None,
+        system_battery_v=12.4,
+        sensor_battery_v=None,
+    )
+    return [station], [reading]
+
+
+async def feed(
+    broker_host: str,
+    broker_port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    once: bool = False,
+    content_mode: str = "binary",
+    state_file: str = "",
+    sample_mode: bool = False,
+) -> None:
+    paho_client = mqtt.Client(
+        callback_api_version=CallbackAPIVersion.VERSION2,
+        client_id=client_id or "",
+        protocol=MQTTv5,
+    )
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+
+    mqtt_client = USWAKingCountyMarineMqttMqttClient(
+        client=paho_client,
+        content_mode=content_mode,  # type: ignore[arg-type]
+        loop=asyncio.get_running_loop(),
+    )
+    bridge = KingCountyMarineBridge(state_file=state_file)
+
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
+    await mqtt_client.connect(broker_host, broker_port)
+    try:
+        while True:
+            if sample_mode:
+                stations, readings = _sample_events()
+            else:
+                stations = []
+                readings = []
+                refresh_references = True
+                if bridge.last_reference_refresh:
+                    last = datetime.fromisoformat(bridge.last_reference_refresh)
+                    refresh_references = (datetime.now(timezone.utc) - last).total_seconds() >= REFERENCE_REFRESH_SECONDS
+                if refresh_references or not bridge.station_metadata:
+                    metadata = {}
+                    for dataset in bridge.discover_datasets():
+                        view = bridge.fetch_view(dataset["id"])
+                        station = bridge.build_station(view)
+                        stations.append(Station(**dataclasses.asdict(station)))
+                        metadata[dataset["id"]] = {"station_id": station.station_id, "station_name": station.station_name, "sensor_level": station.sensor_level}
+                    if metadata:
+                        bridge.station_metadata = metadata  # type: ignore[assignment]
+                        bridge.last_reference_refresh = datetime.now(timezone.utc).isoformat()
+                for dataset_id in list(bridge.station_metadata.keys()):
+                    for row in reversed(bridge.fetch_rows(dataset_id)):
+                        reading = bridge.build_reading(dataset_id, row)
+                        reading_id = f"{reading.station_id}|{reading.observation_time}"
+                        if reading_id in bridge.seen_reading_ids:
+                            continue
+                        readings.append(WaterQualityReading(**dataclasses.asdict(reading)))
+                        bridge._remember(reading_id)
+                bridge.save_state()
+            for station in stations:
+                await mqtt_client.publish_us_wa_king_county_marine_mqtt_station(station.station_id, station)
+            for reading in readings:
+                await mqtt_client.publish_us_wa_king_county_marine_mqtt_water_quality_reading(reading.station_id, reading)
+            logger.info("Published %d stations and %d readings to MQTT", len(stations), len(readings))
+            if once:
+                break
+            await asyncio.sleep(900)
+    finally:
+        await mqtt_client.disconnect()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="King County Marine MQTT/UNS bridge")
+    parser.add_argument("feed", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--state-file", default=os.getenv("KING_COUNTY_MARINE_STATE_FILE", "/var/lib/king-county-marine/state.json"))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    parser.add_argument("--sample-mode", action="store_true", default=os.getenv("KING_COUNTY_MARINE_SAMPLE_MODE", "").lower() in ("1", "true", "yes"))
+    args = parser.parse_args()
+    if args.feed != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, parsed_tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(
+        host,
+        port,
+        username=args.username or None,
+        password=args.password or None,
+        tls=parsed_tls,
+        client_id=args.client_id or None,
+        once=args.once,
+        content_mode=args.content_mode,
+        state_file=args.state_file,
+        sample_mode=args.sample_mode,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/king-county-marine/king_county_marine_mqtt/pyproject.toml
+++ b/king-county-marine/king_county_marine_mqtt/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "king-county-marine-mqtt"
+version = "0.1.0"
+description = "King County Marine MQTT/UNS feeder"
+requires-python = ">=3.10"
+dependencies = [
+    "paho-mqtt",
+    "dataclasses_json",
+    "cloudevents",
+    "king-county-marine",
+    "king_county_marine_mqtt_producer_data",
+    "king_county_marine_mqtt_producer_mqtt_client",
+]
+
+[project.scripts]
+king-county-marine-mqtt = "king_county_marine_mqtt.app:main"
+
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["king_county_marine_mqtt*"]

--- a/king-county-marine/king_county_marine_mqtt_producer/Makefile
+++ b/king-county-marine/king_county_marine_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./king_county_marine_mqtt_producer_data ./king_county_marine_mqtt_producer_mqtt_client
+
+install: build
+	cd king_county_marine_mqtt_producer_data && poetry install
+	cd king_county_marine_mqtt_producer_mqtt_client && poetry install
+	pip install ./king_county_marine_mqtt_producer_data ./king_county_marine_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./king_county_marine_mqtt_producer_mqtt_client/tests ./king_county_marine_mqtt_producer_data/tests

--- a/king-county-marine/king_county_marine_mqtt_producer/README.md
+++ b/king-county-marine/king_county_marine_mqtt_producer/README.md
@@ -1,0 +1,1081 @@
+# King_county_marine_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the king_county_marine_mqtt_producer message definitions.
+
+# King_county_marine_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - USWAKingCountyMarineMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from king_county_marine_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure
+Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = USWAKingCountyMarineMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### USWAKingCountyMarineMqttEventDispatcher
+
+
+
+# Publish message`USWAKingCountyMarineMqttEventDispatcher` handles events for the US.WA.KingCounty.Marine.mqtt message
+group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from king_county_marine_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = USWAKingCountyMarineMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the
+Event Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe USWAKingCountyMarineMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `us_wa_king_county_marine_mqtt_station_async`
+
+
+
+## Test```python
+
+us_wa_king_county_marine_mqtt_station_async:  Callable[[PartitionContext, EventData, CloudEvent, Station],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `US.WA.KingCounty.Marine.mqtt.Station`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `king_county_marine_mqtt_producer_data.Station`.
+
+Example:
+
+```python
+async def us_wa_king_county_marine_mqtt_station_event(partition_context: PartitionContext, event: EventData,
+cloud_event: CloudEvent, data: Station) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+us_wa_king_county_marine_mqtt_dispatcher.us_wa_king_county_marine_mqtt_station_async =
+us_wa_king_county_marine_mqtt_station_event
+```
+
+
+
+make build
+
+```##### `us_wa_king_county_marine_mqtt_water_quality_reading_async`
+
+
+
+## Test```python
+
+us_wa_king_county_marine_mqtt_water_quality_reading_async:  Callable[[PartitionContext, EventData, CloudEvent,
+WaterQualityReading], Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `US.WA.KingCounty.Marine.mqtt.WaterQualityReading`:
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `king_county_marine_mqtt_producer_data.WaterQualityReading`.
+
+Example:
+
+```python
+async def us_wa_king_county_marine_mqtt_water_quality_reading_event(partition_context: PartitionContext, event:
+EventData, cloud_event: CloudEvent, data: WaterQualityReading) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+us_wa_king_county_marine_mqtt_dispatcher.us_wa_king_county_marine_mqtt_water_quality_reading_async =
+us_wa_king_county_marine_mqtt_water_quality_reading_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/king-county-marine/king_county_marine_mqtt_producer/install.bat
+++ b/king-county-marine/king_county_marine_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\king_county_marine_mqtt_producer_data
+pip install .\king_county_marine_mqtt_producer_mqtt_client

--- a/king-county-marine/king_county_marine_mqtt_producer/install.sh
+++ b/king-county-marine/king_county_marine_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./king_county_marine_mqtt_producer_data
+pip install ./king_county_marine_mqtt_producer_mqtt_client

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/pyproject.toml
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "king-county-marine-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "king_county_marine_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/__init__.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .station import Station
+from .waterqualityreading import WaterQualityReading
+
+__all__ = ["Station", "WaterQualityReading"]

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/station.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/station.py
@@ -1,0 +1,176 @@
+""" Station dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Station:
+    """
+    Reference metadata for one active King County buoy or mooring raw-data dataset.
+    
+    Attributes:
+        station_id (str)
+        station_name (str)
+        dataset_id (str)
+        dataset_name (str)
+        dataset_url (str)
+        sensor_level (str)
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+    """
+    
+    
+    station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    station_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_name"))
+    dataset_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dataset_id"))
+    dataset_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dataset_name"))
+    dataset_url: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dataset_url"))
+    sensor_level: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sensor_level"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Station':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['Station']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return Station.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'Station':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            station_id='ejwbrnxkkydkhiiayogj',
+            station_name='cmmgwjxghhbkmvmywhcv',
+            dataset_id='iejyxebilqtyvsiwnxhh',
+            dataset_name='wkesnzqwixpeeobatoel',
+            dataset_url='grdlzemvsdmbkfduvxxt',
+            sensor_level='urjxucepouvsqmnatpxr',
+            latitude=float(61.91724474112619),
+            longitude=float(47.390238055676384)
+        )

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/waterqualityreading.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/src/king_county_marine_mqtt_producer_data/waterqualityreading.py
@@ -1,0 +1,227 @@
+""" WaterQualityReading dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class WaterQualityReading:
+    """
+    Normalized King County buoy or mooring reading carrying the documented water-quality and weather measurements published by the current raw-data datasets.
+    
+    Attributes:
+        station_id (str)
+        station_name (str)
+        observation_time (str)
+        water_temperature_c (typing.Optional[float])
+        conductivity_s_m (typing.Optional[float])
+        pressure_dbar (typing.Optional[float])
+        dissolved_oxygen_mg_l (typing.Optional[float])
+        ph (typing.Optional[float])
+        chlorophyll_ug_l (typing.Optional[float])
+        turbidity_ntu (typing.Optional[float])
+        chlorophyll_stddev_ug_l (typing.Optional[float])
+        turbidity_stddev_ntu (typing.Optional[float])
+        salinity_psu (typing.Optional[float])
+        specific_conductivity_s_m (typing.Optional[float])
+        dissolved_oxygen_saturation_pct (typing.Optional[float])
+        nitrate_umol (typing.Optional[float])
+        nitrate_mg_l (typing.Optional[float])
+        wind_direction_deg (typing.Optional[float])
+        wind_speed_m_s (typing.Optional[float])
+        photosynthetically_active_radiation_umol_s_m2 (typing.Optional[float])
+        air_temperature_f (typing.Optional[float])
+        air_humidity_pct (typing.Optional[float])
+        air_pressure_in_hg (typing.Optional[float])
+        system_battery_v (typing.Optional[float])
+        sensor_battery_v (typing.Optional[float])
+    """
+    
+    
+    station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    station_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_name"))
+    observation_time: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="observation_time"))
+    water_temperature_c: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="water_temperature_c"))
+    conductivity_s_m: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="conductivity_s_m"))
+    pressure_dbar: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure_dbar"))
+    dissolved_oxygen_mg_l: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dissolved_oxygen_mg_l"))
+    ph: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ph"))
+    chlorophyll_ug_l: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="chlorophyll_ug_l"))
+    turbidity_ntu: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="turbidity_ntu"))
+    chlorophyll_stddev_ug_l: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="chlorophyll_stddev_ug_l"))
+    turbidity_stddev_ntu: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="turbidity_stddev_ntu"))
+    salinity_psu: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="salinity_psu"))
+    specific_conductivity_s_m: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="specific_conductivity_s_m"))
+    dissolved_oxygen_saturation_pct: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dissolved_oxygen_saturation_pct"))
+    nitrate_umol: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="nitrate_umol"))
+    nitrate_mg_l: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="nitrate_mg_l"))
+    wind_direction_deg: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction_deg"))
+    wind_speed_m_s: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed_m_s"))
+    photosynthetically_active_radiation_umol_s_m2: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="photosynthetically_active_radiation_umol_s_m2"))
+    air_temperature_f: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="air_temperature_f"))
+    air_humidity_pct: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="air_humidity_pct"))
+    air_pressure_in_hg: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="air_pressure_in_hg"))
+    system_battery_v: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="system_battery_v"))
+    sensor_battery_v: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sensor_battery_v"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'WaterQualityReading':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['WaterQualityReading']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return WaterQualityReading.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'WaterQualityReading':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            station_id='mwfditawtuajdjwzomli',
+            station_name='hgdbjgegbnhnoihpytsk',
+            observation_time='abqtwbktzvlewovgeeqe',
+            water_temperature_c=float(99.17724721847311),
+            conductivity_s_m=float(30.788921957826567),
+            pressure_dbar=float(78.65130504456988),
+            dissolved_oxygen_mg_l=float(68.19895002954627),
+            ph=float(27.07903907158309),
+            chlorophyll_ug_l=float(42.85501216570024),
+            turbidity_ntu=float(15.038937810517206),
+            chlorophyll_stddev_ug_l=float(61.532712221052186),
+            turbidity_stddev_ntu=float(70.03270595681929),
+            salinity_psu=float(35.92990605671324),
+            specific_conductivity_s_m=float(8.601621586916297),
+            dissolved_oxygen_saturation_pct=float(81.73995353268235),
+            nitrate_umol=float(36.41455674240237),
+            nitrate_mg_l=float(82.36403986423724),
+            wind_direction_deg=float(75.1110051620823),
+            wind_speed_m_s=float(0.6623360917644927),
+            photosynthetically_active_radiation_umol_s_m2=float(18.780990756627215),
+            air_temperature_f=float(51.235489691836236),
+            air_humidity_pct=float(18.41430019767255),
+            air_pressure_in_hg=float(32.3678708742918),
+            system_battery_v=float(74.4155417701577),
+            sensor_battery_v=float(24.85128644420348)
+        )

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/tests/test_station.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/tests/test_station.py
@@ -1,0 +1,125 @@
+"""
+Test case for Station
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from king_county_marine_mqtt_producer_data.station import Station
+
+
+class Test_Station(unittest.TestCase):
+    """
+    Test case for Station
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_Station.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of Station for testing
+        """
+        instance = Station(
+            station_id='ejwbrnxkkydkhiiayogj',
+            station_name='cmmgwjxghhbkmvmywhcv',
+            dataset_id='iejyxebilqtyvsiwnxhh',
+            dataset_name='wkesnzqwixpeeobatoel',
+            dataset_url='grdlzemvsdmbkfduvxxt',
+            sensor_level='urjxucepouvsqmnatpxr',
+            latitude=float(61.91724474112619),
+            longitude=float(47.390238055676384)
+        )
+        return instance
+
+    
+    def test_station_id_property(self):
+        """
+        Test station_id property
+        """
+        test_value = 'ejwbrnxkkydkhiiayogj'
+        self.instance.station_id = test_value
+        self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_station_name_property(self):
+        """
+        Test station_name property
+        """
+        test_value = 'cmmgwjxghhbkmvmywhcv'
+        self.instance.station_name = test_value
+        self.assertEqual(self.instance.station_name, test_value)
+    
+    def test_dataset_id_property(self):
+        """
+        Test dataset_id property
+        """
+        test_value = 'iejyxebilqtyvsiwnxhh'
+        self.instance.dataset_id = test_value
+        self.assertEqual(self.instance.dataset_id, test_value)
+    
+    def test_dataset_name_property(self):
+        """
+        Test dataset_name property
+        """
+        test_value = 'wkesnzqwixpeeobatoel'
+        self.instance.dataset_name = test_value
+        self.assertEqual(self.instance.dataset_name, test_value)
+    
+    def test_dataset_url_property(self):
+        """
+        Test dataset_url property
+        """
+        test_value = 'grdlzemvsdmbkfduvxxt'
+        self.instance.dataset_url = test_value
+        self.assertEqual(self.instance.dataset_url, test_value)
+    
+    def test_sensor_level_property(self):
+        """
+        Test sensor_level property
+        """
+        test_value = 'urjxucepouvsqmnatpxr'
+        self.instance.sensor_level = test_value
+        self.assertEqual(self.instance.sensor_level, test_value)
+    
+    def test_latitude_property(self):
+        """
+        Test latitude property
+        """
+        test_value = float(61.91724474112619)
+        self.instance.latitude = test_value
+        self.assertEqual(self.instance.latitude, test_value)
+    
+    def test_longitude_property(self):
+        """
+        Test longitude property
+        """
+        test_value = float(47.390238055676384)
+        self.instance.longitude = test_value
+        self.assertEqual(self.instance.longitude, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = Station.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = Station.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/tests/test_waterqualityreading.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_data/tests/test_waterqualityreading.py
@@ -1,0 +1,278 @@
+"""
+Test case for WaterQualityReading
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from king_county_marine_mqtt_producer_data.waterqualityreading import WaterQualityReading
+
+
+class Test_WaterQualityReading(unittest.TestCase):
+    """
+    Test case for WaterQualityReading
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_WaterQualityReading.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WaterQualityReading for testing
+        """
+        instance = WaterQualityReading(
+            station_id='mwfditawtuajdjwzomli',
+            station_name='hgdbjgegbnhnoihpytsk',
+            observation_time='abqtwbktzvlewovgeeqe',
+            water_temperature_c=float(99.17724721847311),
+            conductivity_s_m=float(30.788921957826567),
+            pressure_dbar=float(78.65130504456988),
+            dissolved_oxygen_mg_l=float(68.19895002954627),
+            ph=float(27.07903907158309),
+            chlorophyll_ug_l=float(42.85501216570024),
+            turbidity_ntu=float(15.038937810517206),
+            chlorophyll_stddev_ug_l=float(61.532712221052186),
+            turbidity_stddev_ntu=float(70.03270595681929),
+            salinity_psu=float(35.92990605671324),
+            specific_conductivity_s_m=float(8.601621586916297),
+            dissolved_oxygen_saturation_pct=float(81.73995353268235),
+            nitrate_umol=float(36.41455674240237),
+            nitrate_mg_l=float(82.36403986423724),
+            wind_direction_deg=float(75.1110051620823),
+            wind_speed_m_s=float(0.6623360917644927),
+            photosynthetically_active_radiation_umol_s_m2=float(18.780990756627215),
+            air_temperature_f=float(51.235489691836236),
+            air_humidity_pct=float(18.41430019767255),
+            air_pressure_in_hg=float(32.3678708742918),
+            system_battery_v=float(74.4155417701577),
+            sensor_battery_v=float(24.85128644420348)
+        )
+        return instance
+
+    
+    def test_station_id_property(self):
+        """
+        Test station_id property
+        """
+        test_value = 'mwfditawtuajdjwzomli'
+        self.instance.station_id = test_value
+        self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_station_name_property(self):
+        """
+        Test station_name property
+        """
+        test_value = 'hgdbjgegbnhnoihpytsk'
+        self.instance.station_name = test_value
+        self.assertEqual(self.instance.station_name, test_value)
+    
+    def test_observation_time_property(self):
+        """
+        Test observation_time property
+        """
+        test_value = 'abqtwbktzvlewovgeeqe'
+        self.instance.observation_time = test_value
+        self.assertEqual(self.instance.observation_time, test_value)
+    
+    def test_water_temperature_c_property(self):
+        """
+        Test water_temperature_c property
+        """
+        test_value = float(99.17724721847311)
+        self.instance.water_temperature_c = test_value
+        self.assertEqual(self.instance.water_temperature_c, test_value)
+    
+    def test_conductivity_s_m_property(self):
+        """
+        Test conductivity_s_m property
+        """
+        test_value = float(30.788921957826567)
+        self.instance.conductivity_s_m = test_value
+        self.assertEqual(self.instance.conductivity_s_m, test_value)
+    
+    def test_pressure_dbar_property(self):
+        """
+        Test pressure_dbar property
+        """
+        test_value = float(78.65130504456988)
+        self.instance.pressure_dbar = test_value
+        self.assertEqual(self.instance.pressure_dbar, test_value)
+    
+    def test_dissolved_oxygen_mg_l_property(self):
+        """
+        Test dissolved_oxygen_mg_l property
+        """
+        test_value = float(68.19895002954627)
+        self.instance.dissolved_oxygen_mg_l = test_value
+        self.assertEqual(self.instance.dissolved_oxygen_mg_l, test_value)
+    
+    def test_ph_property(self):
+        """
+        Test ph property
+        """
+        test_value = float(27.07903907158309)
+        self.instance.ph = test_value
+        self.assertEqual(self.instance.ph, test_value)
+    
+    def test_chlorophyll_ug_l_property(self):
+        """
+        Test chlorophyll_ug_l property
+        """
+        test_value = float(42.85501216570024)
+        self.instance.chlorophyll_ug_l = test_value
+        self.assertEqual(self.instance.chlorophyll_ug_l, test_value)
+    
+    def test_turbidity_ntu_property(self):
+        """
+        Test turbidity_ntu property
+        """
+        test_value = float(15.038937810517206)
+        self.instance.turbidity_ntu = test_value
+        self.assertEqual(self.instance.turbidity_ntu, test_value)
+    
+    def test_chlorophyll_stddev_ug_l_property(self):
+        """
+        Test chlorophyll_stddev_ug_l property
+        """
+        test_value = float(61.532712221052186)
+        self.instance.chlorophyll_stddev_ug_l = test_value
+        self.assertEqual(self.instance.chlorophyll_stddev_ug_l, test_value)
+    
+    def test_turbidity_stddev_ntu_property(self):
+        """
+        Test turbidity_stddev_ntu property
+        """
+        test_value = float(70.03270595681929)
+        self.instance.turbidity_stddev_ntu = test_value
+        self.assertEqual(self.instance.turbidity_stddev_ntu, test_value)
+    
+    def test_salinity_psu_property(self):
+        """
+        Test salinity_psu property
+        """
+        test_value = float(35.92990605671324)
+        self.instance.salinity_psu = test_value
+        self.assertEqual(self.instance.salinity_psu, test_value)
+    
+    def test_specific_conductivity_s_m_property(self):
+        """
+        Test specific_conductivity_s_m property
+        """
+        test_value = float(8.601621586916297)
+        self.instance.specific_conductivity_s_m = test_value
+        self.assertEqual(self.instance.specific_conductivity_s_m, test_value)
+    
+    def test_dissolved_oxygen_saturation_pct_property(self):
+        """
+        Test dissolved_oxygen_saturation_pct property
+        """
+        test_value = float(81.73995353268235)
+        self.instance.dissolved_oxygen_saturation_pct = test_value
+        self.assertEqual(self.instance.dissolved_oxygen_saturation_pct, test_value)
+    
+    def test_nitrate_umol_property(self):
+        """
+        Test nitrate_umol property
+        """
+        test_value = float(36.41455674240237)
+        self.instance.nitrate_umol = test_value
+        self.assertEqual(self.instance.nitrate_umol, test_value)
+    
+    def test_nitrate_mg_l_property(self):
+        """
+        Test nitrate_mg_l property
+        """
+        test_value = float(82.36403986423724)
+        self.instance.nitrate_mg_l = test_value
+        self.assertEqual(self.instance.nitrate_mg_l, test_value)
+    
+    def test_wind_direction_deg_property(self):
+        """
+        Test wind_direction_deg property
+        """
+        test_value = float(75.1110051620823)
+        self.instance.wind_direction_deg = test_value
+        self.assertEqual(self.instance.wind_direction_deg, test_value)
+    
+    def test_wind_speed_m_s_property(self):
+        """
+        Test wind_speed_m_s property
+        """
+        test_value = float(0.6623360917644927)
+        self.instance.wind_speed_m_s = test_value
+        self.assertEqual(self.instance.wind_speed_m_s, test_value)
+    
+    def test_photosynthetically_active_radiation_umol_s_m2_property(self):
+        """
+        Test photosynthetically_active_radiation_umol_s_m2 property
+        """
+        test_value = float(18.780990756627215)
+        self.instance.photosynthetically_active_radiation_umol_s_m2 = test_value
+        self.assertEqual(self.instance.photosynthetically_active_radiation_umol_s_m2, test_value)
+    
+    def test_air_temperature_f_property(self):
+        """
+        Test air_temperature_f property
+        """
+        test_value = float(51.235489691836236)
+        self.instance.air_temperature_f = test_value
+        self.assertEqual(self.instance.air_temperature_f, test_value)
+    
+    def test_air_humidity_pct_property(self):
+        """
+        Test air_humidity_pct property
+        """
+        test_value = float(18.41430019767255)
+        self.instance.air_humidity_pct = test_value
+        self.assertEqual(self.instance.air_humidity_pct, test_value)
+    
+    def test_air_pressure_in_hg_property(self):
+        """
+        Test air_pressure_in_hg property
+        """
+        test_value = float(32.3678708742918)
+        self.instance.air_pressure_in_hg = test_value
+        self.assertEqual(self.instance.air_pressure_in_hg, test_value)
+    
+    def test_system_battery_v_property(self):
+        """
+        Test system_battery_v property
+        """
+        test_value = float(74.4155417701577)
+        self.instance.system_battery_v = test_value
+        self.assertEqual(self.instance.system_battery_v, test_value)
+    
+    def test_sensor_battery_v_property(self):
+        """
+        Test sensor_battery_v property
+        """
+        test_value = float(24.85128644420348)
+        self.instance.sensor_battery_v = test_value
+        self.assertEqual(self.instance.sensor_battery_v, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = WaterQualityReading.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = WaterQualityReading.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/pyproject.toml
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "king-county-marine-mqtt-producer-mqtt-client"
+description = "king_county_marine_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "king_county_marine_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+king-county-marine-mqtt-producer-data = {path = "../king_county_marine_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/src/king_county_marine_mqtt_producer_mqtt_client/__init__.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/src/king_county_marine_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import USWAKingCountyMarineMqttMqttClient
+
+__all__ = [
+    "USWAKingCountyMarineMqttMqttClient",
+]

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/src/king_county_marine_mqtt_producer_mqtt_client/client.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/src/king_county_marine_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,509 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import king_county_marine_mqtt_producer_data
+from king_county_marine_mqtt_producer_data import Station
+from king_county_marine_mqtt_producer_data import WaterQualityReading
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_us_wa_kingcounty_marine_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the US.WA.KingCounty.Marine.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "US.WA.KingCounty.Marine.mqtt.Station": "maritime/us/wa/king-county/king-county-marine/{station_id}/info",
+        "US.WA.KingCounty.Marine.mqtt.WaterQualityReading": "maritime/us/wa/king-county/king-county-marine/{station_id}/water-quality",
+    }
+
+
+def get_subscription_topics_us_wa_kingcounty_marine_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_us_wa_kingcounty_marine_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class USWAKingCountyMarineMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the US.WA.KingCounty.Marine.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_us_wa_kingcounty_marine_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.us_wa_king_county_marine_mqtt_station_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, king_county_marine_mqtt_producer_data.Station, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.us_wa_king_county_marine_mqtt_water_quality_reading_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, king_county_marine_mqtt_producer_data.WaterQualityReading, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "US.WA.KingCounty.Marine.Station":
+            if self.us_wa_king_county_marine_mqtt_station_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = king_county_marine_mqtt_producer_data.Station.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "US.WA.KingCounty.Marine.mqtt.Station")
+                    await self.us_wa_king_county_marine_mqtt_station_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in us_wa_king_county_marine_mqtt_station handler: {e}")
+            return
+        
+        if event_type == "US.WA.KingCounty.Marine.WaterQualityReading":
+            if self.us_wa_king_county_marine_mqtt_water_quality_reading_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = king_county_marine_mqtt_producer_data.WaterQualityReading.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "US.WA.KingCounty.Marine.mqtt.WaterQualityReading")
+                    await self.us_wa_king_county_marine_mqtt_water_quality_reading_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in us_wa_king_county_marine_mqtt_water_quality_reading handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_us_wa_kingcounty_marine_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_us_wa_king_county_marine_mqtt_station(self,
+        station_id: str,
+        data: king_county_marine_mqtt_producer_data.Station,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'US.WA.KingCounty.Marine.mqtt.Station' event to an MQTT topic.
+
+        Args:
+        
+            station_id: URI template variable for 'station_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'maritime/us/wa/king-county/king-county-marine/{station_id}/info'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "maritime/us/wa/king-county/king-county-marine/{station_id}/info"
+        _topic_template_values: Dict[str, str] = {
+            "station_id": str(station_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"US.WA.KingCounty.Marine.Station",
+             "source":"https://data.kingcounty.gov/",
+             "subject":"{station_id}".format(station_id = station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_us_wa_king_county_marine_mqtt_water_quality_reading(self,
+        station_id: str,
+        data: king_county_marine_mqtt_producer_data.WaterQualityReading,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'US.WA.KingCounty.Marine.mqtt.WaterQualityReading' event to an MQTT topic.
+
+        Args:
+        
+            station_id: URI template variable for 'station_id'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'maritime/us/wa/king-county/king-county-marine/{station_id}/water-quality'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "maritime/us/wa/king-county/king-county-marine/{station_id}/water-quality"
+        _topic_template_values: Dict[str, str] = {
+            "station_id": str(station_id),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"US.WA.KingCounty.Marine.WaterQualityReading",
+             "source":"https://data.kingcounty.gov/",
+             "subject":"{station_id}".format(station_id = station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+        if _MQTT5_AVAILABLE and _MqttProperties is not None and _MqttPacketTypes is not None:
+            props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+            props.MessageExpiryInterval = 3600
+            publish_kwargs["properties"] = props
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                mqtt5_props.MessageExpiryInterval = 3600
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/king_county_marine_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,176 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../king_county_marine_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../king_county_marine_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../king_county_marine_mqtt_producer_mqtt_client/src')))
+
+import king_county_marine_mqtt_producer_data
+from king_county_marine_mqtt_producer_data import Station
+from test_station import Test_Station
+from king_county_marine_mqtt_producer_data import WaterQualityReading
+from test_waterqualityreading import Test_WaterQualityReading
+from king_county_marine_mqtt_producer_mqtt_client import USWAKingCountyMarineMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_us_wa_kingcounty_marine_mqtt_us_wa_king_county_marine_mqtt_station_py(mosquitto_broker):
+    """Test publishing and receiving US.WA.KingCounty.Marine.mqtt.Station message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Station.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = USWAKingCountyMarineMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = USWAKingCountyMarineMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_us_wa_king_county_marine_mqtt_station(mqtt_msg, cloud_event, data: king_county_marine_mqtt_producer_data.Station, topic_params: dict):
+        """Handler for US.WA.KingCounty.Marine.mqtt.Station messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "US.WA.KingCounty.Marine.Station"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.us_wa_king_county_marine_mqtt_station_async = on_us_wa_king_county_marine_mqtt_station
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/us_wa_kingcounty_marine_mqtt/us_wa_king_county_marine_mqtt_station"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_us_wa_king_county_marine_mqtt_station(
+            topic=test_topic,
+            station_id=f"test_station_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_us_wa_kingcounty_marine_mqtt_us_wa_king_county_marine_mqtt_water_quality_reading_py(mosquitto_broker):
+    """Test publishing and receiving US.WA.KingCounty.Marine.mqtt.WaterQualityReading message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_WaterQualityReading.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = USWAKingCountyMarineMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = USWAKingCountyMarineMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_us_wa_king_county_marine_mqtt_water_quality_reading(mqtt_msg, cloud_event, data: king_county_marine_mqtt_producer_data.WaterQualityReading, topic_params: dict):
+        """Handler for US.WA.KingCounty.Marine.mqtt.WaterQualityReading messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "US.WA.KingCounty.Marine.WaterQualityReading"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.us_wa_king_county_marine_mqtt_water_quality_reading_async = on_us_wa_king_county_marine_mqtt_water_quality_reading
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/us_wa_kingcounty_marine_mqtt/us_wa_king_county_marine_mqtt_water_quality_reading"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_us_wa_king_county_marine_mqtt_water_quality_reading(
+            topic=test_topic,
+            station_id=f"test_station_id_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/king-county-marine/king_county_marine_mqtt_producer/samples/sample.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/samples/sample.py
@@ -1,0 +1,87 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from king_county_marine_mqtt_producer_data import *
+from king_county_marine_mqtt_producer_mqtt_client.client import USWAKingCountyMarineMqttProducer, USWAKingCountyMarineMqttDispatcher
+
+async def handle_us_wa_king_county_marine_mqtt_station(mqtt_msg,cloud_event, us_wa_king_county_marine_mqtt_station_data):
+    """ Handles the US.WA.KingCounty.Marine.mqtt.Station message """
+    print(f"Received US.WA.KingCounty.Marine.mqtt.Station on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {us_wa_king_county_marine_mqtt_station_data}")
+
+async def handle_us_wa_king_county_marine_mqtt_water_quality_reading(mqtt_msg,cloud_event, us_wa_king_county_marine_mqtt_water_quality_reading_data):
+    """ Handles the US.WA.KingCounty.Marine.mqtt.WaterQualityReading message """
+    print(f"Received US.WA.KingCounty.Marine.mqtt.WaterQualityReading on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {us_wa_king_county_marine_mqtt_water_quality_reading_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/king-county-marine/king_county_marine_mqtt_producer/scripts/build.py
+++ b/king-county-marine/king_county_marine_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["king_county_marine_mqtt_producer_mqtt_client", "king_county_marine_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/king-county-marine/xreg/king_county_marine.xreg.json
+++ b/king-county-marine/xreg/king_county_marine.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "US.WA.KingCounty.Marine.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,31 @@
           "key": "{station_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/US.WA.KingCounty.Marine"]
+      "messagegroups": [
+        "#/messagegroups/US.WA.KingCounty.Marine"
+      ]
+    },
+    "US.WA.KingCounty.Marine.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/US.WA.KingCounty.Marine.mqtt"
+      ],
+      "description": "MQTT/5.0 binary-mode CloudEvents producer for the King County Marine UNS topic tree."
     }
   },
   "messagegroups": {
@@ -56,6 +82,32 @@
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/US.WA.KingCounty.Marine.jstruct/schemas/US.WA.KingCounty.Marine.WaterQualityReading"
+        }
+      }
+    },
+    "US.WA.KingCounty.Marine.mqtt": {
+      "description": "MQTT/5.0 transport variants for King County marine station reference data and water-quality readings. The station-only UNS topic tree is maritime/us/wa/king-county/king-county-marine/{station_id}/{event}. Station info and latest water-quality readings are retained with QoS 1 so late subscribers can discover stations and their latest values.",
+      "messages": {
+        "US.WA.KingCounty.Marine.mqtt.Station": {
+          "name": "Station",
+          "basemessageurl": "/messagegroups/US.WA.KingCounty.Marine/messages/US.WA.KingCounty.Marine.Station",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "maritime/us/wa/king-county/king-county-marine/{station_id}/info",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "US.WA.KingCounty.Marine.mqtt.WaterQualityReading": {
+          "name": "WaterQualityReading",
+          "basemessageurl": "/messagegroups/US.WA.KingCounty.Marine/messages/US.WA.KingCounty.Marine.WaterQualityReading",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "maritime/us/wa/king-county/king-county-marine/{station_id}/water-quality",
+            "qos": 1,
+            "retain": true,
+            "message_expiry_interval": 3600
+          }
         }
       }
     }
@@ -110,11 +162,17 @@
                     "description": "Sensor position classification inferred from the dataset title, such as surface, bottom, or water-column."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Station latitude in decimal degrees north, parsed from the dataset description."
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Station longitude in decimal degrees east of Greenwich; King County locations are negative because they lie west of Greenwich."
                   }
                 }
@@ -154,131 +212,197 @@
                     "description": "Observation timestamp normalized to UTC ISO 8601 form."
                   },
                   "water_temperature_c": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Water temperature in degrees Celsius.",
                     "unit": "Cel",
-                    "symbol": "°C"
+                    "symbol": "Â°C"
                   },
                   "conductivity_s_m": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Electrical conductivity in siemens per meter.",
                     "unit": "S/m",
                     "symbol": "S/m"
                   },
                   "pressure_dbar": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Water pressure in decibar as published by the raw datasets.",
                     "unit": "dbar",
                     "symbol": "dbar"
                   },
                   "dissolved_oxygen_mg_l": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Dissolved oxygen concentration in milligrams per liter.",
                     "unit": "mg/L",
                     "symbol": "mg/L"
                   },
                   "ph": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Measured pH value."
                   },
                   "chlorophyll_ug_l": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Chlorophyll fluorescence or chlorophyll concentration in micrograms per liter.",
                     "unit": "ug/L",
-                    "symbol": "µg/L"
+                    "symbol": "Âµg/L"
                   },
                   "turbidity_ntu": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Turbidity in nephelometric turbidity units.",
                     "unit": "NTU",
                     "symbol": "NTU"
                   },
                   "chlorophyll_stddev_ug_l": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Standard deviation of chlorophyll fluorescence in micrograms per liter.",
                     "unit": "ug/L",
-                    "symbol": "µg/L"
+                    "symbol": "Âµg/L"
                   },
                   "turbidity_stddev_ntu": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Standard deviation of turbidity in nephelometric turbidity units.",
                     "unit": "NTU",
                     "symbol": "NTU"
                   },
                   "salinity_psu": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Salinity in practical salinity units.",
                     "unit": "PSU",
                     "symbol": "PSU"
                   },
                   "specific_conductivity_s_m": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Specific conductivity in siemens per meter.",
                     "unit": "S/m",
                     "symbol": "S/m"
                   },
                   "dissolved_oxygen_saturation_pct": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Dissolved oxygen saturation as a percentage.",
                     "unit": "P1",
                     "symbol": "%"
                   },
                   "nitrate_umol": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Nitrate or nitrate-plus-nitrite concentration in micromoles.",
                     "unit": "umol",
-                    "symbol": "µmol"
+                    "symbol": "Âµmol"
                   },
                   "nitrate_mg_l": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Nitrate or nitrate-plus-nitrite concentration in milligrams per liter.",
                     "unit": "mg/L",
                     "symbol": "mg/L"
                   },
                   "wind_direction_deg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Wind direction in degrees at the buoy surface.",
                     "unit": "deg",
-                    "symbol": "°"
+                    "symbol": "Â°"
                   },
                   "wind_speed_m_s": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Wind speed in meters per second at the buoy surface.",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "photosynthetically_active_radiation_umol_s_m2": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Photosynthetically active radiation in micromoles per second per square meter.",
                     "unit": "umol/s/m2",
-                    "symbol": "µmol/s/m²"
+                    "symbol": "Âµmol/s/mÂ²"
                   },
                   "air_temperature_f": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Air temperature in degrees Fahrenheit.",
                     "unit": "[degF]",
-                    "symbol": "°F"
+                    "symbol": "Â°F"
                   },
                   "air_humidity_pct": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Relative humidity percentage.",
                     "unit": "P1",
                     "symbol": "%"
                   },
                   "air_pressure_in_hg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Air pressure in inches of mercury.",
                     "unit": "[in_i'Hg]",
                     "symbol": "inHg"
                   },
                   "system_battery_v": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "System battery voltage in volts.",
                     "unit": "V",
                     "symbol": "V"
                   },
                   "sensor_battery_v": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Sensor or sonde battery voltage in volts.",
                     "unit": "V",
                     "symbol": "V"

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -334,6 +334,12 @@
       "image": "australia-wildfires-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "australia_wildfires_mqtt"
+    },
+    {
+      "dir": "king-county-marine",
+      "image": "king-county-marine-mqtt",
+      "file": "Dockerfile.mqtt",
+      "module": "king_county_marine_mqtt"
     }
   ],
   "flow": [
@@ -641,6 +647,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestAustraliaWildfiresMqttDockerFlow"
+    },
+    {
+      "dir": "king-county-marine",
+      "image": "king-county-marine-mqtt",
+      "file": "Dockerfile.mqtt",
+      "test_file": "test_docker_mqtt_flow.py",
+      "test_class": "TestKingCountyMarineMqttDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -4266,3 +4266,82 @@ class TestAustraliaWildfiresMqttDockerFlow:
         assert payload.get('state') == 'nsw'
         assert payload.get('status') == 'under-control'
         assert payload.get('incident_id') == 'sample-incident-001'
+
+# ---- king-county-marine ---------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def king_county_marine_mqtt_image():
+    return build_image('king-county-marine', dockerfile='Dockerfile.mqtt', tag='test-king-county-marine-mqtt')
+
+
+@pytest.fixture()
+def mosquitto_king_county_marine():
+    container, network, host_port = _generic_mosquitto(
+        'king-county-marine-mqtt-e2e', 'king-county-marine-mqtt-e2e-broker'
+    )
+    try:
+        yield {
+            'host_port': host_port,
+            'internal_host': 'king-county-marine-mqtt-e2e-broker',
+            'internal_port': 1883,
+            'network': network.name,
+        }
+    finally:
+        try:
+            container.kill()
+        except docker.errors.APIError:
+            pass
+        try:
+            network.remove()
+        except docker.errors.APIError:
+            pass
+
+
+class TestKingCountyMarineMqttDockerFlow:
+    """Verify the king-county-marine-mqtt container publishes a valid UNS tree."""
+
+    def test_emits_retained_uns_topics(self, mosquitto_king_county_marine, king_county_marine_mqtt_image):
+        client = docker.from_env()
+        broker_url = f"mqtt://{mosquitto_king_county_marine['internal_host']}:{mosquitto_king_county_marine['internal_port']}"
+        feeder = client.containers.run(
+            king_county_marine_mqtt_image.id,
+            detach=True,
+            remove=False,
+            network=mosquitto_king_county_marine['network'],
+            environment={
+                'MQTT_BROKER_URL': broker_url,
+                'ONCE_MODE': 'true',
+                'KING_COUNTY_MARINE_SAMPLE_MODE': 'true',
+                'PYTHONUNBUFFERED': '1',
+            },
+        )
+        try:
+            result = feeder.wait(timeout=180)
+            logs = feeder.logs().decode('utf-8', errors='replace')
+            assert result.get('StatusCode') == 0, f"Feeder exited non-zero: {result}\n--- LOGS ---\n{logs}"
+        finally:
+            try:
+                feeder.remove(force=True)
+            except docker.errors.APIError:
+                pass
+
+        messages = _collect_messages_topic(
+            '127.0.0.1', mosquitto_king_county_marine['host_port'],
+            'maritime/us/wa/king-county/king-county-marine/#', timeout=20.0,
+        )
+        assert messages, 'No retained MQTT messages received from broker'
+        topics = {m['topic'] for m in messages}
+        assert 'maritime/us/wa/king-county/king-county-marine/sample-station/info' in topics
+        assert 'maritime/us/wa/king-county/king-county-marine/sample-station/water-quality' in topics
+        for sample in messages:
+            assert sample['retain'] is True
+            assert sample['qos'] == 1
+            up = sample['user_properties']
+            for required in ('id', 'source', 'type', 'subject', 'specversion'):
+                assert required in up, f"missing CE attribute {required} on {sample['topic']}: {up}"
+            assert up.get('_contenttype') == 'application/json'
+            assert up.get('subject') == 'sample-station'
+            payload = _to_dict(sample['payload'])
+            assert payload is not None
+            assert payload.get('station_id') == 'sample-station'


### PR DESCRIPTION
## Topic tree

- `maritime/us/wa/king-county/king-county-marine/{station_id}/info`
- `maritime/us/wa/king-county/king-county-marine/{station_id}/water-quality`
- Station-only per user decision; no water_body enrichment.

## Specialist review

- xRegistry Expert: no MUST-FIX. Confirmed endpoint/messagegroup, `basemessageurl`, no schema fork, required `{station_id}` fields, subject inclusion, generated method alignment.
- UNS Catalog Architect: MUST-FIX retained-latest semantics/dedupe and persistent state fixed by preserving source dedupe/refresh behavior, publishing rows oldest-to-newest, saving state, and adding persistent MQTT state volume. SHOULD-FIXes addressed: station-id fallback and 1-hour expiry for retained water-quality readings.

## Validation

- `xrcg validate --definitions king-county-marine\xreg\king_county_marine.xreg.json`
- `PYTHONPATH=... python -m pytest king-county-marine\tests -q -x` (10 passed)
- `python -m pytest king-county-marine\king_county_marine_mqtt_producer\king_county_marine_mqtt_producer_data\tests king-county-marine\king_county_marine_mqtt_producer\king_county_marine_mqtt_producer_mqtt_client\tests -q -x` (76 passed)
- `docker build -f king-county-marine\Dockerfile.mqtt -t test-king-county-marine-mqtt king-county-marine`
- `python -m pytest tests\docker_e2e\test_docker_mqtt_flow.py::TestKingCountyMarineMqttDockerFlow -q -x` (1 passed)