### PR TITLE
mqtt(vatsim): add split MQTT UNS feeder

### DIFF
--- a/vatsim/Dockerfile.mqtt
+++ b/vatsim/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/vatsim"
+LABEL org.opencontainers.image.title="VATSIM → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls VATSIM live network data and publishes MQTT 5.0 binary-mode CloudEvents into aviation-network/intl/vatsim/vatsim/{pilots,controllers,facilities}/... topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/vatsim/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./vatsim_mqtt_producer/vatsim_mqtt_producer_data \
+ && pip install --no-cache-dir ./vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client \
+ && pip install --no-cache-dir ./vatsim_producer/vatsim_producer_data \
+ && pip install --no-cache-dir . \
+ && pip install --no-cache-dir ./vatsim_mqtt
+
+ENV MQTT_BROKER_URL=""
+
+CMD ["python", "-m", "vatsim_mqtt", "feed"]

--- a/vatsim/generate_mqtt_producer.ps1
+++ b/vatsim/generate_mqtt_producer.ps1
@@ -1,0 +1,11 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\vatsim.xreg.json `
+    --endpoint net.vatsim.Mqtt `
+    --projectname vatsim_mqtt_producer `
+    --output vatsim_mqtt_producer

--- a/vatsim/tests/test_vatsim_unit.py
+++ b/vatsim/tests/test_vatsim_unit.py
@@ -201,16 +201,19 @@ class TestBuildNetworkStatus:
     def test_build_network_status(self):
         status = VatsimBridge.build_network_status(SAMPLE_GENERAL, 720, 73)
         assert status.callsign == "status"
+        assert status.facility == "network"
         assert status.connected_clients == 853
         assert status.unique_users == 795
         assert status.pilot_count == 720
         assert status.controller_count == 73
-        assert isinstance(status.update_timestamp, datetime.datetime)
+        assert isinstance(status.update_timestamp, str)
+        assert status.update_timestamp.startswith("2026-")
 
     def test_build_network_status_type(self):
         from vatsim_producer_data.net.vatsim.networkstatus import NetworkStatus
         status = VatsimBridge.build_network_status(SAMPLE_GENERAL, 100, 10)
         assert isinstance(status, NetworkStatus)
+        assert status.facility == "network"
 
 
 @pytest.mark.unit

--- a/vatsim/vatsim/vatsim.py
+++ b/vatsim/vatsim/vatsim.py
@@ -153,6 +153,7 @@ class VatsimBridge:
         """Build a NetworkStatus from the general section."""
         return NetworkStatus(
             callsign="status",
+            facility="network",
             update_timestamp=_normalize_rfc3339(general["update_timestamp"]),
             connected_clients=general.get("connected_clients", 0),
             unique_users=general.get("unique_users", 0),

--- a/vatsim/vatsim_mqtt/pyproject.toml
+++ b/vatsim/vatsim_mqtt/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "vatsim-mqtt"
+version = "0.1.0"
+description = "VATSIM bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+requests = ">=2.32.3"
+vatsim_producer_data = {path = "../vatsim_producer/vatsim_producer_data"}
+vatsim_mqtt_producer_data = {path = "../vatsim_mqtt_producer/vatsim_mqtt_producer_data"}
+vatsim_mqtt_producer_mqtt_client = {path = "../vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+vatsim-mqtt = "vatsim_mqtt:main"

--- a/vatsim/vatsim_mqtt/vatsim_mqtt/__init__.py
+++ b/vatsim/vatsim_mqtt/vatsim_mqtt/__init__.py
@@ -1,0 +1,4 @@
+"""VATSIM MQTT bridge package."""
+from .app import main
+
+__all__ = ["main"]

--- a/vatsim/vatsim_mqtt/vatsim_mqtt/__main__.py
+++ b/vatsim/vatsim_mqtt/vatsim_mqtt/__main__.py
@@ -1,0 +1,4 @@
+"""CLI entry point for VATSIM MQTT bridge."""
+from .app import main
+if __name__ == "__main__":
+    main()

--- a/vatsim/vatsim_mqtt/vatsim_mqtt/app.py
+++ b/vatsim/vatsim_mqtt/vatsim_mqtt/app.py
@@ -1,0 +1,139 @@
+"""MQTT feeder application for VATSIM → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import time
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from vatsim.vatsim import VatsimBridge, _load_state, _save_state
+from vatsim_mqtt_producer_mqtt_client.client import NetVatsimMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+async def _publish_poll_cycle(
+    bridge: VatsimBridge,
+    mqtt_client: NetVatsimMqttMqttClient,
+    previous_pilots: dict[str, str],
+    previous_controllers: dict[str, str],
+) -> tuple[int, int]:
+    data = await asyncio.to_thread(bridge.fetch_data)
+    general = data.get("general", {})
+    pilots = data.get("pilots", [])
+    controllers = data.get("controllers", [])
+
+    status = bridge.build_network_status(general, len(pilots), len(controllers))
+    await mqtt_client.publish_net_vatsim_mqtt_facility_status(
+        callsign=status.callsign,
+        facility=status.facility,
+        data=status,
+    )
+
+    tasks: list[asyncio.Task[None]] = []
+    pilot_count = 0
+    for raw_pilot in pilots:
+        callsign = raw_pilot.get("callsign", "")
+        if not callsign:
+            continue
+        fingerprint = bridge.pilot_fingerprint(raw_pilot)
+        if previous_pilots.get(callsign) == fingerprint:
+            continue
+        try:
+            pilot = bridge.parse_pilot(raw_pilot)
+            tasks.append(asyncio.create_task(mqtt_client.publish_net_vatsim_mqtt_pilot_position(callsign=pilot.callsign, data=pilot)))
+            pilot_count += 1
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error publishing pilot %s: %s", callsign, exc)
+        previous_pilots[callsign] = fingerprint
+
+    controller_count = 0
+    for raw_controller in controllers:
+        callsign = raw_controller.get("callsign", "")
+        if not callsign:
+            continue
+        fingerprint = bridge.controller_fingerprint(raw_controller)
+        if previous_controllers.get(callsign) == fingerprint:
+            continue
+        try:
+            controller = bridge.parse_controller(raw_controller)
+            tasks.append(asyncio.create_task(mqtt_client.publish_net_vatsim_mqtt_controller_position(callsign=controller.callsign, data=controller)))
+            controller_count += 1
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error publishing controller %s: %s", callsign, exc)
+        previous_controllers[callsign] = fingerprint
+
+    if tasks:
+        await asyncio.gather(*tasks)
+    return pilot_count, controller_count
+
+
+async def feed(
+    bridge: VatsimBridge,
+    broker_host: str,
+    broker_port: int,
+    polling_interval: int,
+    state_file: str,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    content_mode: str = "binary",
+    once: bool = False,
+) -> None:
+    paho_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, client_id=client_id or "", protocol=MQTTv5)
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+    mqtt_client = NetVatsimMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
+    await mqtt_client.connect(broker_host, broker_port)
+    state = _load_state(state_file)
+    previous_pilots = state.get("pilots", {})
+    previous_controllers = state.get("controllers", {})
+    try:
+        while True:
+            started = time.monotonic()
+            pilot_count, controller_count = await _publish_poll_cycle(bridge, mqtt_client, previous_pilots, previous_controllers)
+            _save_state(state_file, {"pilots": previous_pilots, "controllers": previous_controllers})
+            elapsed = time.monotonic() - started
+            logger.info("Published VATSIM status, %d pilots, %d controllers in %.1fs", pilot_count, controller_count, elapsed)
+            if once:
+                break
+            await asyncio.sleep(max(0, polling_interval - elapsed))
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="VATSIM MQTT/UNS bridge")
+    parser.add_argument("feed_command", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--polling-interval", type=int, default=int(os.getenv("POLLING_INTERVAL", "60")))
+    parser.add_argument("--state-file", default=os.getenv("STATE_FILE", os.path.expanduser("~/.vatsim_mqtt_state.json")))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed_command != "feed":
+        parser.error("only the 'feed' command is supported")
+    host, port, tls = _parse_broker_url(args.broker_url)
+    asyncio.run(feed(VatsimBridge(), host, port, args.polling_interval, args.state_file, username=args.username or None, password=args.password or None, tls=tls, client_id=args.client_id or None, content_mode=args.content_mode, once=args.once))

--- a/vatsim/vatsim_mqtt_producer/Makefile
+++ b/vatsim/vatsim_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./vatsim_mqtt_producer_data ./vatsim_mqtt_producer_mqtt_client
+
+install: build
+	cd vatsim_mqtt_producer_data && poetry install
+	cd vatsim_mqtt_producer_mqtt_client && poetry install
+	pip install ./vatsim_mqtt_producer_data ./vatsim_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./vatsim_mqtt_producer_mqtt_client/tests ./vatsim_mqtt_producer_data/tests

--- a/vatsim/vatsim_mqtt_producer/README.md
+++ b/vatsim/vatsim_mqtt_producer/README.md
@@ -1,0 +1,1123 @@
+# Vatsim_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the vatsim_mqtt_producer message definitions.
+
+# Vatsim_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - NetVatsimMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from vatsim_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = NetVatsimMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### NetVatsimMqttEventDispatcher
+
+
+
+# Publish message`NetVatsimMqttEventDispatcher` handles events for the net.vatsim.mqtt message group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from vatsim_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = NetVatsimMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the Event Hub.-
+`blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe NetVatsimMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `net_vatsim_mqtt_pilot_position_async`
+
+
+
+## Test```python
+
+net_vatsim_mqtt_pilot_position_async:  Callable[[PartitionContext, EventData, CloudEvent, PilotPosition],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `net.vatsim.mqtt.PilotPosition`: Current position, flight plan summary, and state of a
+pilot connected to the VATSIM virtual aviation network.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `vatsim_mqtt_producer_data.PilotPosition`.
+
+Example:
+
+```python
+async def net_vatsim_mqtt_pilot_position_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: PilotPosition) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_pilot_position_async = net_vatsim_mqtt_pilot_position_event
+```
+
+
+
+make build
+
+```##### `net_vatsim_mqtt_controller_position_async`
+
+
+
+## Test```python
+
+net_vatsim_mqtt_controller_position_async:  Callable[[PartitionContext, EventData, CloudEvent, ControllerPosition],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `net.vatsim.mqtt.ControllerPosition`: Current state and frequency of an air traffic
+controller connected to the VATSIM virtual aviation network.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `vatsim_mqtt_producer_data.ControllerPosition`.
+
+Example:
+
+```python
+async def net_vatsim_mqtt_controller_position_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: ControllerPosition) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_controller_position_async = net_vatsim_mqtt_controller_position_event
+```
+
+
+
+make build
+
+```##### `net_vatsim_mqtt_facility_status_async`
+
+
+
+## Test```python
+
+net_vatsim_mqtt_facility_status_async:  Callable[[PartitionContext, EventData, CloudEvent, NetworkStatus],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `net.vatsim.mqtt.FacilityStatus`: Aggregate network status snapshot from the VATSIM
+data feed, emitted once per poll cycle.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `vatsim_mqtt_producer_data.NetworkStatus`.
+
+Example:
+
+```python
+async def net_vatsim_mqtt_facility_status_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: NetworkStatus) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_facility_status_async = net_vatsim_mqtt_facility_status_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/vatsim/vatsim_mqtt_producer/install.bat
+++ b/vatsim/vatsim_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\vatsim_mqtt_producer_data
+pip install .\vatsim_mqtt_producer_mqtt_client

--- a/vatsim/vatsim_mqtt_producer/install.sh
+++ b/vatsim/vatsim_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./vatsim_mqtt_producer_data
+pip install ./vatsim_mqtt_producer_mqtt_client

--- a/vatsim/vatsim_mqtt_producer/samples/sample.py
+++ b/vatsim/vatsim_mqtt_producer/samples/sample.py
@@ -1,0 +1,94 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from vatsim_mqtt_producer_data import *
+from vatsim_mqtt_producer_mqtt_client.client import NetVatsimMqttProducer, NetVatsimMqttDispatcher
+
+async def handle_net_vatsim_mqtt_pilot_position(mqtt_msg,cloud_event, net_vatsim_mqtt_pilot_position_data):
+    """ Handles the net.vatsim.mqtt.PilotPosition message """
+    print(f"Received net.vatsim.mqtt.PilotPosition on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {net_vatsim_mqtt_pilot_position_data}")
+
+async def handle_net_vatsim_mqtt_controller_position(mqtt_msg,cloud_event, net_vatsim_mqtt_controller_position_data):
+    """ Handles the net.vatsim.mqtt.ControllerPosition message """
+    print(f"Received net.vatsim.mqtt.ControllerPosition on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {net_vatsim_mqtt_controller_position_data}")
+
+async def handle_net_vatsim_mqtt_facility_status(mqtt_msg,cloud_event, net_vatsim_mqtt_facility_status_data):
+    """ Handles the net.vatsim.mqtt.FacilityStatus message """
+    print(f"Received net.vatsim.mqtt.FacilityStatus on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {net_vatsim_mqtt_facility_status_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/vatsim/vatsim_mqtt_producer/scripts/build.py
+++ b/vatsim/vatsim_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["vatsim_mqtt_producer_mqtt_client", "vatsim_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/pyproject.toml
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "vatsim-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "vatsim_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/__init__.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/__init__.py
@@ -1,0 +1,3 @@
+from .net import PilotPosition, NetworkStatus, ControllerPosition
+
+__all__ = ["PilotPosition", "NetworkStatus", "ControllerPosition"]

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/__init__.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/__init__.py
@@ -1,0 +1,3 @@
+from .vatsim import PilotPosition, NetworkStatus, ControllerPosition
+
+__all__ = ["PilotPosition", "NetworkStatus", "ControllerPosition"]

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/__init__.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/__init__.py
@@ -1,0 +1,5 @@
+from .pilotposition import PilotPosition
+from .networkstatus import NetworkStatus
+from .controllerposition import ControllerPosition
+
+__all__ = ["PilotPosition", "NetworkStatus", "ControllerPosition"]

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/controllerposition.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/controllerposition.py
@@ -1,0 +1,173 @@
+""" ControllerPosition dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class ControllerPosition:
+    """
+    Current state and frequency of an air traffic controller or observer connected to the VATSIM virtual aviation network.
+    
+    Attributes:
+        cid (int)
+        callsign (str)
+        frequency (str)
+        facility (int)
+        rating (int)
+        text_atis (typing.Optional[str])
+        last_updated (str)
+    """
+    
+    
+    cid: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="cid"))
+    callsign: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="callsign"))
+    frequency: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="frequency"))
+    facility: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="facility"))
+    rating: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="rating"))
+    text_atis: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="text_atis"))
+    last_updated: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="last_updated"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'ControllerPosition':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['ControllerPosition']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return ControllerPosition.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'ControllerPosition':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            cid=int(61),
+            callsign='jrbfuoebktnghewlmldl',
+            frequency='fxgjnafsuwbgkwhnlzxi',
+            facility=int(8),
+            rating=int(81),
+            text_atis='kphdhixpmjunyglludvm',
+            last_updated='zfxcwyhfdhzzimcsyvvk'
+        )

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/networkstatus.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/networkstatus.py
@@ -1,55 +1,42 @@
 """ NetworkStatus dataclass. """
 
 # pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
 import io
 import gzip
-import json
 import enum
 import typing
 import dataclasses
 from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-import avro.schema
-import avro.name
-import avro.io
+import json
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class NetworkStatus:
     """
-    Aggregate VATSIM network status snapshot emitted once per poll cycle.
+    Aggregate VATSIM network status snapshot emitted once per poll cycle, summarising connected client counts.
+    
     Attributes:
-        callsign (str): Constant key value 'status'.
-        facility (str): UNS facility identifier for this aggregate VATSIM network status snapshot. The bridge emits 'network'.
-        update_timestamp (str): UTC timestamp of the VATSIM data snapshot.
-        connected_clients (int): Total connected clients.
-        unique_users (int): Unique connected user IDs.
-        pilot_count (int): Number of pilots currently flying.
-        controller_count (int): Number of controllers connected."""
+        callsign (str)
+        update_timestamp (str)
+        connected_clients (int)
+        unique_users (int)
+        pilot_count (int)
+        controller_count (int)
+        facility (str)
+    """
+    
     
     callsign: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="callsign"))
-    facility: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="facility"))
     update_timestamp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="update_timestamp"))
     connected_clients: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="connected_clients"))
     unique_users: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="unique_users"))
     pilot_count: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pilot_count"))
     controller_count: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="controller_count"))
-    
-    AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.make_avsc_object(
-        json.loads("{\"type\": \"record\", \"name\": \"NetworkStatus\", \"namespace\": \"net.vatsim\", \"doc\": \"Aggregate VATSIM network status snapshot emitted once per poll cycle.\", \"fields\": [{\"name\": \"callsign\", \"type\": \"string\", \"doc\": \"Constant key value 'status'.\"}, {\"name\": \"facility\", \"type\": \"string\", \"doc\": \"UNS facility identifier for this aggregate VATSIM network status snapshot. The bridge emits 'network'.\"}, {\"name\": \"update_timestamp\", \"type\": \"string\", \"doc\": \"UTC timestamp of the VATSIM data snapshot.\"}, {\"name\": \"connected_clients\", \"type\": \"int\", \"doc\": \"Total connected clients.\"}, {\"name\": \"unique_users\", \"type\": \"int\", \"doc\": \"Unique connected user IDs.\"}, {\"name\": \"pilot_count\", \"type\": \"int\", \"doc\": \"Number of pilots currently flying.\"}, {\"name\": \"controller_count\", \"type\": \"int\", \"doc\": \"Number of controllers connected.\"}]}"), avro.name.Names()
-    )
-
-    def __post_init__(self):
-        """ Initializes the dataclass with the provided keyword arguments."""
-        self.callsign=str(self.callsign)
-        self.facility=str(self.facility)
-        self.update_timestamp=str(self.update_timestamp)
-        self.connected_clients=int(self.connected_clients)
-        self.unique_users=int(self.unique_users)
-        self.pilot_count=int(self.pilot_count)
-        self.controller_count=int(self.controller_count)
+    facility: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="facility"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'NetworkStatus':
@@ -60,7 +47,7 @@ class NetworkStatus:
             data: The dictionary to convert to a dataclass.
         
         Returns:
-            The dataclass representation of the dictionary.
+            The dataclass representation of the dataclass.
         """
         return cls(**data)
 
@@ -79,7 +66,7 @@ class NetworkStatus:
         Helps resolving the Enum values to their actual values and fixes the key names.
         """ 
         def _resolve_enum(v):
-            if isinstance(v,enum.Enum):
+            if isinstance(v, enum.Enum):
                 return v.value
             return v
         def _fix_key(k):
@@ -93,8 +80,6 @@ class NetworkStatus:
         Args:
             content_type_string: The content type string to convert the dataclass to.
                 Supported content types:
-                    'avro/binary': Encodes the data to Avro binary format.
-                    'application/vnd.apache.avro+avro': Encodes the data to Avro binary format.
                     'application/json': Encodes the data to JSON format.
                 Supported content type extensions:
                     '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
@@ -107,12 +92,6 @@ class NetworkStatus:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-            stream = io.BytesIO()
-            writer = avro.io.DatumWriter(self.AvroType)
-            encoder = avro.io.BinaryEncoder(stream)
-            writer.write(self.to_serializer_dict(), encoder)
-            result = stream.getvalue()
         if base_content_type == 'application/json':
             #pylint: disable=no-member
             result = self.to_json()
@@ -141,10 +120,6 @@ class NetworkStatus:
             data: The data to convert to a dataclass.
             content_type_string: The content type string to convert the data to. 
                 Supported content types:
-                    'avro/binary': Attempts to decode the data from Avro binary encoded format.
-                    'application/vnd.apache.avro+avro': Attempts to decode the data from Avro binary encoded format.
-                    'avro/json': Attempts to decode the data from Avro JSON encoded format.
-                    'application/vnd.apache.avro+json': Attempts to decode the data from Avro JSON encoded format.
                     'application/json': Attempts to decode the data from JSON encoded format.
                 Supported content type extensions:
                     '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
@@ -170,18 +145,6 @@ class NetworkStatus:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro', 'avro/json', 'application/vnd.apache.avro+json']:
-            if isinstance(data, (bytes, io.BytesIO)):
-                stream = io.BytesIO(data) if isinstance(data, bytes) else data
-            else:
-                raise NotImplementedError('Data is not of a supported type for conversion to Stream')
-            reader = avro.io.DatumReader(cls.AvroType)
-            if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-                decoder = avro.io.BinaryDecoder(stream)
-            else:
-                raise NotImplementedError(f'Unsupported Avro media type {content_type}')
-            _record = reader.read(decoder)            
-            return NetworkStatus.from_serializer_dict(_record)
         if base_content_type == 'application/json':
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
@@ -189,5 +152,22 @@ class NetworkStatus:
                 return NetworkStatus.from_serializer_dict(_record)
             else:
                 raise NotImplementedError('Data is not of a supported type for JSON deserialization')
-
         raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'NetworkStatus':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            callsign='qvyugthcbgrxgzkiwmzd',
+            update_timestamp='idferqijdwsclpfgklon',
+            connected_clients=int(59),
+            unique_users=int(26),
+            pilot_count=int(63),
+            controller_count=int(76),
+            facility='rsgdnlpuofszdyervsfz'
+        )

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/pilotposition.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/src/vatsim_mqtt_producer_data/net/vatsim/pilotposition.py
@@ -1,0 +1,203 @@
+""" PilotPosition dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class PilotPosition:
+    """
+    Current position, flight plan summary, and state of a pilot connected to the VATSIM virtual aviation network. Updated every 15 seconds at the source.
+    
+    Attributes:
+        cid (int)
+        callsign (str)
+        latitude (float)
+        longitude (float)
+        altitude (int)
+        groundspeed (int)
+        heading (int)
+        transponder (str)
+        qnh_mb (int)
+        flight_rules (typing.Optional[str])
+        aircraft_short (typing.Optional[str])
+        departure (typing.Optional[str])
+        arrival (typing.Optional[str])
+        route (typing.Optional[str])
+        cruise_altitude (typing.Optional[str])
+        pilot_rating (int)
+        last_updated (str)
+    """
+    
+    
+    cid: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="cid"))
+    callsign: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="callsign"))
+    latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+    altitude: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altitude"))
+    groundspeed: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="groundspeed"))
+    heading: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="heading"))
+    transponder: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="transponder"))
+    qnh_mb: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="qnh_mb"))
+    flight_rules: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="flight_rules"))
+    aircraft_short: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="aircraft_short"))
+    departure: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="departure"))
+    arrival: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="arrival"))
+    route: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="route"))
+    cruise_altitude: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="cruise_altitude"))
+    pilot_rating: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pilot_rating"))
+    last_updated: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="last_updated"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'PilotPosition':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['PilotPosition']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return PilotPosition.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'PilotPosition':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            cid=int(98),
+            callsign='jfcmszqymmcblnrvbvkq',
+            latitude=float(25.922311803087194),
+            longitude=float(3.6764867928366862),
+            altitude=int(37),
+            groundspeed=int(14),
+            heading=int(54),
+            transponder='flyizojvnjswxrnvvxhf',
+            qnh_mb=int(24),
+            flight_rules='jocjjgehrixndvnqffzn',
+            aircraft_short='kquggiknmeraszcmnzau',
+            departure='yzfxoekgjqzxiicxfhjh',
+            arrival='sassbsavvauvuyoaahpx',
+            route='eaiugsiisgwkaanojmtd',
+            cruise_altitude='pgyyeqhtqagewyhaswkh',
+            pilot_rating=int(64),
+            last_updated='fzzqltbuofxayhlhzqao'
+        )

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_controllerposition.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_controllerposition.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from vatsim_producer_data.net.vatsim.controllerposition import ControllerPosition
+from vatsim_mqtt_producer_data.net.vatsim.controllerposition import ControllerPosition
 
 
 class Test_ControllerPosition(unittest.TestCase):
@@ -28,13 +28,13 @@ class Test_ControllerPosition(unittest.TestCase):
         Create instance of ControllerPosition for testing
         """
         instance = ControllerPosition(
-            cid=int(29),
-            callsign='khedgequmnaqlekcmbhm',
-            frequency='brstdwwzjxswknothwvl',
-            facility=int(98),
-            rating=int(9),
-            text_atis='npxqdmkgfrdbxnxgqnur',
-            last_updated='vymqfrqpyjxpgyhmvotq'
+            cid=int(61),
+            callsign='jrbfuoebktnghewlmldl',
+            frequency='fxgjnafsuwbgkwhnlzxi',
+            facility=int(8),
+            rating=int(81),
+            text_atis='kphdhixpmjunyglludvm',
+            last_updated='zfxcwyhfdhzzimcsyvvk'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test cid property
         """
-        test_value = int(29)
+        test_value = int(61)
         self.instance.cid = test_value
         self.assertEqual(self.instance.cid, test_value)
     
@@ -51,7 +51,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'khedgequmnaqlekcmbhm'
+        test_value = 'jrbfuoebktnghewlmldl'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
     
@@ -59,7 +59,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test frequency property
         """
-        test_value = 'brstdwwzjxswknothwvl'
+        test_value = 'fxgjnafsuwbgkwhnlzxi'
         self.instance.frequency = test_value
         self.assertEqual(self.instance.frequency, test_value)
     
@@ -67,7 +67,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test facility property
         """
-        test_value = int(98)
+        test_value = int(8)
         self.instance.facility = test_value
         self.assertEqual(self.instance.facility, test_value)
     
@@ -75,7 +75,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test rating property
         """
-        test_value = int(9)
+        test_value = int(81)
         self.instance.rating = test_value
         self.assertEqual(self.instance.rating, test_value)
     
@@ -83,7 +83,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test text_atis property
         """
-        test_value = 'npxqdmkgfrdbxnxgqnur'
+        test_value = 'kphdhixpmjunyglludvm'
         self.instance.text_atis = test_value
         self.assertEqual(self.instance.text_atis, test_value)
     
@@ -91,16 +91,26 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test last_updated property
         """
-        test_value = 'vymqfrqpyjxpgyhmvotq'
+        test_value = 'zfxcwyhfdhzzimcsyvvk'
         self.instance.last_updated = test_value
         self.assertEqual(self.instance.last_updated, test_value)
     
-    def test_to_byte_array_avro(self):
+    def test_to_byte_array_json(self):
         """
-        Test to_byte_array method with avro media type
+        Test to_byte_array method with json media type
         """
-        media_type = "application/vnd.apache.avro+avro"
+        media_type = "application/json"
         bytes_data = self.instance.to_byte_array(media_type)
         new_instance = ControllerPosition.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = ControllerPosition.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_networkstatus.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_networkstatus.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from vatsim_producer_data.net.vatsim.networkstatus import NetworkStatus
+from vatsim_mqtt_producer_data.net.vatsim.networkstatus import NetworkStatus
 
 
 class Test_NetworkStatus(unittest.TestCase):
@@ -28,13 +28,13 @@ class Test_NetworkStatus(unittest.TestCase):
         Create instance of NetworkStatus for testing
         """
         instance = NetworkStatus(
-            callsign='bibsysdcnudykywbzris',
-            facility='tzxxbnijobmeuxhlqjwa',
-            update_timestamp='wvtvbjczwlqxwelshidh',
-            connected_clients=int(27),
-            unique_users=int(38),
-            pilot_count=int(84),
-            controller_count=int(45)
+            callsign='qvyugthcbgrxgzkiwmzd',
+            update_timestamp='idferqijdwsclpfgklon',
+            connected_clients=int(59),
+            unique_users=int(26),
+            pilot_count=int(63),
+            controller_count=int(76),
+            facility='rsgdnlpuofszdyervsfz'
         )
         return instance
 
@@ -43,23 +43,15 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'bibsysdcnudykywbzris'
+        test_value = 'qvyugthcbgrxgzkiwmzd'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
-    
-    def test_facility_property(self):
-        """
-        Test facility property
-        """
-        test_value = 'tzxxbnijobmeuxhlqjwa'
-        self.instance.facility = test_value
-        self.assertEqual(self.instance.facility, test_value)
     
     def test_update_timestamp_property(self):
         """
         Test update_timestamp property
         """
-        test_value = 'wvtvbjczwlqxwelshidh'
+        test_value = 'idferqijdwsclpfgklon'
         self.instance.update_timestamp = test_value
         self.assertEqual(self.instance.update_timestamp, test_value)
     
@@ -67,7 +59,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test connected_clients property
         """
-        test_value = int(27)
+        test_value = int(59)
         self.instance.connected_clients = test_value
         self.assertEqual(self.instance.connected_clients, test_value)
     
@@ -75,7 +67,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test unique_users property
         """
-        test_value = int(38)
+        test_value = int(26)
         self.instance.unique_users = test_value
         self.assertEqual(self.instance.unique_users, test_value)
     
@@ -83,7 +75,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test pilot_count property
         """
-        test_value = int(84)
+        test_value = int(63)
         self.instance.pilot_count = test_value
         self.assertEqual(self.instance.pilot_count, test_value)
     
@@ -91,16 +83,34 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test controller_count property
         """
-        test_value = int(45)
+        test_value = int(76)
         self.instance.controller_count = test_value
         self.assertEqual(self.instance.controller_count, test_value)
     
-    def test_to_byte_array_avro(self):
+    def test_facility_property(self):
         """
-        Test to_byte_array method with avro media type
+        Test facility property
         """
-        media_type = "application/vnd.apache.avro+avro"
+        test_value = 'rsgdnlpuofszdyervsfz'
+        self.instance.facility = test_value
+        self.assertEqual(self.instance.facility, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
         bytes_data = self.instance.to_byte_array(media_type)
         new_instance = NetworkStatus.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = NetworkStatus.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_pilotposition.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_data/tests/test_pilotposition.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from vatsim_producer_data.net.vatsim.pilotposition import PilotPosition
+from vatsim_mqtt_producer_data.net.vatsim.pilotposition import PilotPosition
 
 
 class Test_PilotPosition(unittest.TestCase):
@@ -28,23 +28,23 @@ class Test_PilotPosition(unittest.TestCase):
         Create instance of PilotPosition for testing
         """
         instance = PilotPosition(
-            cid=int(33),
-            callsign='bapgpplfthgxaxgyzzwy',
-            latitude=float(13.019229370536767),
-            longitude=float(33.293758419396255),
-            altitude=int(88),
-            groundspeed=int(76),
-            heading=int(0),
-            transponder='tswghhyhsjtficzmserh',
-            qnh_mb=int(79),
-            flight_rules='askfryfwzxxekgwsyvkb',
-            aircraft_short='eoljbfnbpzjpyjcqzzeh',
-            departure='qwjumghrpcmhkmbmedts',
-            arrival='dzeitsgcjvddpxhslgbm',
-            route='ofccxebycyvozxljowzo',
-            cruise_altitude='ztfgnmzxkhqefvcpekyj',
-            pilot_rating=int(10),
-            last_updated='yhdgcvlkjclysqztvlqo'
+            cid=int(98),
+            callsign='jfcmszqymmcblnrvbvkq',
+            latitude=float(25.922311803087194),
+            longitude=float(3.6764867928366862),
+            altitude=int(37),
+            groundspeed=int(14),
+            heading=int(54),
+            transponder='flyizojvnjswxrnvvxhf',
+            qnh_mb=int(24),
+            flight_rules='jocjjgehrixndvnqffzn',
+            aircraft_short='kquggiknmeraszcmnzau',
+            departure='yzfxoekgjqzxiicxfhjh',
+            arrival='sassbsavvauvuyoaahpx',
+            route='eaiugsiisgwkaanojmtd',
+            cruise_altitude='pgyyeqhtqagewyhaswkh',
+            pilot_rating=int(64),
+            last_updated='fzzqltbuofxayhlhzqao'
         )
         return instance
 
@@ -53,7 +53,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test cid property
         """
-        test_value = int(33)
+        test_value = int(98)
         self.instance.cid = test_value
         self.assertEqual(self.instance.cid, test_value)
     
@@ -61,7 +61,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'bapgpplfthgxaxgyzzwy'
+        test_value = 'jfcmszqymmcblnrvbvkq'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
     
@@ -69,7 +69,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(13.019229370536767)
+        test_value = float(25.922311803087194)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -77,7 +77,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(33.293758419396255)
+        test_value = float(3.6764867928366862)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -85,7 +85,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = int(88)
+        test_value = int(37)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -93,7 +93,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test groundspeed property
         """
-        test_value = int(76)
+        test_value = int(14)
         self.instance.groundspeed = test_value
         self.assertEqual(self.instance.groundspeed, test_value)
     
@@ -101,7 +101,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test heading property
         """
-        test_value = int(0)
+        test_value = int(54)
         self.instance.heading = test_value
         self.assertEqual(self.instance.heading, test_value)
     
@@ -109,7 +109,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test transponder property
         """
-        test_value = 'tswghhyhsjtficzmserh'
+        test_value = 'flyizojvnjswxrnvvxhf'
         self.instance.transponder = test_value
         self.assertEqual(self.instance.transponder, test_value)
     
@@ -117,7 +117,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test qnh_mb property
         """
-        test_value = int(79)
+        test_value = int(24)
         self.instance.qnh_mb = test_value
         self.assertEqual(self.instance.qnh_mb, test_value)
     
@@ -125,7 +125,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test flight_rules property
         """
-        test_value = 'askfryfwzxxekgwsyvkb'
+        test_value = 'jocjjgehrixndvnqffzn'
         self.instance.flight_rules = test_value
         self.assertEqual(self.instance.flight_rules, test_value)
     
@@ -133,7 +133,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test aircraft_short property
         """
-        test_value = 'eoljbfnbpzjpyjcqzzeh'
+        test_value = 'kquggiknmeraszcmnzau'
         self.instance.aircraft_short = test_value
         self.assertEqual(self.instance.aircraft_short, test_value)
     
@@ -141,7 +141,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test departure property
         """
-        test_value = 'qwjumghrpcmhkmbmedts'
+        test_value = 'yzfxoekgjqzxiicxfhjh'
         self.instance.departure = test_value
         self.assertEqual(self.instance.departure, test_value)
     
@@ -149,7 +149,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test arrival property
         """
-        test_value = 'dzeitsgcjvddpxhslgbm'
+        test_value = 'sassbsavvauvuyoaahpx'
         self.instance.arrival = test_value
         self.assertEqual(self.instance.arrival, test_value)
     
@@ -157,7 +157,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'ofccxebycyvozxljowzo'
+        test_value = 'eaiugsiisgwkaanojmtd'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -165,7 +165,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test cruise_altitude property
         """
-        test_value = 'ztfgnmzxkhqefvcpekyj'
+        test_value = 'pgyyeqhtqagewyhaswkh'
         self.instance.cruise_altitude = test_value
         self.assertEqual(self.instance.cruise_altitude, test_value)
     
@@ -173,7 +173,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test pilot_rating property
         """
-        test_value = int(10)
+        test_value = int(64)
         self.instance.pilot_rating = test_value
         self.assertEqual(self.instance.pilot_rating, test_value)
     
@@ -181,16 +181,26 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test last_updated property
         """
-        test_value = 'yhdgcvlkjclysqztvlqo'
+        test_value = 'fzzqltbuofxayhlhzqao'
         self.instance.last_updated = test_value
         self.assertEqual(self.instance.last_updated, test_value)
     
-    def test_to_byte_array_avro(self):
+    def test_to_byte_array_json(self):
         """
-        Test to_byte_array method with avro media type
+        Test to_byte_array method with json media type
         """
-        media_type = "application/vnd.apache.avro+avro"
+        media_type = "application/json"
         bytes_data = self.instance.to_byte_array(media_type)
         new_instance = PilotPosition.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = PilotPosition.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/pyproject.toml
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "vatsim-mqtt-producer-mqtt-client"
+description = "vatsim_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "vatsim_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+vatsim-mqtt-producer-data = {path = "../vatsim_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/src/vatsim_mqtt_producer_mqtt_client/__init__.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/src/vatsim_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import NetVatsimMqttMqttClient
+
+__all__ = [
+    "NetVatsimMqttMqttClient",
+]

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/src/vatsim_mqtt_producer_mqtt_client/client.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/src/vatsim_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,596 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import vatsim_mqtt_producer_data
+from vatsim_mqtt_producer_data import PilotPosition
+from vatsim_mqtt_producer_data import ControllerPosition
+from vatsim_mqtt_producer_data import NetworkStatus
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_net_vatsim_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the net.vatsim.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "net.vatsim.mqtt.PilotPosition": "aviation-network/intl/vatsim/vatsim/pilots/{callsign}/pilot-position",
+        "net.vatsim.mqtt.ControllerPosition": "aviation-network/intl/vatsim/vatsim/controllers/{callsign}/controller-position",
+        "net.vatsim.mqtt.FacilityStatus": "aviation-network/intl/vatsim/vatsim/facilities/{facility}/facility-status",
+    }
+
+
+def get_subscription_topics_net_vatsim_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_net_vatsim_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class NetVatsimMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the net.vatsim.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_net_vatsim_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.net_vatsim_mqtt_pilot_position_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, vatsim_mqtt_producer_data.PilotPosition, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.net_vatsim_mqtt_controller_position_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, vatsim_mqtt_producer_data.ControllerPosition, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.net_vatsim_mqtt_facility_status_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, vatsim_mqtt_producer_data.NetworkStatus, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "net.vatsim.PilotPosition":
+            if self.net_vatsim_mqtt_pilot_position_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = vatsim_mqtt_producer_data.PilotPosition.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "net.vatsim.mqtt.PilotPosition")
+                    await self.net_vatsim_mqtt_pilot_position_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in net_vatsim_mqtt_pilot_position handler: {e}")
+            return
+        
+        if event_type == "net.vatsim.ControllerPosition":
+            if self.net_vatsim_mqtt_controller_position_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = vatsim_mqtt_producer_data.ControllerPosition.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "net.vatsim.mqtt.ControllerPosition")
+                    await self.net_vatsim_mqtt_controller_position_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in net_vatsim_mqtt_controller_position handler: {e}")
+            return
+        
+        if event_type == "net.vatsim.NetworkStatus":
+            if self.net_vatsim_mqtt_facility_status_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = vatsim_mqtt_producer_data.NetworkStatus.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "net.vatsim.mqtt.FacilityStatus")
+                    await self.net_vatsim_mqtt_facility_status_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in net_vatsim_mqtt_facility_status handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_net_vatsim_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_net_vatsim_mqtt_pilot_position(self,
+        callsign: str,
+        data: vatsim_mqtt_producer_data.PilotPosition,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'net.vatsim.mqtt.PilotPosition' event to an MQTT topic.
+
+        Args:
+        
+            callsign: URI template variable for 'callsign'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'aviation-network/intl/vatsim/vatsim/pilots/{callsign}/pilot-position'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "aviation-network/intl/vatsim/vatsim/pilots/{callsign}/pilot-position"
+        _topic_template_values: Dict[str, str] = {
+            "callsign": str(callsign),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"net.vatsim.PilotPosition",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_net_vatsim_mqtt_controller_position(self,
+        callsign: str,
+        data: vatsim_mqtt_producer_data.ControllerPosition,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'net.vatsim.mqtt.ControllerPosition' event to an MQTT topic.
+
+        Args:
+        
+            callsign: URI template variable for 'callsign'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'aviation-network/intl/vatsim/vatsim/controllers/{callsign}/controller-position'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "aviation-network/intl/vatsim/vatsim/controllers/{callsign}/controller-position"
+        _topic_template_values: Dict[str, str] = {
+            "callsign": str(callsign),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"net.vatsim.ControllerPosition",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_net_vatsim_mqtt_facility_status(self,
+        callsign: str,
+        facility: str,
+        data: vatsim_mqtt_producer_data.NetworkStatus,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'net.vatsim.mqtt.FacilityStatus' event to an MQTT topic.
+
+        Args:
+        
+            callsign: URI template variable for 'callsign'
+            facility: URI template variable for 'facility'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'aviation-network/intl/vatsim/vatsim/facilities/{facility}/facility-status'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "aviation-network/intl/vatsim/vatsim/facilities/{facility}/facility-status"
+        _topic_template_values: Dict[str, str] = {
+            "callsign": str(callsign),
+            "facility": str(facility),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"net.vatsim.NetworkStatus",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,243 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../vatsim_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../vatsim_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../vatsim_mqtt_producer_mqtt_client/src')))
+
+import vatsim_mqtt_producer_data
+from vatsim_mqtt_producer_data import PilotPosition
+from test_pilotposition import Test_PilotPosition
+from vatsim_mqtt_producer_data import ControllerPosition
+from test_controllerposition import Test_ControllerPosition
+from vatsim_mqtt_producer_data import NetworkStatus
+from test_networkstatus import Test_NetworkStatus
+from vatsim_mqtt_producer_mqtt_client import NetVatsimMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_net_vatsim_mqtt_net_vatsim_mqtt_pilot_position_py(mosquitto_broker):
+    """Test publishing and receiving net.vatsim.mqtt.PilotPosition message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_PilotPosition.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = NetVatsimMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = NetVatsimMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_net_vatsim_mqtt_pilot_position(mqtt_msg, cloud_event, data: vatsim_mqtt_producer_data.PilotPosition, topic_params: dict):
+        """Handler for net.vatsim.mqtt.PilotPosition messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "net.vatsim.PilotPosition"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.net_vatsim_mqtt_pilot_position_async = on_net_vatsim_mqtt_pilot_position
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/net_vatsim_mqtt/net_vatsim_mqtt_pilot_position"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_net_vatsim_mqtt_pilot_position(
+            topic=test_topic,
+            callsign=f"test_callsign_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_net_vatsim_mqtt_net_vatsim_mqtt_controller_position_py(mosquitto_broker):
+    """Test publishing and receiving net.vatsim.mqtt.ControllerPosition message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_ControllerPosition.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = NetVatsimMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = NetVatsimMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_net_vatsim_mqtt_controller_position(mqtt_msg, cloud_event, data: vatsim_mqtt_producer_data.ControllerPosition, topic_params: dict):
+        """Handler for net.vatsim.mqtt.ControllerPosition messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "net.vatsim.ControllerPosition"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.net_vatsim_mqtt_controller_position_async = on_net_vatsim_mqtt_controller_position
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/net_vatsim_mqtt/net_vatsim_mqtt_controller_position"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_net_vatsim_mqtt_controller_position(
+            topic=test_topic,
+            callsign=f"test_callsign_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_net_vatsim_mqtt_net_vatsim_mqtt_facility_status_py(mosquitto_broker):
+    """Test publishing and receiving net.vatsim.mqtt.FacilityStatus message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_NetworkStatus.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = NetVatsimMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = NetVatsimMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_net_vatsim_mqtt_facility_status(mqtt_msg, cloud_event, data: vatsim_mqtt_producer_data.NetworkStatus, topic_params: dict):
+        """Handler for net.vatsim.mqtt.FacilityStatus messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "net.vatsim.NetworkStatus"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.net_vatsim_mqtt_facility_status_async = on_net_vatsim_mqtt_facility_status
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/net_vatsim_mqtt/net_vatsim_mqtt_facility_status"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_net_vatsim_mqtt_facility_status(
+            topic=test_topic,
+            callsign=f"test_callsign_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/vatsim/vatsim_producer/README.md
+++ b/vatsim/vatsim_producer/README.md
@@ -19,7 +19,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 4. [Generated Producer Classes](#generated-producer-classes)    NetVatsimControllersEventDispatcher,
 
-4. [Generated Producer Classes](#generated-producer-classes)    NetVatsimStatusEventDispatcher
+4. [Generated Producer Classes](#generated-producer-classes)    NetVatsimStatusEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    NetVatsimMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -51,6 +53,10 @@ It includes both plain Kafka messages and CloudEvents, offering a versatile
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - NetVatsimStatusProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- NetVatsimMqttProducersolution for event-driven applications.
 
 
 
@@ -272,6 +278,43 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 net_vatsim_status_dispatcher.net_vatsim_pilot_position_async = net_vatsim_pilot_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.PilotPosition`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_pilot_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data: PilotPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_pilot_position_async = net_vatsim_pilot_position_event
 
 **Parameters:**```
 
@@ -615,6 +658,44 @@ net_vatsim_status_dispatcher.net_vatsim_controller_position_async = net_vatsim_c
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.ControllerPosition`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_controller_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ControllerPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_controller_position_async = net_vatsim_controller_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -950,6 +1031,43 @@ net_vatsim_status_dispatcher.net_vatsim_network_status_async = net_vatsim_networ
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.NetworkStatus`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_network_status_event(record: ConsumerRecord, cloud_event: CloudEvent, data: NetworkStatus) -> None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_network_status_async = net_vatsim_network_status_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -1045,6 +1163,946 @@ dispatching events to the appropriate handlers.
 ```python__init__(consumer: KafkaConsumer)
 
 await producer.send_net_vatsim_network_status_batch(```
+
+    messages=[
+
+        NetworkStatus(...),Initializes the runner with a Kafka consumer.
+
+        NetworkStatus(...),
+
+        NetworkStatus(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### NetVatsimMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`NetVatsimMqttEventDispatcher` handles events for the net.vatsim.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from vatsim_producer import NetVatsimPilotsProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = NetVatsimPilotsProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_net_vatsim_pilot_position(```python
+
+    data=PilotPosition(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The NetVatsimMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = NetVatsimPilotsProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `net_vatsim_mqtt_pilot_position_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'net_vatsim_mqtt_pilot_position_async:  Callable[[ConsumerRecord, CloudEvent,
+PilotPosition], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `net.vatsim.mqtt.PilotPosition`: Current position, flight plan summary, and state of a
+pilot connected to the VATSIM virtual aviation network.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimPilotsProducer- `data`: The event data of type `vatsim_producer_data.PilotPosition`.
+
+
+
+Producer for `net.vatsim.pilots` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_pilot_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data: PilotPosition) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimPilotsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_pilots_dispatcher.net_vatsim_mqtt_pilot_position_async = net_vatsim_mqtt_pilot_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimControllersProducer- `data`: The event data of type `vatsim_producer_data.PilotPosition`.
+
+
+
+Producer for `net.vatsim.controllers` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_pilot_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data: PilotPosition) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimControllersProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_controllers_dispatcher.net_vatsim_mqtt_pilot_position_async = net_vatsim_mqtt_pilot_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimStatusProducer- `data`: The event data of type `vatsim_producer_data.PilotPosition`.
+
+
+
+Producer for `net.vatsim.status` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_pilot_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data: PilotPosition) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimStatusProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_status_dispatcher.net_vatsim_mqtt_pilot_position_async = net_vatsim_mqtt_pilot_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.PilotPosition`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_pilot_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data: PilotPosition) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_pilot_position_async = net_vatsim_mqtt_pilot_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `net_vatsim_mqtt_controller_position_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'net_vatsim_mqtt_controller_position_async:  Callable[[ConsumerRecord, CloudEvent,
+ControllerPosition], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `net.vatsim.mqtt.ControllerPosition`: Current state and frequency of an air traffic
+controller connected to the VATSIM virtual aviation network.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimPilotsProducer- `data`: The event data of type `vatsim_producer_data.ControllerPosition`.
+
+
+
+Producer for `net.vatsim.pilots` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_controller_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ControllerPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimPilotsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_pilots_dispatcher.net_vatsim_mqtt_controller_position_async = net_vatsim_mqtt_controller_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimControllersProducer- `data`: The event data of type `vatsim_producer_data.ControllerPosition`.
+
+
+
+Producer for `net.vatsim.controllers` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_controller_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ControllerPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimControllersProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_controllers_dispatcher.net_vatsim_mqtt_controller_position_async = net_vatsim_mqtt_controller_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimStatusProducer- `data`: The event data of type `vatsim_producer_data.ControllerPosition`.
+
+
+
+Producer for `net.vatsim.status` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_controller_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ControllerPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimStatusProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_status_dispatcher.net_vatsim_mqtt_controller_position_async = net_vatsim_mqtt_controller_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.ControllerPosition`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_controller_position_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+ControllerPosition) -> None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_controller_position_async = net_vatsim_mqtt_controller_position_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `net_vatsim_mqtt_facility_status_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'net_vatsim_mqtt_facility_status_async:  Callable[[ConsumerRecord, CloudEvent,
+NetworkStatus], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `net.vatsim.mqtt.FacilityStatus`: Aggregate network status snapshot from the VATSIM data
+feed, emitted once per poll cycle.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimPilotsProducer- `data`: The event data of type `vatsim_producer_data.NetworkStatus`.
+
+
+
+Producer for `net.vatsim.pilots` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_facility_status_event(record: ConsumerRecord, cloud_event: CloudEvent, data: NetworkStatus) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimPilotsProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_pilots_dispatcher.net_vatsim_mqtt_facility_status_async = net_vatsim_mqtt_facility_status_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimControllersProducer- `data`: The event data of type `vatsim_producer_data.NetworkStatus`.
+
+
+
+Producer for `net.vatsim.controllers` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_facility_status_event(record: ConsumerRecord, cloud_event: CloudEvent, data: NetworkStatus) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimControllersProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_controllers_dispatcher.net_vatsim_mqtt_facility_status_async = net_vatsim_mqtt_facility_status_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimStatusProducer- `data`: The event data of type `vatsim_producer_data.NetworkStatus`.
+
+
+
+Producer for `net.vatsim.status` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_facility_status_event(record: ConsumerRecord, cloud_event: CloudEvent, data: NetworkStatus) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimStatusProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_status_dispatcher.net_vatsim_mqtt_facility_status_async = net_vatsim_mqtt_facility_status_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### NetVatsimMqttProducer- `data`: The event data of type `vatsim_producer_data.NetworkStatus`.
+
+
+
+Producer for `net.vatsim.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def net_vatsim_mqtt_facility_status_event(record: ConsumerRecord, cloud_event: CloudEvent, data: NetworkStatus) ->
+None:
+
+```python    # Process the event data
+
+NetVatsimMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+net_vatsim_mqtt_dispatcher.net_vatsim_mqtt_facility_status_async = net_vatsim_mqtt_facility_status_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_net_vatsim_mqtt_pilot_position`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_net_vatsim_mqtt_pilot_position(
+
+    self,##### `_process_event`
+
+    data: PilotPosition,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `net.vatsim.mqtt.PilotPosition` message. Current position, flight plan summary, and state of a pilot
+connected to the VATSIM virtual aviation network.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `PilotPosition`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_net_vatsim_mqtt_pilot_position(
+
+    data=PilotPosition(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `net.vatsim.mqtt.PilotPosition` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_net_vatsim_mqtt_pilot_position_batch(```
+
+    messages=[
+
+        PilotPosition(...),Initializes the runner with a Kafka consumer.
+
+        PilotPosition(...),
+
+        PilotPosition(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_net_vatsim_mqtt_controller_position`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_net_vatsim_mqtt_controller_position(
+
+    self,##### `_process_event`
+
+    data: ControllerPosition,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `net.vatsim.mqtt.ControllerPosition` message. Current state and frequency of an air traffic controller
+connected to the VATSIM virtual aviation network.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `ControllerPosition`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_net_vatsim_mqtt_controller_position(
+
+    data=ControllerPosition(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `net.vatsim.mqtt.ControllerPosition` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_net_vatsim_mqtt_controller_position_batch(```
+
+    messages=[
+
+        ControllerPosition(...),Initializes the runner with a Kafka consumer.
+
+        ControllerPosition(...),
+
+        ControllerPosition(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_net_vatsim_mqtt_facility_status`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_net_vatsim_mqtt_facility_status(
+
+    self,##### `_process_event`
+
+    data: NetworkStatus,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `net.vatsim.mqtt.FacilityStatus` message. Aggregate network status snapshot from the VATSIM data feed,
+emitted once per poll cycle.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `NetworkStatus`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_net_vatsim_mqtt_facility_status(
+
+    data=NetworkStatus(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `net.vatsim.mqtt.FacilityStatus` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_net_vatsim_mqtt_facility_status_batch(```
 
     messages=[
 

--- a/vatsim/vatsim_producer/samples/sample.py
+++ b/vatsim/vatsim_producer/samples/sample.py
@@ -35,6 +35,7 @@ from confluent_kafka import Producer as KafkaProducer
 from vatsim_producer_kafka_producer.producer import NetVatsimPilotsEventProducer
 from vatsim_producer_kafka_producer.producer import NetVatsimControllersEventProducer
 from vatsim_producer_kafka_producer.producer import NetVatsimStatusEventProducer
+from vatsim_producer_kafka_producer.producer import NetVatsimMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -99,6 +100,38 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'net.vatsim.NetworkStatus' event to Kafka topic.
     await net_vatsim_status_event_producer.send_net_vatsim_network_status(_callsign = 'TODO: replace me', data = _network_status)
     print(f"Sent 'net.vatsim.NetworkStatus' event: {_network_status.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        net_vatsim_mqtt_event_producer = NetVatsimMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        net_vatsim_mqtt_event_producer = NetVatsimMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- net.vatsim.mqtt.PilotPosition ----
+    # TODO: Supply event data for the net.vatsim.mqtt.PilotPosition event
+    _pilot_position = PilotPosition()
+
+    # sends the 'net.vatsim.mqtt.PilotPosition' event to Kafka topic.
+    await net_vatsim_mqtt_event_producer.send_net_vatsim_mqtt_pilot_position(_callsign = 'TODO: replace me', data = _pilot_position)
+    print(f"Sent 'net.vatsim.mqtt.PilotPosition' event: {_pilot_position.to_json()}")
+
+    # ---- net.vatsim.mqtt.ControllerPosition ----
+    # TODO: Supply event data for the net.vatsim.mqtt.ControllerPosition event
+    _controller_position = ControllerPosition()
+
+    # sends the 'net.vatsim.mqtt.ControllerPosition' event to Kafka topic.
+    await net_vatsim_mqtt_event_producer.send_net_vatsim_mqtt_controller_position(_callsign = 'TODO: replace me', data = _controller_position)
+    print(f"Sent 'net.vatsim.mqtt.ControllerPosition' event: {_controller_position.to_json()}")
+
+    # ---- net.vatsim.mqtt.FacilityStatus ----
+    # TODO: Supply event data for the net.vatsim.mqtt.FacilityStatus event
+    _network_status = NetworkStatus()
+
+    # sends the 'net.vatsim.mqtt.FacilityStatus' event to Kafka topic.
+    await net_vatsim_mqtt_event_producer.send_net_vatsim_mqtt_facility_status(_callsign = 'TODO: replace me', data = _network_status)
+    print(f"Sent 'net.vatsim.mqtt.FacilityStatus' event: {_network_status.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/__init__.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .net import NetworkStatus, PilotPosition, ControllerPosition
+from .net import ControllerPosition, NetworkStatus, PilotPosition
 
-__all__ = ["NetworkStatus", "PilotPosition", "ControllerPosition"]
+__all__ = ["ControllerPosition", "NetworkStatus", "PilotPosition"]

--- a/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/net/__init__.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/net/__init__.py
@@ -1,3 +1,3 @@
-from .vatsim import NetworkStatus, PilotPosition, ControllerPosition
+from .vatsim import ControllerPosition, NetworkStatus, PilotPosition
 
-__all__ = ["NetworkStatus", "PilotPosition", "ControllerPosition"]
+__all__ = ["ControllerPosition", "NetworkStatus", "PilotPosition"]

--- a/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/net/vatsim/__init__.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/src/vatsim_producer_data/net/vatsim/__init__.py
@@ -1,5 +1,5 @@
+from .controllerposition import ControllerPosition
 from .networkstatus import NetworkStatus
 from .pilotposition import PilotPosition
-from .controllerposition import ControllerPosition
 
-__all__ = ["NetworkStatus", "PilotPosition", "ControllerPosition"]
+__all__ = ["ControllerPosition", "NetworkStatus", "PilotPosition"]

--- a/vatsim/vatsim_producer/vatsim_producer_data/tests/test_controllerposition.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/tests/test_controllerposition.py
@@ -28,13 +28,13 @@ class Test_ControllerPosition(unittest.TestCase):
         Create instance of ControllerPosition for testing
         """
         instance = ControllerPosition(
-            cid=int(29),
-            callsign='khedgequmnaqlekcmbhm',
-            frequency='brstdwwzjxswknothwvl',
-            facility=int(98),
-            rating=int(9),
-            text_atis='npxqdmkgfrdbxnxgqnur',
-            last_updated='vymqfrqpyjxpgyhmvotq'
+            cid=int(55),
+            callsign='fikzjsjchwbofdbccegk',
+            frequency='bsuhvqxpamlftsxgfbbf',
+            facility=int(47),
+            rating=int(43),
+            text_atis='wicvvjgshbfhzjsaylsf',
+            last_updated='cpxjcuizgqgyesdxfcxa'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test cid property
         """
-        test_value = int(29)
+        test_value = int(55)
         self.instance.cid = test_value
         self.assertEqual(self.instance.cid, test_value)
     
@@ -51,7 +51,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'khedgequmnaqlekcmbhm'
+        test_value = 'fikzjsjchwbofdbccegk'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
     
@@ -59,7 +59,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test frequency property
         """
-        test_value = 'brstdwwzjxswknothwvl'
+        test_value = 'bsuhvqxpamlftsxgfbbf'
         self.instance.frequency = test_value
         self.assertEqual(self.instance.frequency, test_value)
     
@@ -67,7 +67,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test facility property
         """
-        test_value = int(98)
+        test_value = int(47)
         self.instance.facility = test_value
         self.assertEqual(self.instance.facility, test_value)
     
@@ -75,7 +75,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test rating property
         """
-        test_value = int(9)
+        test_value = int(43)
         self.instance.rating = test_value
         self.assertEqual(self.instance.rating, test_value)
     
@@ -83,7 +83,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test text_atis property
         """
-        test_value = 'npxqdmkgfrdbxnxgqnur'
+        test_value = 'wicvvjgshbfhzjsaylsf'
         self.instance.text_atis = test_value
         self.assertEqual(self.instance.text_atis, test_value)
     
@@ -91,7 +91,7 @@ class Test_ControllerPosition(unittest.TestCase):
         """
         Test last_updated property
         """
-        test_value = 'vymqfrqpyjxpgyhmvotq'
+        test_value = 'cpxjcuizgqgyesdxfcxa'
         self.instance.last_updated = test_value
         self.assertEqual(self.instance.last_updated, test_value)
     
@@ -104,3 +104,22 @@ class Test_ControllerPosition(unittest.TestCase):
         new_instance = ControllerPosition.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = ControllerPosition.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = ControllerPosition.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_producer/vatsim_producer_data/tests/test_networkstatus.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/tests/test_networkstatus.py
@@ -28,13 +28,13 @@ class Test_NetworkStatus(unittest.TestCase):
         Create instance of NetworkStatus for testing
         """
         instance = NetworkStatus(
-            callsign='bibsysdcnudykywbzris',
-            facility='tzxxbnijobmeuxhlqjwa',
-            update_timestamp='wvtvbjczwlqxwelshidh',
-            connected_clients=int(27),
-            unique_users=int(38),
-            pilot_count=int(84),
-            controller_count=int(45)
+            callsign='qmaslrxskcqjizmknlrr',
+            update_timestamp='woujfgwxhsllpzgfssjo',
+            connected_clients=int(88),
+            unique_users=int(98),
+            pilot_count=int(1),
+            controller_count=int(75),
+            facility='wadyklxwtfjdvzfwtprx'
         )
         return instance
 
@@ -43,23 +43,15 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'bibsysdcnudykywbzris'
+        test_value = 'qmaslrxskcqjizmknlrr'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
-    
-    def test_facility_property(self):
-        """
-        Test facility property
-        """
-        test_value = 'tzxxbnijobmeuxhlqjwa'
-        self.instance.facility = test_value
-        self.assertEqual(self.instance.facility, test_value)
     
     def test_update_timestamp_property(self):
         """
         Test update_timestamp property
         """
-        test_value = 'wvtvbjczwlqxwelshidh'
+        test_value = 'woujfgwxhsllpzgfssjo'
         self.instance.update_timestamp = test_value
         self.assertEqual(self.instance.update_timestamp, test_value)
     
@@ -67,7 +59,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test connected_clients property
         """
-        test_value = int(27)
+        test_value = int(88)
         self.instance.connected_clients = test_value
         self.assertEqual(self.instance.connected_clients, test_value)
     
@@ -75,7 +67,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test unique_users property
         """
-        test_value = int(38)
+        test_value = int(98)
         self.instance.unique_users = test_value
         self.assertEqual(self.instance.unique_users, test_value)
     
@@ -83,7 +75,7 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test pilot_count property
         """
-        test_value = int(84)
+        test_value = int(1)
         self.instance.pilot_count = test_value
         self.assertEqual(self.instance.pilot_count, test_value)
     
@@ -91,9 +83,17 @@ class Test_NetworkStatus(unittest.TestCase):
         """
         Test controller_count property
         """
-        test_value = int(45)
+        test_value = int(75)
         self.instance.controller_count = test_value
         self.assertEqual(self.instance.controller_count, test_value)
+    
+    def test_facility_property(self):
+        """
+        Test facility property
+        """
+        test_value = 'wadyklxwtfjdvzfwtprx'
+        self.instance.facility = test_value
+        self.assertEqual(self.instance.facility, test_value)
     
     def test_to_byte_array_avro(self):
         """
@@ -104,3 +104,22 @@ class Test_NetworkStatus(unittest.TestCase):
         new_instance = NetworkStatus.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = NetworkStatus.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = NetworkStatus.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_producer/vatsim_producer_data/tests/test_pilotposition.py
+++ b/vatsim/vatsim_producer/vatsim_producer_data/tests/test_pilotposition.py
@@ -28,23 +28,23 @@ class Test_PilotPosition(unittest.TestCase):
         Create instance of PilotPosition for testing
         """
         instance = PilotPosition(
-            cid=int(33),
-            callsign='bapgpplfthgxaxgyzzwy',
-            latitude=float(13.019229370536767),
-            longitude=float(33.293758419396255),
-            altitude=int(88),
-            groundspeed=int(76),
-            heading=int(0),
-            transponder='tswghhyhsjtficzmserh',
-            qnh_mb=int(79),
-            flight_rules='askfryfwzxxekgwsyvkb',
-            aircraft_short='eoljbfnbpzjpyjcqzzeh',
-            departure='qwjumghrpcmhkmbmedts',
-            arrival='dzeitsgcjvddpxhslgbm',
-            route='ofccxebycyvozxljowzo',
-            cruise_altitude='ztfgnmzxkhqefvcpekyj',
-            pilot_rating=int(10),
-            last_updated='yhdgcvlkjclysqztvlqo'
+            cid=int(63),
+            callsign='pltspfrxrjftngiyucls',
+            latitude=float(62.113847926232054),
+            longitude=float(53.20605555466481),
+            altitude=int(48),
+            groundspeed=int(88),
+            heading=int(47),
+            transponder='hgcujqskuefgtlmzwxvs',
+            qnh_mb=int(34),
+            flight_rules='pbufzvwrzlsqapokcpog',
+            aircraft_short='pddxvghpeqkioflpljdq',
+            departure='ouzblrrnrghsifvtfqad',
+            arrival='rlqxmwcwnfxrmmtvlxvz',
+            route='aisdecdajjqdykyujoux',
+            cruise_altitude='dplemlhfphetbqczsxfz',
+            pilot_rating=int(22),
+            last_updated='kmllscqaxfzyhidpfllr'
         )
         return instance
 
@@ -53,7 +53,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test cid property
         """
-        test_value = int(33)
+        test_value = int(63)
         self.instance.cid = test_value
         self.assertEqual(self.instance.cid, test_value)
     
@@ -61,7 +61,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test callsign property
         """
-        test_value = 'bapgpplfthgxaxgyzzwy'
+        test_value = 'pltspfrxrjftngiyucls'
         self.instance.callsign = test_value
         self.assertEqual(self.instance.callsign, test_value)
     
@@ -69,7 +69,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(13.019229370536767)
+        test_value = float(62.113847926232054)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -77,7 +77,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(33.293758419396255)
+        test_value = float(53.20605555466481)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -85,7 +85,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = int(88)
+        test_value = int(48)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -93,7 +93,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test groundspeed property
         """
-        test_value = int(76)
+        test_value = int(88)
         self.instance.groundspeed = test_value
         self.assertEqual(self.instance.groundspeed, test_value)
     
@@ -101,7 +101,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test heading property
         """
-        test_value = int(0)
+        test_value = int(47)
         self.instance.heading = test_value
         self.assertEqual(self.instance.heading, test_value)
     
@@ -109,7 +109,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test transponder property
         """
-        test_value = 'tswghhyhsjtficzmserh'
+        test_value = 'hgcujqskuefgtlmzwxvs'
         self.instance.transponder = test_value
         self.assertEqual(self.instance.transponder, test_value)
     
@@ -117,7 +117,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test qnh_mb property
         """
-        test_value = int(79)
+        test_value = int(34)
         self.instance.qnh_mb = test_value
         self.assertEqual(self.instance.qnh_mb, test_value)
     
@@ -125,7 +125,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test flight_rules property
         """
-        test_value = 'askfryfwzxxekgwsyvkb'
+        test_value = 'pbufzvwrzlsqapokcpog'
         self.instance.flight_rules = test_value
         self.assertEqual(self.instance.flight_rules, test_value)
     
@@ -133,7 +133,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test aircraft_short property
         """
-        test_value = 'eoljbfnbpzjpyjcqzzeh'
+        test_value = 'pddxvghpeqkioflpljdq'
         self.instance.aircraft_short = test_value
         self.assertEqual(self.instance.aircraft_short, test_value)
     
@@ -141,7 +141,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test departure property
         """
-        test_value = 'qwjumghrpcmhkmbmedts'
+        test_value = 'ouzblrrnrghsifvtfqad'
         self.instance.departure = test_value
         self.assertEqual(self.instance.departure, test_value)
     
@@ -149,7 +149,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test arrival property
         """
-        test_value = 'dzeitsgcjvddpxhslgbm'
+        test_value = 'rlqxmwcwnfxrmmtvlxvz'
         self.instance.arrival = test_value
         self.assertEqual(self.instance.arrival, test_value)
     
@@ -157,7 +157,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'ofccxebycyvozxljowzo'
+        test_value = 'aisdecdajjqdykyujoux'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -165,7 +165,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test cruise_altitude property
         """
-        test_value = 'ztfgnmzxkhqefvcpekyj'
+        test_value = 'dplemlhfphetbqczsxfz'
         self.instance.cruise_altitude = test_value
         self.assertEqual(self.instance.cruise_altitude, test_value)
     
@@ -173,7 +173,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test pilot_rating property
         """
-        test_value = int(10)
+        test_value = int(22)
         self.instance.pilot_rating = test_value
         self.assertEqual(self.instance.pilot_rating, test_value)
     
@@ -181,7 +181,7 @@ class Test_PilotPosition(unittest.TestCase):
         """
         Test last_updated property
         """
-        test_value = 'yhdgcvlkjclysqztvlqo'
+        test_value = 'kmllscqaxfzyhidpfllr'
         self.instance.last_updated = test_value
         self.assertEqual(self.instance.last_updated, test_value)
     
@@ -194,3 +194,22 @@ class Test_PilotPosition(unittest.TestCase):
         new_instance = PilotPosition.from_data(bytes_data, media_type)
         bytes_data2 = new_instance.to_byte_array(media_type)
         self.assertEqual(bytes_data, bytes_data2)
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = PilotPosition.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = PilotPosition.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/vatsim/vatsim_producer/vatsim_producer_kafka_producer/src/vatsim_producer_kafka_producer/producer.py
+++ b/vatsim/vatsim_producer/vatsim_producer_kafka_producer/src/vatsim_producer_kafka_producer/producer.py
@@ -351,3 +351,178 @@ class NetVatsimStatusEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class NetVatsimMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_net_vatsim_mqtt_pilot_position(self,_callsign : str, data: PilotPosition, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, PilotPosition], str]=None) -> None:
+        """
+        Sends the 'net.vatsim.mqtt.PilotPosition' event to the Kafka topic
+
+        Args:
+            _callsign(str):  Value for placeholder callsign in attribute subject
+            data: (PilotPosition): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, PilotPosition], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"net.vatsim.PilotPosition",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = _callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_net_vatsim_mqtt_controller_position(self,_callsign : str, data: ControllerPosition, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ControllerPosition], str]=None) -> None:
+        """
+        Sends the 'net.vatsim.mqtt.ControllerPosition' event to the Kafka topic
+
+        Args:
+            _callsign(str):  Value for placeholder callsign in attribute subject
+            data: (ControllerPosition): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, ControllerPosition], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"net.vatsim.ControllerPosition",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = _callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_net_vatsim_mqtt_facility_status(self,_callsign : str, data: NetworkStatus, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, NetworkStatus], str]=None) -> None:
+        """
+        Sends the 'net.vatsim.mqtt.FacilityStatus' event to the Kafka topic
+
+        Args:
+            _callsign(str):  Value for placeholder callsign in attribute subject
+            data: (NetworkStatus): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, NetworkStatus], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"net.vatsim.NetworkStatus",
+             "source":"https://data.vatsim.net/v3/vatsim-data.json",
+             "subject":"{callsign}".format(callsign = _callsign)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'NetVatsimMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/vatsim/vatsim_producer/vatsim_producer_kafka_producer/tests/test_producer.py
+++ b/vatsim/vatsim_producer/vatsim_producer_kafka_producer/tests/test_producer.py
@@ -27,6 +27,7 @@ from test_vatsim_producer_data_controllerposition import Test_ControllerPosition
 from vatsim_producer_kafka_producer.producer import NetVatsimStatusEventProducer
 from vatsim_producer_data import NetworkStatus
 from test_vatsim_producer_data_networkstatus import Test_NetworkStatus
+from vatsim_producer_kafka_producer.producer import NetVatsimMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -246,4 +247,187 @@ def test_net_vatsim_status_netvatsimnetworkstatus(kafka_emulator):
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "{callsign}".format(callsign=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_net_vatsim_mqtt_netvatsimmqttpilotposition(kafka_emulator):
+    """Test the NetVatsimMqttPilotPosition event from the Net.Vatsim.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_net_vatsim_mqtt_netvatsimmqttpilotposition',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "net.vatsim.mqtt.PilotPosition":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = NetVatsimMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_PilotPosition.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_net_vatsim_mqtt_pilot_position(_callsign = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_net_vatsim_mqtt_netvatsimmqttcontrollerposition(kafka_emulator):
+    """Test the NetVatsimMqttControllerPosition event from the Net.Vatsim.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_net_vatsim_mqtt_netvatsimmqttcontrollerposition',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "net.vatsim.mqtt.ControllerPosition":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = NetVatsimMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_ControllerPosition.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_net_vatsim_mqtt_controller_position(_callsign = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_net_vatsim_mqtt_netvatsimmqttfacilitystatus(kafka_emulator):
+    """Test the NetVatsimMqttFacilityStatus event from the Net.Vatsim.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_net_vatsim_mqtt_netvatsimmqttfacilitystatus',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "net.vatsim.mqtt.FacilityStatus":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = NetVatsimMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_NetworkStatus.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_net_vatsim_mqtt_facility_status(_callsign = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()

--- a/vatsim/xreg/vatsim.xreg.json
+++ b/vatsim/xreg/vatsim.xreg.json
@@ -62,6 +62,25 @@
       "messagegroups": [
         "#/messagegroups/net.vatsim.status"
       ]
+    },
+    "net.vatsim.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "deployed": false,
+      "endpoints": [
+        {
+          "uri": "mqtt://localhost:1883"
+        }
+      ],
+      "messagegroups": [
+        "#/messagegroups/net.vatsim.mqtt"
+      ]
     }
   },
   "messagegroups": {
@@ -133,6 +152,41 @@
           "dataschemauri": "#/schemagroups/net.vatsim.jstruct/schemas/net.vatsim.NetworkStatus"
         }
       }
+    },
+    "net.vatsim.mqtt": {
+      "description": "MQTT/5.0 transport variant for VATSIM live network data. Non-retained QoS-1 streams split pilots, controllers, and network facility status into distinct UNS topic branches under aviation-network/intl/vatsim/vatsim/...",
+      "messages": {
+        "net.vatsim.mqtt.PilotPosition": {
+          "name": "PilotPosition",
+          "basemessageurl": "/messagegroups/net.vatsim.pilots/messages/net.vatsim.PilotPosition",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "aviation-network/intl/vatsim/vatsim/pilots/{callsign}/pilot-position",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "net.vatsim.mqtt.ControllerPosition": {
+          "name": "ControllerPosition",
+          "basemessageurl": "/messagegroups/net.vatsim.controllers/messages/net.vatsim.ControllerPosition",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "aviation-network/intl/vatsim/vatsim/controllers/{callsign}/controller-position",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "net.vatsim.mqtt.FacilityStatus": {
+          "name": "FacilityStatus",
+          "basemessageurl": "/messagegroups/net.vatsim.status/messages/net.vatsim.NetworkStatus",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "aviation-network/intl/vatsim/vatsim/facilities/{facility}/facility-status",
+            "qos": 1,
+            "retain": false
+          }
+        }
+      }
     }
   },
   "schemagroups": {
@@ -160,7 +214,7 @@
                         "properties": {
                           "cid": {
                             "type": "int32",
-                            "description": "VATSIM Certificate Identifier (CID) — unique numeric member ID."
+                            "description": "VATSIM Certificate Identifier (CID) \u2014 unique numeric member ID."
                           },
                           "callsign": {
                             "type": "string",
@@ -170,13 +224,13 @@
                             "type": "double",
                             "description": "Aircraft latitude in decimal degrees (WGS-84). Positive is north.",
                             "unit": "degree",
-                            "symbol": "°"
+                            "symbol": "\u00b0"
                           },
                           "longitude": {
                             "type": "double",
                             "description": "Aircraft longitude in decimal degrees (WGS-84). Positive is east.",
                             "unit": "degree",
-                            "symbol": "°"
+                            "symbol": "\u00b0"
                           },
                           "altitude": {
                             "type": "int32",
@@ -194,7 +248,7 @@
                             "type": "int32",
                             "description": "Magnetic heading of the aircraft in degrees (0-359).",
                             "unit": "degree",
-                            "symbol": "°"
+                            "symbol": "\u00b0"
                           },
                           "transponder": {
                             "type": "string",
@@ -300,7 +354,7 @@
                         "properties": {
                           "cid": {
                             "type": "int32",
-                            "description": "VATSIM Certificate Identifier (CID) — unique numeric member ID."
+                            "description": "VATSIM Certificate Identifier (CID) \u2014 unique numeric member ID."
                           },
                           "callsign": {
                             "type": "string",
@@ -389,10 +443,15 @@
                           "controller_count": {
                             "type": "int32",
                             "description": "Number of controllers (including observers) currently connected and providing ATC services."
+                          },
+                          "facility": {
+                            "type": "string",
+                            "description": "UNS facility identifier for this aggregate VATSIM network status snapshot. The bridge emits 'network'."
                           }
                         },
                         "required": [
                           "callsign",
+                          "facility",
                           "update_timestamp",
                           "connected_clients",
                           "unique_users",
@@ -424,7 +483,7 @@
                   {
                     "name": "cid",
                     "type": "int",
-                    "doc": "VATSIM Certificate Identifier (CID) — unique numeric member ID."
+                    "doc": "VATSIM Certificate Identifier (CID) \u2014 unique numeric member ID."
                   },
                   {
                     "name": "callsign",
@@ -605,6 +664,11 @@
                     "name": "callsign",
                     "type": "string",
                     "doc": "Constant key value 'status'."
+                  },
+                  {
+                    "name": "facility",
+                    "type": "string",
+                    "doc": "UNS facility identifier for this aggregate VATSIM network status snapshot. The bridge emits 'network'."
                   },
                   {
                     "name": "update_timestamp",


### PR DESCRIPTION
## Summary
- Adds VATSIM MQTT/UNS xRegistry endpoint and generated MQTT producer
- Splits pilots, controllers, and facility status into three MQTT messages/topics
- Adds facility routing field for aggregate network facility status

## Topic tree
- aviation-network/intl/vatsim/vatsim/pilots/{callsign}/pilot-position
- aviation-network/intl/vatsim/vatsim/controllers/{callsign}/controller-position
- aviation-network/intl/vatsim/vatsim/facilities/{facility}/facility-status

## Reviews
- xRegistry Expert: acceptable; no blocking findings
- UNS Catalog Architect: acceptable; non-blocking suggestion to consider retained+expiry facility status later

## Validation
- python -m pytest tests\\test_vatsim_unit.py vatsim_producer\\vatsim_producer_data\\tests -q
- python -m pytest vatsim_mqtt_producer\\vatsim_mqtt_producer_data\\tests -q
- python -m compileall -q vatsim_mqtt\\vatsim_mqtt