### PR TITLE
docs: record MQTT fleet batch 9

### DIFF
--- a/files/053-mqtt-fleet-batch-9.md
+++ b/files/053-mqtt-fleet-batch-9.md
@@ -1,0 +1,26 @@
+# 053 MQTT Fleet Batch 9
+
+## Shipped
+
+1. `gdacs` — PR #390, merge `8ccb37573bd3153de8dace7ed6cc06ed13c6e4a0`
+   - Topic: `alerts/intl/gdacs/gdacs/{event_type}/{alert_color}/{country}/{event_id}/alert`
+   - Review: xRegistry and UNS approved after fixing MQTT endpoint shape, event/alert routing guards, and topic sanitization; no final blockers.
+2. `meteoalarm` — PR #391, merge `c4ed253d6f825a2a2388540c7ffa95fb5e837143`
+   - Topic: `alerts/intl/meteoalarm/meteoalarm/{country}/{severity}/{awareness_type}/{identifier}/warning`
+   - Review: xRegistry and UNS approved; awareness type is normalized for MQTT routing while retaining the raw CAP parameter.
+3. `ptwc-tsunami` — PR #392, merge `a15181491e9f913d8ad46ff373623feedb3c1e1c`
+   - Topic: `alerts/intl/ptwc/ptwc-tsunami/{basin}/{ptwc_level}/{bulletin_id}/bulletin`
+   - Review: xRegistry and UNS approved; basin and ptwc_level routing axes are schema-backed and non-null.
+4. `nina-bbk` — PR #393, merge `2db32ac5003182ce4f739aa7cd7a381d78ec57e5`
+   - Topic: `alerts/de/nina/nina-bbk/{state}/{severity}/{warning_id}/warning`
+   - Review: xRegistry and UNS approved; state is derived from CAP area administrative codes with sender fallback.
+
+## Main CI
+
+- Main was verified green between every merge.
+- Final main CI after #393: Dependency Graph, Docker E2E Tests, Publish Notebook Wheels, and Build Containers all completed successfully.
+
+## Skipped
+
+- `jma-bosai-warning` — not started; deferred to preserve quality and main-green cadence after four alert/bulletin source PRs.
+- `jma-bosai-quake` — not started; deferred to preserve quality and main-green cadence after four alert/bulletin source PRs.

--- a/files/mqtt-fleet-decision-inventory.md
+++ b/files/mqtt-fleet-decision-inventory.md
@@ -12,11 +12,15 @@
   - `transit/no/entur/entur-norway/vm/{operator_ref}/{line_ref}/{service_journey_id}/monitored-vehicle-journey`
   - `transit/no/entur/entur-norway/sx/{severity}/{situation_number}/situation`
 - `eaws-albina` — PR #388, merge `3c198ae84e743a8b0305d6848d36a962a41c8273`; topic `alerts/at/eaws/eaws-albina/{country}/{region_id}/{danger_level}/bulletin`.
+- `gdacs` — PR #390, merge `8ccb37573bd3153de8dace7ed6cc06ed13c6e4a0`; topic `alerts/intl/gdacs/gdacs/{event_type}/{alert_color}/{country}/{event_id}/alert`.
+- `meteoalarm` — PR #391, merge `c4ed253d6f825a2a2388540c7ffa95fb5e837143`; topic `alerts/intl/meteoalarm/meteoalarm/{country}/{severity}/{awareness_type}/{identifier}/warning`.
+- `ptwc-tsunami` — PR #392, merge `a15181491e9f913d8ad46ff373623feedb3c1e1c`; topic `alerts/intl/ptwc/ptwc-tsunami/{basin}/{ptwc_level}/{bulletin_id}/bulletin`.
+- `nina-bbk` — PR #393, merge `2db32ac5003182ce4f739aa7cd7a381d78ec57e5`; topic `alerts/de/nina/nina-bbk/{state}/{severity}/{warning_id}/warning`.
 
 ## Ready-to-ship remaining
 
-- `gdacs` — ready candidate; target `alerts/intl/gdacs/gdacs/{event_type}/{alert_color}/{country}/{event_id}/alert`. Skipped in batch 8 to keep quality high after four source PRs and repeated full main CI waits.
-- `meteoalarm` — ready candidate; target `alerts/intl/meteoalarm/meteoalarm/{country}/{severity}/{awareness_type}/{identifier}/warning`. Skipped in batch 8 to keep quality high after four source PRs and repeated full main CI waits.
+- `jma-bosai-warning` — ready candidate; target `alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}`. Deferred in batch 9 to preserve quality after four source PRs and repeated full main CI waits.
+- `jma-bosai-quake` — ready candidate; target `seismic/jp/jma/jma-bosai-quake/{prefecture}/{magnitude_bucket}/{event_id}/{serial}/report`. Deferred in batch 9 to preserve quality after four source PRs and repeated full main CI waits.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- move gdacs, meteoalarm, ptwc-tsunami, and nina-bbk to Already-shipped
- record batch 9 checkpoint and main CI cadence
- leave JMA warning/quake as deferred ready candidates

## Validation
- documentation-only update
