### PR TITLE
mqtt(jma-bosai-warning): add UNS feeder

### DIFF
--- a/jma-bosai-warning/CONTAINER.md
+++ b/jma-bosai-warning/CONTAINER.md
@@ -1,6 +1,6 @@
 # JMA Bosai Warning Container
 
-This container polls Japan Meteorological Agency public Bosai weather warning and tsunami alert JSON feeds and publishes structured CloudEvents to Kafka-compatible endpoints.
+The Kafka container polls Japan Meteorological Agency public Bosai weather warning and tsunami alert JSON feeds and publishes structured CloudEvents to Kafka-compatible endpoints. `Dockerfile.mqtt` builds the MQTT/UNS weather-warning feeder.
 
 ## Environment
 
@@ -18,9 +18,20 @@ Optional:
 
 ## Run
 
+Kafka:
+
 ```powershell
 docker build -t jma-bosai-warning ./jma-bosai-warning
 docker run --rm -e CONNECTION_STRING="BootstrapServer=host.docker.internal:9092;EntityPath=jma-bosai-warning" -e KAFKA_ENABLE_TLS=false jma-bosai-warning
 ```
+
+MQTT/UNS:
+
+```powershell
+docker build -f ./jma-bosai-warning/Dockerfile.mqtt -t jma-bosai-warning-mqtt ./jma-bosai-warning
+docker run --rm -e MQTT_BROKER_URL="mqtt://host.docker.internal:1883" jma-bosai-warning-mqtt
+```
+
+The MQTT feeder publishes retained office references to `alerts/jp/jma/jma-bosai-warning/{prefecture}/REFERENCE/{office_code}/{area_code}/office` and non-retained warning records to `alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/warning`.
 
 For Azure Event Hubs or Fabric Event Streams, pass the full connection string in `CONNECTION_STRING`. Events are CloudEvents; see `EVENTS.md` for schemas and keys.

--- a/jma-bosai-warning/Dockerfile.mqtt
+++ b/jma-bosai-warning/Dockerfile.mqtt
@@ -1,0 +1,24 @@
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/jma-bosai-warning"
+LABEL org.opencontainers.image.title="JMA Bosai weather warnings → MQTT/UNS bridge"
+LABEL org.opencontainers.image.description="Polls Japan Meteorological Agency Bosai weather warning feeds and publishes MQTT 5.0 binary-mode CloudEvents into alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event} topics."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/jma-bosai-warning/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="mqtt"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir ./jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data \
+    && pip install --no-cache-dir ./jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client \
+    && pip install --no-cache-dir ./jma_bosai_warning_producer/jma_bosai_warning_producer_data \
+    && pip install --no-cache-dir . \
+    && pip install --no-cache-dir ./jma_bosai_warning_mqtt
+
+ENV MQTT_BROKER_URL=""
+ENV POLLING_INTERVAL_WARNING="60"
+ENV OFFICE_METADATA_REFRESH_HOURS="720"
+
+CMD ["python", "-m", "jma_bosai_warning_mqtt", "feed"]

--- a/jma-bosai-warning/README.md
+++ b/jma-bosai-warning/README.md
@@ -1,6 +1,6 @@
 # JMA Bosai Weather Warnings + Tsunami Alerts
 
-This source polls public Japan Meteorological Agency (JMA) Bosai endpoints and emits CloudEvents to Kafka.
+This source polls public Japan Meteorological Agency (JMA) Bosai endpoints and emits CloudEvents to Kafka. It also includes an MQTT/UNS feeder for weather warning and office-reference records.
 
 ## Upstream channels reviewed
 
@@ -21,8 +21,21 @@ See [EVENTS.md](EVENTS.md) for CloudEvents type, subject, key, and payload detai
 
 ## Runtime
 
+Kafka:
+
 ```powershell
 python -m jma_bosai_warning feed --connection-string "BootstrapServer=localhost:9092;EntityPath=jma-bosai-warning" --once
 ```
+
+MQTT/UNS:
+
+```powershell
+python -m jma_bosai_warning_mqtt feed --broker-url mqtt://localhost:1883 --once
+```
+
+MQTT topics:
+
+- `alerts/jp/jma/jma-bosai-warning/{prefecture}/REFERENCE/{office_code}/{area_code}/office` (retained office reference records)
+- `alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/warning` (non-retained weather warning records)
 
 Configuration is via environment variables or CLI flags. Required Kafka configuration is either `CONNECTION_STRING` or `KAFKA_BOOTSTRAP_SERVERS`.

--- a/jma-bosai-warning/generate_mqtt_producer.ps1
+++ b/jma-bosai-warning/generate_mqtt_producer.ps1
@@ -1,0 +1,12 @@
+# Regenerate the MQTT producer (mqttclient style) from the authoritative xreg manifest.
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style mqttclient `
+    --language py `
+    --definitions xreg\jma-bosai-warning.xreg.json `
+    --endpoint JP.JMA.Warning.Mqtt `
+    --projectname jma_bosai_warning_mqtt_producer `
+    --output jma_bosai_warning_mqtt_producer

--- a/jma-bosai-warning/jma_bosai_warning/jma_bosai_warning.py
+++ b/jma-bosai-warning/jma_bosai_warning/jma_bosai_warning.py
@@ -46,6 +46,16 @@ SPECIAL_WARNING_CODES = {"32", "33", "35", "36", "37", "38"}
 INFO_TYPE_MAP = {"発表": "ISSUED", "訂正": "CORRECTED", "取消": "CANCELLED", "キャンセル": "CANCELLED"}
 WARNING_STATUS_MAP = {"発表": "ISSUED", "継続": "CONTINUED", "解除": "CANCELLED", "発表警報・注意報はなし": "NO_WARNINGS_OR_ADVISORIES", "警報": "WARNING", "注意報": "ADVISORY", "特別警報": "EMERGENCY_WARNING"}
 TITLE_EN_MAP = {"津波警報・注意報・予報": "Tsunami warnings, advisories and forecasts", "津波情報": "Tsunami information"}
+PREFECTURE_BY_PREFIX = {
+    "01": "hokkaido", "02": "aomori", "03": "iwate", "04": "miyagi", "05": "akita", "06": "yamagata", "07": "fukushima",
+    "08": "ibaraki", "09": "tochigi", "10": "gunma", "11": "saitama", "12": "chiba", "13": "tokyo", "14": "kanagawa",
+    "15": "niigata", "16": "toyama", "17": "ishikawa", "18": "fukui", "19": "yamanashi", "20": "nagano", "21": "gifu",
+    "22": "shizuoka", "23": "aichi", "24": "mie", "25": "shiga", "26": "kyoto", "27": "osaka", "28": "hyogo",
+    "29": "nara", "30": "wakayama", "31": "tottori", "32": "shimane", "33": "okayama", "34": "hiroshima", "35": "yamaguchi",
+    "36": "tokushima", "37": "kagawa", "38": "ehime", "39": "kochi", "40": "fukuoka", "41": "saga", "42": "nagasaki",
+    "43": "kumamoto", "44": "oita", "45": "miyazaki", "46": "kagoshima", "47": "okinawa",
+}
+SEVERITY_RANK = {"NONE": 0, "ADVISORY": 1, "WARNING": 2, "EMERGENCY_WARNING": 3}
 
 
 def make_retrying_session() -> requests.Session:
@@ -98,6 +108,22 @@ def status_to_severity(status: str | None, code: str | None = None) -> str:
     if "注意報" in status:
         return "ADVISORY"
     return "WARNING"
+
+
+def _topic_segment(value: str | None) -> str:
+    text = (value or "unknown").strip().lower() or "unknown"
+    text = re.sub(r"[^a-z0-9-]+", "-", text)
+    return text.strip("-") or "unknown"
+
+
+def prefecture_for_office(office_code: str, name_en: str | None = None) -> str:
+    return PREFECTURE_BY_PREFIX.get(str(office_code)[:2]) or _topic_segment(name_en)
+
+
+def warning_record_severity(warnings: list[dict[str, Any]]) -> str:
+    if not warnings:
+        return "NONE"
+    return max((str(item.get("severity") or "NONE") for item in warnings), key=lambda value: SEVERITY_RANK.get(value, 0))
 
 
 def _load_state(path: str) -> dict[str, Any]:
@@ -177,6 +203,7 @@ def parse_weather_warning_payload(office_code: str, payload: dict[str, Any], are
                     jp, en = WARNING_CODE_DESCRIPTIONS.get(code or "", (code or "", code or ""))
                 warnings.append({"code": code, "code_description_jp": jp, "code_description_en": en, "status": WARNING_STATUS_MAP.get(status_text, "CONTINUED"), "severity": status_to_severity(status_text, code)})
             records.append({
+                "prefecture": prefecture_for_office(office_code), "severity": warning_record_severity(warnings), "event": "warning",
                 "office_code": office_code, "area_code": area_code, "area_name": area.get("name") or area_names.get(area_code, area_code),
                 "report_datetime": jst_to_utc(local_report) or "1970-01-01T00:00:00Z", "report_datetime_local": local_report or "1970-01-01T00:00:00+09:00",
                 "headline_text": payload.get("headlineText"), "warnings": warnings, "time_defines": time_defines,
@@ -345,8 +372,8 @@ class JmaBosaiWarningAPI:
     def office_records(self) -> list[dict[str, Any]]:
         offices = self.area_catalog.get("offices") if self.area_catalog else None
         if offices:
-            return [{"office_code": code, "area_code": code, "name_jp": item.get("name", code), "name_en": item.get("enName", code), "parent_office_code": item.get("parent"), "office_type": "PREFECTURE" if code.endswith("0000") and not code.startswith("01") else "SUBREGION"} for code, item in offices.items()]
-        return [{**o, "area_code": o["code"]} for o in WARNING_OFFICES]
+            return [{"prefecture": prefecture_for_office(code, item.get("enName")), "severity": "REFERENCE", "event": "office", "office_code": code, "area_code": code, "name_jp": item.get("name", code), "name_en": item.get("enName", code), "parent_office_code": item.get("parent"), "office_type": "PREFECTURE" if code.endswith("0000") and not code.startswith("01") else "SUBREGION"} for code, item in offices.items()]
+        return [{**o, "prefecture": prefecture_for_office(o["code"], o.get("name_en")), "severity": "REFERENCE", "event": "office", "area_code": o["code"]} for o in WARNING_OFFICES]
 
     def fetch_warning_payload(self, office_code: str) -> dict[str, Any]:
         response = self.session.get(WARNING_URL_TEMPLATE.format(office_code=office_code), timeout=20)

--- a/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/__init__.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/__init__.py
@@ -1,0 +1,3 @@
+from .app import main
+
+__all__ = ["main"]

--- a/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/__main__.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/app.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/app.py
@@ -1,0 +1,158 @@
+"""MQTT feeder application for JMA Bosai warnings → Unified Namespace."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion, MQTTv5
+
+from jma_bosai_warning.jma_bosai_warning import (
+    AREA_CATALOG_URL,
+    WARNING_OFFICE_CODES,
+    WARNING_URL_TEMPLATE,
+    BridgeState,
+    JmaBosaiWarningAPI,
+    _cap_list,
+    _load_state,
+    _save_state,
+    parse_weather_warning_payload,
+)
+from jma_bosai_warning_mqtt_producer_data import Office, WeatherWarning
+from jma_bosai_warning_mqtt_producer_mqtt_client.client import JPJMAWarningMqttMqttClient
+
+logger = logging.getLogger(__name__)
+
+
+async def _publish_offices(api: JmaBosaiWarningAPI, mqtt_client: JPJMAWarningMqttMqttClient) -> int:
+    count = 0
+    for record in api.office_records():
+        await mqtt_client.publish_jp_jma_warning_mqtt_office(
+            feedurl=AREA_CATALOG_URL,
+            prefecture=record["prefecture"],
+            severity=record["severity"],
+            office_code=record["office_code"],
+            area_code=record["area_code"],
+            event=record["event"],
+            data=Office(**record),
+        )
+        count += 1
+    return count
+
+
+async def _publish_warning_cycle(api: JmaBosaiWarningAPI, mqtt_client: JPJMAWarningMqttMqttClient, state: BridgeState, office_codes: list[str]) -> int:
+    pending: list[str] = []
+    emitted = 0
+    seen = set(state.seen_weather)
+    for office_code in office_codes:
+        try:
+            records = parse_weather_warning_payload(office_code, api.fetch_warning_payload(office_code), api.area_names)
+        except Exception as exc:
+            logger.warning("Skipping warning office %s after fetch/parse failure: %s", office_code, exc)
+            continue
+        for record in records:
+            dedupe_key = f"{record['office_code']}|{record['area_code']}|{record['report_datetime']}"
+            if dedupe_key in seen:
+                continue
+            await mqtt_client.publish_jp_jma_warning_mqtt_weather_warning(
+                feedurl=WARNING_URL_TEMPLATE.format(office_code=office_code),
+                prefecture=record["prefecture"],
+                severity=record["severity"],
+                office_code=record["office_code"],
+                area_code=record["area_code"],
+                event=record["event"],
+                data=WeatherWarning(**record),
+            )
+            pending.append(dedupe_key)
+            emitted += 1
+    state.seen_weather = _cap_list(state.seen_weather + pending)
+    return emitted
+
+
+async def feed(
+    api: JmaBosaiWarningAPI,
+    broker_host: str,
+    broker_port: int,
+    *,
+    state_file: str,
+    polling_interval_warning: int,
+    office_metadata_refresh_hours: int,
+    office_codes: list[str],
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tls: bool = False,
+    client_id: Optional[str] = None,
+    content_mode: str = "binary",
+    once: bool = False,
+) -> None:
+    paho_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, client_id=client_id or "", protocol=MQTTv5)
+    if username:
+        paho_client.username_pw_set(username, password or "")
+    if tls:
+        paho_client.tls_set()
+    mqtt_client = JPJMAWarningMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
+    await mqtt_client.connect(broker_host, broker_port)
+    state = BridgeState.from_dict(_load_state(state_file))
+    metadata_interval = max(1, office_metadata_refresh_hours) * 3600
+    try:
+        while True:
+            started = time.monotonic()
+            now_utc = datetime.now(timezone.utc)
+            should_refresh = not state.last_metadata_refresh
+            if state.last_metadata_refresh:
+                try:
+                    should_refresh = (now_utc - datetime.fromisoformat(state.last_metadata_refresh.replace("Z", "+00:00"))).total_seconds() >= metadata_interval
+                except ValueError:
+                    should_refresh = True
+            if should_refresh:
+                api.refresh_area_catalog()
+                office_count = await _publish_offices(api, mqtt_client)
+                state.last_metadata_refresh = now_utc.isoformat().replace("+00:00", "Z")
+                _save_state(state_file, state.as_dict())
+                logger.info("Published %d retained JMA office reference record(s)", office_count)
+            emitted = await _publish_warning_cycle(api, mqtt_client, state, office_codes)
+            _save_state(state_file, state.as_dict())
+            logger.info("Published %d JMA weather warning record(s)", emitted)
+            if once:
+                break
+            await asyncio.sleep(max(0, polling_interval_warning - (time.monotonic() - started)))
+    finally:
+        await mqtt_client.disconnect()
+
+
+def _parse_broker_url(url: str) -> tuple[str, int, bool]:
+    parsed = urlparse(url if "://" in url else f"mqtt://{url}")
+    scheme = (parsed.scheme or "mqtt").lower()
+    tls = scheme in ("mqtts", "ssl", "tls")
+    return parsed.hostname or "localhost", parsed.port or (8883 if tls else 1883), tls
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper(), format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="JMA Bosai warning MQTT/UNS bridge")
+    parser.add_argument("feed_command", nargs="?", default="feed")
+    parser.add_argument("--broker-url", default=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"))
+    parser.add_argument("--state-file", default=os.getenv("JMA_BOSAI_WARNING_MQTT_STATE_FILE", os.path.expanduser("~/.jma_bosai_warning_mqtt_state.json")))
+    parser.add_argument("--polling-interval-warning", type=int, default=int(os.getenv("POLLING_INTERVAL_WARNING", "60")))
+    parser.add_argument("--office-metadata-refresh-hours", type=int, default=int(os.getenv("OFFICE_METADATA_REFRESH_HOURS", "720")))
+    parser.add_argument("--office-codes", default=os.getenv("JMA_WARNING_OFFICE_CODES", ",".join(WARNING_OFFICE_CODES)))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--username", default=os.getenv("MQTT_USERNAME", ""))
+    parser.add_argument("--password", default=os.getenv("MQTT_PASSWORD", ""))
+    parser.add_argument("--client-id", default=os.getenv("MQTT_CLIENT_ID", ""))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("MQTT_CONTENT_MODE", "binary"))
+    args = parser.parse_args()
+    if args.feed_command != "feed":
+        parser.error("only the 'feed' command is supported")
+    office_codes = [part.strip() for part in args.office_codes.split(",") if part.strip()]
+    host, port, tls = _parse_broker_url(args.broker_url)
+    api = JmaBosaiWarningAPI()
+    logger.info("Polling JMA Bosai warning feeds and publishing to MQTT %s:%d", host, port)
+    asyncio.run(feed(api, host, port, state_file=args.state_file, polling_interval_warning=args.polling_interval_warning, office_metadata_refresh_hours=args.office_metadata_refresh_hours, office_codes=office_codes, username=args.username or None, password=args.password or None, tls=tls, client_id=args.client_id or None, content_mode=args.content_mode, once=args.once))

--- a/jma-bosai-warning/jma_bosai_warning_mqtt/pyproject.toml
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "jma-bosai-warning-mqtt"
+version = "0.1.0"
+description = "JMA Bosai weather warning bridge to MQTT/UNS"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+cloudevents = ">=1.11.0,<2.0.0"
+dataclasses_json = ">=0.6.7"
+paho-mqtt = ">=2.1.0"
+jma_bosai_warning = {path = ".."}
+jma_bosai_warning_producer_data = {path = "../jma_bosai_warning_producer/jma_bosai_warning_producer_data"}
+jma_bosai_warning_mqtt_producer_data = {path = "../jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data"}
+jma_bosai_warning_mqtt_producer_mqtt_client = {path = "../jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client"}
+
+[tool.poetry.scripts]
+jma-bosai-warning-mqtt = "jma_bosai_warning_mqtt:main"

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/Makefile
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./jma_bosai_warning_mqtt_producer_data ./jma_bosai_warning_mqtt_producer_mqtt_client
+
+install: build
+	cd jma_bosai_warning_mqtt_producer_data && poetry install
+	cd jma_bosai_warning_mqtt_producer_mqtt_client && poetry install
+	pip install ./jma_bosai_warning_mqtt_producer_data ./jma_bosai_warning_mqtt_producer_mqtt_client
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./jma_bosai_warning_mqtt_producer_mqtt_client/tests ./jma_bosai_warning_mqtt_producer_data/tests

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/README.md
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/README.md
@@ -1,0 +1,1079 @@
+# Jma_bosai_warning_mqtt_producer MQTT Client
+
+This library provides MQTT producer and consumer functionality for the jma_bosai_warning_mqtt_producer message definitions.
+
+# Jma_bosai_warning_mqtt_producer Event Dispatcher for Azure Event Hubs
+
+## Installation
+
+This module provides an event dispatcher for processing events from Azure Event Hubs. It supports both plain AMQP
+messages and CloudEvents.
+
+```bash
+
+./install.sh  # Unix/Linux/Mac## Table of Contents
+
+# or1. [Overview](#overview)
+
+install.bat  # Windows2. [Generated Event Dispatchers](#generated-event-dispatchers)
+
+```    - JPJMAWarningMqttEventDispatcher
+
+
+
+## Quick Start3. [Internals](#internals)
+
+    - [EventProcessorRunner](#eventprocessorrunner)
+
+### Publishing Messages    - [_DispatcherBase](#_dispatcherbase)
+
+
+
+```python## Overview
+
+import paho.mqtt.client as mqtt
+
+from jma_bosai_warning_mqtt_producer_mqtt_client import *This module defines an event processing framework for Azure
+Event Hubs,
+
+providing the necessary classes and methods to handle various types of events.
+
+# Create MQTT client and wrapperIt includes both plain AMQP messages and CloudEvents, offering a versatile
+
+mqtt_client = mqtt.Client(client_id="publisher")solution for event-driven applications.## Generated Event Dispatchers
+
+client = JPJMAWarningMqttMqttClient(mqtt_client, content_mode='structured')
+
+# Connect to broker
+
+await client.connect("mqtt.example.com", 1883)### JPJMAWarningMqttEventDispatcher
+
+
+
+# Publish message`JPJMAWarningMqttEventDispatcher` handles events for the JP.JMA.Warning.mqtt message group.
+
+await client.publish_message(
+
+    topic="my/topic",#### Methods:
+
+    # ... CloudEvents attributes
+
+    data=data_object##### `__init__`:
+
+)
+
+```python
+
+await client.disconnect()__init__(self)-> None
+
+``````
+
+
+
+### Subscribing to MessagesInitializes the dispatcher.
+
+
+
+```python##### `create_processor`:
+
+import paho.mqtt.client as mqtt
+
+import asyncio```python
+
+from jma_bosai_warning_mqtt_producer_mqtt_client import *create_processor(self, consumer_group_name: str,
+eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url: str, blob_container_name: str,
+credential) -> EventProcessorRunner`
+
+```
+
+# Create MQTT client and wrapper
+
+mqtt_client = mqtt.Client(client_id="subscriber")Creates an `EventProcessorRunner`.Args:- `consumer_group_name`: The
+name of the consumer group.- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+
+client = JPJMAWarningMqttMqttClient(mqtt_client, content_mode='structured')- `eventhub_name`: The name of the Event
+Hub.- `blob_account_url`: The URL of the Azure Storage account.
+
+- `blob_container_name`: The name of the blob container to store checkpoints.
+
+# Define message handler- `credential`: The credential to use for authentication.
+
+async def on_message(mqtt_msg, cloud_event, data):
+
+    print(f"Received: {data}")##### `create_processor_from_connection_strings`
+
+
+
+# Register handler```python
+
+client.message_handler_async = on_message`create_processor_from_connection_strings(self, consumer_group_name: str,
+connection_str: str, eventhub_name: str, blob_conn_str: str, checkpoint_container: str) -> EventProcessorRunner`
+
+```
+
+# Connect and subscribe
+
+await client.connect("mqtt.example.com", 1883)Creates an `EventProcessorRunner` from connection strings.
+
+await client.subscribe(["my/topic/#"])
+
+Args:
+
+# Keep running- `consumer_group_name`: The name of the consumer group.
+
+try:- `connection_str`: The connection string for the Event Hub.
+
+    while True:- `eventhub_name`: The name of the Event Hub.
+
+        await asyncio.sleep(1)- `blob_conn_str`: The connection string for the Azure Storage account.
+
+finally:- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+    await client.disconnect()
+
+```#### Event Handlers
+
+
+
+## BuildThe JPJMAWarningMqttEventDispatcher defines the following event handler hooks.
+
+
+
+```bash
+
+make build
+
+```##### `jp_jma_warning_mqtt_office_async`
+
+
+
+## Test```python
+
+jp_jma_warning_mqtt_office_async:  Callable[[PartitionContext, EventData, CloudEvent, Office], Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `JP.JMA.Warning.mqtt.Office`: JMA Bosai warning office reference data from area.json
+offices.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `jma_bosai_warning_mqtt_producer_data.Office`.
+
+Example:
+
+```python
+async def jp_jma_warning_mqtt_office_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: Office) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_mqtt_office_async = jp_jma_warning_mqtt_office_event
+```
+
+
+
+make build
+
+```##### `jp_jma_warning_mqtt_weather_warning_async`
+
+
+
+## Test```python
+
+jp_jma_warning_mqtt_weather_warning_async:  Callable[[PartitionContext, EventData, CloudEvent, WeatherWarning],
+Awaitable[None]]
+
+```bash```
+
+make test
+
+```Asynchronous handler hook for `JP.JMA.Warning.mqtt.WeatherWarning`: JMA Bosai weather warning/advisory telemetry for
+one forecast area within an office bulletin.
+
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `partition_context`: The partition context.
+- `event`: The event data.
+- `cloud_event`: The CloudEvent.
+- `data`: The event data of type `jma_bosai_warning_mqtt_producer_data.WeatherWarning`.
+
+Example:
+
+```python
+async def jp_jma_warning_mqtt_weather_warning_event(partition_context: PartitionContext, event: EventData, cloud_event:
+CloudEvent, data: WeatherWarning) -> None:
+    # Process the event data
+    await partition_context.update_checkpoint(event)
+```
+
+The handler functions is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+```python
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_mqtt_weather_warning_async = jp_jma_warning_mqtt_weather_warning_event
+```
+
+
+
+
+## Internals
+
+### Dispatchers
+
+Dispatchers have the following protected methods:
+
+### Methods:
+
+##### `_process_event`
+
+```python
+_process_event(self, partition_context, event)
+```
+
+Processes an incoming event.
+
+Args:
+- `partition_context`: The partition context.
+- `event`: The event data.
+
+### EventProcessorRunner
+
+`EventProcessorRunner` is responsible for managing the event processing loop and dispatching events to the appropriate
+handlers.
+
+#### Methods
+
+##### `__init__`
+
+```python
+__init__(client: EventHubConsumerClient)
+```
+
+Initializes the runner with an Event Hub consumer client.
+
+Args:
+- `client`: The Event Hub consumer client.
+
+#####  `__aenter__()`
+
+Enters the asynchronous context and starts the processor.
+
+#####  `__aexit__`
+
+```python
+__aexit__(exc_type, exc_val, exc_tb)
+```
+
+Exits the asynchronous context and stops the processor.
+
+Args:
+- `exc_type`: The exception type.
+- `exc_val`: The exception value.
+- `exc_tb`: The exception traceback.
+
+#####  `add_dispatcher`
+
+```python
+add_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Adds a dispatcher to the runner.
+
+Args:
+- `dispatcher`: The dispatcher to add.
+
+#####  `remove_dispatcher`
+
+```python
+remove_dispatcher(dispatcher: _DispatcherBase)
+```
+
+Removes a dispatcher from the runner.
+
+Args:
+- `dispatcher`: The dispatcher to remove.
+
+#####  `start()`
+
+Starts the event processor
+
+#####  `cancel()`
+
+Cancels the event processing task.
+
+#####  `create_from_connection_strings`
+
+```python
+create_from_connection_strings(cls, consumer_group_name: str, connection_str: str, eventhub_name: str, blob_conn_str:
+str, checkpoint_container: str) -> 'EventProcessorRunner'
+```
+
+Creates a runner from connection strings.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `connection_str`: The connection string for the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_conn_str`: The connection string for the Azure Storage account.
+- `checkpoint_container`: The name of the blob container to store checkpoints.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+#####  `create`
+
+```python
+create(cls, consumer_group_name: str, eventhubs_fully_qualified_namespace: str, eventhub_name: str, blob_account_url:
+str, blob_container_name: str, credential) -> 'EventProcessorRunner'
+```
+
+Creates a runner from fully qualified namespace and credentials.
+
+Args:
+- `consumer_group_name`: The name of the consumer group.
+- `eventhubs_fully_qualified_namespace`: The fully qualified namespace of the Event Hub.
+- `eventhub_name`: The name of the Event Hub.
+- `blob_account_url`: The URL of the Azure Storage account.
+- `blob_container_name`: The name of the blob container to store checkpoints.
+- `credential`: The credential to use for authentication.
+
+Returns:
+- An `EventProcessorRunner` instance.
+
+
+### _DispatcherBase
+
+`_DispatcherBase` is a base class for event dispatchers, handling CloudEvent detection and conversion.
+
+#### Methods
+
+#####  `_strkey`
+
+```python
+_strkey(key: str | bytes) -> str
+```
+
+Converts a key to a string.
+
+Args:
+- `key`: The key to convert.
+
+#####  `_unhandled_event`
+
+```python
+_unhandled_event(self, _cx, _e, _ce, de)
+```
+
+Default event handler.
+
+#####  `_get_cloud_event_attribute`
+
+```python
+_get_cloud_event_attribute(event_data: EventData, key: str) -> Any
+```
+
+Retrieves a CloudEvent attribute from event data.
+
+Args:
+- `event_data`: The event data.
+- `key`: The attribute key.
+
+
+
+#####  `_is_cloud_event`
+
+```python
+_is_cloud_event(event_data: EventData) -> bool
+```
+
+Checks if the event data is a CloudEvent
+
+Args:
+- `event_data`: The event data.
+
+#####  `_cloud_event_from_event_data`:
+
+```python
+_cloud_event_from_event_data(event_data: EventData) -> CloudEvent
+```
+
+Converts event data to a CloudEvent.
+
+Args:
+- `event_data`: The event data.
+
+## Production-Ready Patterns
+
+This section provides best-practice patterns for building production-grade Azure Event Hubs consumers in Python.
+
+### 1. Connection Management with EventProcessorClient Pooling
+
+Maintain long-lived EventProcessorClient instances with proper lifecycle management.
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+from azure.identity.aio import DefaultAzureCredential
+from typing import Dict, Optional
+import asyncio
+
+class EventHubsConnectionPool:
+    """
+    Manages Event Hubs consumer connections with automatic retry and health checks.
+    Uses async context managers for proper resource cleanup.
+    """
+    _lock: asyncio.Lock = asyncio.Lock()
+    _clients: Dict[str, EventHubConsumerClient] = {}
+
+    @classmethod
+    async def get_client(
+        cls,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        credential: Optional[DefaultAzureCredential] = None
+    ) -> EventHubConsumerClient:
+        """
+        Get or create an Event Hubs consumer client.
+        Reuses existing connections for the same Event Hub and consumer group.
+        """
+        key = f"{fully_qualified_namespace}/{eventhub_name}/{consumer_group}"
+
+        async with cls._lock:
+            if key not in cls._clients:
+                if credential is None:
+                    credential = DefaultAzureCredential()
+
+                cls._clients[key] = EventHubConsumerClient(
+                    fully_qualified_namespace=fully_qualified_namespace,
+                    eventhub_name=eventhub_name,
+                    consumer_group=consumer_group,
+                    credential=credential,
+                    # Production settings
+                    retry_total=3,
+                    retry_backoff_factor=0.8,
+                    retry_backoff_max=60,
+                )
+
+        return cls._clients[key]
+
+    @classmethod
+    async def close_all(cls):
+        """Close all Event Hubs clients gracefully."""
+        async with cls._lock:
+            await asyncio.gather(
+                *[client.close() for client in cls._clients.values()],
+                return_exceptions=True
+            )
+            cls._clients.clear()
+```
+
+### 2. Retry Logic with Azure SDK Built-in Policies
+
+Leverage Azure SDK's built-in retry policies and extend with custom logic.
+
+```python
+from azure.core.exceptions import (
+    ServiceRequestError, ServiceResponseError,
+    HttpResponseError, AzureError
+)
+from tenacity import (
+    retry, stop_after_attempt, wait_exponential,
+    retry_if_exception_type, before_sleep_log
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Transient Azure errors that should trigger retries
+RETRIABLE_AZURE_ERRORS = (
+    ServiceRequestError,  # Network failures
+    ServiceResponseError,  # Transient service errors
+)
+
+@retry(
+    retry=retry_if_exception_type(RETRIABLE_AZURE_ERRORS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    before_sleep=before_sleep_log(logger, logging.WARNING)
+)
+async def process_event_with_retry(partition_context, event, handler):
+    """
+    Process Event Hubs event with automatic retry on transient failures.
+    Uses Polly-style exponential backoff.
+    """
+    try:
+        await handler(partition_context, event)
+        await partition_context.update_checkpoint(event)
+    except HttpResponseError as e:
+        # Check if error is retriable based on status code
+        if e.status_code in {408, 429, 500, 502, 503, 504}:
+            logger.warning(f"Retriable HTTP error {e.status_code}, will retry")
+            raise
+        else:
+            # Non-retriable HTTP error, fail fast
+            logger.error(f"Non-retriable HTTP error {e.status_code}")
+            raise
+    except Exception as e:
+        logger.exception(f"Error processing event: {e}")
+        raise
+```
+
+### 3. Circuit Breaker for Downstream Dependencies
+
+Protect downstream services with circuit breaker pattern using `pybreaker`.
+
+```python
+import pybreaker
+from azure.eventhub import PartitionContext, EventData
+from typing import Callable
+
+# Circuit breaker for downstream HTTP API
+downstream_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,  # Trip after 5 failures
+    timeout_duration=60,  # Stay open for 60 seconds
+    exclude=[ValueError, KeyError],  # Don't count validation errors
+    name='downstream_dependency'
+)
+
+class CircuitBreakerEventProcessor:
+    """Event Hubs processor with circuit breaker for downstream calls."""
+
+    def __init__(self):
+        self.breaker = downstream_breaker
+        self.fallback_enabled = True
+
+    async def process_with_circuit_breaker(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with circuit breaker protection.
+        Falls back to logging when circuit is open.
+        """
+        try:
+            await self.breaker.call_async(handler, partition_context, event)
+            await partition_context.update_checkpoint(event)
+
+        except pybreaker.CircuitBreakerError:
+            logger.error(
+                f"Circuit breaker OPEN for partition {partition_context.partition_id}, "
+                f"event sequence {event.sequence_number}"
+            )
+
+            if self.fallback_enabled:
+                # Fallback: checkpoint anyway to avoid reprocessing
+                await partition_context.update_checkpoint(event)
+                await self.log_to_fallback_storage(event)
+            else:
+                raise
+
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+            raise
+
+    async def log_to_fallback_storage(self, event: EventData):
+        """Log event to fallback storage when downstream is unavailable."""
+        # Implement fallback logic (e.g., write to blob storage)
+        pass
+```
+
+### 4. Batch Processing with Checkpointing
+
+Process events in batches for improved throughput while maintaining reliable checkpointing.
+
+```python
+import asyncio
+from typing import List
+from datetime import datetime, timedelta
+
+class BatchEventProcessor:
+    """
+    Batches Event Hubs events for efficient bulk processing.
+    Checkpoints after successful batch processing.
+    """
+    def __init__(self, batch_size: int = 100, batch_timeout_seconds: float = 5.0):
+        self.batch_size = batch_size
+        self.batch_timeout = timedelta(seconds=batch_timeout_seconds)
+        self.batch: List[tuple[PartitionContext, EventData]] = []
+        self.last_flush = datetime.now()
+        self._lock = asyncio.Lock()
+
+    async def add_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Add event to batch. Flushes when batch size or timeout threshold reached.
+        """
+        async with self._lock:
+            self.batch.append((partition_context, event))
+
+            should_flush = (
+                len(self.batch) >= self.batch_size or
+                datetime.now() - self.last_flush >= self.batch_timeout
+            )
+
+            if should_flush:
+                await self.flush_batch(handler)
+
+    async def flush_batch(self, handler: Callable):
+        """Process and checkpoint current batch."""
+        if not self.batch:
+            return
+
+        try:
+            # Extract events for batch processing
+            events = [event for _, event in self.batch]
+
+            # Process batch (e.g., bulk database insert)
+            await handler(events)
+
+            # Checkpoint the last event in the batch
+            last_partition_context, last_event = self.batch[-1]
+            await last_partition_context.update_checkpoint(last_event)
+
+            logger.info(
+                f"Processed batch of {len(self.batch)} events, "
+                f"last sequence: {last_event.sequence_number}"
+            )
+
+        except Exception as e:
+            logger.exception(f"Batch processing failed: {e}")
+            # Don't checkpoint on failure to allow retry
+            raise
+        finally:
+            self.batch.clear()
+            self.last_flush = datetime.now()
+
+    async def close(self, handler: Callable):
+        """Flush remaining events on shutdown."""
+        async with self._lock:
+            if self.batch:
+                await self.flush_batch(handler)
+```
+
+### 5. Dead Letter Queue (DLQ) Pattern
+
+Route unprocessable events to a separate Event Hub for later analysis.
+
+```python
+from azure.eventhub.aio import EventHubProducerClient
+from azure.eventhub import EventData as ProducerEventData
+from datetime import datetime
+
+class DLQEventProcessor:
+    """
+    Event Hubs processor with DLQ support.
+    Routes failed events to a dedicated DLQ Event Hub after retries.
+    """
+    def __init__(
+        self,
+        dlq_producer: EventHubProducerClient,
+        max_retries: int = 3
+    ):
+        self.dlq_producer = dlq_producer
+        self.max_retries = max_retries
+
+    async def process_with_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with automatic DLQ routing on failure."""
+        retry_count = 0
+        last_error = None
+
+        while retry_count < self.max_retries:
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+                return  # Success
+
+            except Exception as e:
+                retry_count += 1
+                last_error = e
+                logger.warning(
+                    f"Retry {retry_count}/{self.max_retries} for event "
+                    f"sequence {event.sequence_number}: {e}"
+                )
+
+                if retry_count < self.max_retries:
+                    await asyncio.sleep(2 ** retry_count)  # Exponential backoff
+
+        # Exhausted retries, send to DLQ
+        await self.send_to_dlq(partition_context, event, last_error)
+
+        # Checkpoint to avoid reprocessing
+        await partition_context.update_checkpoint(event)
+
+    async def send_to_dlq(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        error: Exception
+    ):
+        """Send event to DLQ Event Hub with rich metadata."""
+        dlq_event = ProducerEventData(event.body_as_str())
+
+        # Preserve original properties
+        dlq_event.properties.update(event.properties)
+
+        # Add DLQ metadata
+        dlq_event.properties.update({
+            'dlq_reason': 'processing_failed',
+            'dlq_timestamp': datetime.utcnow().isoformat(),
+            'original_partition': partition_context.partition_id,
+            'original_sequence': event.sequence_number,
+            'original_offset': event.offset,
+            'original_enqueued_time': event.enqueued_time.isoformat() if event.enqueued_time else None,
+            'error_type': type(error).__name__,
+            'error_message': str(error),
+            'retry_count': self.max_retries
+        })
+
+        async with self.dlq_producer:
+            await self.dlq_producer.send_batch([dlq_event])
+
+        logger.error(
+            f"Event sent to DLQ: partition={partition_context.partition_id}, "
+            f"sequence={event.sequence_number}, error={error}"
+        )
+```
+
+### 6. OpenTelemetry Observability with Application Insights
+
+Instrument Event Hubs consumer with distributed tracing and metrics.
+
+```python
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.propagate import extract
+from azure.monitor.opentelemetry import configure_azure_monitor
+import time
+
+# Configure Application Insights
+configure_azure_monitor(connection_string="InstrumentationKey=...")
+
+tracer = trace.get_tracer(__name__)
+meter = metrics.get_meter(__name__)
+
+# Metrics
+events_processed = meter.create_counter(
+    "eventhubs.events.processed",
+    description="Total events processed",
+    unit="1"
+)
+processing_duration = meter.create_histogram(
+    "eventhubs.event.processing.duration",
+    description="Event processing duration",
+    unit="ms"
+)
+consumer_lag = meter.create_observable_gauge(
+    "eventhubs.consumer.lag",
+    description="Consumer lag (seconds behind)",
+    unit="s"
+)
+
+class ObservableEventProcessor:
+    """Event Hubs processor with OpenTelemetry tracing and Application Insights."""
+
+    async def process_with_tracing(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process event with distributed tracing."""
+        # Extract trace context from Event Hubs properties
+        ctx = extract(event.properties)
+
+        with tracer.start_as_current_span(
+            "eventhubs.process",
+            context=ctx,
+            kind=trace.SpanKind.CONSUMER
+        ) as span:
+            span.set_attribute("messaging.system", "eventhubs")
+            span.set_attribute("messaging.destination", partition_context.eventhub_name)
+            span.set_attribute("messaging.eventhubs.partition_id", partition_context.partition_id)
+            span.set_attribute("messaging.eventhubs.sequence_number", event.sequence_number)
+            span.set_attribute("messaging.eventhubs.offset", event.offset)
+
+            # Calculate lag
+            if event.enqueued_time:
+                lag_seconds = (datetime.now(event.enqueued_time.tzinfo) - event.enqueued_time).total_seconds()
+                span.set_attribute("messaging.eventhubs.lag_seconds", lag_seconds)
+
+            start_time = time.monotonic()
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+
+                # Record success metrics
+                duration_ms = (time.monotonic() - start_time) * 1000
+                processing_duration.record(duration_ms, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "success"
+                })
+
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                events_processed.add(1, {
+                    "partition_id": partition_context.partition_id,
+                    "status": "error"
+                })
+                raise
+```
+
+### 7. Backpressure Control
+
+Prevent memory exhaustion with semaphore-based concurrency control.
+
+```python
+import asyncio
+
+class BackpressureController:
+    """
+    Controls backpressure for Event Hubs processing.
+    Limits concurrent event processing to prevent memory exhaustion.
+    """
+    def __init__(self, max_concurrent: int = 100):
+        self.semaphore = asyncio.Semaphore(max_concurrent)
+        self.in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def process_with_backpressure(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """
+        Process event with backpressure control.
+        Blocks when max concurrent limit reached.
+        """
+        async with self.semaphore:
+            async with self._lock:
+                self.in_flight += 1
+
+            try:
+                await handler(partition_context, event)
+                await partition_context.update_checkpoint(event)
+            finally:
+                async with self._lock:
+                    self.in_flight -= 1
+
+    def get_metrics(self) -> dict:
+        """Get current backpressure metrics."""
+        return {
+            "in_flight": self.in_flight,
+            "available_slots": self.semaphore._value
+        }
+```
+
+### 8. Graceful Shutdown
+
+Ensure clean shutdown with proper checkpointing and resource cleanup.
+
+```python
+import signal
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient
+
+class GracefulEventHubsConsumer:
+    """Event Hubs consumer with graceful shutdown support."""
+
+    def __init__(self, client: EventHubConsumerClient):
+        self.client = client
+        self.shutdown_event = asyncio.Event()
+        self.processing_tasks = set()
+
+        # Register signal handlers
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating graceful shutdown")
+        self.shutdown_event.set()
+
+    async def process_events(self, handler: Callable):
+        """
+        Process events with graceful shutdown.
+        Waits for in-flight events before closing.
+        """
+        async def on_event(partition_context, event):
+            """Wrapper to track processing tasks."""
+            if self.shutdown_event.is_set():
+                logger.info("Shutdown initiated, skipping new events")
+                return
+
+            task = asyncio.create_task(self._process_event(partition_context, event, handler))
+            self.processing_tasks.add(task)
+            task.add_done_callback(self.processing_tasks.discard)
+
+        async def on_error(partition_context, error):
+            """Error handler for Event Hubs client."""
+            logger.error(f"Error in partition {partition_context.partition_id}: {error}")
+
+        try:
+            # Start receiving events
+            async with self.client:
+                await self.client.receive(
+                    on_event=on_event,
+                    on_error=on_error,
+                    starting_position="-1"  # From beginning
+                )
+
+                # Wait for shutdown signal
+                await self.shutdown_event.wait()
+
+            # Wait for in-flight events
+            logger.info(f"Waiting for {len(self.processing_tasks)} in-flight events")
+            if self.processing_tasks:
+                await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+            logger.info("All events processed, shutdown complete")
+
+        finally:
+            await self.client.close()
+
+    async def _process_event(
+        self,
+        partition_context: PartitionContext,
+        event: EventData,
+        handler: Callable
+    ):
+        """Process individual event with error handling."""
+        try:
+            await handler(partition_context, event)
+            await partition_context.update_checkpoint(event)
+        except Exception as e:
+            logger.exception(f"Error processing event: {e}")
+```
+
+### Configuration Best Practices
+
+```python
+from azure.eventhub.aio import EventHubConsumerClient
+from azure.identity.aio import DefaultAzureCredential
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore
+
+# Production-grade Event Hubs consumer configuration
+async def create_production_consumer():
+    """Create Event Hubs consumer with production settings."""
+
+    # Use managed identity in production
+    credential = DefaultAzureCredential()
+
+    # Checkpoint store for distributed processing
+    checkpoint_store = BlobCheckpointStore(
+        blob_account_url="https://<storage-account>.blob.core.windows.net",
+        container_name="eventhubs-checkpoints",
+        credential=credential
+    )
+
+    client = EventHubConsumerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<eventhub-name>",
+        consumer_group="$Default",
+        checkpoint_store=checkpoint_store,
+        credential=credential,
+
+        # Retry configuration
+        retry_total=3,
+        retry_backoff_factor=0.8,
+        retry_backoff_max=60,
+
+        # Prefetch for throughput
+        prefetch=300,
+
+        # Load balancing interval
+        load_balancing_interval=30.0
+    )
+
+    return client
+```
+
+### Integration Example
+
+```python
+import asyncio
+from azure.eventhub.aio import EventHubConsumerClient, EventHubProducerClient
+from azure.identity.aio import DefaultAzureCredential
+
+async def main():
+    """Complete integration example with all patterns."""
+    credential = DefaultAzureCredential()
+
+    # Create consumer
+    consumer = await create_production_consumer()
+
+    # Create DLQ producer
+    dlq_producer = EventHubProducerClient(
+        fully_qualified_namespace="<namespace>.servicebus.windows.net",
+        eventhub_name="<dlq-eventhub>",
+        credential=credential
+    )
+
+    # Initialize components
+    graceful_consumer = GracefulEventHubsConsumer(consumer)
+    observable_processor = ObservableEventProcessor()
+    dlq_processor = DLQEventProcessor(dlq_producer, max_retries=3)
+    batch_processor = BatchEventProcessor(batch_size=100, batch_timeout_seconds=5.0)
+    backpressure = BackpressureController(max_concurrent=100)
+
+    async def process_event(partition_context, event):
+        """Combined event processing with all patterns."""
+        # Backpressure control
+        await backpressure.process_with_backpressure(
+            partition_context, event, business_logic
+        )
+
+        # Observability
+        await observable_processor.process_with_tracing(
+            partition_context, event, business_logic
+        )
+
+        # DLQ on failure
+        await dlq_processor.process_with_dlq(
+            partition_context, event, business_logic
+        )
+
+    async def business_logic(partition_context, event):
+        """Your business logic here."""
+        data = event.body_as_json()
+        # Process data
+        await process_business_logic(data)
+
+    # Start processing with graceful shutdown
+    await graceful_consumer.process_events(process_event)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/install.bat
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/install.bat
@@ -1,0 +1,2 @@
+pip install .\jma_bosai_warning_mqtt_producer_data
+pip install .\jma_bosai_warning_mqtt_producer_mqtt_client

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/install.sh
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install ./jma_bosai_warning_mqtt_producer_data
+pip install ./jma_bosai_warning_mqtt_producer_mqtt_client

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/pyproject.toml
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "jma-bosai-warning-mqtt-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "jma_bosai_warning_mqtt_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/__init__.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/__init__.py
@@ -1,0 +1,9 @@
+from .officetypeenum import OfficeTypeenum
+from .severityenum import SeverityEnum
+from .eventenum import EventEnum
+from .office import Office
+from .statusenum import StatusEnum
+from .warningitem import WarningItem
+from .weatherwarning import WeatherWarning
+
+__all__ = ["OfficeTypeenum", "SeverityEnum", "EventEnum", "Office", "StatusEnum", "WarningItem", "WeatherWarning"]

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/eventenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/eventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class EventEnum(Enum):
+    """
+    Fixed MQTT topic event segment for retained office reference records.
+    """
+    office = 'office'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'EventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (EventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/office.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/office.py
@@ -1,0 +1,182 @@
+""" Office dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Office:
+    """
+    JMA warning office reference record from the Bosai area catalog offices section. These offices are the stable targetArea codes used by warning JSON endpoints and contextualize weather warning area telemetry.
+    
+    Attributes:
+        office_code (str)
+        area_code (str)
+        name_jp (str)
+        name_en (str)
+        parent_office_code (typing.Optional[str])
+        office_type (OfficeTypeenum)
+        prefecture (str)
+        severity (SeverityEnum)
+        event (EventEnum)
+    """
+    
+    
+    office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
+    area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
+    name_jp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name_jp"))
+    name_en: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name_en"))
+    parent_office_code: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="parent_office_code"))
+    office_type: OfficeTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_type"))
+    prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Office':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['Office']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return Office.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'Office':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            office_code='winzdhtqusptibochtvl',
+            area_code='pnfmhwbrqdkcxzhhbggk',
+            name_jp='trwmokcgklowpinosthv',
+            name_en='vyhzarroyewxshdqncyr',
+            parent_office_code='juegloeejrobwjzmpfgs',
+            office_type=OfficeTypeenum.PREFECTURE,
+            prefecture='cekvxwcrchlbwvnomfwh',
+            severity=SeverityEnum.REFERENCE,
+            event=EventEnum.office
+        )

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/officetypeenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/officetypeenum.py
@@ -1,0 +1,45 @@
+from enum import Enum
+
+
+class OfficeTypeenum(Enum):
+    """
+    Normalized office class. PREFECTURE is used for standard prefectural offices, SUBREGION for Hokkaido/Okinawa-style regional warning offices, and OFFICE for other JMA issuing-office catalog entries.
+    """
+    PREFECTURE = 'PREFECTURE'
+    SUBREGION = 'SUBREGION'
+    OFFICE = 'OFFICE'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'OfficeTypeenum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'OfficeTypeenum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (OfficeTypeenum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/severityenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/severityenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class SeverityEnum(Enum):
+    """
+    MQTT topic severity axis. Office REFERENCE records emit REFERENCE; weather warning records emit the highest normalized active warning severity.
+    """
+    REFERENCE = 'REFERENCE'
+    NONE = 'NONE'
+    ADVISORY = 'ADVISORY'
+    WARNING = 'WARNING'
+    EMERGENCY_WARNING = 'EMERGENCY_WARNING'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'SeverityEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'SeverityEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (SeverityEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/statusenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/statusenum.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+
+class StatusEnum(Enum):
+    """
+    Normalized status or alert class for the JMA warning item. Values preserve the documented JMA status set using Python/Avro-safe symbols; lang:ja altenums carries the original JMA labels including 発表警報・注意報はなし.
+    """
+    ISSUED = 'ISSUED'
+    CONTINUED = 'CONTINUED'
+    CANCELLED = 'CANCELLED'
+    NO_WARNINGS_OR_ADVISORIES = 'NO_WARNINGS_OR_ADVISORIES'
+    WARNING = 'WARNING'
+    ADVISORY = 'ADVISORY'
+    EMERGENCY_WARNING = 'EMERGENCY_WARNING'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StatusEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StatusEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StatusEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/warningitem.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/warningitem.py
@@ -1,0 +1,169 @@
+""" WarningItem dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+from jma_bosai_warning_mqtt_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class WarningItem:
+    """
+    Single JMA warning/advisory item for an inner forecast area. JMA warning area entries may either carry a hazard code plus status, or carry only the status 発表警報・注意報はなし when no warnings or advisories are in effect.
+    
+    Attributes:
+        code (typing.Optional[str])
+        code_description_jp (str)
+        code_description_en (str)
+        status (StatusEnum)
+        severity (SeverityEnum)
+    """
+    
+    
+    code: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code"))
+    code_description_jp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code_description_jp"))
+    code_description_en: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code_description_en"))
+    status: StatusEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="status"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'WarningItem':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['WarningItem']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return WarningItem.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'WarningItem':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            code='ocpjamfhfcpvzdopvolq',
+            code_description_jp='kqpuuwpewxphiurexroz',
+            code_description_en='qkjadkufchgwjxqffhvb',
+            status=StatusEnum.ISSUED,
+            severity=SeverityEnum.REFERENCE
+        )

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarning.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarning.py
@@ -1,0 +1,190 @@
+""" WeatherWarning dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
+import json
+from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+import datetime
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class WeatherWarning:
+    """
+    JMA Bosai weather warning/advisory state for one office targetArea and one inner forecast area. The bridge emits one record per (office_code, area_code, report_datetime) change and includes all warning items currently published for that area.
+    
+    Attributes:
+        prefecture (str)
+        severity (SeverityEnum)
+        office_code (str)
+        area_code (str)
+        event (EventEnum)
+        area_name (str)
+        report_datetime (datetime.datetime)
+        report_datetime_local (datetime.datetime)
+        headline_text (typing.Optional[str])
+        warnings (typing.List[WarningItem])
+        time_defines (typing.List[datetime.datetime])
+    """
+    
+    
+    prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+    office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
+    area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
+    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    area_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_name"))
+    report_datetime: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    report_datetime_local: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime_local", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    headline_text: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="headline_text"))
+    warnings: typing.List[WarningItem]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="warnings"))
+    time_defines: typing.List[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="time_defines"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'WeatherWarning':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['WeatherWarning']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return WeatherWarning.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'WeatherWarning':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            prefecture='qhcrjffvwichrapfuers',
+            severity=SeverityEnum.REFERENCE,
+            office_code='bgzjfcnoaddeaxbtipyy',
+            area_code='wichfjpddlwrafsuqajy',
+            event=EventEnum.office,
+            area_name='rulbbegfuneeibdntzjh',
+            report_datetime=datetime.datetime.now(datetime.timezone.utc),
+            report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
+            headline_text='luidrbbbaelvfpdlcjel',
+            warnings=[None, None, None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc)]
+        )

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_eventenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_eventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+
+
+class Test_EventEnum(unittest.TestCase):
+    """
+    Test case for EventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = EventEnum.office
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of EventEnum
+        """
+        return EventEnum.office
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(EventEnum.office.value, 'office')

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_office.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_office.py
@@ -1,0 +1,137 @@
+"""
+Test case for Office
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.office import Office
+from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+
+
+class Test_Office(unittest.TestCase):
+    """
+    Test case for Office
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_Office.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of Office for testing
+        """
+        instance = Office(
+            office_code='winzdhtqusptibochtvl',
+            area_code='pnfmhwbrqdkcxzhhbggk',
+            name_jp='trwmokcgklowpinosthv',
+            name_en='vyhzarroyewxshdqncyr',
+            parent_office_code='juegloeejrobwjzmpfgs',
+            office_type=OfficeTypeenum.PREFECTURE,
+            prefecture='cekvxwcrchlbwvnomfwh',
+            severity=SeverityEnum.REFERENCE,
+            event=EventEnum.office
+        )
+        return instance
+
+    
+    def test_office_code_property(self):
+        """
+        Test office_code property
+        """
+        test_value = 'winzdhtqusptibochtvl'
+        self.instance.office_code = test_value
+        self.assertEqual(self.instance.office_code, test_value)
+    
+    def test_area_code_property(self):
+        """
+        Test area_code property
+        """
+        test_value = 'pnfmhwbrqdkcxzhhbggk'
+        self.instance.area_code = test_value
+        self.assertEqual(self.instance.area_code, test_value)
+    
+    def test_name_jp_property(self):
+        """
+        Test name_jp property
+        """
+        test_value = 'trwmokcgklowpinosthv'
+        self.instance.name_jp = test_value
+        self.assertEqual(self.instance.name_jp, test_value)
+    
+    def test_name_en_property(self):
+        """
+        Test name_en property
+        """
+        test_value = 'vyhzarroyewxshdqncyr'
+        self.instance.name_en = test_value
+        self.assertEqual(self.instance.name_en, test_value)
+    
+    def test_parent_office_code_property(self):
+        """
+        Test parent_office_code property
+        """
+        test_value = 'juegloeejrobwjzmpfgs'
+        self.instance.parent_office_code = test_value
+        self.assertEqual(self.instance.parent_office_code, test_value)
+    
+    def test_office_type_property(self):
+        """
+        Test office_type property
+        """
+        test_value = OfficeTypeenum.PREFECTURE
+        self.instance.office_type = test_value
+        self.assertEqual(self.instance.office_type, test_value)
+    
+    def test_prefecture_property(self):
+        """
+        Test prefecture property
+        """
+        test_value = 'cekvxwcrchlbwvnomfwh'
+        self.instance.prefecture = test_value
+        self.assertEqual(self.instance.prefecture, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.REFERENCE
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
+    def test_event_property(self):
+        """
+        Test event property
+        """
+        test_value = EventEnum.office
+        self.instance.event = test_value
+        self.assertEqual(self.instance.event, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = Office.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = Office.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_officetypeenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_officetypeenum.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
+
+
+class Test_OfficeTypeenum(unittest.TestCase):
+    """
+    Test case for OfficeTypeenum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = OfficeTypeenum.PREFECTURE
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of OfficeTypeenum
+        """
+        return OfficeTypeenum.PREFECTURE
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(OfficeTypeenum.PREFECTURE.value, 'PREFECTURE')
+        self.assertEqual(OfficeTypeenum.SUBREGION.value, 'SUBREGION')
+        self.assertEqual(OfficeTypeenum.OFFICE.value, 'OFFICE')

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_severityenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_severityenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+
+
+class Test_SeverityEnum(unittest.TestCase):
+    """
+    Test case for SeverityEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = SeverityEnum.REFERENCE
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of SeverityEnum
+        """
+        return SeverityEnum.REFERENCE
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(SeverityEnum.REFERENCE.value, 'REFERENCE')
+        self.assertEqual(SeverityEnum.NONE.value, 'NONE')
+        self.assertEqual(SeverityEnum.ADVISORY.value, 'ADVISORY')
+        self.assertEqual(SeverityEnum.WARNING.value, 'WARNING')
+        self.assertEqual(SeverityEnum.EMERGENCY_WARNING.value, 'EMERGENCY_WARNING')

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_statusenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_statusenum.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.statusenum import StatusEnum
+
+
+class Test_StatusEnum(unittest.TestCase):
+    """
+    Test case for StatusEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StatusEnum.ISSUED
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StatusEnum
+        """
+        return StatusEnum.ISSUED
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StatusEnum.ISSUED.value, 'ISSUED')
+        self.assertEqual(StatusEnum.CONTINUED.value, 'CONTINUED')
+        self.assertEqual(StatusEnum.CANCELLED.value, 'CANCELLED')
+        self.assertEqual(StatusEnum.NO_WARNINGS_OR_ADVISORIES.value, 'NO_WARNINGS_OR_ADVISORIES')
+        self.assertEqual(StatusEnum.WARNING.value, 'WARNING')
+        self.assertEqual(StatusEnum.ADVISORY.value, 'ADVISORY')
+        self.assertEqual(StatusEnum.EMERGENCY_WARNING.value, 'EMERGENCY_WARNING')

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_warningitem.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_warningitem.py
@@ -1,0 +1,100 @@
+"""
+Test case for WarningItem
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
+from jma_bosai_warning_mqtt_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+
+
+class Test_WarningItem(unittest.TestCase):
+    """
+    Test case for WarningItem
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_WarningItem.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WarningItem for testing
+        """
+        instance = WarningItem(
+            code='ocpjamfhfcpvzdopvolq',
+            code_description_jp='kqpuuwpewxphiurexroz',
+            code_description_en='qkjadkufchgwjxqffhvb',
+            status=StatusEnum.ISSUED,
+            severity=SeverityEnum.REFERENCE
+        )
+        return instance
+
+    
+    def test_code_property(self):
+        """
+        Test code property
+        """
+        test_value = 'ocpjamfhfcpvzdopvolq'
+        self.instance.code = test_value
+        self.assertEqual(self.instance.code, test_value)
+    
+    def test_code_description_jp_property(self):
+        """
+        Test code_description_jp property
+        """
+        test_value = 'kqpuuwpewxphiurexroz'
+        self.instance.code_description_jp = test_value
+        self.assertEqual(self.instance.code_description_jp, test_value)
+    
+    def test_code_description_en_property(self):
+        """
+        Test code_description_en property
+        """
+        test_value = 'qkjadkufchgwjxqffhvb'
+        self.instance.code_description_en = test_value
+        self.assertEqual(self.instance.code_description_en, test_value)
+    
+    def test_status_property(self):
+        """
+        Test status property
+        """
+        test_value = StatusEnum.ISSUED
+        self.instance.status = test_value
+        self.assertEqual(self.instance.status, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.REFERENCE
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = WarningItem.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = WarningItem.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarning.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarning.py
@@ -1,0 +1,156 @@
+"""
+Test case for WeatherWarning
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.weatherwarning import WeatherWarning
+from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+import datetime
+
+
+class Test_WeatherWarning(unittest.TestCase):
+    """
+    Test case for WeatherWarning
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_WeatherWarning.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WeatherWarning for testing
+        """
+        instance = WeatherWarning(
+            prefecture='qhcrjffvwichrapfuers',
+            severity=SeverityEnum.REFERENCE,
+            office_code='bgzjfcnoaddeaxbtipyy',
+            area_code='wichfjpddlwrafsuqajy',
+            event=EventEnum.office,
+            area_name='rulbbegfuneeibdntzjh',
+            report_datetime=datetime.datetime.now(datetime.timezone.utc),
+            report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
+            headline_text='luidrbbbaelvfpdlcjel',
+            warnings=[None, None, None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc)]
+        )
+        return instance
+
+    
+    def test_prefecture_property(self):
+        """
+        Test prefecture property
+        """
+        test_value = 'qhcrjffvwichrapfuers'
+        self.instance.prefecture = test_value
+        self.assertEqual(self.instance.prefecture, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.REFERENCE
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
+    def test_office_code_property(self):
+        """
+        Test office_code property
+        """
+        test_value = 'bgzjfcnoaddeaxbtipyy'
+        self.instance.office_code = test_value
+        self.assertEqual(self.instance.office_code, test_value)
+    
+    def test_area_code_property(self):
+        """
+        Test area_code property
+        """
+        test_value = 'wichfjpddlwrafsuqajy'
+        self.instance.area_code = test_value
+        self.assertEqual(self.instance.area_code, test_value)
+    
+    def test_event_property(self):
+        """
+        Test event property
+        """
+        test_value = EventEnum.office
+        self.instance.event = test_value
+        self.assertEqual(self.instance.event, test_value)
+    
+    def test_area_name_property(self):
+        """
+        Test area_name property
+        """
+        test_value = 'rulbbegfuneeibdntzjh'
+        self.instance.area_name = test_value
+        self.assertEqual(self.instance.area_name, test_value)
+    
+    def test_report_datetime_property(self):
+        """
+        Test report_datetime property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.report_datetime = test_value
+        self.assertEqual(self.instance.report_datetime, test_value)
+    
+    def test_report_datetime_local_property(self):
+        """
+        Test report_datetime_local property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.report_datetime_local = test_value
+        self.assertEqual(self.instance.report_datetime_local, test_value)
+    
+    def test_headline_text_property(self):
+        """
+        Test headline_text property
+        """
+        test_value = 'luidrbbbaelvfpdlcjel'
+        self.instance.headline_text = test_value
+        self.assertEqual(self.instance.headline_text, test_value)
+    
+    def test_warnings_property(self):
+        """
+        Test warnings property
+        """
+        test_value = [None, None, None, None]
+        self.instance.warnings = test_value
+        self.assertEqual(self.instance.warnings, test_value)
+    
+    def test_time_defines_property(self):
+        """
+        Test time_defines property
+        """
+        test_value = [datetime.datetime.now(datetime.timezone.utc)]
+        self.instance.time_defines = test_value
+        self.assertEqual(self.instance.time_defines, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = WeatherWarning.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = WeatherWarning.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/pyproject.toml
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "jma-bosai-warning-mqtt-producer-mqtt-client"
+description = "jma_bosai_warning_mqtt_producer_mqtt_client MQTT client library"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "jma_bosai_warning_mqtt_producer_mqtt_client", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+jma-bosai-warning-mqtt-producer-data = {path = "../jma_bosai_warning_mqtt_producer_data", develop = true}
+paho-mqtt = ">=2.1.0"
+cloudevents = ">=1.10.1,<2.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/src/jma_bosai_warning_mqtt_producer_mqtt_client/__init__.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/src/jma_bosai_warning_mqtt_producer_mqtt_client/__init__.py
@@ -1,0 +1,6 @@
+""" __init__.py """
+from .client import JPJMAWarningMqttMqttClient
+
+__all__ = [
+    "JPJMAWarningMqttMqttClient",
+]

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/src/jma_bosai_warning_mqtt_producer_mqtt_client/client.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/src/jma_bosai_warning_mqtt_producer_mqtt_client/client.py
@@ -1,0 +1,534 @@
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+import json
+import re
+import typing
+from typing import Callable, Awaitable, Optional, Dict, List
+import asyncio
+import paho.mqtt.client as mqtt
+try:
+    # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
+    from paho.mqtt.properties import Properties as _MqttProperties
+    from paho.mqtt.packettypes import PacketTypes as _MqttPacketTypes
+    _MQTT5_AVAILABLE = True
+except Exception:  # pragma: no cover - paho < 2 fallback
+    _MqttProperties = None  # type: ignore
+    _MqttPacketTypes = None  # type: ignore
+    _MQTT5_AVAILABLE = False
+from cloudevents.conversion import to_binary, to_structured
+from cloudevents.http import CloudEvent
+import jma_bosai_warning_mqtt_producer_data
+from jma_bosai_warning_mqtt_producer_data import Office
+from jma_bosai_warning_mqtt_producer_data import WeatherWarning
+
+
+# URI template regex pattern
+_URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+
+def _topic_to_mqtt_wildcard(topic: str) -> str:
+    """Convert URI template placeholders to MQTT wildcards (+)."""
+    return _URI_TEMPLATE_PATTERN.sub('+', topic)
+
+
+def _apply_topic_template(topic_pattern: str, template_values: Optional[Dict[str, str]] = None) -> str:
+    """Apply template values to a topic pattern."""
+    if not template_values:
+        return topic_pattern
+    result = topic_pattern
+    for key, value in template_values.items():
+        result = result.replace('{' + key + '}', value)
+    return result
+
+
+def _build_topic_regex(topic_pattern: str) -> re.Pattern:
+    """Build a regex pattern for matching topics and extracting template values."""
+    # Escape regex special chars in the topic pattern
+    escaped = re.escape(topic_pattern)
+    # Restore placeholders (which were escaped to \{...\}) and convert to named groups
+    pattern = re.sub(r'\\{([A-Za-z0-9_]+)\\}', r'(?P<\1>[^/]+)', escaped)
+    return re.compile('^' + pattern + '$')
+
+
+def _extract_topic_parameters(topic: str, pattern: re.Pattern) -> Dict[str, str]:
+    """Extract URI template placeholder values from a topic."""
+    match = pattern.match(topic)
+    if match:
+        return {k: v for k, v in match.groupdict().items() if v is not None}
+    return {}
+
+
+def _ce_headers_to_mqtt5_properties(headers: Dict[str, str]):
+    """Map CloudEvents binary-mode HTTP-style headers onto MQTT 5 PUBLISH properties.
+
+    Per the CloudEvents MQTT 5 protocol binding (binary mode):
+      * ``datacontenttype`` becomes the MQTT 5 Content Type property.
+      * Every other CloudEvents attribute becomes a User Property whose name
+        is the bare attribute name (no ``ce-`` prefix).
+
+    Returns ``None`` when paho's MQTT 5 properties API is unavailable so the
+    caller can degrade gracefully without crashing.
+    """
+    if not _MQTT5_AVAILABLE or _MqttProperties is None or _MqttPacketTypes is None:
+        return None
+    props = _MqttProperties(_MqttPacketTypes.PUBLISH)
+    user_properties: List[tuple] = []
+    for raw_key, raw_value in (headers or {}).items():
+        if raw_value is None:
+            continue
+        key = str(raw_key).lower()
+        value = raw_value if isinstance(raw_value, str) else str(raw_value)
+        if key in ("content-type", "datacontenttype"):
+            try:
+                props.ContentType = value
+            except Exception:
+                user_properties.append(("datacontenttype", value))
+            continue
+        if key.startswith("ce-"):
+            key = key[3:]
+        if key in ("data", "data_base64"):
+            continue
+        user_properties.append((key, value))
+    if user_properties:
+        props.UserProperty = user_properties
+    return props
+
+
+def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
+    """Inverse of :func:`_ce_headers_to_mqtt5_properties` for the receive path."""
+    headers: Dict[str, str] = {}
+    if properties is None:
+        return headers
+    content_type = getattr(properties, "ContentType", None)
+    if content_type:
+        headers["content-type"] = content_type
+    user_props = getattr(properties, "UserProperty", None) or []
+    for entry in user_props:
+        try:
+            k, v = entry
+        except Exception:
+            continue
+        headers["ce-" + str(k).lower()] = str(v)
+    return headers
+
+
+class _ClientBase:
+    """Base class for MQTT client with CloudEvent detection."""
+    
+    @staticmethod
+    def _is_cloud_event(message: mqtt.MQTTMessage) -> bool:
+        """Check if the MQTT message contains a CloudEvent (structured or binary)."""
+        # Binary mode: MQTT 5 User Properties carry the CE attributes.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                keys = {str(k).lower() for k, _ in user_props}
+                if {"specversion", "type", "source", "id"}.issubset(keys):
+                    return True
+        except Exception:
+            pass
+        # Structured mode: JSON body with CE fields.
+        try:
+            if message.payload:
+                if isinstance(message.payload, bytes):
+                    payload_str = message.payload.decode('utf-8')
+                    data = json.loads(payload_str)
+                    return all(k in data for k in ['specversion', 'type', 'source', 'id'])
+            return False
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            return False
+
+    @staticmethod
+    def _cloud_event_from_message(message: mqtt.MQTTMessage) -> Optional[CloudEvent]:
+        """Extract CloudEvent from MQTT message (structured or binary mode)."""
+        # Binary mode first - rebuild a CloudEvent from MQTT 5 user properties.
+        try:
+            props = getattr(message, "properties", None)
+            user_props = getattr(props, "UserProperty", None) if props is not None else None
+            if user_props:
+                attributes: Dict[str, str] = {}
+                for entry in user_props:
+                    try:
+                        k, v = entry
+                    except Exception:
+                        continue
+                    attributes[str(k).lower()] = str(v)
+                if {"specversion", "type", "source", "id"}.issubset(attributes.keys()):
+                    content_type = getattr(props, "ContentType", None)
+                    if content_type:
+                        attributes["datacontenttype"] = content_type
+                    payload = message.payload
+                    if isinstance(payload, bytes) and (content_type or "").lower().startswith("application/json"):
+                        try:
+                            payload = json.loads(payload.decode("utf-8"))
+                        except Exception:
+                            pass
+                    return CloudEvent(attributes, payload)
+        except Exception:
+            pass
+        # Fall back to structured mode (CE JSON in payload).
+        try:
+            if isinstance(message.payload, bytes):
+                payload_str = message.payload.decode('utf-8')
+                from cloudevents.http import from_json
+                event = from_json(payload_str)
+                return event
+            return None
+        except (json.JSONDecodeError, UnicodeDecodeError, KeyError, Exception):
+            return None
+
+
+
+def get_default_topic_mappings_jp_jma_warning_mqtt() -> Dict[str, str]:
+    """
+    Get the default topic mappings for the JP.JMA.Warning.mqtt message group.
+    
+    Returns:
+        Dictionary mapping message identifiers to their default topic patterns.
+    """
+    return {
+        "JP.JMA.Warning.mqtt.Office": "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}",
+        "JP.JMA.Warning.mqtt.WeatherWarning": "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}",
+    }
+
+
+def get_subscription_topics_jp_jma_warning_mqtt(topic_mappings: Optional[Dict[str, str]] = None) -> List[str]:
+    """
+    Get subscription topics with URI template placeholders replaced by MQTT wildcards (+).
+    
+    Args:
+        topic_mappings: Optional topic mappings. If None, uses default mappings.
+        
+    Returns:
+        List of topic patterns suitable for MQTT subscription.
+    """
+    mappings = topic_mappings or get_default_topic_mappings_jp_jma_warning_mqtt()
+    topics = []
+    for topic in mappings.values():
+        wildcard_topic = _topic_to_mqtt_wildcard(topic)
+        if wildcard_topic not in topics:
+            topics.append(wildcard_topic)
+    return topics
+
+
+class JPJMAWarningMqttMqttClient(_ClientBase):
+    """MQTT Client for producing and consuming messages in the JP.JMA.Warning.mqtt message group."""
+    
+    def __init__(
+        self, 
+        client: mqtt.Client, 
+        topic_mappings: Optional[Dict[str, str]] = None,
+        content_mode: typing.Literal['structured', 'binary'] = 'structured', 
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
+        """
+        Initialize the MQTT client.
+
+        Args:
+            client: Paho MQTT client instance
+            topic_mappings: Optional dictionary mapping message identifiers to topic patterns.
+                Topic patterns may be URI templates with placeholders like {placeholder}.
+                For consumers, placeholders are converted to MQTT wildcards (+) for subscription.
+                If not provided, uses default 1:1 mapping.
+            content_mode: The content mode for CloudEvents ('structured' or 'binary')
+            loop: Optional event loop to use for async operations. If None, will try to get the running loop.
+        """
+        self.client = client
+        self.content_mode = content_mode
+        self.loop = loop
+        self._topic_mappings = topic_mappings or get_default_topic_mappings_jp_jma_warning_mqtt()
+        self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        
+        # Message handler callbacks (Dispatcher pattern)
+        
+        self.jp_jma_warning_mqtt_office_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, jma_bosai_warning_mqtt_producer_data.Office, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.jp_jma_warning_mqtt_weather_warning_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, jma_bosai_warning_mqtt_producer_data.WeatherWarning, Dict[str, str]], Awaitable[None]]] = None
+        
+        
+        # Attach message callback
+        self.client.on_message = self._on_message
+
+    @property
+    def topic_mappings(self) -> Dict[str, str]:
+        """Get the current topic mappings."""
+        return self._topic_mappings.copy()
+    
+    def _on_message(self, client, userdata, message: mqtt.MQTTMessage):
+        """Internal MQTT message callback that dispatches to async handlers."""
+        loop = self.loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(self._process_message(message), loop)
+    
+    async def _process_message(self, message: mqtt.MQTTMessage):
+        """Process incoming MQTT message and dispatch to appropriate handler."""
+        try:
+            if self._is_cloud_event(message):
+                cloud_event = self._cloud_event_from_message(message)
+                if cloud_event:
+                    await self._dispatch_cloud_event(message, cloud_event)
+            else:
+                # Handle plain MQTT messages (if needed)
+                pass
+        except Exception as e:
+            print(f"Error processing message: {e}")
+    
+    def _extract_topic_params(self, topic: str, message_id: str) -> Dict[str, str]:
+        """Extract URI template placeholder values from a topic."""
+        if message_id in self._topic_patterns:
+            return _extract_topic_parameters(topic, self._topic_patterns[message_id])
+        return {}
+    
+    async def _dispatch_cloud_event(self, mqtt_message: mqtt.MQTTMessage, cloud_event: CloudEvent):
+        """Dispatch CloudEvent to the appropriate handler based on type."""
+        event_type = cloud_event['type']
+        
+        
+        if event_type == "JP.JMA.Warning.Office":
+            if self.jp_jma_warning_mqtt_office_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = jma_bosai_warning_mqtt_producer_data.Office.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "JP.JMA.Warning.mqtt.Office")
+                    await self.jp_jma_warning_mqtt_office_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in jp_jma_warning_mqtt_office handler: {e}")
+            return
+        
+        if event_type == "JP.JMA.Warning.WeatherWarning":
+            if self.jp_jma_warning_mqtt_weather_warning_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = jma_bosai_warning_mqtt_producer_data.WeatherWarning.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "JP.JMA.Warning.mqtt.WeatherWarning")
+                    await self.jp_jma_warning_mqtt_weather_warning_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in jp_jma_warning_mqtt_weather_warning handler: {e}")
+            return
+        
+    
+    async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
+        """
+        Subscribe to MQTT topics.
+
+        Args:
+            topics: List of topic patterns to subscribe to. If None, subscribes to all 
+                default topics with URI template placeholders replaced by MQTT wildcards.
+            qos: Quality of Service level (0, 1, or 2)
+        """
+        if topics is None:
+            topics = get_subscription_topics_jp_jma_warning_mqtt(self._topic_mappings)
+        for topic in topics:
+            self.client.subscribe(topic, qos)
+    
+    async def unsubscribe(self, topics: typing.List[str]):
+        """
+        Unsubscribe from MQTT topics.
+
+        Args:
+            topics: List of topics to unsubscribe from
+        """
+        for topic in topics:
+            self.client.unsubscribe(topic)
+    
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+        """
+        Connect to MQTT broker.
+
+        Args:
+            broker: Broker hostname or IP
+            port: Broker port
+            keepalive: Keepalive interval in seconds
+        """
+        self.client.connect(broker, port, keepalive)
+        self.client.loop_start()
+    
+    async def disconnect(self):
+        """Disconnect from MQTT broker."""
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    # Producer methods
+    
+    async def publish_jp_jma_warning_mqtt_office(self,
+        feedurl: str,
+        office_code: str,
+        area_code: str,
+        prefecture: str,
+        severity: str,
+        event: str,
+        data: jma_bosai_warning_mqtt_producer_data.Office,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'JP.JMA.Warning.mqtt.Office' event to an MQTT topic.
+
+        Args:
+        
+            feedurl: URI template variable for 'feedurl'
+            office_code: URI template variable for 'office_code'
+            area_code: URI template variable for 'area_code'
+            prefecture: URI template variable for 'prefecture'
+            severity: URI template variable for 'severity'
+            event: URI template variable for 'event'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}"
+        _topic_template_values: Dict[str, str] = {
+            "feedurl": str(feedurl),
+            "office_code": str(office_code),
+            "area_code": str(area_code),
+            "prefecture": str(prefecture),
+            "severity": str(severity),
+            "event": str(event),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"JP.JMA.Warning.Office",
+             "source":"{feedurl}".format(feedurl = feedurl),
+             "subject":"jp.jma.warning/{office_code}/{area_code}".format(office_code = office_code,area_code = area_code)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_jp_jma_warning_mqtt_weather_warning(self,
+        feedurl: str,
+        office_code: str,
+        area_code: str,
+        prefecture: str,
+        severity: str,
+        event: str,
+        data: jma_bosai_warning_mqtt_producer_data.WeatherWarning,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'JP.JMA.Warning.mqtt.WeatherWarning' event to an MQTT topic.
+
+        Args:
+        
+            feedurl: URI template variable for 'feedurl'
+            office_code: URI template variable for 'office_code'
+            area_code: URI template variable for 'area_code'
+            prefecture: URI template variable for 'prefecture'
+            severity: URI template variable for 'severity'
+            event: URI template variable for 'event'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}"
+        _topic_template_values: Dict[str, str] = {
+            "feedurl": str(feedurl),
+            "office_code": str(office_code),
+            "area_code": str(area_code),
+            "prefecture": str(prefecture),
+            "severity": str(severity),
+            "event": str(event),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"JP.JMA.Warning.WeatherWarning",
+             "source":"{feedurl}".format(feedurl = feedurl),
+             "subject":"jp.jma.warning/{office_code}/{area_code}".format(office_code = office_code,area_code = area_code)
+        }
+        attributes["datacontenttype"] = content_type
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = False if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/tests/test_client.py
@@ -1,0 +1,180 @@
+# pylint: disable=line-too-long, trailing-whitespace, missing-module-docstring, missing-function-docstring, missing-class-docstring, redefined-outer-name, unused-argument, broad-exception-caught, broad-exception-raised, invalid-name, trailing-newlines, wrong-import-position, import-error, no-name-in-module
+
+import os
+import sys
+import pytest
+import pytest_asyncio
+import asyncio
+import time
+import paho.mqtt.client as mqtt
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../jma_bosai_warning_mqtt_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../jma_bosai_warning_mqtt_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../jma_bosai_warning_mqtt_producer_mqtt_client/src')))
+
+import jma_bosai_warning_mqtt_producer_data
+from jma_bosai_warning_mqtt_producer_data import Office
+from test_jma_bosai_warning_mqtt_producer_data_office import Test_Office
+from jma_bosai_warning_mqtt_producer_data import WeatherWarning
+from test_jma_bosai_warning_mqtt_producer_data_weatherwarning import Test_WeatherWarning
+from jma_bosai_warning_mqtt_producer_mqtt_client import JPJMAWarningMqttMqttClient
+
+@pytest_asyncio.fixture
+async def mosquitto_broker():
+    """Start Mosquitto MQTT broker in container."""
+    container = DockerContainer("eclipse-mosquitto:2.0")
+    container.with_exposed_ports(1883)
+    container.with_command("mosquitto -c /mosquitto-no-auth.conf")
+    
+    container.start()
+    
+    try:
+        # Wait for Mosquitto to start
+        wait_for_logs(container, "mosquitto version .* running", timeout=10)
+        await asyncio.sleep(2)  # Additional stabilization time
+        
+        # Get mapped port
+        broker_port = container.get_exposed_port(1883)
+        broker_host = "localhost"
+        
+        yield broker_host, broker_port
+    finally:
+        container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_jp_jma_warning_mqtt_jp_jma_warning_mqtt_office_py(mosquitto_broker):
+    """Test publishing and receiving JP.JMA.Warning.mqtt.Office message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Office.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = JPJMAWarningMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = JPJMAWarningMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_jp_jma_warning_mqtt_office(mqtt_msg, cloud_event, data: jma_bosai_warning_mqtt_producer_data.Office, topic_params: dict):
+        """Handler for JP.JMA.Warning.mqtt.Office messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "JP.JMA.Warning.Office"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.jp_jma_warning_mqtt_office_async = on_jp_jma_warning_mqtt_office
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/jp_jma_warning_mqtt/jp_jma_warning_mqtt_office"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_jp_jma_warning_mqtt_office(
+            topic=test_topic,
+            feedurl=f"test_feedurl_{i}",
+            office_code=f"test_office_code_{i}",
+            area_code=f"test_area_code_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_jp_jma_warning_mqtt_jp_jma_warning_mqtt_weather_warning_py(mosquitto_broker):
+    """Test publishing and receiving JP.JMA.Warning.mqtt.WeatherWarning message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_WeatherWarning.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = JPJMAWarningMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = JPJMAWarningMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_jp_jma_warning_mqtt_weather_warning(mqtt_msg, cloud_event, data: jma_bosai_warning_mqtt_producer_data.WeatherWarning, topic_params: dict):
+        """Handler for JP.JMA.Warning.mqtt.WeatherWarning messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "JP.JMA.Warning.WeatherWarning"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.jp_jma_warning_mqtt_weather_warning_async = on_jp_jma_warning_mqtt_weather_warning
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/jp_jma_warning_mqtt/jp_jma_warning_mqtt_weather_warning"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_jp_jma_warning_mqtt_weather_warning(
+            topic=test_topic,
+            feedurl=f"test_feedurl_{i}",
+            office_code=f"test_office_code_{i}",
+            area_code=f"test_area_code_{i}",
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/samples/sample.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/samples/sample.py
@@ -1,0 +1,87 @@
+
+"""
+This is sample code to use the MQTT client contained in this project.
+
+The sample demonstrates both publishing and subscribing to MQTT messages with
+the
+producer and dispatcher functionality.
+
+There is a handler for each defined message type. The handler is an async
+function that takes the following parameters:
+- mqtt_message: The paho.mqtt.client.MQTTMessage object (message context).
+- cloud_event: The CloudEvent data (if using CloudEvents).
+- message_data: The deserialized message data.The main function creates a client
+that can both produce and consume messages.
+It starts a dispatcher to handle incoming messages and then publishes sample
+messages.
+
+The script either reads the configuration from the command line or uses the
+environment variables. The following environment variables are recognized:
+
+- MQTT_BROKER_HOST: The MQTT broker hostname.
+- MQTT_BROKER_PORT: The MQTT broker port (default: 1883).
+- MQTT_TOPIC: The MQTT topic to publish/subscribe to.
+- MQTT_USERNAME: The MQTT username (optional).
+- MQTT_PASSWORD: The MQTT password (optional).
+
+Alternatively, you can pass the configuration as command-line arguments.
+
+python sample.py --broker-host <broker_host> --broker-port <broker_port> --topic
+<topic>
+
+The main function waits for a signal (Press Ctrl+C) to stop.
+"""
+
+import argparse
+import asyncio
+import os
+import signal
+from jma_bosai_warning_mqtt_producer_data import *
+from jma_bosai_warning_mqtt_producer_mqtt_client.client import JPJMAWarningMqttProducer, JPJMAWarningMqttDispatcher
+
+async def handle_jp_jma_warning_mqtt_office(mqtt_msg,cloud_event, jp_jma_warning_mqtt_office_data):
+    """ Handles the JP.JMA.Warning.mqtt.Office message """
+    print(f"Received JP.JMA.Warning.mqtt.Office on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {jp_jma_warning_mqtt_office_data}")
+
+async def handle_jp_jma_warning_mqtt_weather_warning(mqtt_msg,cloud_event, jp_jma_warning_mqtt_weather_warning_data):
+    """ Handles the JP.JMA.Warning.mqtt.WeatherWarning message """
+    print(f"Received JP.JMA.Warning.mqtt.WeatherWarning on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
+    print(f"  Data: {jp_jma_warning_mqtt_weather_warning_data}")
+
+async def main(broker_host, broker_port, topic, username=None, password=None):
+    """ Main function for MQTT client """
+    print(f"Connecting to {broker_host}:{broker_port}...")
+    print(f"Topic: {topic}")
+    print("Press Ctrl+C to stop\n")
+    
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: stop_event.set())
+    loop.add_signal_handler(signal.SIGINT, lambda: stop_event.set())
+    
+    await stop_event.wait()
+    print("\nStopping...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+    parser.add_argument('--broker-host', default=os.getenv('MQTT_BROKER_HOST', 'localhost'), help='MQTT broker hostname')
+    parser.add_argument('--broker-port', type=int, default=int(os.getenv('MQTT_BROKER_PORT', '1883')), help='MQTT broker port')
+    parser.add_argument('--topic', default=os.getenv('MQTT_TOPIC', 'testtopic'), help='MQTT topic')
+    parser.add_argument('--username', default=os.getenv('MQTT_USERNAME'), help='MQTT username (optional)')
+    parser.add_argument('--password', default=os.getenv('MQTT_PASSWORD'), help='MQTT password (optional)')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        args.broker_host,
+        args.broker_port,
+        args.topic,
+        args.username,
+        args.password
+    ))

--- a/jma-bosai-warning/jma_bosai_warning_mqtt_producer/scripts/build.py
+++ b/jma-bosai-warning/jma_bosai_warning_mqtt_producer/scripts/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+
+def main():
+    packages = ["jma_bosai_warning_mqtt_producer_mqtt_client", "jma_bosai_warning_mqtt_producer_data"]
+
+    for package in packages:
+        os.chdir(package)
+        subprocess.run(["poetry", "build"], check=True)
+        os.chdir("..")
+
+if __name__ == "__main__":
+    main()

--- a/jma-bosai-warning/jma_bosai_warning_producer/README.md
+++ b/jma-bosai-warning/jma_bosai_warning_producer/README.md
@@ -17,7 +17,9 @@ event dispatcher for processing events from Apache Kafka. It supports both plain
 
 3. [Quick Start](#quick-start)    - JPJMAWarningEventDispatcher,
 
-4. [Generated Producer Classes](#generated-producer-classes)    JPJMATsunamiEventDispatcher
+4. [Generated Producer Classes](#generated-producer-classes)    JPJMATsunamiEventDispatcher,
+
+4. [Generated Producer Classes](#generated-producer-classes)    JPJMAWarningMqttEventDispatcher
 
 4. [Generated Producer Classes](#generated-producer-classes)
 
@@ -45,6 +47,10 @@ It includes both plain Kafka messages and CloudEvents, offering a versatile
 It includes both plain Kafka messages and CloudEvents, offering a versatile
 
 - JPJMATsunamiProducersolution for event-driven applications.
+
+It includes both plain Kafka messages and CloudEvents, offering a versatile
+
+- JPJMAWarningMqttProducersolution for event-driven applications.
 
 
 
@@ -233,6 +239,43 @@ jp_jma_tsunami_dispatcher.jp_jma_warning_office_async = jp_jma_warning_office_ev
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningMqttProducer- `data`: The event data of type `jma_bosai_warning_producer_data.Office`.
+
+
+
+Producer for `JP.JMA.Warning.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_office_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Office) -> None:
+
+```python    # Process the event data
+
+JPJMAWarningMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_office_async = jp_jma_warning_office_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -330,6 +373,44 @@ responsible for calling the appropriate handler function when a message is recei
 ``````python
 
 jp_jma_tsunami_dispatcher.jp_jma_warning_weather_warning_async = jp_jma_warning_weather_warning_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningMqttProducer- `data`: The event data of type `jma_bosai_warning_producer_data.WeatherWarning`.
+
+
+
+Producer for `JP.JMA.Warning.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_weather_warning_event(record: ConsumerRecord, cloud_event: CloudEvent, data: WeatherWarning) ->
+None:
+
+```python    # Process the event data
+
+JPJMAWarningMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_weather_warning_async = jp_jma_warning_weather_warning_event
 
 **Parameters:**```
 
@@ -738,6 +819,44 @@ jp_jma_tsunami_dispatcher.jp_jma_tsunami_tsunami_alert_async = jp_jma_tsunami_ts
 
 - `bootstrap_servers`: Comma-separated list of broker addresses
 
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningMqttProducer- `data`: The event data of type `jma_bosai_warning_producer_data.TsunamiAlert`.
+
+
+
+Producer for `JP.JMA.Warning.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_tsunami_tsunami_alert_event(record: ConsumerRecord, cloud_event: CloudEvent, data: TsunamiAlert) ->
+None:
+
+```python    # Process the event data
+
+JPJMAWarningMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_mqtt_dispatcher.jp_jma_tsunami_tsunami_alert_async = jp_jma_tsunami_tsunami_alert_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
 - `client_id`: Optional client identifier
 
 - `**kwargs`: Additional Kafka producer configuration
@@ -841,6 +960,584 @@ await producer.send_jp_jma_tsunami_tsunami_alert_batch(```
         TsunamiAlert(...),
 
         TsunamiAlert(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+
+
+
+
+**Apache Kafka** is a distributed streaming platform that:
+
+- **Handles high-throughput** real-time data feeds with low latency
+
+- **Provides durability** through log-based storage with configurable retention
+
+- **Scales horizontally** across multiple brokers and partitions### JPJMAWarningMqttEventDispatcher
+
+- **Enables pub/sub messaging** with topic-based routing
+
+`JPJMAWarningMqttEventDispatcher` handles events for the JP.JMA.Warning.mqtt message group.
+
+Use cases: Event streaming, log aggregation, real-time analytics, data integration.
+
+#### Methods:
+
+## Quick Start
+
+##### `__init__`:
+
+### Installation
+
+```python
+
+```bash__init__(self)-> None
+
+pip install confluent-kafka cloudevents pydantic```
+
+```
+
+Initializes the dispatcher.
+
+### Basic Usage
+
+##### `create_processor`:
+
+```python
+
+from jma_bosai_warning_producer import JPJMAWarningProducer```python
+
+create_processor(self, bootstrap_servers: str, group_id: str, topics: List[str]) -> EventProcessorRunner
+
+# Create producer```
+
+producer = JPJMAWarningProducer(
+
+    bootstrap_servers='localhost:9092',Creates an `EventProcessorRunner`.
+
+    client_id='my-producer'
+
+)Args:
+
+- `bootstrap_servers`: The Kafka bootstrap servers.
+
+- `group_id`: The consumer group ID.- `topics`: The list of topics to subscribe to.##### `add_consumer`:
+
+# Send single message
+
+await producer.send_jp_jma_warning_office(```python
+
+    data=Office(...),add_consumer(self, consumer: KafkaConsumer)
+
+    partition_key='device-123'```
+
+)Adds a Kafka consumer to the dispatcher.
+
+
+
+# Close producerArgs:
+
+await producer.close()- `consumer`: The Kafka consumer.
+
+```
+
+#### Event Handlers
+
+### With SSL/SASL
+
+The JPJMAWarningMqttEventDispatcher defines the following event handler hooks.
+
+```python
+
+producer = JPJMAWarningProducer(
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `jp_jma_warning_mqtt_office_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'jp_jma_warning_mqtt_office_async:  Callable[[ConsumerRecord, CloudEvent, Office],
+Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `JP.JMA.Warning.mqtt.Office`: JMA Bosai warning office reference data from area.json
+offices.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningProducer- `data`: The event data of type `jma_bosai_warning_producer_data.Office`.
+
+
+
+Producer for `JP.JMA.Warning` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_office_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Office) -> None:
+
+```python    # Process the event data
+
+JPJMAWarningProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_dispatcher.jp_jma_warning_mqtt_office_async = jp_jma_warning_mqtt_office_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMATsunamiProducer- `data`: The event data of type `jma_bosai_warning_producer_data.Office`.
+
+
+
+Producer for `JP.JMA.Tsunami` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_office_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Office) -> None:
+
+```python    # Process the event data
+
+JPJMATsunamiProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_tsunami_dispatcher.jp_jma_warning_mqtt_office_async = jp_jma_warning_mqtt_office_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningMqttProducer- `data`: The event data of type `jma_bosai_warning_producer_data.Office`.
+
+
+
+Producer for `JP.JMA.Warning.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_office_event(record: ConsumerRecord, cloud_event: CloudEvent, data: Office) -> None:
+
+```python    # Process the event data
+
+JPJMAWarningMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_mqtt_office_async = jp_jma_warning_mqtt_office_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+    bootstrap_servers='localhost:9093',
+
+    security_protocol='SASL_SSL',##### `jp_jma_warning_mqtt_weather_warning_async`
+
+    sasl_mechanism='PLAIN',
+
+    sasl_username='your-username',```python
+
+    sasl_password='your-password'jp_jma_warning_mqtt_weather_warning_async:  Callable[[ConsumerRecord, CloudEvent,
+WeatherWarning], Awaitable[None]]
+
+)```
+
+```
+
+Asynchronous handler hook for `JP.JMA.Warning.mqtt.WeatherWarning`: JMA Bosai weather warning/advisory telemetry for one
+forecast area within an office bulletin.
+
+## Generated Producer Classes
+
+The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
+
+- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningProducer- `data`: The event data of type `jma_bosai_warning_producer_data.WeatherWarning`.
+
+
+
+Producer for `JP.JMA.Warning` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_weather_warning_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WeatherWarning) -> None:
+
+```python    # Process the event data
+
+JPJMAWarningProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_dispatcher.jp_jma_warning_mqtt_weather_warning_async = jp_jma_warning_mqtt_weather_warning_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMATsunamiProducer- `data`: The event data of type `jma_bosai_warning_producer_data.WeatherWarning`.
+
+
+
+Producer for `JP.JMA.Tsunami` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_weather_warning_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WeatherWarning) -> None:
+
+```python    # Process the event data
+
+JPJMATsunamiProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_tsunami_dispatcher.jp_jma_warning_mqtt_weather_warning_async = jp_jma_warning_mqtt_weather_warning_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier- `record`: The Kafka record.
+
+- `cloud_event`: The CloudEvent.
+
+### JPJMAWarningMqttProducer- `data`: The event data of type `jma_bosai_warning_producer_data.WeatherWarning`.
+
+
+
+Producer for `JP.JMA.Warning.mqtt` message group.Example:
+
+
+
+#### Constructor```python
+
+async def jp_jma_warning_mqtt_weather_warning_event(record: ConsumerRecord, cloud_event: CloudEvent, data:
+WeatherWarning) -> None:
+
+```python    # Process the event data
+
+JPJMAWarningMqttProducer(    await some_processing_function(record, cloud_event, data)
+
+    bootstrap_servers: str,```
+
+    client_id: Optional[str] = None,
+
+    **kwargsThe handler function is then assigned to the event dispatcher for the message group. The event dispatcher is
+responsible for calling the appropriate handler function when a message is received. Example:
+
+) -> None
+
+``````python
+
+jp_jma_warning_mqtt_dispatcher.jp_jma_warning_mqtt_weather_warning_async = jp_jma_warning_mqtt_weather_warning_event
+
+**Parameters:**```
+
+- `bootstrap_servers`: Comma-separated list of broker addresses
+
+- `client_id`: Optional client identifier
+
+- `**kwargs`: Additional Kafka producer configuration
+
+
+
+#### Send Methods## Internals
+
+
+
+### Dispatchers
+
+##### `send_jp_jma_warning_mqtt_office`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_jp_jma_warning_mqtt_office(
+
+    self,##### `_process_event`
+
+    data: Office,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `JP.JMA.Warning.mqtt.Office` message. JMA Bosai warning office reference data from area.json offices.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `Office`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_jp_jma_warning_mqtt_office(
+
+    data=Office(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `JP.JMA.Warning.mqtt.Office` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_jp_jma_warning_mqtt_office_batch(```
+
+    messages=[
+
+        Office(...),Initializes the runner with a Kafka consumer.
+
+        Office(...),
+
+        Office(...)Args:
+
+    ],- `consumer`: The Kafka consumer.
+
+    partition_key='batch-001'
+
+)#####  `__aenter__()`
+
+```
+
+Enters the asynchronous context and starts the processor.
+
+### Dispatchers
+
+##### `send_jp_jma_warning_mqtt_weather_warning`Dispatchers have the following protected methods:
+
+
+
+```python### Methods:
+
+async def send_jp_jma_warning_mqtt_weather_warning(
+
+    self,##### `_process_event`
+
+    data: WeatherWarning,
+
+    partition_key: Optional[str] = None,```python
+
+    headers: Optional[Dict[str, str]] = None,_process_event(self, record)
+
+    topic: Optional[str] = None```
+
+) -> None
+
+```Processes an incoming event.
+
+
+
+Send a single `JP.JMA.Warning.mqtt.WeatherWarning` message. JMA Bosai weather warning/advisory telemetry for one
+forecast area within an office bulletin.Args:
+
+- `record`: The Kafka record.
+
+**Parameters:**
+
+- `data`: Message data of type `WeatherWarning`
+
+- `partition_key`: Optional partition key (defaults to random partitioning)##### `_dispatch_cloud_event`
+
+- `headers`: Optional message headers
+
+- `topic`: Optional topic override (uses default topic if not specified)```python
+
+_dispatch_cloud_event(self, record, cloud_event)
+
+**Example:**```
+
+
+
+```pythonDispatches a CloudEvent to the appropriate handler.
+
+await producer.send_jp_jma_warning_mqtt_weather_warning(
+
+    data=WeatherWarning(...),Args:
+
+    partition_key='device-001',- `record`: The Kafka record.
+
+    headers={'source': 'sensor-gateway'}- `cloud_event`: The CloudEvent.
+
+)
+
+```
+
+Send multiple `JP.JMA.Warning.mqtt.WeatherWarning` messages in a batch.
+
+### EventProcessorRunner
+
+**Parameters:**
+
+- `messages`: List of message data`EventProcessorRunner` is responsible for managing the event processing loop and
+dispatching events to the appropriate handlers.
+
+- `partition_key`: Optional partition key for all messages
+
+- `headers`: Optional headers for all messages#### Methods
+
+- `topic`: Optional topic override
+
+##### `__init__`
+
+**Example:**
+
+```python
+
+```python__init__(consumer: KafkaConsumer)
+
+await producer.send_jp_jma_warning_mqtt_weather_warning_batch(```
+
+    messages=[
+
+        WeatherWarning(...),Initializes the runner with a Kafka consumer.
+
+        WeatherWarning(...),
+
+        WeatherWarning(...)Args:
 
     ],- `consumer`: The Kafka consumer.
 

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/__init__.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/__init__.py
@@ -1,3 +1,8 @@
+from .severityenum import SeverityEnum
+from .eventenum import EventEnum
+from .statusenum import StatusEnum
+from .warningitem import WarningItem
+from .weatherwarning import WeatherWarning
 from .infotypeenum import InfoTypeenum
 from .categoryenum import CategoryEnum
 from .affectedcoastalregion import AffectedCoastalRegion
@@ -6,9 +11,5 @@ from .tsunamiobservation import TsunamiObservation
 from .tsunamialert import TsunamiAlert
 from .officetypeenum import OfficeTypeenum
 from .office import Office
-from .statusenum import StatusEnum
-from .severityenum import SeverityEnum
-from .warningitem import WarningItem
-from .weatherwarning import WeatherWarning
 
-__all__ = ["InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert", "OfficeTypeenum", "Office", "StatusEnum", "SeverityEnum", "WarningItem", "WeatherWarning"]
+__all__ = ["SeverityEnum", "EventEnum", "StatusEnum", "WarningItem", "WeatherWarning", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert", "OfficeTypeenum", "Office"]

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/affectedcoastalregion.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/affectedcoastalregion.py
@@ -164,10 +164,10 @@ class AffectedCoastalRegion:
             An instance of the dataclass.
         """
         return cls(
-            code='ysvejmuudewntpbajcig',
-            name='uoumgegikwqguqqvlkzx',
+            code='okafqaccphatdbgptvls',
+            name='adbydzgpfybrptghrfyg',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(52.857835539122455),
+            expected_max_wave_height_m=float(95.23617934271941),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/eventenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/eventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class EventEnum(Enum):
+    """
+    Fixed MQTT topic event segment for JMA Bosai weather warning state records.
+    """
+    warning = 'warning'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'EventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (EventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/office.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/office.py
@@ -12,6 +12,8 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
 from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.eventenum import EventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -27,6 +29,9 @@ class Office:
         name_en (str)
         parent_office_code (typing.Optional[str])
         office_type (OfficeTypeenum)
+        prefecture (str)
+        severity (SeverityEnum)
+        event (EventEnum)
     """
     
     
@@ -36,6 +41,9 @@ class Office:
     name_en: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name_en"))
     parent_office_code: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="parent_office_code"))
     office_type: OfficeTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_type"))
+    prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Office':
@@ -162,10 +170,13 @@ class Office:
             An instance of the dataclass.
         """
         return cls(
-            office_code='cjvkgwksnxnhuyeienhh',
-            area_code='zrlcnfatzsiuqkvngzvb',
-            name_jp='jwmqqnasqpcelkntahdi',
-            name_en='qmuquimxogqzepclnnih',
-            parent_office_code='ixfonklewtcdcwdfnsra',
-            office_type=OfficeTypeenum.PREFECTURE
+            office_code='uoabfxgvawqapeawlkii',
+            area_code='uegltbcexassemfatmwv',
+            name_jp='uvczlldtcpxwkgulfrxf',
+            name_en='lmtnhanofyucizmecdml',
+            parent_office_code='aynshcxzconpjliwvwqh',
+            office_type=OfficeTypeenum.PREFECTURE,
+            prefecture='qbnvxcxlqyjbrivpsgap',
+            severity=SeverityEnum.REFERENCE,
+            event=EventEnum.warning
         )

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/severityenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/severityenum.py
@@ -3,8 +3,9 @@ from enum import Enum
 
 class SeverityEnum(Enum):
     """
-    Normalized severity derived from the JMA status text and special-warning codes. NONE represents 発表警報・注意報はなし, ADVISORY represents 注意報-level notices, WARNING represents 警報/発表/継続 items, and EMERGENCY_WARNING represents 特別警報 or special-warning category codes 32-38.
+    MQTT topic severity axis. Weather warning records emit the highest normalized warning severity present in the area bulletin; retained office REFERENCE records use REFERENCE on the same shared axis.
     """
+    REFERENCE = 'REFERENCE'
     NONE = 'NONE'
     ADVISORY = 'ADVISORY'
     WARNING = 'WARNING'

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamialert.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamialert.py
@@ -12,8 +12,8 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
 from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
 from jma_bosai_warning_producer_data.affectedcoastalregion import AffectedCoastalRegion
 import datetime
 
@@ -176,15 +176,15 @@ class TsunamiAlert:
             An instance of the dataclass.
         """
         return cls(
-            event_id='vmcyjuctlfreufczkifb',
-            serial=int(92),
+            event_id='wpnkhztnzcgqzcrjtyfu',
+            serial=int(67),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='vpnqenreccvlbyicxjzw',
-            title_en='qdtswpawebsymdegyzsl',
-            bulletin_type='ppponecruompycssloht',
-            detail_url='axirwdcpoqfgitvhkzen',
-            affected_coastal_regions=[None, None, None, None],
-            observations=[None, None]
+            title_jp='xtmqoilnovayyixespny',
+            title_en='mdiinkusgmedjdegfifu',
+            bulletin_type='jkrpqayphakjqqkmivcy',
+            detail_url='vvzpmsukbwxhitzmlslf',
+            affected_coastal_regions=[None, None, None],
+            observations=[None, None, None, None, None]
         )

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamiobservation.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamiobservation.py
@@ -166,10 +166,10 @@ class TsunamiObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='mhzlwcazoqtxvltvystd',
-            station_name_jp='vnntvraxhynmhlbzdpwc',
-            station_name_en='bsnospvdtoqnnlxzupvy',
-            observed_max_wave_height_m=float(91.64369297776543),
+            station_code='otqoekwpcvmqnzoywula',
+            station_name_jp='jaznlkbgizntjexlnetj',
+            station_name_en='vnizelzkdayvltqsrque',
+            observed_max_wave_height_m=float(6.5583118816877395),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/warningitem.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/warningitem.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -161,9 +161,9 @@ class WarningItem:
             An instance of the dataclass.
         """
         return cls(
-            code='cuazskuozzeioahnigvb',
-            code_description_jp='clkjdnbdnefrmoeopzsu',
-            code_description_en='zzpxpyhpkikgkjczuipw',
+            code='fktclkxjeqwkavqxycth',
+            code_description_jp='bcpftlcnlrnlqvhlartj',
+            code_description_en='oavllirmpojcymegrxtc',
             status=StatusEnum.ISSUED,
-            severity=SeverityEnum.NONE
+            severity=SeverityEnum.REFERENCE
         )

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarning.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarning.py
@@ -13,6 +13,8 @@ from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
 from jma_bosai_warning_producer_data.warningitem import WarningItem
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.eventenum import EventEnum
 import datetime
 
 
@@ -23,8 +25,11 @@ class WeatherWarning:
     JMA Bosai weather warning/advisory state for one office targetArea and one inner forecast area. The bridge emits one record per (office_code, area_code, report_datetime) change and includes all warning items currently published for that area.
     
     Attributes:
+        prefecture (str)
+        severity (SeverityEnum)
         office_code (str)
         area_code (str)
+        event (EventEnum)
         area_name (str)
         report_datetime (datetime.datetime)
         report_datetime_local (datetime.datetime)
@@ -34,8 +39,11 @@ class WeatherWarning:
     """
     
     
+    prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
     office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
     area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
+    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
     area_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_name"))
     report_datetime: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     report_datetime_local: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime_local", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -168,12 +176,15 @@ class WeatherWarning:
             An instance of the dataclass.
         """
         return cls(
-            office_code='mpqgrgufzcgweojbiwve',
-            area_code='fvyxbdkbqgxuoapyrqsu',
-            area_name='ayikcndysykmiwkfmwta',
+            prefecture='upcjoayxipqfvkuhbakt',
+            severity=SeverityEnum.REFERENCE,
+            office_code='nchjuxrjaywlkozcjabl',
+            area_code='atrbqtrtlmonivzyylup',
+            event=EventEnum.warning,
+            area_name='eydorkmolqbxhhujjqxh',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='kzdxnjwrnnfacuzbxvvn',
-            warnings=[None, None],
+            headline_text='tjcdtwhtabzasjzhqlbh',
+            warnings=[None],
             time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_affectedcoastalregion.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_affectedcoastalregion.py
@@ -30,10 +30,10 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         Create instance of AffectedCoastalRegion for testing
         """
         instance = AffectedCoastalRegion(
-            code='ysvejmuudewntpbajcig',
-            name='uoumgegikwqguqqvlkzx',
+            code='okafqaccphatdbgptvls',
+            name='adbydzgpfybrptghrfyg',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(52.857835539122455),
+            expected_max_wave_height_m=float(95.23617934271941),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )
@@ -44,7 +44,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'ysvejmuudewntpbajcig'
+        test_value = 'okafqaccphatdbgptvls'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -52,7 +52,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'uoumgegikwqguqqvlkzx'
+        test_value = 'adbydzgpfybrptghrfyg'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -68,7 +68,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test expected_max_wave_height_m property
         """
-        test_value = float(52.857835539122455)
+        test_value = float(95.23617934271941)
         self.instance.expected_max_wave_height_m = test_value
         self.assertEqual(self.instance.expected_max_wave_height_m, test_value)
     

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_arrivalstatusenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_arrivalstatusenum.py
@@ -29,6 +29,6 @@ class Test_ArrivalStatusenum(unittest.TestCase):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(ArrivalStatusenum.ESTIMATED.value, "ESTIMATED")
-        self.assertEqual(ArrivalStatusenum.FIRST_WAVE_OBSERVED.value, "FIRST_WAVE_OBSERVED")
-        self.assertEqual(ArrivalStatusenum.MAX_WAVE_OBSERVED.value, "MAX_WAVE_OBSERVED")
+        self.assertEqual(ArrivalStatusenum.ESTIMATED.value, 'ESTIMATED')
+        self.assertEqual(ArrivalStatusenum.FIRST_WAVE_OBSERVED.value, 'FIRST_WAVE_OBSERVED')
+        self.assertEqual(ArrivalStatusenum.MAX_WAVE_OBSERVED.value, 'MAX_WAVE_OBSERVED')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_categoryenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_categoryenum.py
@@ -29,7 +29,7 @@ class Test_CategoryEnum(unittest.TestCase):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(CategoryEnum.MAJOR_WARNING.value, "MAJOR_WARNING")
-        self.assertEqual(CategoryEnum.WARNING.value, "WARNING")
-        self.assertEqual(CategoryEnum.ADVISORY.value, "ADVISORY")
-        self.assertEqual(CategoryEnum.FORECAST.value, "FORECAST")
+        self.assertEqual(CategoryEnum.MAJOR_WARNING.value, 'MAJOR_WARNING')
+        self.assertEqual(CategoryEnum.WARNING.value, 'WARNING')
+        self.assertEqual(CategoryEnum.ADVISORY.value, 'ADVISORY')
+        self.assertEqual(CategoryEnum.FORECAST.value, 'FORECAST')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_eventenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_eventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_producer_data.eventenum import EventEnum
+
+
+class Test_EventEnum(unittest.TestCase):
+    """
+    Test case for EventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = EventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of EventEnum
+        """
+        return EventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(EventEnum.warning.value, 'warning')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_infotypeenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_infotypeenum.py
@@ -29,6 +29,6 @@ class Test_InfoTypeenum(unittest.TestCase):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(InfoTypeenum.ISSUED.value, "ISSUED")
-        self.assertEqual(InfoTypeenum.CORRECTED.value, "CORRECTED")
-        self.assertEqual(InfoTypeenum.CANCELLED.value, "CANCELLED")
+        self.assertEqual(InfoTypeenum.ISSUED.value, 'ISSUED')
+        self.assertEqual(InfoTypeenum.CORRECTED.value, 'CORRECTED')
+        self.assertEqual(InfoTypeenum.CANCELLED.value, 'CANCELLED')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_office.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_office.py
@@ -10,6 +10,8 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_warning_producer_data.office import Office
 from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.eventenum import EventEnum
 
 
 class Test_Office(unittest.TestCase):
@@ -29,12 +31,15 @@ class Test_Office(unittest.TestCase):
         Create instance of Office for testing
         """
         instance = Office(
-            office_code='cjvkgwksnxnhuyeienhh',
-            area_code='zrlcnfatzsiuqkvngzvb',
-            name_jp='jwmqqnasqpcelkntahdi',
-            name_en='qmuquimxogqzepclnnih',
-            parent_office_code='ixfonklewtcdcwdfnsra',
-            office_type=OfficeTypeenum.PREFECTURE
+            office_code='uoabfxgvawqapeawlkii',
+            area_code='uegltbcexassemfatmwv',
+            name_jp='uvczlldtcpxwkgulfrxf',
+            name_en='lmtnhanofyucizmecdml',
+            parent_office_code='aynshcxzconpjliwvwqh',
+            office_type=OfficeTypeenum.PREFECTURE,
+            prefecture='qbnvxcxlqyjbrivpsgap',
+            severity=SeverityEnum.REFERENCE,
+            event=EventEnum.warning
         )
         return instance
 
@@ -43,7 +48,7 @@ class Test_Office(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'cjvkgwksnxnhuyeienhh'
+        test_value = 'uoabfxgvawqapeawlkii'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -51,7 +56,7 @@ class Test_Office(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'zrlcnfatzsiuqkvngzvb'
+        test_value = 'uegltbcexassemfatmwv'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -59,7 +64,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'jwmqqnasqpcelkntahdi'
+        test_value = 'uvczlldtcpxwkgulfrxf'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -67,7 +72,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'qmuquimxogqzepclnnih'
+        test_value = 'lmtnhanofyucizmecdml'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -75,7 +80,7 @@ class Test_Office(unittest.TestCase):
         """
         Test parent_office_code property
         """
-        test_value = 'ixfonklewtcdcwdfnsra'
+        test_value = 'aynshcxzconpjliwvwqh'
         self.instance.parent_office_code = test_value
         self.assertEqual(self.instance.parent_office_code, test_value)
     
@@ -86,6 +91,30 @@ class Test_Office(unittest.TestCase):
         test_value = OfficeTypeenum.PREFECTURE
         self.instance.office_type = test_value
         self.assertEqual(self.instance.office_type, test_value)
+    
+    def test_prefecture_property(self):
+        """
+        Test prefecture property
+        """
+        test_value = 'qbnvxcxlqyjbrivpsgap'
+        self.instance.prefecture = test_value
+        self.assertEqual(self.instance.prefecture, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.REFERENCE
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
+    def test_event_property(self):
+        """
+        Test event property
+        """
+        test_value = EventEnum.warning
+        self.instance.event = test_value
+        self.assertEqual(self.instance.event, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_officetypeenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_officetypeenum.py
@@ -29,6 +29,6 @@ class Test_OfficeTypeenum(unittest.TestCase):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(OfficeTypeenum.PREFECTURE.value, "PREFECTURE")
-        self.assertEqual(OfficeTypeenum.SUBREGION.value, "SUBREGION")
-        self.assertEqual(OfficeTypeenum.OFFICE.value, "OFFICE")
+        self.assertEqual(OfficeTypeenum.PREFECTURE.value, 'PREFECTURE')
+        self.assertEqual(OfficeTypeenum.SUBREGION.value, 'SUBREGION')
+        self.assertEqual(OfficeTypeenum.OFFICE.value, 'OFFICE')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_severityenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_severityenum.py
@@ -16,20 +16,21 @@ class Test_SeverityEnum(unittest.TestCase):
         """
         Setup test
         """
-        self.instance = SeverityEnum.NONE
+        self.instance = SeverityEnum.REFERENCE
 
     @staticmethod
     def create_instance():
         """
         Create instance of SeverityEnum
         """
-        return SeverityEnum.NONE
+        return SeverityEnum.REFERENCE
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(SeverityEnum.NONE.value, "NONE")
-        self.assertEqual(SeverityEnum.ADVISORY.value, "ADVISORY")
-        self.assertEqual(SeverityEnum.WARNING.value, "WARNING")
-        self.assertEqual(SeverityEnum.EMERGENCY_WARNING.value, "EMERGENCY_WARNING")
+        self.assertEqual(SeverityEnum.REFERENCE.value, 'REFERENCE')
+        self.assertEqual(SeverityEnum.NONE.value, 'NONE')
+        self.assertEqual(SeverityEnum.ADVISORY.value, 'ADVISORY')
+        self.assertEqual(SeverityEnum.WARNING.value, 'WARNING')
+        self.assertEqual(SeverityEnum.EMERGENCY_WARNING.value, 'EMERGENCY_WARNING')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_statusenum.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_statusenum.py
@@ -29,10 +29,10 @@ class Test_StatusEnum(unittest.TestCase):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(StatusEnum.ISSUED.value, "ISSUED")
-        self.assertEqual(StatusEnum.CONTINUED.value, "CONTINUED")
-        self.assertEqual(StatusEnum.CANCELLED.value, "CANCELLED")
-        self.assertEqual(StatusEnum.NO_WARNINGS_OR_ADVISORIES.value, "NO_WARNINGS_OR_ADVISORIES")
-        self.assertEqual(StatusEnum.WARNING.value, "WARNING")
-        self.assertEqual(StatusEnum.ADVISORY.value, "ADVISORY")
-        self.assertEqual(StatusEnum.EMERGENCY_WARNING.value, "EMERGENCY_WARNING")
+        self.assertEqual(StatusEnum.ISSUED.value, 'ISSUED')
+        self.assertEqual(StatusEnum.CONTINUED.value, 'CONTINUED')
+        self.assertEqual(StatusEnum.CANCELLED.value, 'CANCELLED')
+        self.assertEqual(StatusEnum.NO_WARNINGS_OR_ADVISORIES.value, 'NO_WARNINGS_OR_ADVISORIES')
+        self.assertEqual(StatusEnum.WARNING.value, 'WARNING')
+        self.assertEqual(StatusEnum.ADVISORY.value, 'ADVISORY')
+        self.assertEqual(StatusEnum.EMERGENCY_WARNING.value, 'EMERGENCY_WARNING')

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamialert.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamialert.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_producer_data.tsunamialert import TsunamiAlert
-from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
 from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
 from jma_bosai_warning_producer_data.affectedcoastalregion import AffectedCoastalRegion
 import datetime
 
@@ -32,17 +32,17 @@ class Test_TsunamiAlert(unittest.TestCase):
         Create instance of TsunamiAlert for testing
         """
         instance = TsunamiAlert(
-            event_id='vmcyjuctlfreufczkifb',
-            serial=int(92),
+            event_id='wpnkhztnzcgqzcrjtyfu',
+            serial=int(67),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='vpnqenreccvlbyicxjzw',
-            title_en='qdtswpawebsymdegyzsl',
-            bulletin_type='ppponecruompycssloht',
-            detail_url='axirwdcpoqfgitvhkzen',
-            affected_coastal_regions=[None, None, None, None],
-            observations=[None, None]
+            title_jp='xtmqoilnovayyixespny',
+            title_en='mdiinkusgmedjdegfifu',
+            bulletin_type='jkrpqayphakjqqkmivcy',
+            detail_url='vvzpmsukbwxhitzmlslf',
+            affected_coastal_regions=[None, None, None],
+            observations=[None, None, None, None, None]
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'vmcyjuctlfreufczkifb'
+        test_value = 'wpnkhztnzcgqzcrjtyfu'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test serial property
         """
-        test_value = int(92)
+        test_value = int(67)
         self.instance.serial = test_value
         self.assertEqual(self.instance.serial, test_value)
     
@@ -91,7 +91,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_jp property
         """
-        test_value = 'vpnqenreccvlbyicxjzw'
+        test_value = 'xtmqoilnovayyixespny'
         self.instance.title_jp = test_value
         self.assertEqual(self.instance.title_jp, test_value)
     
@@ -99,7 +99,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_en property
         """
-        test_value = 'qdtswpawebsymdegyzsl'
+        test_value = 'mdiinkusgmedjdegfifu'
         self.instance.title_en = test_value
         self.assertEqual(self.instance.title_en, test_value)
     
@@ -107,7 +107,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test bulletin_type property
         """
-        test_value = 'ppponecruompycssloht'
+        test_value = 'jkrpqayphakjqqkmivcy'
         self.instance.bulletin_type = test_value
         self.assertEqual(self.instance.bulletin_type, test_value)
     
@@ -115,7 +115,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test detail_url property
         """
-        test_value = 'axirwdcpoqfgitvhkzen'
+        test_value = 'vvzpmsukbwxhitzmlslf'
         self.instance.detail_url = test_value
         self.assertEqual(self.instance.detail_url, test_value)
     
@@ -123,7 +123,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test affected_coastal_regions property
         """
-        test_value = [None, None, None, None]
+        test_value = [None, None, None]
         self.instance.affected_coastal_regions = test_value
         self.assertEqual(self.instance.affected_coastal_regions, test_value)
     
@@ -131,7 +131,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test observations property
         """
-        test_value = [None, None]
+        test_value = [None, None, None, None, None]
         self.instance.observations = test_value
         self.assertEqual(self.instance.observations, test_value)
     

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamiobservation.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamiobservation.py
@@ -30,10 +30,10 @@ class Test_TsunamiObservation(unittest.TestCase):
         Create instance of TsunamiObservation for testing
         """
         instance = TsunamiObservation(
-            station_code='mhzlwcazoqtxvltvystd',
-            station_name_jp='vnntvraxhynmhlbzdpwc',
-            station_name_en='bsnospvdtoqnnlxzupvy',
-            observed_max_wave_height_m=float(91.64369297776543),
+            station_code='otqoekwpcvmqnzoywula',
+            station_name_jp='jaznlkbgizntjexlnetj',
+            station_name_en='vnizelzkdayvltqsrque',
+            observed_max_wave_height_m=float(6.5583118816877395),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED
@@ -45,7 +45,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'mhzlwcazoqtxvltvystd'
+        test_value = 'otqoekwpcvmqnzoywula'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -53,7 +53,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_jp property
         """
-        test_value = 'vnntvraxhynmhlbzdpwc'
+        test_value = 'jaznlkbgizntjexlnetj'
         self.instance.station_name_jp = test_value
         self.assertEqual(self.instance.station_name_jp, test_value)
     
@@ -61,7 +61,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_en property
         """
-        test_value = 'bsnospvdtoqnnlxzupvy'
+        test_value = 'vnizelzkdayvltqsrque'
         self.instance.station_name_en = test_value
         self.assertEqual(self.instance.station_name_en, test_value)
     
@@ -69,7 +69,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test observed_max_wave_height_m property
         """
-        test_value = float(91.64369297776543)
+        test_value = float(6.5583118816877395)
         self.instance.observed_max_wave_height_m = test_value
         self.assertEqual(self.instance.observed_max_wave_height_m, test_value)
     

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_warningitem.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_warningitem.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_producer_data.warningitem import WarningItem
-from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 
 
 class Test_WarningItem(unittest.TestCase):
@@ -30,11 +30,11 @@ class Test_WarningItem(unittest.TestCase):
         Create instance of WarningItem for testing
         """
         instance = WarningItem(
-            code='cuazskuozzeioahnigvb',
-            code_description_jp='clkjdnbdnefrmoeopzsu',
-            code_description_en='zzpxpyhpkikgkjczuipw',
+            code='fktclkxjeqwkavqxycth',
+            code_description_jp='bcpftlcnlrnlqvhlartj',
+            code_description_en='oavllirmpojcymegrxtc',
             status=StatusEnum.ISSUED,
-            severity=SeverityEnum.NONE
+            severity=SeverityEnum.REFERENCE
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'cuazskuozzeioahnigvb'
+        test_value = 'fktclkxjeqwkavqxycth'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -51,7 +51,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_jp property
         """
-        test_value = 'clkjdnbdnefrmoeopzsu'
+        test_value = 'bcpftlcnlrnlqvhlartj'
         self.instance.code_description_jp = test_value
         self.assertEqual(self.instance.code_description_jp, test_value)
     
@@ -59,7 +59,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_en property
         """
-        test_value = 'zzpxpyhpkikgkjczuipw'
+        test_value = 'oavllirmpojcymegrxtc'
         self.instance.code_description_en = test_value
         self.assertEqual(self.instance.code_description_en, test_value)
     
@@ -75,7 +75,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = SeverityEnum.NONE
+        test_value = SeverityEnum.REFERENCE
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarning.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarning.py
@@ -10,6 +10,8 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_warning_producer_data.weatherwarning import WeatherWarning
 from jma_bosai_warning_producer_data.warningitem import WarningItem
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.eventenum import EventEnum
 import datetime
 
 
@@ -30,23 +32,42 @@ class Test_WeatherWarning(unittest.TestCase):
         Create instance of WeatherWarning for testing
         """
         instance = WeatherWarning(
-            office_code='mpqgrgufzcgweojbiwve',
-            area_code='fvyxbdkbqgxuoapyrqsu',
-            area_name='ayikcndysykmiwkfmwta',
+            prefecture='upcjoayxipqfvkuhbakt',
+            severity=SeverityEnum.REFERENCE,
+            office_code='nchjuxrjaywlkozcjabl',
+            area_code='atrbqtrtlmonivzyylup',
+            event=EventEnum.warning,
+            area_name='eydorkmolqbxhhujjqxh',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='kzdxnjwrnnfacuzbxvvn',
-            warnings=[None, None],
+            headline_text='tjcdtwhtabzasjzhqlbh',
+            warnings=[None],
             time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )
         return instance
 
     
+    def test_prefecture_property(self):
+        """
+        Test prefecture property
+        """
+        test_value = 'upcjoayxipqfvkuhbakt'
+        self.instance.prefecture = test_value
+        self.assertEqual(self.instance.prefecture, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.REFERENCE
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
     def test_office_code_property(self):
         """
         Test office_code property
         """
-        test_value = 'mpqgrgufzcgweojbiwve'
+        test_value = 'nchjuxrjaywlkozcjabl'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -54,15 +75,23 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'fvyxbdkbqgxuoapyrqsu'
+        test_value = 'atrbqtrtlmonivzyylup'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
+    
+    def test_event_property(self):
+        """
+        Test event property
+        """
+        test_value = EventEnum.warning
+        self.instance.event = test_value
+        self.assertEqual(self.instance.event, test_value)
     
     def test_area_name_property(self):
         """
         Test area_name property
         """
-        test_value = 'ayikcndysykmiwkfmwta'
+        test_value = 'eydorkmolqbxhhujjqxh'
         self.instance.area_name = test_value
         self.assertEqual(self.instance.area_name, test_value)
     
@@ -86,7 +115,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test headline_text property
         """
-        test_value = 'kzdxnjwrnnfacuzbxvvn'
+        test_value = 'tjcdtwhtabzasjzhqlbh'
         self.instance.headline_text = test_value
         self.assertEqual(self.instance.headline_text, test_value)
     
@@ -94,7 +123,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test warnings property
         """
-        test_value = [None, None]
+        test_value = [None]
         self.instance.warnings = test_value
         self.assertEqual(self.instance.warnings, test_value)
     

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_kafka_producer/src/jma_bosai_warning_producer_kafka_producer/producer.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_kafka_producer/src/jma_bosai_warning_producer_kafka_producer/producer.py
@@ -275,3 +275,151 @@ class JPJMATsunamiEventProducer:
             raise ValueError("Topic name not found in connection string")
         return cls(Producer(config), topic_name, content_mode)
 
+
+
+class JPJMAWarningMqttEventProducer:
+    def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
+        """
+        Initializes the Kafka producer
+
+        Args:
+            producer (Producer): The Kafka producer client
+            topic (str): The Kafka topic to send events to
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+        """
+        self.producer = producer
+        self.topic = topic
+        self.content_mode = content_mode
+
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
+        """
+        Maps a CloudEvent to a Kafka key
+
+        Args:
+            x (CloudEvent): The CloudEvent to map
+            m (Any): The event data
+            key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
+        """
+        if key_mapper:
+            return key_mapper(x, m)
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
+
+    def send_jp_jma_warning_mqtt_office(self,_feedurl : str, _office_code : str, _area_code : str, data: Office, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Office], str]=None) -> None:
+        """
+        Sends the 'JP.JMA.Warning.mqtt.Office' event to the Kafka topic
+
+        Args:
+            _feedurl(str):  Value for placeholder feedurl in attribute source
+            _office_code(str):  Value for placeholder office_code in attribute subject
+            _area_code(str):  Value for placeholder area_code in attribute subject
+            data: (Office): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, Office], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"JP.JMA.Warning.Office",
+             "source":"{feedurl}".format(feedurl = _feedurl),
+             "subject":"jp.jma.warning/{office_code}/{area_code}".format(office_code = _office_code,area_code = _area_code)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    def send_jp_jma_warning_mqtt_weather_warning(self,_feedurl : str, _office_code : str, _area_code : str, data: WeatherWarning, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, WeatherWarning], str]=None) -> None:
+        """
+        Sends the 'JP.JMA.Warning.mqtt.WeatherWarning' event to the Kafka topic
+
+        Args:
+            _feedurl(str):  Value for placeholder feedurl in attribute source
+            _office_code(str):  Value for placeholder office_code in attribute subject
+            _area_code(str):  Value for placeholder area_code in attribute subject
+            data: (WeatherWarning): The event data to be sent
+            content_type (str): The content type that the event data shall be sent with
+            flush_producer(bool): Whether to flush the producer after sending the event (default: True)
+            key_mapper(Callable[[CloudEvent, WeatherWarning], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        """
+        kafka_key = None
+        attributes = {
+             "type":"JP.JMA.Warning.WeatherWarning",
+             "source":"{feedurl}".format(feedurl = _feedurl),
+             "subject":"jp.jma.warning/{office_code}/{area_code}".format(office_code = _office_code,area_code = _area_code)
+        }
+        attributes["datacontenttype"] = content_type
+        event = CloudEvent.create(attributes, data)
+        if self.content_mode == "structured":
+            message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+            message.headers["content-type"] = b"application/cloudevents+json"
+        else:
+            # For binary mode, datacontenttype is already set in attributes above
+            # The to_binary() function will create the ce_datacontenttype header
+            message = to_binary(event, data_marshaller=lambda x: x.to_byte_array("application/json"), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
+        self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
+        if flush_producer:
+            self.producer.flush()
+
+
+    @classmethod
+    def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:
+        """
+        Parse the connection string and extract bootstrap server, topic name, username, and password.
+
+        Args:
+            connection_string (str): The connection string.
+
+        Returns:
+            Tuple[Dict[str, str], str]: Kafka config, topic name
+        """
+        config_dict = {
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanisms': 'PLAIN',
+            'sasl.username': '$ConnectionString',
+            'sasl.password': connection_string.strip()
+        }
+        kafka_topic = None
+        try:
+            for part in connection_string.split(';'):
+                if 'Endpoint' in part:
+                    config_dict['bootstrap.servers'] = part.split('=')[1].strip(
+                        '"').replace('sb://', '').replace('/', '')+':9093'
+                elif 'EntityPath' in part:
+                    kafka_topic = part.split('=')[1].strip('"')
+        except IndexError as e:
+            raise ValueError("Invalid connection string format") from e
+        return config_dict, kafka_topic
+
+    @classmethod
+    def from_connection_string(cls, connection_string: str, topic: typing.Optional[str]=None, content_mode: typing.Literal['structured','binary']='structured') -> 'JPJMAWarningMqttEventProducer':
+        """
+        Create a Kafka producer from a connection string and a topic name.
+
+        Args:
+            connection_string (str): The connection string.
+            topic (Optional[str]): The Kafka topic.
+            content_mode (typing.Literal['structured','binary']): The content mode to use for sending events
+
+        Returns:
+            Producer: The Kafka producer
+        """
+        config, topic_name = cls.parse_connection_string(connection_string)
+        if topic:
+            topic_name = topic
+        if not topic_name:
+            raise ValueError("Topic name not found in connection string")
+        return cls(Producer(config), topic_name, content_mode)
+

--- a/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_kafka_producer/tests/test_producer.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_kafka_producer/tests/test_producer.py
@@ -26,6 +26,7 @@ from test_jma_bosai_warning_producer_data_weatherwarning import Test_WeatherWarn
 from jma_bosai_warning_producer_kafka_producer.producer import JPJMATsunamiEventProducer
 from jma_bosai_warning_producer_data import TsunamiAlert
 from test_jma_bosai_warning_producer_data_tsunamialert import Test_TsunamiAlert
+from jma_bosai_warning_producer_kafka_producer.producer import JPJMAWarningMqttEventProducer
 
 @pytest.fixture(scope="module")
 def kafka_emulator():
@@ -245,6 +246,128 @@ def test_jp_jma_tsunami_jpjmatsunamitsunamialert(kafka_emulator):
         assert received_key is not None, f"Failed to receive message {i+1} of 5"
         expected_key = "jp.jma.tsunami/{event_id}/{serial}".format(event_id=f'test_{i}', serial=f'test_{i}')
         assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+    consumer.close()
+
+
+def test_jp_jma_warning_mqtt_jpjmawarningmqttoffice(kafka_emulator):
+    """Test the JPJMAWarningMqttOffice event from the JP.JMA.Warning.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_jp_jma_warning_mqtt_jpjmawarningmqttoffice',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "JP.JMA.Warning.mqtt.Office":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = JPJMAWarningMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_Office.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_jp_jma_warning_mqtt_office(_feedurl = f'test_{i}', _office_code = f'test_{i}', _area_code = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+    consumer.close()
+
+
+def test_jp_jma_warning_mqtt_jpjmawarningmqttweatherwarning(kafka_emulator):
+    """Test the JPJMAWarningMqttWeatherWarning event from the JP.JMA.Warning.Mqtt message group"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    producer = Producer({'bootstrap.servers': bootstrap_servers})
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_jp_jma_warning_mqtt_jpjmawarningmqttweatherwarning',  # Unique group per test
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([topic])
+    
+    # Wait for partition assignment before producing messages
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    
+    # Verify partition assignment succeeded
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    
+    # Give consumer time to stabilize and seek to beginning
+    time.sleep(1)
+
+    def on_event():
+        import time
+        timeout = time.time() + 20  # 20 second timeout for CI robustness
+        while True:
+            if time.time() > timeout:
+                return None
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                continue
+            cloudevent = parse_cloudevent(msg)
+            if cloudevent['type'] == "JP.JMA.Warning.mqtt.WeatherWarning":
+                return msg.key().decode('utf-8') if msg.key() else None
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = JPJMAWarningMqttEventProducer(kafka_producer, topic, 'binary')
+    # Create valid test data using the test helper
+    event_data = Test_WeatherWarning.create_instance()
+    
+    # Send 5 messages to test message settlement and ordering
+    for i in range(5):
+        producer_instance.send_jp_jma_warning_mqtt_weather_warning(_feedurl = f'test_{i}', _office_code = f'test_{i}', _area_code = f'test_{i}', data = event_data)
+    
+    # Flush producer to ensure messages are sent before consumer polling
+    kafka_producer.flush(timeout=5.0)
+
+    # Verify all 5 messages received and assert Kafka key
+    for i in range(5):
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
     consumer.close()
 
 

--- a/jma-bosai-warning/jma_bosai_warning_producer/samples/sample.py
+++ b/jma-bosai-warning/jma_bosai_warning_producer/samples/sample.py
@@ -34,6 +34,7 @@ from confluent_kafka import Producer as KafkaProducer
 
 from jma_bosai_warning_producer_kafka_producer.producer import JPJMAWarningEventProducer
 from jma_bosai_warning_producer_kafka_producer.producer import JPJMATsunamiEventProducer
+from jma_bosai_warning_producer_kafka_producer.producer import JPJMAWarningMqttEventProducer
 
 # imports for the data classes for each event
 
@@ -90,6 +91,30 @@ async def main(connection_string: Optional[str], producer_config: Optional[str],
     # sends the 'JP.JMA.Tsunami.TsunamiAlert' event to Kafka topic.
     await jpjmatsunami_event_producer.send_jp_jma_tsunami_tsunami_alert(_feedurl = 'TODO: replace me', _event_id = 'TODO: replace me', _serial = 'TODO: replace me', data = _tsunami_alert)
     print(f"Sent 'JP.JMA.Tsunami.TsunamiAlert' event: {_tsunami_alert.to_json()}")
+    if connection_string:
+        # use a connection string obtained for an Event Stream from the Microsoft Fabric portal
+        # or an Azure Event Hubs connection string
+        jpjmawarning_mqtt_event_producer = JPJMAWarningMqttEventProducer.from_connection_string(connection_string, topic, 'binary')
+    else:
+        # use a Kafka producer configuration provided as JSON text
+        kafka_producer = KafkaProducer(json.loads(producer_config))
+        jpjmawarning_mqtt_event_producer = JPJMAWarningMqttEventProducer(kafka_producer, topic, 'binary')
+
+    # ---- JP.JMA.Warning.mqtt.Office ----
+    # TODO: Supply event data for the JP.JMA.Warning.mqtt.Office event
+    _office = Office()
+
+    # sends the 'JP.JMA.Warning.mqtt.Office' event to Kafka topic.
+    await jpjmawarning_mqtt_event_producer.send_jp_jma_warning_mqtt_office(_feedurl = 'TODO: replace me', _office_code = 'TODO: replace me', _area_code = 'TODO: replace me', data = _office)
+    print(f"Sent 'JP.JMA.Warning.mqtt.Office' event: {_office.to_json()}")
+
+    # ---- JP.JMA.Warning.mqtt.WeatherWarning ----
+    # TODO: Supply event data for the JP.JMA.Warning.mqtt.WeatherWarning event
+    _weather_warning = WeatherWarning()
+
+    # sends the 'JP.JMA.Warning.mqtt.WeatherWarning' event to Kafka topic.
+    await jpjmawarning_mqtt_event_producer.send_jp_jma_warning_mqtt_weather_warning(_feedurl = 'TODO: replace me', _office_code = 'TODO: replace me', _area_code = 'TODO: replace me', data = _weather_warning)
+    print(f"Sent 'JP.JMA.Warning.mqtt.WeatherWarning' event: {_weather_warning.to_json()}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Kafka Producer")

--- a/jma-bosai-warning/pyproject.toml
+++ b/jma-bosai-warning/pyproject.toml
@@ -17,8 +17,11 @@ confluent-kafka = ">=2.5.3"
 cloudevents = ">=1.11.0,<2.0.0"
 dataclasses_json = ">=0.6.7"
 avro = ">=1.11.3"
+paho-mqtt = ">=2.1.0"
 jma_bosai_warning_producer_data = {path = "jma_bosai_warning_producer/jma_bosai_warning_producer_data"}
 jma_bosai_warning_producer_kafka_producer = {path = "jma_bosai_warning_producer/jma_bosai_warning_producer_kafka_producer"}
+jma_bosai_warning_mqtt_producer_data = {path = "jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data"}
+jma_bosai_warning_mqtt_producer_mqtt_client = {path = "jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client"}
 
 [tool.poetry.dev-dependencies]
 pytest = ">=9.0.3"

--- a/jma-bosai-warning/tests/test_unit.py
+++ b/jma-bosai-warning/tests/test_unit.py
@@ -7,6 +7,7 @@ from jma_bosai_warning.jma_bosai_warning import (
     jst_to_utc,
     parse_tsunami_alert,
     parse_weather_warning_payload,
+    prefecture_for_office,
     status_to_severity,
 )
 
@@ -75,6 +76,12 @@ def test_jst_to_utc_conversion():
     assert jst_to_utc("2026-05-21T04:02:00+09:00") == "2026-05-20T19:02:00Z"
 
 
+def test_prefecture_for_office_uses_ascii_romanized_axis():
+    assert prefecture_for_office("130000", "東京都") == "tokyo"
+    assert prefecture_for_office("270000", "大阪府") == "osaka"
+    assert prefecture_for_office("471000", "沖縄本島地方") == "okinawa"
+
+
 @pytest.mark.parametrize(
     ("status", "code", "severity"),
     [("注意報", "10", "ADVISORY"), ("警報", "03", "WARNING"), ("特別警報", "32", "EMERGENCY_WARNING"), ("継続", "38", "EMERGENCY_WARNING"), ("発表警報・注意報はなし", None, "NONE")],
@@ -103,6 +110,9 @@ def test_warning_fixture_parsing():
     records = parse_weather_warning_payload("130000", warning_fixture())
     assert len(records) == 1
     record = records[0]
+    assert record["prefecture"] == "tokyo"
+    assert record["severity"] == "EMERGENCY_WARNING"
+    assert record["event"] == "warning"
     assert record["office_code"] == "130000"
     assert record["area_code"] == "1310100"
     assert record["report_datetime"] == "2026-05-20T19:02:00Z"
@@ -191,7 +201,11 @@ def test_reference_refresh_failure_keeps_cached_catalog():
     api.area_catalog = {"offices": {"130000": {"name": "東京都", "enName": "Tokyo", "parent": "010300"}}}
     api.fetch_area_catalog = lambda: (_ for _ in ()).throw(RuntimeError("timeout"))
     assert api.refresh_area_catalog() is False
-    assert api.office_records()[0]["office_code"] == "130000"
+    office = api.office_records()[0]
+    assert office["office_code"] == "130000"
+    assert office["prefecture"] == "tokyo"
+    assert office["severity"] == "REFERENCE"
+    assert office["event"] == "office"
 
 
 def test_one_failed_office_does_not_abort_cycle():

--- a/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
+++ b/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
@@ -41,6 +41,25 @@
       "messagegroups": [
         "#/messagegroups/JP.JMA.Tsunami"
       ]
+    },
+    "JP.JMA.Warning.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "messagegroups": [
+        "#/messagegroups/JP.JMA.Warning.mqtt"
+      ],
+      "deployed": false,
+      "endpoints": [
+        {
+          "uri": "mqtt://localhost:1883"
+        }
+      ]
     }
   },
   "messagegroups": {
@@ -111,6 +130,31 @@
           "dataschemauri": "#/schemagroups/JP.JMA.Tsunami.jstruct/schemas/JP.JMA.Tsunami.TsunamiAlert"
         }
       }
+    },
+    "JP.JMA.Warning.mqtt": {
+      "description": "MQTT/5.0 transport variant for JMA Bosai weather warnings. Retained QoS-1 office reference records and non-retained QoS-1 warning events route by Romanized prefecture, severity, issuing office code, forecast area code, and fixed event name under alerts/jp/jma/jma-bosai-warning/... so wildcard subscribers can follow one prefecture, severity, office, or area without parsing Japanese administrative names.",
+      "messages": {
+        "JP.JMA.Warning.mqtt.Office": {
+          "name": "Office",
+          "basemessageurl": "/messagegroups/JP.JMA.Warning/messages/JP.JMA.Warning.Office",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "JP.JMA.Warning.mqtt.WeatherWarning": {
+          "name": "WeatherWarning",
+          "basemessageurl": "/messagegroups/JP.JMA.Warning/messages/JP.JMA.Warning.WeatherWarning",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/{event}",
+            "qos": 1,
+            "retain": false
+          }
+        }
+      }
     }
   },
   "schemagroups": {
@@ -167,6 +211,29 @@
                       "SUBREGION",
                       "OFFICE"
                     ]
+                  },
+                  "prefecture": {
+                    "type": "string",
+                    "description": "ASCII-safe Romanized prefecture or JMA warning subregion slug derived from the JMA office code/name for MQTT topic routing. Japanese administrative names are preserved separately in name_jp/area_name.",
+                    "pattern": "^[a-z0-9][a-z0-9-]*$"
+                  },
+                  "severity": {
+                    "type": "string",
+                    "description": "MQTT topic severity axis. Office REFERENCE records emit REFERENCE; weather warning records emit the highest normalized active warning severity.",
+                    "enum": [
+                      "REFERENCE",
+                      "NONE",
+                      "ADVISORY",
+                      "WARNING",
+                      "EMERGENCY_WARNING"
+                    ]
+                  },
+                  "event": {
+                    "type": "string",
+                    "description": "Fixed MQTT topic event segment for retained office reference records.",
+                    "enum": [
+                      "office"
+                    ]
                   }
                 },
                 "required": [
@@ -175,7 +242,10 @@
                   "name_jp",
                   "name_en",
                   "parent_office_code",
-                  "office_type"
+                  "office_type",
+                  "prefecture",
+                  "severity",
+                  "event"
                 ]
               }
             }
@@ -195,6 +265,22 @@
                 "type": "object",
                 "description": "JMA Bosai weather warning/advisory state for one office targetArea and one inner forecast area. The bridge emits one record per (office_code, area_code, report_datetime) change and includes all warning items currently published for that area.",
                 "properties": {
+                  "prefecture": {
+                    "type": "string",
+                    "description": "ASCII-safe Romanized prefecture or JMA warning subregion slug derived from the JMA office code/name for MQTT topic routing. Japanese administrative names are preserved separately in name_jp/area_name.",
+                    "pattern": "^[a-z0-9][a-z0-9-]*$"
+                  },
+                  "severity": {
+                    "type": "string",
+                    "description": "MQTT topic severity axis. Weather warning records emit the highest normalized warning severity present in the area bulletin; retained office REFERENCE records use REFERENCE on the same shared axis.",
+                    "enum": [
+                      "REFERENCE",
+                      "NONE",
+                      "ADVISORY",
+                      "WARNING",
+                      "EMERGENCY_WARNING"
+                    ]
+                  },
                   "office_code": {
                     "type": "string",
                     "description": "Six-digit JMA Bosai office targetArea code used in the warning/{office_code}.json endpoint. This is the first stable key component.",
@@ -210,6 +296,13 @@
                     "altnames": {
                       "jma-bosai": "timeSeries[].areas[].code"
                     }
+                  },
+                  "event": {
+                    "type": "string",
+                    "description": "Fixed MQTT topic event segment for JMA Bosai weather warning state records.",
+                    "enum": [
+                      "warning"
+                    ]
                   },
                   "area_name": {
                     "type": "string",
@@ -395,6 +488,7 @@
                   }
                 },
                 "required": [
+                  "prefecture",
                   "office_code",
                   "area_code",
                   "area_name",
@@ -402,7 +496,9 @@
                   "report_datetime_local",
                   "headline_text",
                   "warnings",
-                  "time_defines"
+                  "time_defines",
+                  "severity",
+                  "event"
                 ]
               }
             }


### PR DESCRIPTION
## Summary
- adds MQTT/5.0 xRegistry endpoint/messagegroup for JMA Bosai warning office references and weather warning events
- derives Romanized ASCII prefecture routing fields and fixed event segments
- adds generated MQTT client, MQTT feeder package, Dockerfile.mqtt, and docs

## Topic tree
- retained QoS 1: alerts/jp/jma/jma-bosai-warning/{prefecture}/REFERENCE/{office_code}/{area_code}/office
- non-retained QoS 1: alerts/jp/jma/jma-bosai-warning/{prefecture}/{severity}/{office_code}/{area_code}/warning

## Specialist reviews
- xRegistry Expert: CLEAN
- UNS Catalog Architect: CLEAN

## Validation
- python -m pytest tests -q
- python -m pytest jma_bosai_warning_mqtt_producer\\jma_bosai_warning_mqtt_producer_data\\tests -q
- python -m compileall -q jma_bosai_warning jma_bosai_warning_mqtt jma_bosai_warning_mqtt_producer