### PR TITLE
docs(xreg): improve descriptions — batch A hydro/water

### DIFF
--- a/bafu-hydro/EVENTS.md
+++ b/bafu-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # BAFU Hydrology Bridge Usage Guide Events
 
-MQTT/5.0 transport variants of the BAFU Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/ch/bafu/bafu-hydro/{water_body_name}/{station_id}/... The {water_body_name} placeholder is sourced from the upstream existenz.ch station catalog (BAFU/FOEN field 'water-body-name', e.g. 'Rhein', 'Aare') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers / lakes (e.g. hydro/ch/bafu/bafu-hydro/rhein/+/water-level).
+BAFU Hydrology publishes water level, discharge, and water temperature observations from the Swiss Federal Office for the Environment (BAFU/FOEN) for Swiss river, lake, and stream gauges. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `CH.BAFU.Hydrology.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Swiss river, lake, and stream gauge published by the Swiss Federal Office for the Environment (BAFU/FOEN). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the BAFU Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,12 +69,12 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `name`, `latitude`, `longitude`.
 
-- **`station_id`** (string, required): No description provided.
-- **`name`** (string, required): No description provided.
-- **`water_body_name`** (string, optional): No description provided.
-- **`water_body_type`** (string, optional): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`name`** (string, required): Human-readable name of the station, site, or location.
+- **`water_body_name`** (string, optional): Name of the river, lake, canal, reservoir, or other water body observed at the station.
+- **`water_body_type`** (string, optional): Provider classification for the observed water body.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -100,11 +100,11 @@ CloudEvents type: `CH.BAFU.Hydrology.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Swiss Federal Office for the Environment (BAFU/FOEN) for one monitoring site. It carries water level, discharge, and water temperature observations when the upstream feed reports a new or refreshed value. Measurement payload for water level, discharge, and water temperature observations in the BAFU Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -117,17 +117,17 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`, `water_body_name`.
 
-- **`station_id`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
 - **`water_body_name`** (string, required): Name of the water body the station observes (BAFU/FOEN 'water-body-name' field, e.g. 'Rhein', 'Aare', 'Bodensee'). Sourced by the bridge from the station catalog (existenz.ch /apiv1/hydro/locations endpoint, details.water-body-name) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river / lake. Used as the {water_body_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.
-- **`water_level`** (double, optional): No description provided.
-- **`water_level_unit`** (string, optional): No description provided.
-- **`water_level_timestamp`** (datetime, optional): No description provided.
-- **`discharge`** (double, optional): No description provided.
-- **`discharge_unit`** (string, optional): No description provided.
-- **`discharge_timestamp`** (datetime, optional): No description provided.
-- **`water_temperature`** (double, optional): No description provided.
-- **`water_temperature_unit`** (string, optional): No description provided.
-- **`water_temperature_timestamp`** (datetime, optional): No description provided.
+- **`water_level`** (double, optional): Current water level reported for the station.
+- **`water_level_unit`** (string, optional): Unit used for the water-level value.
+- **`water_level_timestamp`** (datetime, optional): Time associated with the water-level measurement.
+- **`discharge`** (double, optional): Current streamflow or discharge reported for the station.
+- **`discharge_unit`** (string, optional): Unit used for the discharge value.
+- **`discharge_timestamp`** (datetime, optional): Time associated with the discharge measurement.
+- **`water_temperature`** (double, optional): Current water temperature reported for the station.
+- **`water_temperature_unit`** (string, optional): Unit used for the water-temperature value.
+- **`water_temperature_timestamp`** (datetime, optional): Time associated with the water-temperature measurement.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/bafu-hydro/xreg/bafu_hydro.xreg.json
+++ b/bafu-hydro/xreg/bafu_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/CH.BAFU.Hydrology"
-      ]
+      ],
+      "description": "Kafka producer endpoint for BAFU Hydrology CloudEvents on the `bafu-hydro` topic keyed by `{station_id}`."
     },
     "CH.BAFU.Hydrology.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/CH.BAFU.Hydrology.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for BAFU Hydrology CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CH.BAFU.Hydrology.jstruct/schemas/CH.BAFU.Hydrology.Station"
+          "dataschemauri": "#/schemagroups/CH.BAFU.Hydrology.jstruct/schemas/CH.BAFU.Hydrology.Station",
+          "description": "A reference record for one Swiss river, lake, and stream gauge published by the Swiss Federal Office for the Environment (BAFU/FOEN). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "CH.BAFU.Hydrology.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CH.BAFU.Hydrology.jstruct/schemas/CH.BAFU.Hydrology.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/CH.BAFU.Hydrology.jstruct/schemas/CH.BAFU.Hydrology.WaterLevelObservation",
+          "description": "A current measurement from the Swiss Federal Office for the Environment (BAFU/FOEN) for one monitoring site. It carries water level, discharge, and water temperature observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from BAFU Hydrology covering Swiss river, lake, and stream gauges and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "CH.BAFU.Hydrology.mqtt": {
-      "description": "MQTT/5.0 transport variants of the BAFU Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/ch/bafu/bafu-hydro/{water_body_name}/{station_id}/... The {water_body_name} placeholder is sourced from the upstream existenz.ch station catalog (BAFU/FOEN field 'water-body-name', e.g. 'Rhein', 'Aare') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers / lakes (e.g. hydro/ch/bafu/bafu-hydro/rhein/+/water-level).",
+      "description": "MQTT 5 variant of the BAFU Hydrology events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "CH.BAFU.Hydrology.mqtt.Station": {
           "name": "Station",
@@ -132,26 +137,32 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the station, site, or location."
                   },
                   "water_body_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the river, lake, canal, reservoir, or other water body observed at the station."
                   },
                   "water_body_type": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider classification for the observed water body."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   }
                 },
                 "$id": "https://example.com/schemas/CH/BAFU/Hydrology/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the BAFU Hydrology source."
               }
             }
           }
@@ -173,42 +184,52 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "water_body_name": {
                     "type": "string",
                     "description": "Name of the water body the station observes (BAFU/FOEN 'water-body-name' field, e.g. 'Rhein', 'Aare', 'Bodensee'). Sourced by the bridge from the station catalog (existenz.ch /apiv1/hydro/locations endpoint, details.water-body-name) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river / lake. Used as the {water_body_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "water_level": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current water level reported for the station."
                   },
                   "water_level_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the water-level value."
                   },
                   "water_level_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the water-level measurement."
                   },
                   "discharge": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the discharge value."
                   },
                   "discharge_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the discharge measurement."
                   },
                   "water_temperature": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current water temperature reported for the station."
                   },
                   "water_temperature_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the water-temperature value."
                   },
                   "water_temperature_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the water-temperature measurement."
                   }
                 },
                 "$id": "https://example.com/schemas/CH/BAFU/Hydrology/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level, discharge, and water temperature observations in the BAFU Hydrology source."
               }
             }
           }
@@ -227,7 +248,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the BAFU Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -262,7 +283,8 @@
                     "type": "double"
                   }
                 ],
-                "namespace": "CH.BAFU.Hydrology"
+                "namespace": "CH.BAFU.Hydrology",
+                "description": "Reference details for one monitoring station or site in the BAFU Hydrology source."
               }
             }
           }
@@ -277,7 +299,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the BAFU Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -370,12 +392,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "CH.BAFU.Hydrology"
+                "namespace": "CH.BAFU.Hydrology",
+                "description": "Measurement payload for observations in the BAFU Hydrology source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "BAFU Hydrology publishes water level, discharge, and water temperature observations from the Swiss Federal Office for the Environment (BAFU/FOEN) for Swiss river, lake, and stream gauges. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for BAFU Hydrology, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/canada-eccc-wateroffice/EVENTS.md
+++ b/canada-eccc-wateroffice/EVENTS.md
@@ -1,6 +1,6 @@
 # Canada ECCC Water Office Hydrometric Bridge Events
 
-Real-time hydrometric data from [Environment and Climate Change Canada (ECCC) Water Survey of Canada](https://wateroffice.ec.gc.ca/) bridged to Apache Kafka as CloudEvents.
+ECCC Water Office publishes real-time water level and flow observations from Environment and Climate Change Canada Water Survey of Canada for Canadian hydrometric stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `CA.Gov.ECCC.Hydro.Station`
 
 #### What it tells you
 
-Reference data for a Water Survey of Canada hydrometric monitoring station from the ECCC OGC API hydrometric-stations collection.
+A reference record for one Canadian hydrometric station published by Environment and Climate Change Canada Water Survey of Canada. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference data for a Water Survey of Canada hydrometric monitoring station from the ECCC OGC API hydrometric-stations collection.
 
 #### Identity
 
@@ -95,7 +95,7 @@ CloudEvents type: `CA.Gov.ECCC.Hydro.Observation`
 
 #### What it tells you
 
-Real-time hydrometric observation from the ECCC OGC API hydrometric-realtime collection. Data are provisional and updated approximately every 5 minutes.
+A current measurement from Environment and Climate Change Canada Water Survey of Canada for one monitoring site. It carries real-time water level and flow observations when the upstream feed reports a new or refreshed value. Real-time hydrometric observation from the ECCC OGC API hydrometric-realtime collection.
 
 #### Identity
 

--- a/canada-eccc-wateroffice/xreg/canada-eccc-wateroffice.xreg.json
+++ b/canada-eccc-wateroffice/xreg/canada-eccc-wateroffice.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/CA.Gov.ECCC.Hydro"
-      ]
+      ],
+      "description": "Kafka producer endpoint for ECCC Water Office CloudEvents on the `canada-eccc-wateroffice` topic keyed by `stations/{station_number}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Hydro.jstruct/schemas/CA.Gov.ECCC.Hydro.Station"
+          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Hydro.jstruct/schemas/CA.Gov.ECCC.Hydro.Station",
+          "description": "A reference record for one Canadian hydrometric station published by Environment and Climate Change Canada Water Survey of Canada. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "CA.Gov.ECCC.Hydro.Observation": {
           "name": "Observation",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Hydro.jstruct/schemas/CA.Gov.ECCC.Hydro.Observation"
+          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Hydro.jstruct/schemas/CA.Gov.ECCC.Hydro.Observation",
+          "description": "A current measurement from Environment and Climate Change Canada Water Survey of Canada for one monitoring site. It carries real-time water level and flow observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from ECCC Water Office covering Canadian hydrometric stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -89,60 +93,102 @@
                   "station_number": {
                     "type": "string",
                     "description": "Unique WSC station identifier following the scheme 2-digit major drainage area + letter + station digits, e.g. '05BJ004'. Upstream field: STATION_NUMBER.",
-                    "altnames": ["STATION_NUMBER"]
+                    "altnames": [
+                      "STATION_NUMBER"
+                    ]
                   },
                   "station_name": {
                     "type": "string",
                     "description": "Official name of the hydrometric station, e.g. 'ELBOW RIVER AT BRAGG CREEK'. Upstream field: STATION_NAME.",
-                    "altnames": ["STATION_NAME"]
+                    "altnames": [
+                      "STATION_NAME"
+                    ]
                   },
                   "prov_terr_state_loc": {
                     "type": "string",
                     "description": "Two-letter province, territory or state location code where the station is situated, e.g. 'AB' for Alberta. Upstream field: PROV_TERR_STATE_LOC.",
-                    "altnames": ["PROV_TERR_STATE_LOC"]
+                    "altnames": [
+                      "PROV_TERR_STATE_LOC"
+                    ]
                   },
                   "status_en": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Operational status of the station in English, e.g. 'Active', 'Discontinued'. Upstream field: STATUS_EN.",
-                    "altnames": ["STATUS_EN"]
+                    "altnames": [
+                      "STATUS_EN"
+                    ]
                   },
                   "contributor_en": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the contributing agency responsible for operating this station in English, e.g. 'Water Survey of Canada'. Upstream field: CONTRIBUTOR_EN.",
-                    "altnames": ["CONTRIBUTOR_EN"]
+                    "altnames": [
+                      "CONTRIBUTOR_EN"
+                    ]
                   },
                   "drainage_area_gross": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Gross drainage area of the watershed upstream of this station in square kilometres. Upstream field: DRAINAGE_AREA_GROSS.",
-                    "altnames": ["DRAINAGE_AREA_GROSS"],
+                    "altnames": [
+                      "DRAINAGE_AREA_GROSS"
+                    ],
                     "unit": "square kilometre",
                     "symbol": "km²"
                   },
                   "drainage_area_effect": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Effective (contributing) drainage area of the watershed upstream of this station in square kilometres, excluding non-contributing areas. Upstream field: DRAINAGE_AREA_EFFECT.",
-                    "altnames": ["DRAINAGE_AREA_EFFECT"],
+                    "altnames": [
+                      "DRAINAGE_AREA_EFFECT"
+                    ],
                     "unit": "square kilometre",
                     "symbol": "km²"
                   },
                   "rhbn": {
-                    "type": ["boolean", "null"],
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
                     "description": "Indicates whether the station is part of the Reference Hydrometric Basin Network (RHBN), a subset of hydrologically stable, minimally disturbed basins used for climate change studies. Upstream field: RHBN.",
-                    "altnames": ["RHBN"]
+                    "altnames": [
+                      "RHBN"
+                    ]
                   },
                   "real_time": {
-                    "type": ["boolean", "null"],
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
                     "description": "Indicates whether real-time data are available for this station via the WSC real-time data service. Upstream field: REAL_TIME.",
-                    "altnames": ["REAL_TIME"]
+                    "altnames": [
+                      "REAL_TIME"
+                    ]
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geographic latitude of the station in decimal degrees (WGS84), derived from the GeoJSON geometry coordinates.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geographic longitude of the station in decimal degrees (WGS84), derived from the GeoJSON geometry coordinates.",
                     "unit": "degree",
                     "symbol": "°"
@@ -176,50 +222,76 @@
                   "station_number": {
                     "type": "string",
                     "description": "Unique WSC station identifier, e.g. '05BJ004'. Upstream field: STATION_NUMBER.",
-                    "altnames": ["STATION_NUMBER"]
+                    "altnames": [
+                      "STATION_NUMBER"
+                    ]
                   },
                   "identifier": {
                     "type": "string",
                     "description": "Unique observation identifier composed of station number and ISO 8601 observation datetime, e.g. '05BJ004.2026-03-07T07:00:00Z'. Upstream field: IDENTIFIER.",
-                    "altnames": ["IDENTIFIER"]
+                    "altnames": [
+                      "IDENTIFIER"
+                    ]
                   },
                   "station_name": {
                     "type": "string",
                     "description": "Official name of the hydrometric station. Upstream field: STATION_NAME.",
-                    "altnames": ["STATION_NAME"]
+                    "altnames": [
+                      "STATION_NAME"
+                    ]
                   },
                   "prov_terr_state_loc": {
                     "type": "string",
                     "description": "Two-letter province, territory or state location code. Upstream field: PROV_TERR_STATE_LOC.",
-                    "altnames": ["PROV_TERR_STATE_LOC"]
+                    "altnames": [
+                      "PROV_TERR_STATE_LOC"
+                    ]
                   },
                   "observation_datetime": {
                     "type": "datetime",
                     "description": "Timestamp of the observation in UTC. Upstream field: DATETIME.",
-                    "altnames": ["DATETIME"]
+                    "altnames": [
+                      "DATETIME"
+                    ]
                   },
                   "level": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Water level at the station gauge in metres above the station datum. Null when not measured or unavailable. Upstream field: LEVEL.",
-                    "altnames": ["LEVEL"],
+                    "altnames": [
+                      "LEVEL"
+                    ],
                     "unit": "metre",
                     "symbol": "m"
                   },
                   "discharge": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Water discharge (flow rate) at the station in cubic metres per second. Null when not measured or unavailable. Upstream field: DISCHARGE.",
-                    "altnames": ["DISCHARGE"],
+                    "altnames": [
+                      "DISCHARGE"
+                    ],
                     "unit": "cubic metre per second",
                     "symbol": "m³/s"
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geographic latitude of the station in decimal degrees (WGS84), derived from the GeoJSON geometry coordinates.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Geographic longitude of the station in decimal degrees (WGS84), derived from the GeoJSON geometry coordinates.",
                     "unit": "degree",
                     "symbol": "°"
@@ -263,53 +335,78 @@
                   },
                   {
                     "name": "status_en",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "default": null,
                     "doc": "Operational status of the station in English. Upstream field: STATUS_EN."
                   },
                   {
                     "name": "contributor_en",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "default": null,
                     "doc": "Name of the contributing agency in English. Upstream field: CONTRIBUTOR_EN."
                   },
                   {
                     "name": "drainage_area_gross",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Gross drainage area in km². Upstream field: DRAINAGE_AREA_GROSS."
                   },
                   {
                     "name": "drainage_area_effect",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Effective drainage area in km². Upstream field: DRAINAGE_AREA_EFFECT."
                   },
                   {
                     "name": "rhbn",
-                    "type": ["null", "boolean"],
+                    "type": [
+                      "null",
+                      "boolean"
+                    ],
                     "default": null,
                     "doc": "Part of the Reference Hydrometric Basin Network. Upstream field: RHBN."
                   },
                   {
                     "name": "real_time",
-                    "type": ["null", "boolean"],
+                    "type": [
+                      "null",
+                      "boolean"
+                    ],
                     "default": null,
                     "doc": "Real-time data availability flag. Upstream field: REAL_TIME."
                   },
                   {
                     "name": "latitude",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Station latitude in decimal degrees (WGS84)."
                   },
                   {
                     "name": "longitude",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Station longitude in decimal degrees (WGS84)."
                   }
-                ]
+                ],
+                "description": "Reference details for one monitoring station or site in the ECCC Water Office source."
               }
             }
           }
@@ -357,34 +454,52 @@
                   },
                   {
                     "name": "level",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Water level in metres. Upstream field: LEVEL."
                   },
                   {
                     "name": "discharge",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Discharge in m³/s. Upstream field: DISCHARGE."
                   },
                   {
                     "name": "latitude",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Station latitude in decimal degrees (WGS84)."
                   },
                   {
                     "name": "longitude",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
                     "doc": "Station longitude in decimal degrees (WGS84)."
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the ECCC Water Office source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "ECCC Water Office publishes real-time water level and flow observations from Environment and Climate Change Canada Water Survey of Canada for Canadian hydrometric stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for ECCC Water Office, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/cdec-reservoirs/EVENTS.md
+++ b/cdec-reservoirs/EVENTS.md
@@ -1,6 +1,6 @@
 # CDEC California Reservoirs Bridge Events
 
-This source bridges real-time reservoir data from the California Data Exchange Center (CDEC) to Apache Kafka, Azure Event Hubs, or Fabric Event Streams.
+CDEC California Reservoirs publishes reservoir storage and elevation observations from the California Data Exchange Center (CDEC) for California reservoirs. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -37,7 +37,7 @@ CloudEvents type: `gov.ca.water.cdec.ReservoirReading`
 
 #### What it tells you
 
-A single sensor reading from a CDEC reservoir station, representing an hourly (or sub-hourly) observation of storage, elevation, inflow, outflow, or river stage. Each reading corresponds to one station/sensor/timestamp combination as reported by the California Data Exchange Center JSON Data Servlet. A single sensor reading from a CDEC reservoir station.
+A current reservoir record from the California Data Exchange Center (CDEC). It reports the latest storage, elevation, capacity, or related reservoir status available for one reservoir. A single sensor reading from a CDEC reservoir station.
 
 #### Identity
 

--- a/cdec-reservoirs/xreg/cdec_reservoirs.xreg.json
+++ b/cdec-reservoirs/xreg/cdec_reservoirs.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/gov.ca.water.cdec"
-      ]
+      ],
+      "description": "Kafka producer endpoint for CDEC California Reservoirs CloudEvents on the `cdec-reservoirs` topic keyed by `{station_id}/{sensor_num}`."
     }
   },
   "messagegroups": {
@@ -28,7 +29,7 @@
         "gov.ca.water.cdec.ReservoirReading": {
           "name": "ReservoirReading",
           "envelope": "CloudEvents/1.0",
-          "description": "A single sensor reading from a CDEC reservoir station, representing an hourly (or sub-hourly) observation of storage, elevation, inflow, outflow, or river stage. Each reading corresponds to one station/sensor/timestamp combination as reported by the California Data Exchange Center JSON Data Servlet.",
+          "description": "A current reservoir record from the California Data Exchange Center (CDEC). It reports the latest storage, elevation, capacity, or related reservoir status available for one reservoir.",
           "envelopemetadata": {
             "type": {
               "value": "gov.ca.water.cdec.ReservoirReading"
@@ -45,7 +46,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/gov.ca.water.cdec.jstruct/schemas/gov.ca.water.cdec.ReservoirReading"
         }
-      }
+      },
+      "description": "Events from CDEC California Reservoirs covering California reservoirs and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -124,7 +126,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reservoir status record from the CDEC California Reservoirs source."
               }
             }
           }
@@ -186,7 +189,8 @@
                     "type": "string",
                     "doc": "Quality flag character applied to the observation by CDEC. A single space ' ' means no flag (normal data). Other values indicate provisional, edited, or suspect data."
                   }
-                ]
+                ],
+                "description": "Reservoir status record from the CDEC California Reservoirs source."
               }
             }
           },
@@ -194,5 +198,10 @@
         }
       }
     }
+  },
+  "description": "CDEC California Reservoirs publishes reservoir storage and elevation observations from the California Data Exchange Center (CDEC) for California reservoirs. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for CDEC California Reservoirs, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/chmi-hydro/EVENTS.md
+++ b/chmi-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # ČHMÚ Hydrological Data Bridge Events
 
-MQTT/5.0 transport variants of the CHMI Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/cz/chmi/chmi-hydro/{stream_name}/{station_id}/... The {stream_name} placeholder is sourced from the CHMI hydrology catalog (Czech: 'tok', e.g. 'Vltava', 'Labe', 'Morava') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/cz/chmi/chmi-hydro/vltava/+/water-level).
+ČHMÚ Hydrological Data publishes water level and discharge observations from the Czech Hydrometeorological Institute (ČHMÚ) for Czech hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `CZ.Gov.CHMI.Hydro.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Czech hydrological monitoring station published by the Czech Hydrometeorological Institute (ČHMÚ). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the ČHMÚ Hydrological Data source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,17 +69,17 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `station_name`, `stream_name`, `latitude`, `longitude`.
 
-- **`station_id`** (string, required): No description provided.
-- **`dbc`** (string or null, optional): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`stream_name`** (string, required): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`flood_level_1`** (double or null, optional): No description provided.
-- **`flood_level_2`** (double or null, optional): No description provided.
-- **`flood_level_3`** (double or null, optional): No description provided.
-- **`flood_level_4`** (double or null, optional): No description provided.
-- **`has_forecast`** (boolean or null, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`dbc`** (string or null, optional): Provider-supplied dbc value for this record.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`stream_name`** (string, required): Human-readable name of the stream.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
+- **`flood_level_1`** (double or null, optional): Provider-supplied flood level 1 value for this record.
+- **`flood_level_2`** (double or null, optional): Provider-supplied flood level 2 value for this record.
+- **`flood_level_3`** (double or null, optional): Provider-supplied flood level 3 value for this record.
+- **`flood_level_4`** (double or null, optional): Provider-supplied flood level 4 value for this record.
+- **`has_forecast`** (boolean or null, optional): Provider-supplied has forecast value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -110,11 +110,11 @@ CloudEvents type: `CZ.Gov.CHMI.Hydro.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Czech Hydrometeorological Institute (ČHMÚ) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water level and discharge observations in the ČHMÚ Hydrological Data source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -127,15 +127,15 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`, `station_name`, `stream_name`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
 - **`stream_name`** (string, required): Name of the watercourse / stream the station observes (Czech: 'tok', e.g. 'Vltava', 'Labe', 'Morava'). Sourced by the bridge from the CHMI hydrology station catalog and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {stream_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.
-- **`water_level`** (double or null, optional): No description provided.
-- **`water_level_timestamp`** (datetime or null, optional): No description provided.
-- **`discharge`** (double or null, optional): No description provided.
-- **`discharge_timestamp`** (datetime or null, optional): No description provided.
-- **`water_temperature`** (double or null, optional): No description provided.
-- **`water_temperature_timestamp`** (datetime or null, optional): No description provided.
+- **`water_level`** (double or null, optional): Current water level reported for the station.
+- **`water_level_timestamp`** (datetime or null, optional): Time associated with the water-level measurement.
+- **`discharge`** (double or null, optional): Current streamflow or discharge reported for the station.
+- **`discharge_timestamp`** (datetime or null, optional): Time associated with the discharge measurement.
+- **`water_temperature`** (double or null, optional): Current water temperature reported for the station.
+- **`water_temperature_timestamp`** (datetime or null, optional): Time associated with the water-temperature measurement.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/chmi-hydro/xreg/chmi_hydro.xreg.json
+++ b/chmi-hydro/xreg/chmi_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/CZ.Gov.CHMI.Hydro"
-      ]
+      ],
+      "description": "Kafka producer endpoint for ČHMÚ Hydrological Data CloudEvents on the `chmi-hydro` topic keyed by `{station_id}`."
     },
     "CZ.Gov.CHMI.Hydro.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/CZ.Gov.CHMI.Hydro.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for ČHMÚ Hydrological Data CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CZ.Gov.CHMI.Hydro.jstruct/schemas/CZ.Gov.CHMI.Hydro.Station"
+          "dataschemauri": "#/schemagroups/CZ.Gov.CHMI.Hydro.jstruct/schemas/CZ.Gov.CHMI.Hydro.Station",
+          "description": "A reference record for one Czech hydrological monitoring station published by the Czech Hydrometeorological Institute (ČHMÚ). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "CZ.Gov.CHMI.Hydro.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CZ.Gov.CHMI.Hydro.jstruct/schemas/CZ.Gov.CHMI.Hydro.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/CZ.Gov.CHMI.Hydro.jstruct/schemas/CZ.Gov.CHMI.Hydro.WaterLevelObservation",
+          "description": "A current measurement from the Czech Hydrometeorological Institute (ČHMÚ) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from ČHMÚ Hydrological Data covering Czech hydrological monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "CZ.Gov.CHMI.Hydro.mqtt": {
-      "description": "MQTT/5.0 transport variants of the CHMI Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/cz/chmi/chmi-hydro/{stream_name}/{station_id}/... The {stream_name} placeholder is sourced from the CHMI hydrology catalog (Czech: 'tok', e.g. 'Vltava', 'Labe', 'Morava') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/cz/chmi/chmi-hydro/vltava/+/water-level).",
+      "description": "MQTT 5 variant of the ČHMÚ Hydrological Data events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "CZ.Gov.CHMI.Hydro.mqtt.Station": {
           "name": "Station",
@@ -133,41 +138,70 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "dbc": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider-supplied dbc value for this record."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "stream_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the stream."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "flood_level_1": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Provider-supplied flood level 1 value for this record."
                   },
                   "flood_level_2": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Provider-supplied flood level 2 value for this record."
                   },
                   "flood_level_3": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Provider-supplied flood level 3 value for this record."
                   },
                   "flood_level_4": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Provider-supplied flood level 4 value for this record."
                   },
                   "has_forecast": {
-                    "type": ["boolean", "null"]
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Provider-supplied has forecast value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/CZ/Gov/CHMI/Hydro/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the ČHMÚ Hydrological Data source."
               }
             }
           }
@@ -190,36 +224,62 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "stream_name": {
                     "type": "string",
                     "description": "Name of the watercourse / stream the station observes (Czech: 'tok', e.g. 'Vltava', 'Labe', 'Morava'). Sourced by the bridge from the CHMI hydrology station catalog and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {stream_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "water_level": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Current water level reported for the station."
                   },
                   "water_level_timestamp": {
-                    "type": ["datetime", "null"]
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Time associated with the water-level measurement."
                   },
                   "discharge": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_timestamp": {
-                    "type": ["datetime", "null"]
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Time associated with the discharge measurement."
                   },
                   "water_temperature": {
-                    "type": ["double", "null"]
+                    "type": [
+                      "double",
+                      "null"
+                    ],
+                    "description": "Current water temperature reported for the station."
                   },
                   "water_temperature_timestamp": {
-                    "type": ["datetime", "null"]
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Time associated with the water-temperature measurement."
                   }
                 },
                 "$id": "https://example.com/schemas/CZ/Gov/CHMI/Hydro/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level and discharge observations in the ČHMÚ Hydrological Data source."
               }
             }
           }
@@ -238,7 +298,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the ČHMÚ Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -309,7 +369,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "CZ.Gov.CHMI.Hydro"
+                "namespace": "CZ.Gov.CHMI.Hydro",
+                "description": "Reference details for one monitoring station or site in the ČHMÚ Hydrological Data source."
               }
             }
           }
@@ -324,7 +385,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the ČHMÚ Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -397,12 +458,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "CZ.Gov.CHMI.Hydro"
+                "namespace": "CZ.Gov.CHMI.Hydro",
+                "description": "Measurement payload for observations in the ČHMÚ Hydrological Data source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "ČHMÚ Hydrological Data publishes water level and discharge observations from the Czech Hydrometeorological Institute (ČHMÚ) for Czech hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for ČHMÚ Hydrological Data, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/german-waters/EVENTS.md
+++ b/german-waters/EVENTS.md
@@ -1,6 +1,6 @@
 # German Waters Bridge Events
 
-MQTT/5.0 transport variants of the German Waters Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/de/wsv/german-waters/{water_body}/{station_id}/... The {water_body} placeholder is sourced from the per-provider station catalog (Station.water_body field, e.g. 'Rhein', 'Donau', 'Elbe') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/de/wsv/german-waters/rhein/+/water-level).
+German Waters publishes water level and discharge observations from German state open data portals for German state water monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `DE.Waters.Hydrology.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one German state water monitoring station published by German state open data portals. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the German Waters source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,21 +69,21 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `station_name`, `water_body`, `provider`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`water_body`** (string, required): No description provided.
-- **`state`** (string, optional): No description provided.
-- **`region`** (string, optional): No description provided.
-- **`provider`** (string, required): No description provided.
-- **`latitude`** (double, optional): No description provided.
-- **`longitude`** (double, optional): No description provided.
-- **`river_km`** (double, optional): No description provided.
-- **`altitude`** (double, optional): No description provided.
-- **`station_type`** (string, optional): No description provided.
-- **`warn_level_cm`** (double, optional): No description provided.
-- **`alarm_level_cm`** (double, optional): No description provided.
-- **`warn_level_m3s`** (double, optional): No description provided.
-- **`alarm_level_m3s`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`water_body`** (string, required): Provider-supplied water body value for this record.
+- **`state`** (string, optional): State, province, or region containing the station.
+- **`region`** (string, optional): Provider-supplied region value for this record.
+- **`provider`** (string, required): Provider-supplied provider value for this record.
+- **`latitude`** (double, optional): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, optional): Longitude of the station in WGS 84 coordinates.
+- **`river_km`** (double, optional): Provider-supplied river km value for this record.
+- **`altitude`** (double, optional): Provider-supplied altitude value for this record.
+- **`station_type`** (string, optional): Provider-supplied station type value for this record.
+- **`warn_level_cm`** (double, optional): Provider-supplied warn level cm value for this record.
+- **`alarm_level_cm`** (double, optional): Provider-supplied alarm level cm value for this record.
+- **`warn_level_m3s`** (double, optional): Provider-supplied warn level m3s value for this record.
+- **`alarm_level_m3s`** (double, optional): Provider-supplied alarm level m3s value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -118,11 +118,11 @@ CloudEvents type: `DE.Waters.Hydrology.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from German state open data portals for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water level and discharge observations in the German Waters source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -135,17 +135,17 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`, `provider`, `water_body`.
 
-- **`station_id`** (string, required): No description provided.
-- **`provider`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`provider`** (string, required): Provider-supplied provider value for this record.
 - **`water_body`** (string, required): Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Sourced by the bridge from the per-provider station catalog (Station.water_body field) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {water_body} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.
-- **`water_level`** (double, optional): No description provided.
-- **`water_level_unit`** (string, optional): No description provided.
-- **`water_level_timestamp`** (datetime, optional): No description provided.
-- **`discharge`** (double, optional): No description provided.
-- **`discharge_unit`** (string, optional): No description provided.
-- **`discharge_timestamp`** (datetime, optional): No description provided.
-- **`trend`** (int32, optional): No description provided.
-- **`situation`** (int32, optional): No description provided.
+- **`water_level`** (double, optional): Current water level reported for the station.
+- **`water_level_unit`** (string, optional): Unit used for the water-level value.
+- **`water_level_timestamp`** (datetime, optional): Time associated with the water-level measurement.
+- **`discharge`** (double, optional): Current streamflow or discharge reported for the station.
+- **`discharge_unit`** (string, optional): Unit used for the discharge value.
+- **`discharge_timestamp`** (datetime, optional): Time associated with the discharge measurement.
+- **`trend`** (int32, optional): Provider-supplied trend value for this record.
+- **`situation`** (int32, optional): Provider-supplied situation value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/german-waters/xreg/german_waters.xreg.json
+++ b/german-waters/xreg/german_waters.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.Waters.Hydrology"
-      ]
+      ],
+      "description": "Kafka producer endpoint for German Waters CloudEvents on the `german-waters` topic keyed by `{station_id}`."
     },
     "DE.Waters.Hydrology.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.Waters.Hydrology.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for German Waters CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Waters.Hydrology.jstruct/schemas/DE.Waters.Hydrology.Station"
+          "dataschemauri": "#/schemagroups/DE.Waters.Hydrology.jstruct/schemas/DE.Waters.Hydrology.Station",
+          "description": "A reference record for one German state water monitoring station published by German state open data portals. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "DE.Waters.Hydrology.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Waters.Hydrology.jstruct/schemas/DE.Waters.Hydrology.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/DE.Waters.Hydrology.jstruct/schemas/DE.Waters.Hydrology.WaterLevelObservation",
+          "description": "A current measurement from German state open data portals for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from German Waters covering German state water monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "DE.Waters.Hydrology.mqtt": {
-      "description": "MQTT/5.0 transport variants of the German Waters Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/de/wsv/german-waters/{water_body}/{station_id}/... The {water_body} placeholder is sourced from the per-provider station catalog (Station.water_body field, e.g. 'Rhein', 'Donau', 'Elbe') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/de/wsv/german-waters/rhein/+/water-level).",
+      "description": "MQTT 5 variant of the German Waters events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "DE.Waters.Hydrology.mqtt.Station": {
           "name": "Station",
@@ -132,59 +137,74 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "water_body": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "Gewaesser"
-                    }
+                    },
+                    "description": "Provider-supplied water body value for this record."
                   },
                   "state": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "State, province, or region containing the station."
                   },
                   "region": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied region value for this record."
                   },
                   "provider": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied provider value for this record."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "river_km": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied river km value for this record."
                   },
                   "altitude": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "Hoehe"
-                    }
+                    },
+                    "description": "Provider-supplied altitude value for this record."
                   },
                   "station_type": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied station type value for this record."
                   },
                   "warn_level_cm": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied warn level cm value for this record."
                   },
                   "alarm_level_cm": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied alarm level cm value for this record."
                   },
                   "warn_level_m3s": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied warn level m3s value for this record."
                   },
                   "alarm_level_m3s": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied alarm level m3s value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/Waters/Hydrology/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the German Waters source."
               }
             }
           }
@@ -207,42 +227,52 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "provider": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied provider value for this record."
                   },
                   "water_body": {
                     "type": "string",
                     "description": "Name of the water body the station observes (e.g. 'Rhein', 'Donau', 'Elbe'). Sourced by the bridge from the per-provider station catalog (Station.water_body field) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {water_body} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "water_level": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current water level reported for the station."
                   },
                   "water_level_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the water-level value."
                   },
                   "water_level_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the water-level measurement."
                   },
                   "discharge": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the discharge value."
                   },
                   "discharge_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the discharge measurement."
                   },
                   "trend": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider-supplied trend value for this record."
                   },
                   "situation": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider-supplied situation value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/Waters/Hydrology/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level and discharge observations in the German Waters source."
               }
             }
           }
@@ -261,7 +291,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the German Waters source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -368,7 +398,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "DE.Waters.Hydrology"
+                "namespace": "DE.Waters.Hydrology",
+                "description": "Reference details for one monitoring station or site in the German Waters source."
               }
             }
           }
@@ -383,7 +414,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the German Waters source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -469,12 +500,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "DE.Waters.Hydrology"
+                "namespace": "DE.Waters.Hydrology",
+                "description": "Measurement payload for observations in the German Waters source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "German Waters publishes water level and discharge observations from German state open data portals for German state water monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for German Waters, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/hubeau-hydrometrie/EVENTS.md
+++ b/hubeau-hydrometrie/EVENTS.md
@@ -1,6 +1,6 @@
 # Hub'Eau Hydrométrie API Bridge Events
 
-This project bridges the [Hub'Eau Hydrométrie API](https://hubeau.eaufrance.fr/page/api-hydrometrie) to Apache Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams. It provides real-time water level (height) and flow (discharge) data from approximately 6,300 monitoring stations across France.
+Hub'Eau Hydrométrie publishes water height and discharge observations from the French Eaufrance Hub'Eau hydrometry API for French hydrometric monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,11 +38,11 @@ CloudEvents type: `FR.Gov.Eaufrance.HubEau.Hydrometrie.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one French hydrometric monitoring station published by the French Eaufrance Hub'Eau hydrometry API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the Hub'Eau Hydrométrie source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{code_station}`. `{code_station}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{code_station}`. `{code_station}` is permanent hydrometry-station code assigned by the French monitoring network. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -54,16 +54,16 @@ Each event identifies the real-world resource with `{code_station}`. `{code_stat
 
 `Station` payloads are JSON object. Required fields: `code_station`, `libelle_station`, `longitude_station`, `latitude_station`.
 
-- **`code_station`** (string, required): No description provided.
-- **`libelle_station`** (string, required): No description provided.
-- **`code_site`** (string or null, optional): No description provided.
-- **`longitude_station`** (double, required): No description provided.
-- **`latitude_station`** (double, required): No description provided.
-- **`libelle_cours_eau`** (string or null, optional): No description provided.
-- **`libelle_commune`** (string or null, optional): No description provided.
-- **`code_departement`** (string or null, optional): No description provided.
-- **`en_service`** (boolean or null, optional): No description provided.
-- **`date_ouverture_station`** (string or null, optional): No description provided.
+- **`code_station`** (string, required): Permanent hydrometry-station code assigned by the French monitoring network. Use it as the stable identity for station records and related observations.
+- **`libelle_station`** (string, required): Display label for the hydrometry station as published by Hub'Eau. It is useful for maps and UI labels but should not be used as a stable key.
+- **`code_site`** (string or null, optional): Optional Hub'Eau site code grouping one or more stations at the same monitoring location.
+- **`longitude_station`** (double, required): Longitude of the station in WGS 84 coordinates.
+- **`latitude_station`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`libelle_cours_eau`** (string or null, optional): Name of the river or watercourse monitored by the station.
+- **`libelle_commune`** (string or null, optional): Municipality where the station is located.
+- **`code_departement`** (string or null, optional): French department code for the station location.
+- **`en_service`** (boolean or null, optional): Whether Hub'Eau marks the station as currently in service.
+- **`date_ouverture_station`** (string or null, optional): Date when the station began operating, when the upstream catalog provides it.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -93,11 +93,11 @@ CloudEvents type: `FR.Gov.Eaufrance.HubEau.Hydrometrie.Observation`
 
 #### What it tells you
 
-This event carries observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the French Eaufrance Hub'Eau hydrometry API for one monitoring site. It carries water height and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water height and discharge observations in the Hub'Eau Hydrométrie source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{code_station}`. `{code_station}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{code_station}`. `{code_station}` is permanent hydrometry-station code assigned by the French monitoring network. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -109,12 +109,12 @@ Each event identifies the real-world resource with `{code_station}`. `{code_stat
 
 `Observation` payloads are JSON object. Required fields: `code_station`, `date_obs`, `resultat_obs`, `grandeur_hydro`.
 
-- **`code_station`** (string, required): No description provided.
-- **`date_obs`** (datetime, required): No description provided.
-- **`resultat_obs`** (double, required): No description provided.
-- **`grandeur_hydro`** (string, required): No description provided.
-- **`libelle_methode_obs`** (string or null, optional): No description provided.
-- **`libelle_qualification_obs`** (string or null, optional): No description provided.
+- **`code_station`** (string, required): Permanent hydrometry-station code assigned by the French monitoring network. Use it as the stable identity for station records and related observations.
+- **`date_obs`** (datetime, required): Observation timestamp published by Hub'Eau for this measurement.
+- **`resultat_obs`** (double, required): Measured hydrometric value. Interpret the quantity and unit from `grandeur_hydro`, such as discharge or water height.
+- **`grandeur_hydro`** (string, required): Hydrometric quantity code identifying what `resultat_obs` measures, such as discharge or water height.
+- **`libelle_methode_obs`** (string or null, optional): Provider label for the observation method used to produce the measurement.
+- **`libelle_qualification_obs`** (string or null, optional): Provider quality label describing how Hub'Eau qualifies the observation.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/hubeau-hydrometrie/xreg/hubeau_hydrometrie.xreg.json
+++ b/hubeau-hydrometrie/xreg/hubeau_hydrometrie.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/FR.Gov.Eaufrance.HubEau.Hydrometrie"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Hub'Eau Hydrométrie CloudEvents on the `hubeau-hydrometrie` topic keyed by `{code_station}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FR.Gov.Eaufrance.HubEau.Hydrometrie.jstruct/schemas/FR.Gov.Eaufrance.HubEau.Hydrometrie.Station"
+          "dataschemauri": "#/schemagroups/FR.Gov.Eaufrance.HubEau.Hydrometrie.jstruct/schemas/FR.Gov.Eaufrance.HubEau.Hydrometrie.Station",
+          "description": "A reference record for one French hydrometric monitoring station published by the French Eaufrance Hub'Eau hydrometry API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "FR.Gov.Eaufrance.HubEau.Hydrometrie.Observation": {
           "name": "Observation",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FR.Gov.Eaufrance.HubEau.Hydrometrie.jstruct/schemas/FR.Gov.Eaufrance.HubEau.Hydrometrie.Observation"
+          "dataschemauri": "#/schemagroups/FR.Gov.Eaufrance.HubEau.Hydrometrie.jstruct/schemas/FR.Gov.Eaufrance.HubEau.Hydrometrie.Observation",
+          "description": "A current measurement from the French Eaufrance Hub'Eau hydrometry API for one monitoring site. It carries water height and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Hub'Eau Hydrométrie covering French hydrometric monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -86,38 +90,66 @@
                 "name": "Station",
                 "properties": {
                   "code_station": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Permanent hydrometry-station code assigned by the French monitoring network. Use it as the stable identity for station records and related observations."
                   },
                   "libelle_station": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Display label for the hydrometry station as published by Hub'Eau. It is useful for maps and UI labels but should not be used as a stable key."
                   },
                   "code_site": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Optional Hub'Eau site code grouping one or more stations at the same monitoring location."
                   },
                   "longitude_station": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "latitude_station": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "libelle_cours_eau": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the river or watercourse monitored by the station."
                   },
                   "libelle_commune": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Municipality where the station is located."
                   },
                   "code_departement": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "French department code for the station location."
                   },
                   "en_service": {
-                    "type": ["boolean", "null"]
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether Hub'Eau marks the station as currently in service."
                   },
                   "date_ouverture_station": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Date when the station began operating, when the upstream catalog provides it."
                   }
                 },
                 "$id": "https://example.com/schemas/FR/Gov/Eaufrance/HubEau/Hydrometrie/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the Hub'Eau Hydrométrie source."
               }
             }
           }
@@ -141,26 +173,38 @@
                 "name": "Observation",
                 "properties": {
                   "code_station": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Permanent hydrometry-station code assigned by the French monitoring network. Use it as the stable identity for station records and related observations."
                   },
                   "date_obs": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Observation timestamp published by Hub'Eau for this measurement."
                   },
                   "resultat_obs": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Measured hydrometric value. Interpret the quantity and unit from `grandeur_hydro`, such as discharge or water height."
                   },
                   "grandeur_hydro": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Hydrometric quantity code identifying what `resultat_obs` measures, such as discharge or water height."
                   },
                   "libelle_methode_obs": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider label for the observation method used to produce the measurement."
                   },
                   "libelle_qualification_obs": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider quality label describing how Hub'Eau qualifies the observation."
                   }
                 },
                 "$id": "https://example.com/schemas/FR/Gov/Eaufrance/HubEau/Hydrometrie/Observation",
-                "description": "Observation"
+                "description": "Measurement payload for water height and discharge observations in the Hub'Eau Hydrométrie source."
               }
             }
           }
@@ -179,7 +223,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the Hub'Eau Hydrométrie source.",
                 "fields": [
                   {
                     "name": "code_station",
@@ -246,7 +290,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "FR.Gov.Eaufrance.HubEau.Hydrometrie"
+                "namespace": "FR.Gov.Eaufrance.HubEau.Hydrometrie",
+                "description": "Reference details for one monitoring station or site in the Hub'Eau Hydrométrie source."
               }
             }
           }
@@ -261,7 +306,7 @@
               "schema": {
                 "type": "record",
                 "name": "Observation",
-                "doc": "Observation",
+                "doc": "Measurement payload for observations in the Hub'Eau Hydrométrie source.",
                 "fields": [
                   {
                     "name": "code_station",
@@ -299,12 +344,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "FR.Gov.Eaufrance.HubEau.Hydrometrie"
+                "namespace": "FR.Gov.Eaufrance.HubEau.Hydrometrie",
+                "description": "Measurement payload for observations in the Hub'Eau Hydrométrie source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Hub'Eau Hydrométrie publishes water height and discharge observations from the French Eaufrance Hub'Eau hydrometry API for French hydrometric monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Hub'Eau Hydrométrie, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/imgw-hydro/EVENTS.md
+++ b/imgw-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # IMGW-PIB Hydrological Data Bridge Events
 
-This bridge fetches real-time hydrological data from the Polish Institute of Meteorology and Water Management (IMGW-PIB) public API and forwards it to Apache Kafka or Microsoft Azure Event Hubs as CloudEvents.
+IMGW-PIB Hydrological Data publishes water level and discharge observations from the Polish Institute of Meteorology and Water Management (IMGW-PIB) for Polish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -37,11 +37,11 @@ CloudEvents type: `PL.Gov.IMGW.Hydro.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Polish hydrological monitoring station published by the Polish Institute of Meteorology and Water Management (IMGW-PIB). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the IMGW-PIB Hydrological Data source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -53,12 +53,12 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `station_name`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`river`** (string or null, optional): No description provided.
-- **`voivodeship`** (string or null, optional): No description provided.
-- **`longitude`** (double or null, optional): No description provided.
-- **`latitude`** (double or null, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`river`** (string or null, optional): Provider-supplied river value for this record.
+- **`voivodeship`** (string or null, optional): Provider-supplied voivodeship value for this record.
+- **`longitude`** (double or null, optional): Longitude of the station in WGS 84 coordinates.
+- **`latitude`** (double or null, optional): Latitude of the station in WGS 84 coordinates.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -84,11 +84,11 @@ CloudEvents type: `PL.Gov.IMGW.Hydro.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Polish Institute of Meteorology and Water Management (IMGW-PIB) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water level and discharge observations in the IMGW-PIB Hydrological Data source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -100,18 +100,18 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`, `station_name`, `water_level`, `water_level_timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`river`** (string or null, optional): No description provided.
-- **`voivodeship`** (string or null, optional): No description provided.
-- **`water_level`** (double, required): No description provided.
-- **`water_level_timestamp`** (datetime, required): No description provided.
-- **`water_temperature`** (double or null, optional): No description provided.
-- **`water_temperature_timestamp`** (datetime or null, optional): No description provided.
-- **`discharge`** (double or null, optional): No description provided.
-- **`discharge_timestamp`** (datetime or null, optional): No description provided.
-- **`ice_phenomenon_code`** (string or null, optional): No description provided.
-- **`overgrowth_code`** (string or null, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`river`** (string or null, optional): Provider-supplied river value for this record.
+- **`voivodeship`** (string or null, optional): Provider-supplied voivodeship value for this record.
+- **`water_level`** (double, required): Current water level reported for the station.
+- **`water_level_timestamp`** (datetime, required): Time associated with the water-level measurement.
+- **`water_temperature`** (double or null, optional): Current water temperature reported for the station.
+- **`water_temperature_timestamp`** (datetime or null, optional): Time associated with the water-temperature measurement.
+- **`discharge`** (double or null, optional): Current streamflow or discharge reported for the station.
+- **`discharge_timestamp`** (datetime or null, optional): Time associated with the discharge measurement.
+- **`ice_phenomenon_code`** (string or null, optional): Provider code identifying the ice phenomenon.
+- **`overgrowth_code`** (string or null, optional): Provider code identifying the overgrowth.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/imgw-hydro/xreg/imgw_hydro.xreg.json
+++ b/imgw-hydro/xreg/imgw_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/PL.Gov.IMGW.Hydro"
-      ]
+      ],
+      "description": "Kafka producer endpoint for IMGW-PIB Hydrological Data CloudEvents on the `imgw-hydro` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/PL.Gov.IMGW.Hydro.jstruct/schemas/PL.Gov.IMGW.Hydro.Station"
+          "dataschemauri": "#/schemagroups/PL.Gov.IMGW.Hydro.jstruct/schemas/PL.Gov.IMGW.Hydro.Station",
+          "description": "A reference record for one Polish hydrological monitoring station published by the Polish Institute of Meteorology and Water Management (IMGW-PIB). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "PL.Gov.IMGW.Hydro.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/PL.Gov.IMGW.Hydro.jstruct/schemas/PL.Gov.IMGW.Hydro.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/PL.Gov.IMGW.Hydro.jstruct/schemas/PL.Gov.IMGW.Hydro.WaterLevelObservation",
+          "description": "A current measurement from the Polish Institute of Meteorology and Water Management (IMGW-PIB) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from IMGW-PIB Hydrological Data covering Polish hydrological monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -87,13 +91,15 @@
                     "type": "string",
                     "altnames": {
                       "lang:pl": "id_stacji"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
                     "type": "string",
                     "altnames": {
                       "lang:pl": "stacja"
-                    }
+                    },
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "river": {
                     "type": [
@@ -102,7 +108,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "rzeka"
-                    }
+                    },
+                    "description": "Provider-supplied river value for this record."
                   },
                   "voivodeship": {
                     "type": [
@@ -111,23 +118,26 @@
                     ],
                     "altnames": {
                       "lang:pl": "wojewodztwo"
-                    }
+                    },
+                    "description": "Provider-supplied voivodeship value for this record."
                   },
                   "longitude": {
                     "type": [
                       "double",
                       "null"
-                    ]
+                    ],
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "latitude": {
                     "type": [
                       "double",
                       "null"
-                    ]
+                    ],
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   }
                 },
                 "$id": "https://example.com/schemas/PL/Gov/IMGW/Hydro/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the IMGW-PIB Hydrological Data source."
               }
             }
           }
@@ -154,13 +164,15 @@
                     "type": "string",
                     "altnames": {
                       "lang:pl": "id_stacji"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
                     "type": "string",
                     "altnames": {
                       "lang:pl": "stacja"
-                    }
+                    },
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "river": {
                     "type": [
@@ -169,7 +181,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "rzeka"
-                    }
+                    },
+                    "description": "Provider-supplied river value for this record."
                   },
                   "voivodeship": {
                     "type": [
@@ -178,19 +191,22 @@
                     ],
                     "altnames": {
                       "lang:pl": "wojewodztwo"
-                    }
+                    },
+                    "description": "Provider-supplied voivodeship value for this record."
                   },
                   "water_level": {
                     "type": "double",
                     "altnames": {
                       "lang:pl": "stan_wody"
-                    }
+                    },
+                    "description": "Current water level reported for the station."
                   },
                   "water_level_timestamp": {
                     "type": "datetime",
                     "altnames": {
                       "lang:pl": "stan_wody_data_pomiaru"
-                    }
+                    },
+                    "description": "Time associated with the water-level measurement."
                   },
                   "water_temperature": {
                     "type": [
@@ -199,7 +215,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "temperatura_wody"
-                    }
+                    },
+                    "description": "Current water temperature reported for the station."
                   },
                   "water_temperature_timestamp": {
                     "type": [
@@ -208,7 +225,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "temperatura_wody_data_pomiaru"
-                    }
+                    },
+                    "description": "Time associated with the water-temperature measurement."
                   },
                   "discharge": {
                     "type": [
@@ -217,7 +235,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "przeplyw"
-                    }
+                    },
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_timestamp": {
                     "type": [
@@ -226,7 +245,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "przeplyw_data"
-                    }
+                    },
+                    "description": "Time associated with the discharge measurement."
                   },
                   "ice_phenomenon_code": {
                     "type": [
@@ -235,7 +255,8 @@
                     ],
                     "altnames": {
                       "lang:pl": "zjawisko_lodowe"
-                    }
+                    },
+                    "description": "Provider code identifying the ice phenomenon."
                   },
                   "overgrowth_code": {
                     "type": [
@@ -244,11 +265,12 @@
                     ],
                     "altnames": {
                       "lang:pl": "zjawisko_zarastania"
-                    }
+                    },
+                    "description": "Provider code identifying the overgrowth."
                   }
                 },
                 "$id": "https://example.com/schemas/PL/Gov/IMGW/Hydro/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level and discharge observations in the IMGW-PIB Hydrological Data source."
               }
             }
           }
@@ -267,7 +289,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the IMGW-PIB Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -310,7 +332,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "PL.Gov.IMGW.Hydro"
+                "namespace": "PL.Gov.IMGW.Hydro",
+                "description": "Reference details for one monitoring station or site in the IMGW-PIB Hydrological Data source."
               }
             }
           }
@@ -325,7 +348,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the IMGW-PIB Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -417,12 +440,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "PL.Gov.IMGW.Hydro"
+                "namespace": "PL.Gov.IMGW.Hydro",
+                "description": "Measurement payload for observations in the IMGW-PIB Hydrological Data source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "IMGW-PIB Hydrological Data publishes water level and discharge observations from the Polish Institute of Meteorology and Water Management (IMGW-PIB) for Polish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for IMGW-PIB Hydrological Data, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/ireland-opw-waterlevel/EVENTS.md
+++ b/ireland-opw-waterlevel/EVENTS.md
@@ -1,6 +1,6 @@
 # Ireland OPW waterlevel.ie Bridge Events
 
-This project provides a bridge that reads real-time water level, temperature, and voltage data from Ireland's OPW (Office of Public Works) hydrometric stations via the [waterlevel.ie](https://waterlevel.ie) GeoJSON API and emits the data as CloudEvents to Apache Kafka, Azure Event Hubs, or Fabric Event Streams.
+Ireland OPW waterlevel.ie publishes water level, temperature, and sensor voltage observations from Ireland's Office of Public Works (OPW) for Irish hydrometric stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `ie.gov.opw.waterlevel.Station`
 
 #### What it tells you
 
-Reference data for an OPW hydrometric station in Ireland, including location and region.
+A reference record for one Irish hydrometric station published by Ireland's Office of Public Works (OPW). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference data for an OPW hydrometric station in Ireland, including location and region.
 
 #### Identity
 
@@ -83,7 +83,7 @@ CloudEvents type: `ie.gov.opw.waterlevel.WaterLevelReading`
 
 #### What it tells you
 
-A sensor reading from an OPW hydrometric station, covering water level, temperature, voltage, or Ordnance Datum.
+A current measurement from Ireland's Office of Public Works (OPW) for one monitoring site. It carries water level, temperature, and sensor voltage observations when the upstream feed reports a new or refreshed value. A sensor reading from an OPW hydrometric station, covering water level, temperature, voltage, or Ordnance Datum.
 
 #### Identity
 

--- a/ireland-opw-waterlevel/xreg/ireland_opw_waterlevel.xreg.json
+++ b/ireland-opw-waterlevel/xreg/ireland_opw_waterlevel.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/ie.gov.opw.waterlevel"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Ireland OPW waterlevel.ie CloudEvents on the `ireland-opw-waterlevel` topic keyed by `{station_ref}`."
     }
   },
   "messagegroups": {
@@ -28,7 +29,7 @@
         "ie.gov.opw.waterlevel.Station": {
           "name": "Station",
           "envelope": "CloudEvents/1.0",
-          "description": "Reference data for an OPW hydrometric station in Ireland, including location and region.",
+          "description": "A reference record for one Irish hydrometric station published by Ireland's Office of Public Works (OPW). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "ie.gov.opw.waterlevel.Station"
@@ -48,7 +49,7 @@
         "ie.gov.opw.waterlevel.WaterLevelReading": {
           "name": "WaterLevelReading",
           "envelope": "CloudEvents/1.0",
-          "description": "A sensor reading from an OPW hydrometric station, covering water level, temperature, voltage, or Ordnance Datum.",
+          "description": "A current measurement from Ireland's Office of Public Works (OPW) for one monitoring site. It carries water level, temperature, and sensor voltage observations when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "ie.gov.opw.waterlevel.WaterLevelReading"
@@ -65,7 +66,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/ie.gov.opw.waterlevel.jstruct/schemas/ie.gov.opw.waterlevel.WaterLevelReading"
         }
-      }
+      },
+      "description": "Events from Ireland OPW waterlevel.ie covering Irish hydrometric stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -126,7 +128,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reference details for one monitoring station or site in the Ireland OPW waterlevel.ie source."
               }
             }
           }
@@ -165,7 +168,10 @@
                                 "description": "Sensor reference code identifying the measurement type: '0001' for water level (metres), '0002' for temperature (degrees Celsius), '0003' for voltage (volts), 'OD' for Ordnance Datum level (metres)."
                               },
                               "value": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Numeric sensor reading value. Units depend on sensor_ref: metres for water level ('0001') and OD ('OD'), degrees Celsius for temperature ('0002'), volts for voltage ('0003'). Null if the value could not be parsed from the upstream string representation."
                               },
                               "datetime": {
@@ -191,7 +197,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the Ireland OPW waterlevel.ie source."
               }
             }
           }
@@ -235,7 +242,8 @@
                     "type": "double",
                     "doc": "Latitude of the station location in WGS84 decimal degrees."
                   }
-                ]
+                ],
+                "description": "Reference details for one monitoring station or site in the Ireland OPW waterlevel.ie source."
               }
             }
           },
@@ -268,7 +276,10 @@
                   },
                   {
                     "name": "value",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Numeric sensor reading value. Units depend on sensor_ref: metres for water level ('0001') and OD ('OD'), degrees Celsius for temperature ('0002'), volts for voltage ('0003'). Null if the value could not be parsed from the upstream string representation."
                   },
                   {
@@ -281,7 +292,8 @@
                     "type": "int",
                     "doc": "Upstream error code for the reading. A value of 99 indicates the reading is valid (OK). Other values indicate various error conditions."
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the Ireland OPW waterlevel.ie source."
               }
             }
           },
@@ -289,5 +301,10 @@
         }
       }
     }
+  },
+  "description": "Ireland OPW waterlevel.ie publishes water level, temperature, and sensor voltage observations from Ireland's Office of Public Works (OPW) for Irish hydrometric stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Ireland OPW waterlevel.ie, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/nepal-bipad-hydrology/EVENTS.md
+++ b/nepal-bipad-hydrology/EVENTS.md
@@ -1,6 +1,6 @@
 # Nepal BIPAD Portal — Real-Time River Monitoring Bridge Events
 
-This project provides a bridge between the [Nepal BIPAD Portal](https://bipadportal.gov.np/) river monitoring API and Apache Kafka, Azure Event Hubs, and Fabric Event Streams.
+Nepal BIPAD River Monitoring publishes river water level observations from Nepal's BIPAD Portal for river monitoring stations in Nepal. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `np.gov.bipad.hydrology.RiverStation`
 
 #### What it tells you
 
-Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.
+A reference record for one river monitoring stations in Nepal published by Nepal's BIPAD Portal. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.
 
 #### Identity
 
@@ -101,7 +101,7 @@ CloudEvents type: `np.gov.bipad.hydrology.WaterLevelReading`
 
 #### What it tells you
 
-Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal, including current water level, alert status, and trend direction.
+A current measurement from Nepal's BIPAD Portal for one monitoring site. It carries river water level observations when the upstream feed reports a new or refreshed value. Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal, including current water level, alert status, and trend direction.
 
 #### Identity
 

--- a/nepal-bipad-hydrology/xreg/nepal_bipad_hydrology.xreg.json
+++ b/nepal-bipad-hydrology/xreg/nepal_bipad_hydrology.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/np.gov.bipad.hydrology"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Nepal BIPAD River Monitoring CloudEvents on the `nepal-bipad-hydrology` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -28,7 +29,7 @@
         "np.gov.bipad.hydrology.RiverStation": {
           "name": "RiverStation",
           "envelope": "CloudEvents/1.0",
-          "description": "Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.",
+          "description": "A reference record for one river monitoring stations in Nepal published by Nepal's BIPAD Portal. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "np.gov.bipad.hydrology.RiverStation"
@@ -48,7 +49,7 @@
         "np.gov.bipad.hydrology.WaterLevelReading": {
           "name": "WaterLevelReading",
           "envelope": "CloudEvents/1.0",
-          "description": "Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal, including current water level, alert status, and trend direction.",
+          "description": "A current measurement from Nepal's BIPAD Portal for one monitoring site. It carries river water level observations when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "np.gov.bipad.hydrology.WaterLevelReading"
@@ -65,7 +66,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/np.gov.bipad.hydrology.jstruct/schemas/np.gov.bipad.hydrology.WaterLevelReading"
         }
-      }
+      },
+      "description": "Events from Nepal BIPAD River Monitoring covering river monitoring stations in Nepal and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -114,19 +116,31 @@
                                 "description": "Longitude coordinate of the station in WGS84 decimal degrees, extracted from the GeoJSON point geometry."
                               },
                               "elevation": {
-                                "type": ["integer", "null"],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
                                 "description": "Elevation of the station in meters above sea level, as reported by the BIPAD portal. Null when not available."
                               },
                               "danger_level": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Configured danger water level threshold in meters for the station. Water levels above this indicate a danger condition. Null when not configured."
                               },
                               "warning_level": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Configured warning water level threshold in meters for the station. Water levels above this indicate a warning condition. Null when not configured."
                               },
                               "description": {
-                                "type": ["string", "null"],
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
                                 "description": "Free-text description of the station, may include historical notes, relocation history, or elevation corrections. Null when not provided."
                               },
                               "data_source": {
@@ -134,19 +148,31 @@
                                 "description": "Origin system providing the station data, typically 'hydrology.gov.np' for Nepal Department of Hydrology and Meteorology stations."
                               },
                               "province": {
-                                "type": ["integer", "null"],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
                                 "description": "Nepal province administrative code for the station location. Null when not assigned."
                               },
                               "district": {
-                                "type": ["integer", "null"],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
                                 "description": "Nepal district administrative code for the station location. Null when not assigned."
                               },
                               "municipality": {
-                                "type": ["integer", "null"],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
                                 "description": "Nepal municipality or rural municipality administrative code for the station location. Null when not assigned."
                               },
                               "ward": {
-                                "type": ["integer", "null"],
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ],
                                 "description": "Nepal ward-level administrative code for the station location. Null when not assigned."
                               }
                             },
@@ -163,7 +189,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reference details for one monitoring station or site in the Nepal BIPAD River Monitoring source."
               }
             }
           }
@@ -203,15 +230,24 @@
                                 "description": "Name of the river basin the station belongs to at the time of the reading."
                               },
                               "water_level": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Current water level at the station in meters. Null when the station has no current reading available."
                               },
                               "danger_level": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Configured danger water level threshold in meters. Null when not configured."
                               },
                               "warning_level": {
-                                "type": ["double", "null"],
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
                                 "description": "Configured warning water level threshold in meters. Null when not configured."
                               },
                               "status": {
@@ -240,7 +276,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the Nepal BIPAD River Monitoring source."
               }
             }
           }
@@ -259,21 +296,110 @@
                 "namespace": "np.gov.bipad.hydrology",
                 "doc": "Reference data for a BIPAD river monitoring station in Nepal, including location, river basin, administrative boundaries, and configured danger/warning thresholds.",
                 "fields": [
-                  { "name": "station_id", "type": "string", "doc": "Unique integer identifier of the river station assigned by the BIPAD portal, transmitted as a string for key compatibility." },
-                  { "name": "title", "type": "string", "doc": "Human-readable name of the river station, typically in the format 'River at Location'." },
-                  { "name": "basin", "type": "string", "doc": "Name of the river basin the station belongs to." },
-                  { "name": "latitude", "type": "double", "doc": "Latitude coordinate of the station in WGS84 decimal degrees." },
-                  { "name": "longitude", "type": "double", "doc": "Longitude coordinate of the station in WGS84 decimal degrees." },
-                  { "name": "elevation", "type": ["null", "int"], "doc": "Elevation of the station in meters above sea level. Null when not available.", "default": null },
-                  { "name": "danger_level", "type": ["null", "double"], "doc": "Configured danger water level threshold in meters. Null when not configured.", "default": null },
-                  { "name": "warning_level", "type": ["null", "double"], "doc": "Configured warning water level threshold in meters. Null when not configured.", "default": null },
-                  { "name": "description", "type": ["null", "string"], "doc": "Free-text description of the station. Null when not provided.", "default": null },
-                  { "name": "data_source", "type": "string", "doc": "Origin system providing the station data, typically 'hydrology.gov.np'." },
-                  { "name": "province", "type": ["null", "int"], "doc": "Nepal province administrative code. Null when not assigned.", "default": null },
-                  { "name": "district", "type": ["null", "int"], "doc": "Nepal district administrative code. Null when not assigned.", "default": null },
-                  { "name": "municipality", "type": ["null", "int"], "doc": "Nepal municipality administrative code. Null when not assigned.", "default": null },
-                  { "name": "ward", "type": ["null", "int"], "doc": "Nepal ward-level administrative code. Null when not assigned.", "default": null }
-                ]
+                  {
+                    "name": "station_id",
+                    "type": "string",
+                    "doc": "Unique integer identifier of the river station assigned by the BIPAD portal, transmitted as a string for key compatibility."
+                  },
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "doc": "Human-readable name of the river station, typically in the format 'River at Location'."
+                  },
+                  {
+                    "name": "basin",
+                    "type": "string",
+                    "doc": "Name of the river basin the station belongs to."
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double",
+                    "doc": "Latitude coordinate of the station in WGS84 decimal degrees."
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double",
+                    "doc": "Longitude coordinate of the station in WGS84 decimal degrees."
+                  },
+                  {
+                    "name": "elevation",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "doc": "Elevation of the station in meters above sea level. Null when not available.",
+                    "default": null
+                  },
+                  {
+                    "name": "danger_level",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "doc": "Configured danger water level threshold in meters. Null when not configured.",
+                    "default": null
+                  },
+                  {
+                    "name": "warning_level",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "doc": "Configured warning water level threshold in meters. Null when not configured.",
+                    "default": null
+                  },
+                  {
+                    "name": "description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "doc": "Free-text description of the station. Null when not provided.",
+                    "default": null
+                  },
+                  {
+                    "name": "data_source",
+                    "type": "string",
+                    "doc": "Origin system providing the station data, typically 'hydrology.gov.np'."
+                  },
+                  {
+                    "name": "province",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "doc": "Nepal province administrative code. Null when not assigned.",
+                    "default": null
+                  },
+                  {
+                    "name": "district",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "doc": "Nepal district administrative code. Null when not assigned.",
+                    "default": null
+                  },
+                  {
+                    "name": "municipality",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "doc": "Nepal municipality administrative code. Null when not assigned.",
+                    "default": null
+                  },
+                  {
+                    "name": "ward",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "doc": "Nepal ward-level administrative code. Null when not assigned.",
+                    "default": null
+                  }
+                ],
+                "description": "Reference details for one monitoring station or site in the Nepal BIPAD River Monitoring source."
               }
             }
           },
@@ -289,16 +415,65 @@
                 "namespace": "np.gov.bipad.hydrology",
                 "doc": "Real-time water level telemetry reading from a BIPAD river monitoring station in Nepal.",
                 "fields": [
-                  { "name": "station_id", "type": "string", "doc": "Unique integer identifier of the river station." },
-                  { "name": "title", "type": "string", "doc": "Human-readable name of the river station at the time of the reading." },
-                  { "name": "basin", "type": "string", "doc": "Name of the river basin the station belongs to." },
-                  { "name": "water_level", "type": ["null", "double"], "doc": "Current water level at the station in meters. Null when no reading available.", "default": null },
-                  { "name": "danger_level", "type": ["null", "double"], "doc": "Configured danger water level threshold in meters. Null when not configured.", "default": null },
-                  { "name": "warning_level", "type": ["null", "double"], "doc": "Configured warning water level threshold in meters. Null when not configured.", "default": null },
-                  { "name": "status", "type": "string", "doc": "Current alert status: 'BELOW WARNING LEVEL', 'WARNING', or 'DANGER'." },
-                  { "name": "trend", "type": "string", "doc": "Direction of water level change: 'STEADY', 'RISING', or 'FALLING'." },
-                  { "name": "water_level_on", "type": "string", "doc": "ISO 8601 timestamp of when the water level was measured." }
-                ]
+                  {
+                    "name": "station_id",
+                    "type": "string",
+                    "doc": "Unique integer identifier of the river station."
+                  },
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "doc": "Human-readable name of the river station at the time of the reading."
+                  },
+                  {
+                    "name": "basin",
+                    "type": "string",
+                    "doc": "Name of the river basin the station belongs to."
+                  },
+                  {
+                    "name": "water_level",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "doc": "Current water level at the station in meters. Null when no reading available.",
+                    "default": null
+                  },
+                  {
+                    "name": "danger_level",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "doc": "Configured danger water level threshold in meters. Null when not configured.",
+                    "default": null
+                  },
+                  {
+                    "name": "warning_level",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "doc": "Configured warning water level threshold in meters. Null when not configured.",
+                    "default": null
+                  },
+                  {
+                    "name": "status",
+                    "type": "string",
+                    "doc": "Current alert status: 'BELOW WARNING LEVEL', 'WARNING', or 'DANGER'."
+                  },
+                  {
+                    "name": "trend",
+                    "type": "string",
+                    "doc": "Direction of water level change: 'STEADY', 'RISING', or 'FALLING'."
+                  },
+                  {
+                    "name": "water_level_on",
+                    "type": "string",
+                    "doc": "ISO 8601 timestamp of when the water level was measured."
+                  }
+                ],
+                "description": "Measurement payload for observations in the Nepal BIPAD River Monitoring source."
               }
             }
           },
@@ -306,5 +481,10 @@
         }
       }
     }
+  },
+  "description": "Nepal BIPAD River Monitoring publishes river water level observations from Nepal's BIPAD Portal for river monitoring stations in Nepal. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Nepal BIPAD River Monitoring, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/nve-hydro/EVENTS.md
+++ b/nve-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # NVE Hydrology Bridge Usage Guide Events
 
-MQTT/5.0 transport variants of the NVE Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/no/nve/nve-hydro/{river_name}/{station_id}/... The {river_name} placeholder is sourced from the NVE HydAPI station catalog field 'riverName' (Norwegian: 'Vassdrag', e.g. 'Glomma', 'Drammenselva') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/no/nve/nve-hydro/glomma/+/water-level).
+NVE Hydrology publishes water level and discharge observations from the Norwegian Water Resources and Energy Directorate (NVE) for Norwegian hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `NO.NVE.Hydrology.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Norwegian hydrological monitoring station published by the Norwegian Water Resources and Energy Directorate (NVE). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the NVE Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,15 +69,15 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `station_name`, `latitude`, `longitude`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`river_name`** (string, optional): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`masl`** (double, optional): No description provided.
-- **`council_name`** (string, optional): No description provided.
-- **`county_name`** (string, optional): No description provided.
-- **`drainage_basin_area`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`river_name`** (string, optional): Name of the river or watercourse observed at the station.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
+- **`masl`** (double, optional): Provider-supplied masl value for this record.
+- **`council_name`** (string, optional): Human-readable name of the council.
+- **`county_name`** (string, optional): Human-readable name of the county.
+- **`drainage_basin_area`** (double, optional): Provider-supplied drainage basin area value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -106,11 +106,11 @@ CloudEvents type: `NO.NVE.Hydrology.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Norwegian Water Resources and Energy Directorate (NVE) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water level and discharge observations in the NVE Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -123,14 +123,14 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`, `river_name`.
 
-- **`station_id`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
 - **`river_name`** (string, required): Name of the river the station observes (NVE HydAPI 'riverName' field, in Norwegian 'Vassdrag', e.g. 'Glomma', 'Drammenselva'). Sourced by the bridge from the station catalog (https://hydapi.nve.no/api/v1/Stations) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {river_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.
-- **`water_level`** (double, optional): No description provided.
-- **`water_level_unit`** (string, optional): No description provided.
-- **`water_level_timestamp`** (datetime, optional): No description provided.
-- **`discharge`** (double, optional): No description provided.
-- **`discharge_unit`** (string, optional): No description provided.
-- **`discharge_timestamp`** (datetime, optional): No description provided.
+- **`water_level`** (double, optional): Current water level reported for the station.
+- **`water_level_unit`** (string, optional): Unit used for the water-level value.
+- **`water_level_timestamp`** (datetime, optional): Time associated with the water-level measurement.
+- **`discharge`** (double, optional): Current streamflow or discharge reported for the station.
+- **`discharge_unit`** (string, optional): Unit used for the discharge value.
+- **`discharge_timestamp`** (datetime, optional): Time associated with the discharge measurement.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/nve-hydro/xreg/nve_hydro.xreg.json
+++ b/nve-hydro/xreg/nve_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NO.NVE.Hydrology"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NVE Hydrology CloudEvents on the `nve-hydro` topic keyed by `{station_id}`."
     },
     "NO.NVE.Hydrology.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NO.NVE.Hydrology.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for NVE Hydrology CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.NVE.Hydrology.jstruct/schemas/NO.NVE.Hydrology.Station"
+          "dataschemauri": "#/schemagroups/NO.NVE.Hydrology.jstruct/schemas/NO.NVE.Hydrology.Station",
+          "description": "A reference record for one Norwegian hydrological monitoring station published by the Norwegian Water Resources and Energy Directorate (NVE). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "NO.NVE.Hydrology.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.NVE.Hydrology.jstruct/schemas/NO.NVE.Hydrology.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/NO.NVE.Hydrology.jstruct/schemas/NO.NVE.Hydrology.WaterLevelObservation",
+          "description": "A current measurement from the Norwegian Water Resources and Energy Directorate (NVE) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from NVE Hydrology covering Norwegian hydrological monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "NO.NVE.Hydrology.mqtt": {
-      "description": "MQTT/5.0 transport variants of the NVE Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/no/nve/nve-hydro/{river_name}/{station_id}/... The {river_name} placeholder is sourced from the NVE HydAPI station catalog field 'riverName' (Norwegian: 'Vassdrag', e.g. 'Glomma', 'Drammenselva') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole rivers (e.g. hydro/no/nve/nve-hydro/glomma/+/water-level).",
+      "description": "MQTT 5 variant of the NVE Hydrology events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "NO.NVE.Hydrology.mqtt.Station": {
           "name": "Station",
@@ -132,35 +137,44 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "river_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the river or watercourse observed at the station."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "masl": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied masl value for this record."
                   },
                   "council_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the council."
                   },
                   "county_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the county."
                   },
                   "drainage_basin_area": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied drainage basin area value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/NO/NVE/Hydrology/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the NVE Hydrology source."
               }
             }
           }
@@ -182,33 +196,40 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "river_name": {
                     "type": "string",
                     "description": "Name of the river the station observes (NVE HydAPI 'riverName' field, in Norwegian 'Vassdrag', e.g. 'Glomma', 'Drammenselva'). Sourced by the bridge from the station catalog (https://hydapi.nve.no/api/v1/Stations) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river. Used as the {river_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "water_level": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current water level reported for the station."
                   },
                   "water_level_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the water-level value."
                   },
                   "water_level_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the water-level measurement."
                   },
                   "discharge": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the discharge value."
                   },
                   "discharge_timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the discharge measurement."
                   }
                 },
                 "$id": "https://example.com/schemas/NO/NVE/Hydrology/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level and discharge observations in the NVE Hydrology source."
               }
             }
           }
@@ -227,7 +248,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the NVE Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -286,7 +307,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "NO.NVE.Hydrology"
+                "namespace": "NO.NVE.Hydrology",
+                "description": "Reference details for one monitoring station or site in the NVE Hydrology source."
               }
             }
           }
@@ -301,7 +323,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the NVE Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -367,12 +389,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "NO.NVE.Hydrology"
+                "namespace": "NO.NVE.Hydrology",
+                "description": "Measurement payload for observations in the NVE Hydrology source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "NVE Hydrology publishes water level and discharge observations from the Norwegian Water Resources and Energy Directorate (NVE) for Norwegian hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for NVE Hydrology, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/pegelonline/EVENTS.md
+++ b/pegelonline/EVENTS.md
@@ -1,6 +1,6 @@
 # PegelOnline → Apache Kafka, MQTT/UNS & AMQP 1.0 Events
 
-Kafka-transport variants of the PegelOnline CloudEvents, adding per-message Kafka key for partitioning.
+PegelOnline publishes water level measurements for rivers, canals, and estuaries from Germany's Federal Waterways and Shipping Administration (WSV) for federally administered German inland and coastal gauges. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -66,7 +66,7 @@ CloudEvents type: `de.wsv.pegelonline.Station`
 
 #### What it tells you
 
-Reference catalog entry for one WSV PegelOnline gauge installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API v2.
+A reference record for one federally administered German inland and coastal gauge published by Germany's Federal Waterways and Shipping Administration (WSV). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. WSV PegelOnline gauge installation.
 
 #### Identity
 
@@ -131,7 +131,7 @@ CloudEvents type: `de.wsv.pegelonline.CurrentMeasurement`
 
 #### What it tells you
 
-Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.
+A current measurement from Germany's Federal Waterways and Shipping Administration (WSV) for one monitoring site. It carries water level measurements for rivers, canals, and estuaries when the upstream feed reports a new or refreshed value. Latest 15-minute water-level reading for one WSV PegelOnline gauge.
 
 #### Identity
 

--- a/pegelonline/xreg/pegelonline.xreg.json
+++ b/pegelonline/xreg/pegelonline.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/de.wsv.pegelonline.kafka"
-      ]
+      ],
+      "description": "Kafka producer endpoint for PegelOnline CloudEvents on the `pegelonline` topic keyed by `{station_id}`."
     },
     "de.wsv.pegelonline.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/de.wsv.pegelonline.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for PegelOnline CloudEvents using the source's documented topic hierarchy and retain settings."
     },
     "de.wsv.pegelonline.Amqp": {
       "usage": [
@@ -61,7 +63,8 @@
       },
       "messagegroups": [
         "#/messagegroups/de.wsv.pegelonline.amqp"
-      ]
+      ],
+      "description": "AMQP 1.0 producer endpoint for PegelOnline CloudEvents on the configured broker address."
     }
   },
   "messagegroups": {
@@ -70,7 +73,7 @@
         "de.wsv.pegelonline.Station": {
           "name": "Station",
           "envelope": "CloudEvents/1.0",
-          "description": "Reference catalog entry for one WSV PegelOnline gauge installation. Emitted at bridge startup and periodically refreshed so downstream consumers can interpret CurrentMeasurement events without an out-of-band lookup. Sourced from `GET /stations.json` on the PegelOnline REST API v2.",
+          "description": "A reference record for one federally administered German inland and coastal gauge published by Germany's Federal Waterways and Shipping Administration (WSV). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "de.wsv.pegelonline.Station"
@@ -90,7 +93,7 @@
         "de.wsv.pegelonline.CurrentMeasurement": {
           "name": "CurrentMeasurement",
           "envelope": "CloudEvents/1.0",
-          "description": "Latest 15-minute water-level reading (W timeseries) for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Telemetry counterpart to the Station reference event; both share the `station_id` keying.",
+          "description": "A current measurement from Germany's Federal Waterways and Shipping Administration (WSV) for one monitoring site. It carries water level measurements for rivers, canals, and estuaries when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "de.wsv.pegelonline.CurrentMeasurement"
@@ -107,10 +110,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/de.wsv.pegelonline.jstruct/schemas/de.wsv.pegelonline.CurrentMeasurement"
         }
-      }
+      },
+      "description": "Events from PegelOnline covering federally administered German inland and coastal gauges and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "de.wsv.pegelonline.kafka": {
-      "description": "Kafka-transport variants of the PegelOnline CloudEvents, adding per-message Kafka key for partitioning.",
+      "description": "Kafka variant of the PegelOnline events. It carries the same station and measurement semantics as the source events and uses stable site identifiers for partitioning where configured.",
       "messages": {
         "de.wsv.pegelonline.kafka.Station": {
           "name": "Station",
@@ -139,7 +143,7 @@
       }
     },
     "de.wsv.pegelonline.mqtt": {
-      "description": "MQTT/5.0 transport variants of the PegelOnline CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/de/wsv/pegelonline/...",
+      "description": "MQTT 5 variant of the PegelOnline events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "de.wsv.pegelonline.mqtt.Station": {
           "name": "Station",
@@ -164,7 +168,7 @@
       }
     },
     "de.wsv.pegelonline.amqp": {
-      "description": "AMQP 1.0 transport variants of the PegelOnline CloudEvents, sent in binary CloudEvents mode to a single AMQP node ('pegelonline') — works with generic brokers (ActiveMQ Artemis, RabbitMQ AMQP 1.0 plugin, Qpid Dispatch) and with Azure Service Bus / Event Hubs via CBS + Entra ID or SAS-token. Routing key is the CloudEvent subject (`{station_id}`); per-waterway routing is exposed as the `water_shortname` AMQP application property so brokers and SB/EH subscription filters can route without cracking the JSON body.",
+      "description": "AMQP 1.0 variant of the PegelOnline events. It carries the same station and measurement semantics as the source events for brokers and services that consume AMQP messages.",
       "messages": {
         "de.wsv.pegelonline.amqp.Station": {
           "name": "Station",
@@ -280,7 +284,10 @@
                               "description": "Canonical gauge name as used in WSV publications (≤255 characters). Mutable — do not use as a routing key."
                             },
                             "km": {
-                              "type": ["null", "double"],
+                              "type": [
+                                "null",
+                                "double"
+                              ],
                               "unit": "km",
                               "symbol": "km",
                               "description": "Position along the federal waterway expressed as river-kilometre downstream from the waterway's official origin (e.g. Rhine-km 0 at the Old Rhine Bridge in Konstanz). The decimal fraction is the hectometre offset within the kilometre. Negative values occur on tributaries where the kilometre count is measured upstream from a confluence (e.g. Ohře gauge LOUNY at km -61.4 of the Elbe/Ohře system). **Optional**: absent or null for tidal / coastal gauges (Küstenpegel on the North Sea and Baltic) and for waterways without a kilometre reference. Sourced from the upstream `km` field. Unit: km."
@@ -326,7 +333,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reference details for one monitoring station or site in the PegelOnline source."
               }
             }
           }
@@ -419,7 +427,10 @@
                               "description": "Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series — HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown')."
                             },
                             "trend": {
-                              "type": ["int8", "null"],
+                              "type": [
+                                "int8",
+                                "null"
+                              ],
                               "enum": [
                                 -1,
                                 0,
@@ -444,7 +455,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the PegelOnline source."
               }
             }
           }
@@ -528,7 +540,8 @@
                       ]
                     }
                   }
-                ]
+                ],
+                "description": "Reference details for one monitoring station or site in the PegelOnline source."
               }
             }
           },
@@ -612,7 +625,8 @@
                     "default": null,
                     "doc": "Short-term trend of the water level relative to the previous reading: -1 falling, 0 steady, +1 rising. Sourced from the upstream 'trend' field. Null when upstream cannot compute a trend (e.g. first reading after a gap)."
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the PegelOnline source."
               }
             }
           },
@@ -620,5 +634,10 @@
         }
       }
     }
+  },
+  "description": "PegelOnline publishes water level measurements for rivers, canals, and estuaries from Germany's Federal Waterways and Shipping Administration (WSV) for federally administered German inland and coastal gauges. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for PegelOnline, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/rws-waterwebservices/EVENTS.md
+++ b/rws-waterwebservices/EVENTS.md
@@ -1,6 +1,6 @@
 # RWS Waterwebservices (Netherlands) Water Level Bridge Events
 
-MQTT/5.0 transport variants of the RWS Waterwebservices CloudEvents, mapping each message to retained, QoS-1 Unified Namespace topics under hydro/nl/rws/rws-waterwebservices/{station_code}/... RWS Waterwebservices does not expose a stable shared water-body axis in the station catalog, so the MQTT tree intentionally uses the station code as the stable subscriber axis.
+RWS Waterwebservices publishes water level observations from Rijkswaterstaat for Dutch water monitoring locations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `NL.RWS.Waterwebservices.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Dutch water monitoring location published by Rijkswaterstaat. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the RWS Waterwebservices source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_code}`. `{station_code}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_code}`. `{station_code}` is provider code identifying the station. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,11 +69,11 @@ Each event identifies the real-world resource with `{station_code}`. `{station_c
 
 `Station` payloads are JSON object. Required fields: `station_code`, `name`, `latitude`, `longitude`.
 
-- **`station_code`** (string, required): No description provided.
-- **`name`** (string, required): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`coordinate_system`** (string, optional): No description provided.
+- **`station_code`** (string, required): Provider code identifying the station.
+- **`name`** (string, required): Human-readable name of the station, site, or location.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
+- **`coordinate_system`** (string, optional): Provider-supplied coordinate system value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -98,11 +98,11 @@ CloudEvents type: `NL.RWS.Waterwebservices.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from Rijkswaterstaat for one monitoring site. It carries water level observations when the upstream feed reports a new or refreshed value. Measurement payload for water level observations in the RWS Waterwebservices source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_code}`. `{station_code}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_code}`. `{station_code}` is provider code identifying the station. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -115,15 +115,15 @@ Each event identifies the real-world resource with `{station_code}`. `{station_c
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_code`, `timestamp`, `value`.
 
-- **`station_code`** (string, required): No description provided.
-- **`location_name`** (string, optional): No description provided.
-- **`timestamp`** (datetime, required): No description provided.
-- **`value`** (double, required): No description provided.
-- **`unit`** (string, optional): No description provided.
-- **`quality_code`** (string, optional): No description provided.
-- **`status`** (string, optional): No description provided.
-- **`compartment`** (string, optional): No description provided.
-- **`parameter`** (string, optional): No description provided.
+- **`station_code`** (string, required): Provider code identifying the station.
+- **`location_name`** (string, optional): Human-readable name of the location.
+- **`timestamp`** (datetime, required): Time when the provider recorded or published the observation.
+- **`value`** (double, required): Measured value reported by the upstream provider.
+- **`unit`** (string, optional): Unit used for the measured value.
+- **`quality_code`** (string, optional): Provider code identifying the quality.
+- **`status`** (string, optional): Provider status value for the station, measurement, or alert.
+- **`compartment`** (string, optional): Provider-supplied compartment value for this record.
+- **`parameter`** (string, optional): Provider-supplied parameter value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/rws-waterwebservices/xreg/rws_waterwebservices.xreg.json
+++ b/rws-waterwebservices/xreg/rws_waterwebservices.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.RWS.Waterwebservices"
-      ]
+      ],
+      "description": "Kafka producer endpoint for RWS Waterwebservices CloudEvents on the `rws-waterwebservices` topic keyed by `{station_code}`."
     },
     "NL.RWS.Waterwebservices.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.RWS.Waterwebservices.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for RWS Waterwebservices CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NL.RWS.Waterwebservices.jstruct/schemas/NL.RWS.Waterwebservices.Station"
+          "dataschemauri": "#/schemagroups/NL.RWS.Waterwebservices.jstruct/schemas/NL.RWS.Waterwebservices.Station",
+          "description": "A reference record for one Dutch water monitoring location published by Rijkswaterstaat. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "NL.RWS.Waterwebservices.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NL.RWS.Waterwebservices.jstruct/schemas/NL.RWS.Waterwebservices.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/NL.RWS.Waterwebservices.jstruct/schemas/NL.RWS.Waterwebservices.WaterLevelObservation",
+          "description": "A current measurement from Rijkswaterstaat for one monitoring site. It carries water level observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from RWS Waterwebservices covering Dutch water monitoring locations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "NL.RWS.Waterwebservices.mqtt": {
-      "description": "MQTT/5.0 transport variants of the RWS Waterwebservices CloudEvents, mapping each message to retained, QoS-1 Unified Namespace topics under hydro/nl/rws/rws-waterwebservices/{station_code}/... RWS Waterwebservices does not expose a stable shared water-body axis in the station catalog, so the MQTT tree intentionally uses the station code as the stable subscriber axis.",
+      "description": "MQTT 5 variant of the RWS Waterwebservices events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "NL.RWS.Waterwebservices.mqtt.Station": {
           "name": "Station",
@@ -133,29 +138,34 @@
                 "name": "Station",
                 "properties": {
                   "station_code": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider code identifying the station."
                   },
                   "name": {
                     "type": "string",
                     "altnames": {
                       "lang:nl": "Naam"
-                    }
+                    },
+                    "description": "Human-readable name of the station, site, or location."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   },
                   "coordinate_system": {
                     "type": "string",
                     "altnames": {
                       "lang:nl": "Coordinatenstelsel"
-                    }
+                    },
+                    "description": "Provider-supplied coordinate system value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/NL/RWS/Waterwebservices/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the RWS Waterwebservices source."
               }
             }
           }
@@ -178,50 +188,59 @@
                 "name": "WaterLevelObservation",
                 "properties": {
                   "station_code": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider code identifying the station."
                   },
                   "location_name": {
                     "type": "string",
                     "altnames": {
                       "lang:nl": "Naam"
-                    }
+                    },
+                    "description": "Human-readable name of the location."
                   },
                   "timestamp": {
                     "type": "datetime",
                     "altnames": {
                       "lang:nl": "Tijdstip"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the observation."
                   },
                   "value": {
                     "type": "double",
                     "altnames": {
                       "lang:nl": "Waarde_Numeriek"
-                    }
+                    },
+                    "description": "Measured value reported by the upstream provider."
                   },
                   "unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the measured value."
                   },
                   "quality_code": {
                     "type": "string",
                     "altnames": {
                       "lang:nl": "Kwaliteitswaardecode"
-                    }
+                    },
+                    "description": "Provider code identifying the quality."
                   },
                   "status": {
                     "type": "string",
                     "altnames": {
                       "lang:nl": "Statuswaarde"
-                    }
+                    },
+                    "description": "Provider status value for the station, measurement, or alert."
                   },
                   "compartment": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied compartment value for this record."
                   },
                   "parameter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied parameter value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/NL/RWS/Waterwebservices/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level observations in the RWS Waterwebservices source."
               }
             }
           }
@@ -240,7 +259,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the RWS Waterwebservices source.",
                 "fields": [
                   {
                     "name": "station_code",
@@ -267,7 +286,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "NL.RWS.Waterwebservices"
+                "namespace": "NL.RWS.Waterwebservices",
+                "description": "Reference details for one monitoring station or site in the RWS Waterwebservices source."
               }
             }
           }
@@ -282,7 +302,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the RWS Waterwebservices source.",
                 "fields": [
                   {
                     "name": "station_code",
@@ -345,12 +365,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "NL.RWS.Waterwebservices"
+                "namespace": "NL.RWS.Waterwebservices",
+                "description": "Measurement payload for observations in the RWS Waterwebservices source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "RWS Waterwebservices publishes water level observations from Rijkswaterstaat for Dutch water monitoring locations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for RWS Waterwebservices, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/smhi-hydro/EVENTS.md
+++ b/smhi-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # SMHI Hydrological Data Bridge Events
 
-MQTT/5.0 transport variants of the SMHI Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/se/smhi/smhi-hydro/{catchment_name}/{station_id}/... The {catchment_name} placeholder is sourced from the SMHI station catalog (field 'catchmentName', e.g. 'Torneälven', 'Dalälven') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole catchments (e.g. hydro/se/smhi/smhi-hydro/tornealven/+/discharge).
+SMHI Hydrological Data publishes river discharge observations from the Swedish Meteorological and Hydrological Institute (SMHI) for Swedish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -52,11 +52,11 @@ CloudEvents type: `SE.Gov.SMHI.Hydro.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Swedish hydrological monitoring station published by the Swedish Meteorological and Hydrological Institute (SMHI). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the SMHI Hydrological Data source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,16 +69,16 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `name`, `catchment_name`, `latitude`, `longitude`.
 
-- **`station_id`** (string, required): No description provided.
-- **`name`** (string, required): No description provided.
-- **`owner`** (string, optional): No description provided.
-- **`measuring_stations`** (string, optional): No description provided.
-- **`region`** (int32, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`name`** (string, required): Human-readable name of the station, site, or location.
+- **`owner`** (string, optional): Provider-supplied owner value for this record.
+- **`measuring_stations`** (string, optional): Provider-supplied measuring stations value for this record.
+- **`region`** (int32, optional): Provider-supplied region value for this record.
 - **`catchment_name`** (string, required): Name of the catchment area the station belongs to (SMHI 'catchmentName' field, e.g. 'Torneälven', 'Dalälven'). Sourced by the bridge from the SMHI bulk API station catalog. When the catalog has no catchmentName for a station the bridge substitutes the lowercase sentinel 'unknown' so the field stays non-null and the {catchment_name} MQTT topic segment remains populated. Normalized to lowercase kebab-case before publishing.
-- **`catchment_number`** (int32, optional): No description provided.
-- **`catchment_size`** (double, optional): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
+- **`catchment_number`** (int32, optional): Provider-supplied catchment number value for this record.
+- **`catchment_size`** (double, optional): Provider-supplied catchment size value for this record.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -108,11 +108,11 @@ CloudEvents type: `SE.Gov.SMHI.Hydro.DischargeObservation`
 
 #### What it tells you
 
-This event carries discharge observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Swedish Meteorological and Hydrological Institute (SMHI) for one monitoring site. It carries river discharge observations when the upstream feed reports a new or refreshed value. DischargeObservation
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -125,12 +125,12 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Discharge Observation` payloads are JSON object. Required fields: `station_id`, `station_name`, `catchment_name`, `timestamp`, `discharge`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
 - **`catchment_name`** (string, required): Name of the catchment area the station belongs to (SMHI 'catchmentName' field, e.g. 'Torneälven', 'Dalälven'). Sourced by the bridge from the SMHI bulk API station catalog and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by catchment. When the catalog has no catchmentName the bridge substitutes the lowercase sentinel 'unknown'. Used as the {catchment_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing.
-- **`timestamp`** (datetime, required): No description provided.
-- **`discharge`** (double, required): No description provided.
-- **`quality`** (string, optional): No description provided.
+- **`timestamp`** (datetime, required): Time when the provider recorded or published the observation.
+- **`discharge`** (double, required): Current streamflow or discharge reported for the station.
+- **`quality`** (string, optional): Provider quality flag or qualification for the measurement.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/smhi-hydro/xreg/smhi_hydro.xreg.json
+++ b/smhi-hydro/xreg/smhi_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/SE.Gov.SMHI.Hydro"
-      ]
+      ],
+      "description": "Kafka producer endpoint for SMHI Hydrological Data CloudEvents on the `smhi-hydro` topic keyed by `{station_id}`."
     },
     "SE.Gov.SMHI.Hydro.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/SE.Gov.SMHI.Hydro.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for SMHI Hydrological Data CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Hydro.jstruct/schemas/SE.Gov.SMHI.Hydro.Station"
+          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Hydro.jstruct/schemas/SE.Gov.SMHI.Hydro.Station",
+          "description": "A reference record for one Swedish hydrological monitoring station published by the Swedish Meteorological and Hydrological Institute (SMHI). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "SE.Gov.SMHI.Hydro.DischargeObservation": {
           "name": "DischargeObservation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Hydro.jstruct/schemas/SE.Gov.SMHI.Hydro.DischargeObservation"
+          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Hydro.jstruct/schemas/SE.Gov.SMHI.Hydro.DischargeObservation",
+          "description": "A current measurement from the Swedish Meteorological and Hydrological Institute (SMHI) for one monitoring site. It carries river discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from SMHI Hydrological Data covering Swedish hydrological monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "SE.Gov.SMHI.Hydro.mqtt": {
-      "description": "MQTT/5.0 transport variants of the SMHI Hydrology CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under hydro/se/smhi/smhi-hydro/{catchment_name}/{station_id}/... The {catchment_name} placeholder is sourced from the SMHI station catalog (field 'catchmentName', e.g. 'Torneälven', 'Dalälven') and normalized by the bridge to lowercase kebab-case before publishing so subscribers can wildcard whole catchments (e.g. hydro/se/smhi/smhi-hydro/tornealven/+/discharge).",
+      "description": "MQTT 5 variant of the SMHI Hydrological Data events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "SE.Gov.SMHI.Hydro.mqtt.Station": {
           "name": "Station",
@@ -133,39 +138,48 @@
                 "name": "Station",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the station, site, or location."
                   },
                   "owner": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied owner value for this record."
                   },
                   "measuring_stations": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied measuring stations value for this record."
                   },
                   "region": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider-supplied region value for this record."
                   },
                   "catchment_name": {
                     "type": "string",
                     "description": "Name of the catchment area the station belongs to (SMHI 'catchmentName' field, e.g. 'Torneälven', 'Dalälven'). Sourced by the bridge from the SMHI bulk API station catalog. When the catalog has no catchmentName for a station the bridge substitutes the lowercase sentinel 'unknown' so the field stays non-null and the {catchment_name} MQTT topic segment remains populated. Normalized to lowercase kebab-case before publishing."
                   },
                   "catchment_number": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider-supplied catchment number value for this record."
                   },
                   "catchment_size": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied catchment size value for this record."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   }
                 },
                 "$id": "https://example.com/schemas/SE/Gov/SMHI/Hydro/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the SMHI Hydrological Data source."
               }
             }
           }
@@ -190,23 +204,28 @@
                 "name": "DischargeObservation",
                 "properties": {
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "catchment_name": {
                     "type": "string",
                     "description": "Name of the catchment area the station belongs to (SMHI 'catchmentName' field, e.g. 'Torneälven', 'Dalälven'). Sourced by the bridge from the SMHI bulk API station catalog and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by catchment. When the catalog has no catchmentName the bridge substitutes the lowercase sentinel 'unknown'. Used as the {catchment_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time when the provider recorded or published the observation."
                   },
                   "discharge": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Current streamflow or discharge reported for the station."
                   },
                   "quality": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider quality flag or qualification for the measurement."
                   }
                 },
                 "$id": "https://example.com/schemas/SE/Gov/SMHI/Hydro/DischargeObservation",
@@ -229,7 +248,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the SMHI Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -293,7 +312,8 @@
                     "type": "double"
                   }
                 ],
-                "namespace": "SE.Gov.SMHI.Hydro"
+                "namespace": "SE.Gov.SMHI.Hydro",
+                "description": "Reference details for one monitoring station or site in the SMHI Hydrological Data source."
               }
             }
           }
@@ -308,7 +328,7 @@
               "schema": {
                 "type": "record",
                 "name": "DischargeObservation",
-                "doc": "DischargeObservation",
+                "doc": "Measurement payload for observations in the SMHI Hydrological Data source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -343,12 +363,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "SE.Gov.SMHI.Hydro"
+                "namespace": "SE.Gov.SMHI.Hydro",
+                "description": "Measurement payload for observations in the SMHI Hydrological Data source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "SMHI Hydrological Data publishes river discharge observations from the Swedish Meteorological and Hydrological Institute (SMHI) for Swedish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for SMHI Hydrological Data, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/syke-hydro/EVENTS.md
+++ b/syke-hydro/EVENTS.md
@@ -1,6 +1,6 @@
 # SYKE Hydrology Bridge Usage Guide Events
 
-**SYKE Hydrology Bridge** connects to the Finnish Environment Institute's (SYKE) hydrological monitoring network — via the [Hydrology OData API](https://rajapinnat.ymparisto.fi/api/Hydrologiarajapinta/1.1/odata) — and forwards water level and discharge observations to a Kafka topic as [CloudEvents](https://cloudevents.io/) in JSON format.
+SYKE Hydrology publishes water level and discharge observations from the Finnish Environment Institute (SYKE) for Finnish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,11 +38,11 @@ CloudEvents type: `FI.SYKE.Hydrology.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Finnish hydrological monitoring station published by the Finnish Environment Institute (SYKE). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the SYKE Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -54,13 +54,13 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station` payloads are JSON object. Required fields: `station_id`, `name`, `latitude`, `longitude`.
 
-- **`station_id`** (string, required): No description provided.
-- **`name`** (string, required): No description provided.
-- **`river_name`** (string, optional): No description provided.
-- **`water_area_name`** (string, optional): No description provided.
-- **`municipality`** (string, optional): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`name`** (string, required): Human-readable name of the station, site, or location.
+- **`river_name`** (string, optional): Name of the river or watercourse observed at the station.
+- **`water_area_name`** (string, optional): Human-readable name of the water area.
+- **`municipality`** (string, optional): Provider-supplied municipality value for this record.
+- **`latitude`** (double, required): Latitude of the station in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station in WGS 84 coordinates.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -87,11 +87,11 @@ CloudEvents type: `FI.SYKE.Hydrology.WaterLevelObservation`
 
 #### What it tells you
 
-This event carries water level observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from the Finnish Environment Institute (SYKE) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value. Measurement payload for water level and discharge observations in the SYKE Hydrology source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the monitoring station or site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -103,7 +103,7 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Water Level Observation` payloads are JSON object. Required fields: `station_id`.
 
-- **`station_id`** (string, required): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the monitoring station or site.
 - **`water_level`** (double or null, optional): Water level reading value in centimetres. Null when the station does not report a water level in the current polling window.
 - **`water_level_unit`** (string or null, optional): Unit of measurement for water_level. Constant 'cm' when present, null when water_level is null.
 - **`water_level_timestamp`** (datetime or null, optional): RFC3339 UTC timestamp (with 'Z' suffix) of the water level observation, derived from the SYKE 'Aika' field. Null when no water level is available.

--- a/syke-hydro/xreg/syke_hydro.xreg.json
+++ b/syke-hydro/xreg/syke_hydro.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/FI.SYKE.Hydrology"
-      ]
+      ],
+      "description": "Kafka producer endpoint for SYKE Hydrology CloudEvents on the `syke-hydro` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FI.SYKE.Hydrology.jstruct/schemas/FI.SYKE.Hydrology.Station"
+          "dataschemauri": "#/schemagroups/FI.SYKE.Hydrology.jstruct/schemas/FI.SYKE.Hydrology.Station",
+          "description": "A reference record for one Finnish hydrological monitoring station published by the Finnish Environment Institute (SYKE). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "FI.SYKE.Hydrology.WaterLevelObservation": {
           "name": "WaterLevelObservation",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FI.SYKE.Hydrology.jstruct/schemas/FI.SYKE.Hydrology.WaterLevelObservation"
+          "dataschemauri": "#/schemagroups/FI.SYKE.Hydrology.jstruct/schemas/FI.SYKE.Hydrology.WaterLevelObservation",
+          "description": "A current measurement from the Finnish Environment Institute (SYKE) for one monitoring site. It carries water level and discharge observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from SYKE Hydrology covering Finnish hydrological monitoring stations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -89,41 +93,48 @@
                     "type": "string",
                     "altnames": {
                       "lang:fi": "Paikka_Id"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "name": {
                     "type": "string",
                     "altnames": {
                       "lang:fi": "Nimi"
-                    }
+                    },
+                    "description": "Human-readable name of the station, site, or location."
                   },
                   "river_name": {
                     "type": "string",
                     "altnames": {
                       "lang:fi": "PaaVesalNimi"
-                    }
+                    },
+                    "description": "Name of the river or watercourse observed at the station."
                   },
                   "water_area_name": {
                     "type": "string",
                     "altnames": {
                       "lang:fi": "VesalNimi"
-                    }
+                    },
+                    "description": "Human-readable name of the water area."
                   },
                   "municipality": {
                     "type": "string",
                     "altnames": {
                       "lang:fi": "KuntaNimi"
-                    }
+                    },
+                    "description": "Provider-supplied municipality value for this record."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station in WGS 84 coordinates."
                   }
                 },
                 "$id": "https://example.com/schemas/FI/SYKE/Hydrology/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the SYKE Hydrology source."
               }
             }
           }
@@ -147,39 +158,58 @@
                     "type": "string",
                     "altnames": {
                       "lang:fi": "Paikka_Id"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "water_level": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Water level reading value in centimetres. Null when the station does not report a water level in the current polling window.",
                     "altnames": {
                       "lang:fi": "Arvo"
                     }
                   },
                   "water_level_unit": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Unit of measurement for water_level. Constant 'cm' when present, null when water_level is null."
                   },
                   "water_level_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "RFC3339 UTC timestamp (with 'Z' suffix) of the water level observation, derived from the SYKE 'Aika' field. Null when no water level is available.",
                     "altnames": {
                       "lang:fi": "Aika"
                     }
                   },
                   "discharge": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Discharge (flow) reading value in cubic metres per second. Null for stations that do not measure discharge.",
                     "altnames": {
                       "lang:fi": "Arvo"
                     }
                   },
                   "discharge_unit": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Unit of measurement for discharge. Constant 'm3/s' when present, null when discharge is null."
                   },
                   "discharge_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "RFC3339 UTC timestamp (with 'Z' suffix) of the discharge observation, derived from the SYKE 'Aika' field. Null when no discharge is available.",
                     "altnames": {
                       "lang:fi": "Aika"
@@ -187,7 +217,7 @@
                   }
                 },
                 "$id": "https://example.com/schemas/FI/SYKE/Hydrology/WaterLevelObservation",
-                "description": "WaterLevelObservation"
+                "description": "Measurement payload for water level and discharge observations in the SYKE Hydrology source."
               }
             }
           }
@@ -206,7 +236,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the SYKE Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -249,7 +279,8 @@
                     "type": "double"
                   }
                 ],
-                "namespace": "FI.SYKE.Hydrology"
+                "namespace": "FI.SYKE.Hydrology",
+                "description": "Reference details for one monitoring station or site in the SYKE Hydrology source."
               }
             }
           }
@@ -264,7 +295,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelObservation",
-                "doc": "WaterLevelObservation",
+                "doc": "Measurement payload for observations in the SYKE Hydrology source.",
                 "fields": [
                   {
                     "name": "station_id",
@@ -325,12 +356,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "FI.SYKE.Hydrology"
+                "namespace": "FI.SYKE.Hydrology",
+                "description": "Measurement payload for observations in the SYKE Hydrology source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "SYKE Hydrology publishes water level and discharge observations from the Finnish Environment Institute (SYKE) for Finnish hydrological monitoring stations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for SYKE Hydrology, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/uk-ea-flood-monitoring/EVENTS.md
+++ b/uk-ea-flood-monitoring/EVENTS.md
@@ -1,6 +1,6 @@
 # UK Environment Agency Flood Monitoring API Bridge Events
 
-This project bridges the [UK Environment Agency Flood Monitoring API](https://environment.data.gov.uk/flood-monitoring/doc/reference) to Apache Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams. It provides real-time water level and flow data from approximately 4,000 monitoring stations across England.
+UK Environment Agency Flood Monitoring publishes water level and flow observations from the Environment Agency flood-monitoring API for monitoring stations across England. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,11 +38,11 @@ CloudEvents type: `UK.Gov.Environment.EA.FloodMonitoring.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one monitoring stations across England published by the Environment Agency flood-monitoring API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the UK Environment Agency Flood Monitoring source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_reference}`. `{station_reference}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_reference}`. `{station_reference}` is provider-supplied station reference value for this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -54,16 +54,16 @@ Each event identifies the real-world resource with `{station_reference}`. `{stat
 
 `Station` payloads are JSON object. Required fields: `station_reference`, `label`, `lat`, `long`, `notation`.
 
-- **`station_reference`** (string, required): No description provided.
-- **`label`** (string, required): No description provided.
-- **`river_name`** (string or null, optional): No description provided.
-- **`catchment_name`** (string or null, optional): No description provided.
-- **`town`** (string or null, optional): No description provided.
-- **`lat`** (double, required): No description provided.
-- **`long`** (double, required): No description provided.
-- **`notation`** (string, required): No description provided.
-- **`status`** (string or null, optional): No description provided.
-- **`date_opened`** (string or null, optional): No description provided.
+- **`station_reference`** (string, required): Provider-supplied station reference value for this record.
+- **`label`** (string, required): Provider-supplied label value for this record.
+- **`river_name`** (string or null, optional): Name of the river or watercourse observed at the station.
+- **`catchment_name`** (string or null, optional): Human-readable name of the catchment.
+- **`town`** (string or null, optional): Provider-supplied town value for this record.
+- **`lat`** (double, required): Provider-supplied lat value for this record.
+- **`long`** (double, required): Provider-supplied long value for this record.
+- **`notation`** (string, required): Provider-supplied notation value for this record.
+- **`status`** (string or null, optional): Provider status value for the station, measurement, or alert.
+- **`date_opened`** (string or null, optional): Provider-supplied date opened value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -93,11 +93,11 @@ CloudEvents type: `UK.Gov.Environment.EA.FloodMonitoring.Reading`
 
 #### What it tells you
 
-This event carries reading data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reading event from the Environment Agency flood-monitoring API. It represents source data for monitoring stations across England as published by the upstream feed. Payload record for reading events in the UK Environment Agency Flood Monitoring source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_reference}`. `{station_reference}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_reference}`. `{station_reference}` is provider-supplied station reference value for this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -109,10 +109,10 @@ Each event identifies the real-world resource with `{station_reference}`. `{stat
 
 `Reading` payloads are JSON object. Required fields: `station_reference`, `date_time`, `measure`, `value`.
 
-- **`station_reference`** (string, required): No description provided.
-- **`date_time`** (datetime, required): No description provided.
-- **`measure`** (string, required): No description provided.
-- **`value`** (double, required): No description provided.
+- **`station_reference`** (string, required): Provider-supplied station reference value for this record.
+- **`date_time`** (datetime, required): Time associated with the date time value.
+- **`measure`** (string, required): Provider-supplied measure value for this record.
+- **`value`** (double, required): Measured value reported by the upstream provider.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/uk-ea-flood-monitoring/xreg/uk_ea_flood_monitoring.xreg.json
+++ b/uk-ea-flood-monitoring/xreg/uk_ea_flood_monitoring.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/UK.Gov.Environment.EA.FloodMonitoring"
-      ]
+      ],
+      "description": "Kafka producer endpoint for UK Environment Agency Flood Monitoring CloudEvents on the `uk-ea-flood-monitoring` topic keyed by `{station_reference}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/UK.Gov.Environment.EA.FloodMonitoring.jstruct/schemas/UK.Gov.Environment.EA.FloodMonitoring.Station"
+          "dataschemauri": "#/schemagroups/UK.Gov.Environment.EA.FloodMonitoring.jstruct/schemas/UK.Gov.Environment.EA.FloodMonitoring.Station",
+          "description": "A reference record for one monitoring stations across England published by the Environment Agency flood-monitoring API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "UK.Gov.Environment.EA.FloodMonitoring.Reading": {
           "name": "Reading",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/UK.Gov.Environment.EA.FloodMonitoring.jstruct/schemas/UK.Gov.Environment.EA.FloodMonitoring.Reading"
+          "dataschemauri": "#/schemagroups/UK.Gov.Environment.EA.FloodMonitoring.jstruct/schemas/UK.Gov.Environment.EA.FloodMonitoring.Reading",
+          "description": "A reading event from the Environment Agency flood-monitoring API. It represents source data for monitoring stations across England as published by the upstream feed."
         }
-      }
+      },
+      "description": "Events from UK Environment Agency Flood Monitoring covering monitoring stations across England and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -87,38 +91,63 @@
                 "name": "Station",
                 "properties": {
                   "station_reference": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied station reference value for this record."
                   },
                   "label": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied label value for this record."
                   },
                   "river_name": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the river or watercourse observed at the station."
                   },
                   "catchment_name": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable name of the catchment."
                   },
                   "town": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider-supplied town value for this record."
                   },
                   "lat": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied lat value for this record."
                   },
                   "long": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied long value for this record."
                   },
                   "notation": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied notation value for this record."
                   },
                   "status": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider status value for the station, measurement, or alert."
                   },
                   "date_opened": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider-supplied date opened value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/UK/Gov/Environment/EA/FloodMonitoring/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the UK Environment Agency Flood Monitoring source."
               }
             }
           }
@@ -142,20 +171,24 @@
                 "name": "Reading",
                 "properties": {
                   "station_reference": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied station reference value for this record."
                   },
                   "date_time": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time associated with the date time value."
                   },
                   "measure": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied measure value for this record."
                   },
                   "value": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Measured value reported by the upstream provider."
                   }
                 },
                 "$id": "https://example.com/schemas/UK/Gov/Environment/EA/FloodMonitoring/Reading",
-                "description": "Reading"
+                "description": "Payload record for reading events in the UK Environment Agency Flood Monitoring source."
               }
             }
           }
@@ -174,7 +207,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the UK Environment Agency Flood Monitoring source.",
                 "fields": [
                   {
                     "name": "station_reference",
@@ -237,7 +270,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "UK.Gov.Environment.EA.FloodMonitoring"
+                "namespace": "UK.Gov.Environment.EA.FloodMonitoring",
+                "description": "Reference details for one monitoring station or site in the UK Environment Agency Flood Monitoring source."
               }
             }
           }
@@ -252,7 +286,7 @@
               "schema": {
                 "type": "record",
                 "name": "Reading",
-                "doc": "Reading",
+                "doc": "Measurement payload for observations in the UK Environment Agency Flood Monitoring source.",
                 "fields": [
                   {
                     "name": "station_reference",
@@ -274,12 +308,18 @@
                     "type": "double"
                   }
                 ],
-                "namespace": "UK.Gov.Environment.EA.FloodMonitoring"
+                "namespace": "UK.Gov.Environment.EA.FloodMonitoring",
+                "description": "Measurement payload for observations in the UK Environment Agency Flood Monitoring source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "UK Environment Agency Flood Monitoring publishes water level and flow observations from the Environment Agency flood-monitoring API for monitoring stations across England. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for UK Environment Agency Flood Monitoring, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/usgs-iv/EVENTS.md
+++ b/usgs-iv/EVENTS.md
@@ -1,12 +1,12 @@
 # USGS Water Services - Instantaneous Value Service Usage Guide Events
 
-MQTT/5.0 transport variants for USGS site metadata. Topics are retained QoS-1 site info leaves under hydro/us/usgs/usgs-iv/{site_no}/info. The manifest intentionally uses existing schema field names site_no and parameter_cd rather than adding aliases.
+USGS Instantaneous Values publishes instantaneous water observations such as gauge height, discharge, and temperature from the U.S. Geological Survey (USGS) Water Services API for United States streamgages and other monitoring sites. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 28 documented event types (56 transport bindings in the manifest).
 - **Transports:** KAFKA, MQTT/5.0
-- **Reference vs telemetry:** 1 reference/catalog event type and 27 telemetry event types.
+- **Reference vs telemetry:** 3 reference/catalog event types and 25 telemetry event types.
 - **Identity:** `{agency_cd}/{site_no}`, `{agency_cd}/{site_no}/{parameter_cd}/{timeseries_cd}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -52,11 +52,11 @@ CloudEvents type: `USGS.Sites.Site`
 
 #### What it tells you
 
-USGS site metadata.
+A reference record for one United States streamgages and other monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.
 
 #### Identity
 
-Each event identifies the real-world resource with `{agency_cd}/{site_no}`. `{agency_cd}` is agency code; `{site_no}` is USGS site number. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{agency_cd}/{site_no}`. `{agency_cd}` is USGS or partner agency code for the site; `{site_no}` is USGS site number within the agency. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -69,22 +69,22 @@ Each event identifies the real-world resource with `{agency_cd}/{site_no}`. `{ag
 
 `Site` payloads are JSON object. Required fields: `agency_cd`, `site_no`, `station_nm`, `site_tp_cd`, `lat_va`, `long_va`, `coord_meth_cd`, `coord_acy_cd`, `coord_datum_cd`, `dec_coord_datum_cd`, `district_cd`, `state_cd`, `county_cd`, `country_cd`, `land_net_ds`, `map_nm`, `alt_meth_cd`, `alt_datum_cd`, `huc_cd`, `basin_cd`, `topo_cd`, `instruments_cd`, `tz_cd`, `local_time_fg`, `reliability_cd`, `gw_file_cd`, `nat_aqfr_cd`, `aqfr_cd`, `aqfr_type_cd`, `depth_src_cd`, `project_no`.
 
-- **`agency_cd`** (string, required): Agency code.
-- **`site_no`** (string, required): USGS site number.
-- **`station_nm`** (string, required): Station name.
-- **`site_tp_cd`** (string, required): Site type code.
-- **`lat_va`** (string, required): DMS latitude.
-- **`long_va`** (string, required): DMS longitude.
-- **`dec_lat_va`** (float, optional): Decimal latitude.
-- **`dec_long_va`** (float, optional): Decimal longitude.
-- **`coord_meth_cd`** (string, required): Latitude-longitude method code.
-- **`coord_acy_cd`** (string, required): Coordinate accuracy code.
-- **`coord_datum_cd`** (string, required): Latitude-longitude datum code.
-- **`dec_coord_datum_cd`** (string, required): Decimal latitude-longitude datum code.
-- **`district_cd`** (string, required): District code.
-- **`state_cd`** (string, required): State code.
-- **`county_cd`** (string, required): County code.
-- **`country_cd`** (string, required): Country code.
+- **`agency_cd`** (string, required): USGS or partner agency code for the site. Combined with `site_no`, it forms the stable site identity used in CloudEvents subjects and transport keys.
+- **`site_no`** (string, required): USGS site number within the agency. Combined with `agency_cd`, it uniquely identifies the monitoring location.
+- **`station_nm`** (string, required): Human-readable site name published by USGS. Use `agency_cd` and `site_no` for stable joins because names can change.
+- **`site_tp_cd`** (string, required): USGS site-type code describing the kind of monitoring location, such as stream, lake, well, or atmospheric site.
+- **`lat_va`** (string, required): Latitude in degrees-minutes-seconds text as published by USGS.
+- **`long_va`** (string, required): Longitude in degrees-minutes-seconds text as published by USGS.
+- **`dec_lat_va`** (float, optional): Latitude in decimal degrees when USGS provides decimal coordinates.
+- **`dec_long_va`** (float, optional): Longitude in decimal degrees when USGS provides decimal coordinates.
+- **`coord_meth_cd`** (string, required): USGS method code describing how the latitude and longitude were determined.
+- **`coord_acy_cd`** (string, required): USGS accuracy code for the published coordinates.
+- **`coord_datum_cd`** (string, required): Horizontal datum code for the degrees-minutes-seconds coordinates.
+- **`dec_coord_datum_cd`** (string, required): Horizontal datum code for the decimal coordinates.
+- **`district_cd`** (string, required): USGS district code responsible for or associated with the site.
+- **`state_cd`** (string, required): FIPS state code for the site location.
+- **`county_cd`** (string, required): FIPS county code for the site location.
+- **`country_cd`** (string, required): Country code for the site location.
 - **`land_net_ds`** (string, required): Land net location description.
 - **`map_nm`** (string, required): Location map name.
 - **`map_scale_fc`** (float, optional): Location map scale factor.
@@ -92,17 +92,17 @@ Each event identifies the real-world resource with `{agency_cd}/{site_no}`. `{ag
 - **`alt_meth_cd`** (string, required): Method altitude determined code.
 - **`alt_acy_va`** (float, optional): Altitude accuracy.
 - **`alt_datum_cd`** (string, required): Altitude datum code.
-- **`huc_cd`** (string, required): Hydrologic unit code.
+- **`huc_cd`** (string, required): Hydrologic Unit Code identifying the watershed containing the site.
 - **`basin_cd`** (string, required): Drainage basin code.
 - **`topo_cd`** (string, required): Topographic setting code.
-- **`instruments_cd`** (string, required): Flags for instruments at site.
+- **`instruments_cd`** (string, required): USGS code summarizing the instrumentation installed at the site.
 - **`construction_dt`** (string, optional): Date of first construction.
 - **`inventory_dt`** (string, optional): Date site established or inventoried.
 - **`drain_area_va`** (float, optional): Drainage area.
 - **`contrib_drain_area_va`** (float, optional): Contributing drainage area.
-- **`tz_cd`** (string, required): Time Zone abbreviation.
-- **`local_time_fg`** (boolean, required): Site honors Daylight Savings Time flag.
-- **`reliability_cd`** (string, required): Data reliability code.
+- **`tz_cd`** (string, required): Time-zone code used for local timestamps at the site.
+- **`local_time_fg`** (boolean, required): Flag indicating whether timestamps are reported in the site local time zone.
+- **`reliability_cd`** (string, required): USGS reliability code describing the expected reliability of the site data.
 - **`gw_file_cd`** (string, required): Data-other GW files code.
 - **`nat_aqfr_cd`** (string, required): National aquifer code.
 - **`aqfr_cd`** (string, required): Local aquifer code.
@@ -110,7 +110,7 @@ Each event identifies the real-world resource with `{agency_cd}/{site_no}`. `{ag
 - **`well_depth_va`** (float, optional): Well depth.
 - **`hole_depth_va`** (float, optional): Hole depth.
 - **`depth_src_cd`** (string, required): Source of depth data.
-- **`project_no`** (string, required): Project number.
+- **`project_no`** (string, required): USGS project number associated with the site, when provided.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -164,7 +164,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity. MQTT may retain the latest copy so late subscribers can build local context immediately.
 
 ### Site Timeseries
 
@@ -172,7 +172,7 @@ CloudEvents type: `USGS.Sites.SiteTimeseries`
 
 #### What it tells you
 
-USGS site timeseries metadata.
+A reference record for one United States streamgages and other monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.
 
 #### Identity
 
@@ -210,7 +210,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity. MQTT may retain the latest copy so late subscribers can build local context immediately.
 
 ### Other Parameter
 
@@ -218,7 +218,7 @@ CloudEvents type: `USGS.InstantaneousValues.OtherParameter`
 
 #### What it tells you
 
-USGS other parameter data.
+A other parameter event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -270,7 +270,7 @@ CloudEvents type: `USGS.InstantaneousValues.Precipitation`
 
 #### What it tells you
 
-USGS precipitation data. Parameter code 00045.
+A precipitation event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -322,7 +322,7 @@ CloudEvents type: `USGS.InstantaneousValues.Streamflow`
 
 #### What it tells you
 
-USGS streamflow data. Parameter code 00060.
+A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -366,7 +366,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Gage Height
 
@@ -374,7 +374,7 @@ CloudEvents type: `USGS.InstantaneousValues.GageHeight`
 
 #### What it tells you
 
-USGS gage height data. Parameter code 00065.
+A gage height event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -426,7 +426,7 @@ CloudEvents type: `USGS.InstantaneousValues.WaterTemperature`
 
 #### What it tells you
 
-USGS water temperature data. Parameter code 00010.
+A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -470,7 +470,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Dissolved Oxygen
 
@@ -478,7 +478,7 @@ CloudEvents type: `USGS.InstantaneousValues.DissolvedOxygen`
 
 #### What it tells you
 
-USGS dissolved oxygen data. Parameter code 00300.
+A dissolved oxygen event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -530,7 +530,7 @@ CloudEvents type: `USGS.InstantaneousValues.pH`
 
 #### What it tells you
 
-USGS pH data. Parameter code 00400.
+A p h event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -582,7 +582,7 @@ CloudEvents type: `USGS.InstantaneousValues.SpecificConductance`
 
 #### What it tells you
 
-USGS specific conductance data. Parameter code 00095.
+A specific conductance event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -634,7 +634,7 @@ CloudEvents type: `USGS.InstantaneousValues.Turbidity`
 
 #### What it tells you
 
-USGS turbidity data. Parameter code 00076.
+A turbidity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -686,7 +686,7 @@ CloudEvents type: `USGS.InstantaneousValues.AirTemperature`
 
 #### What it tells you
 
-USGS air temperature data. Parameter code 00020.
+A air temperature event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -738,7 +738,7 @@ CloudEvents type: `USGS.InstantaneousValues.WindSpeed`
 
 #### What it tells you
 
-USGS wind speed data. Parameter code 00035.
+A wind speed event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -790,7 +790,7 @@ CloudEvents type: `USGS.InstantaneousValues.WindDirection`
 
 #### What it tells you
 
-USGS wind direction data. Parameter codes 00036 and 163695.
+A wind direction event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -842,7 +842,7 @@ CloudEvents type: `USGS.InstantaneousValues.RelativeHumidity`
 
 #### What it tells you
 
-USGS relative humidity data. Parameter code 00052.
+A relative humidity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -894,7 +894,7 @@ CloudEvents type: `USGS.InstantaneousValues.BarometricPressure`
 
 #### What it tells you
 
-USGS barometric pressure data. Parameter codes 62605 and 75969.
+A barometric pressure event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -946,7 +946,7 @@ CloudEvents type: `USGS.InstantaneousValues.TurbidityFNU`
 
 #### What it tells you
 
-USGS turbidity data (FNU). Parameter code 63680.
+A turbidity f n u event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -998,7 +998,7 @@ CloudEvents type: `USGS.InstantaneousValues.fDOM`
 
 #### What it tells you
 
-USGS dissolved organic matter fluorescence data (fDOM). Parameter codes 32295 and 32322.
+A f d o m event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1050,7 +1050,7 @@ CloudEvents type: `USGS.InstantaneousValues.ReservoirStorage`
 
 #### What it tells you
 
-USGS reservoir storage data. Parameter code 00054.
+A current reservoir record from the U.S. Geological Survey (USGS) Water Services API. It reports the latest storage, elevation, capacity, or related reservoir status available for one reservoir.
 
 #### Identity
 
@@ -1094,7 +1094,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Lake Elevation NGVD29
 
@@ -1102,7 +1102,7 @@ CloudEvents type: `USGS.InstantaneousValues.LakeElevationNGVD29`
 
 #### What it tells you
 
-USGS lake or reservoir water surface elevation above NGVD 1929, feet. Parameter code 62614.
+A lake elevation n g v d29 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1154,7 +1154,7 @@ CloudEvents type: `USGS.InstantaneousValues.WaterDepth`
 
 #### What it tells you
 
-USGS water depth data. Parameter code 72199.
+A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -1198,7 +1198,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Equipment Status
 
@@ -1206,7 +1206,7 @@ CloudEvents type: `USGS.InstantaneousValues.EquipmentStatus`
 
 #### What it tells you
 
-USGS equipment alarm status data. Parameter code 99235.
+A equipment status event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1252,7 +1252,7 @@ CloudEvents type: `USGS.InstantaneousValues.TidallyFilteredDischarge`
 
 #### What it tells you
 
-USGS tidally filtered discharge data. Parameter code 72137.
+A tidally filtered discharge event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1304,7 +1304,7 @@ CloudEvents type: `USGS.InstantaneousValues.WaterVelocity`
 
 #### What it tells you
 
-USGS water velocity data. Parameter code 72254.
+A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -1348,7 +1348,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Estuary Elevation NGVD29
 
@@ -1356,7 +1356,7 @@ CloudEvents type: `USGS.InstantaneousValues.EstuaryElevationNGVD29`
 
 #### What it tells you
 
-USGS estuary or ocean water surface elevation above NGVD 1929, feet. Parameter code 62619.
+A estuary elevation n g v d29 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1408,7 +1408,7 @@ CloudEvents type: `USGS.InstantaneousValues.LakeElevationNAVD88`
 
 #### What it tells you
 
-USGS lake or reservoir water surface elevation above NAVD 1988, feet. Parameter code 62615.
+A lake elevation n a v d88 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1460,7 +1460,7 @@ CloudEvents type: `USGS.InstantaneousValues.Salinity`
 
 #### What it tells you
 
-USGS salinity data. Parameter code 00480.
+A salinity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 
@@ -1512,7 +1512,7 @@ CloudEvents type: `USGS.InstantaneousValues.GateOpening`
 
 #### What it tells you
 
-USGS gate opening data. Parameter code 45592.
+A gate opening event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.
 
 #### Identity
 

--- a/usgs-iv/xreg/usgs_iv.xreg.json
+++ b/usgs-iv/xreg/usgs_iv.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/USGS.Sites"
-      ]
+      ],
+      "description": "Kafka producer endpoint for USGS Instantaneous Values CloudEvents on the `usgs-iv` topic keyed by `{agency_cd}/{site_no}`."
     },
     "USGS.Timeseries.Kafka": {
       "usage": [
@@ -41,7 +42,8 @@
       "messagegroups": [
         "#/messagegroups/USGS.SiteTimeseries",
         "#/messagegroups/USGS.InstantaneousValues"
-      ]
+      ],
+      "description": "Kafka producer endpoint for USGS Instantaneous Values CloudEvents on the `usgs-iv` topic keyed by `{agency_cd}/{site_no}/{parameter_cd}/{timeseries_cd}`."
     },
     "USGS.IV.Mqtt": {
       "usage": [
@@ -62,7 +64,8 @@
         "#/messagegroups/USGS.Sites.mqtt",
         "#/messagegroups/USGS.SiteTimeseries.mqtt",
         "#/messagegroups/USGS.InstantaneousValues.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for USGS Instantaneous Values CloudEvents using the source's documented topic hierarchy and retain settings."
     }
   },
   "messagegroups": {
@@ -71,7 +74,7 @@
         "USGS.Sites.Site": {
           "name": "Site",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS site metadata.",
+          "description": "A reference record for one United States streamgages and other monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.Sites.Site"
@@ -88,14 +91,15 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/USGS.Sites.jstruct/schemas/USGS.Sites.Site"
         }
-      }
+      },
+      "description": "Events from USGS Instantaneous Values covering United States streamgages and other monitoring sites and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "USGS.SiteTimeseries": {
       "messages": {
         "USGS.Sites.SiteTimeseries": {
           "name": "SiteTimeseries",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS site timeseries metadata.",
+          "description": "A reference record for one United States streamgages and other monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.Sites.SiteTimeseries"
@@ -112,14 +116,15 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/USGS.Sites.jstruct/schemas/USGS.Sites.SiteTimeseries"
         }
-      }
+      },
+      "description": "Events from USGS Instantaneous Values covering United States streamgages and other monitoring sites and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "USGS.InstantaneousValues": {
       "messages": {
         "USGS.InstantaneousValues.OtherParameter": {
           "name": "OtherParameter",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS other parameter data.",
+          "description": "A other parameter event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.OtherParameter"
@@ -143,7 +148,7 @@
         "USGS.InstantaneousValues.Precipitation": {
           "name": "Precipitation",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS precipitation data. Parameter code 00045.",
+          "description": "A precipitation event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.Precipitation"
@@ -167,7 +172,7 @@
         "USGS.InstantaneousValues.Streamflow": {
           "name": "Streamflow",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS streamflow data. Parameter code 00060.",
+          "description": "A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.Streamflow"
@@ -191,7 +196,7 @@
         "USGS.InstantaneousValues.GageHeight": {
           "name": "GageHeight",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS gage height data. Parameter code 00065.",
+          "description": "A gage height event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.GageHeight"
@@ -215,7 +220,7 @@
         "USGS.InstantaneousValues.WaterTemperature": {
           "name": "WaterTemperature",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS water temperature data. Parameter code 00010.",
+          "description": "A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.WaterTemperature"
@@ -239,7 +244,7 @@
         "USGS.InstantaneousValues.DissolvedOxygen": {
           "name": "DissolvedOxygen",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS dissolved oxygen data. Parameter code 00300.",
+          "description": "A dissolved oxygen event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.DissolvedOxygen"
@@ -263,7 +268,7 @@
         "USGS.InstantaneousValues.pH": {
           "name": "pH",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS pH data. Parameter code 00400.",
+          "description": "A p h event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.pH"
@@ -287,7 +292,7 @@
         "USGS.InstantaneousValues.SpecificConductance": {
           "name": "SpecificConductance",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS specific conductance data. Parameter code 00095.",
+          "description": "A specific conductance event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.SpecificConductance"
@@ -311,7 +316,7 @@
         "USGS.InstantaneousValues.Turbidity": {
           "name": "Turbidity",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS turbidity data. Parameter code 00076.",
+          "description": "A turbidity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.Turbidity"
@@ -335,7 +340,7 @@
         "USGS.InstantaneousValues.AirTemperature": {
           "name": "AirTemperature",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS air temperature data. Parameter code 00020.",
+          "description": "A air temperature event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.AirTemperature"
@@ -359,7 +364,7 @@
         "USGS.InstantaneousValues.WindSpeed": {
           "name": "WindSpeed",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS wind speed data. Parameter code 00035.",
+          "description": "A wind speed event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.WindSpeed"
@@ -383,7 +388,7 @@
         "USGS.InstantaneousValues.WindDirection": {
           "name": "WindDirection",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS wind direction data. Parameter codes 00036 and 163695.",
+          "description": "A wind direction event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.WindDirection"
@@ -407,7 +412,7 @@
         "USGS.InstantaneousValues.RelativeHumidity": {
           "name": "RelativeHumidity",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS relative humidity data. Parameter code 00052.",
+          "description": "A relative humidity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.RelativeHumidity"
@@ -431,7 +436,7 @@
         "USGS.InstantaneousValues.BarometricPressure": {
           "name": "BarometricPressure",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS barometric pressure data. Parameter codes 62605 and 75969.",
+          "description": "A barometric pressure event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.BarometricPressure"
@@ -455,7 +460,7 @@
         "USGS.InstantaneousValues.TurbidityFNU": {
           "name": "TurbidityFNU",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS turbidity data (FNU). Parameter code 63680.",
+          "description": "A turbidity f n u event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.TurbidityFNU"
@@ -479,7 +484,7 @@
         "USGS.InstantaneousValues.fDOM": {
           "name": "fDOM",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS dissolved organic matter fluorescence data (fDOM). Parameter codes 32295 and 32322.",
+          "description": "A f d o m event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.fDOM"
@@ -503,7 +508,7 @@
         "USGS.InstantaneousValues.ReservoirStorage": {
           "name": "ReservoirStorage",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS reservoir storage data. Parameter code 00054.",
+          "description": "A current reservoir record from the U.S. Geological Survey (USGS) Water Services API. It reports the latest storage, elevation, capacity, or related reservoir status available for one reservoir.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.ReservoirStorage"
@@ -527,7 +532,7 @@
         "USGS.InstantaneousValues.LakeElevationNGVD29": {
           "name": "LakeElevationNGVD29",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS lake or reservoir water surface elevation above NGVD 1929, feet. Parameter code 62614.",
+          "description": "A lake elevation n g v d29 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.LakeElevationNGVD29"
@@ -551,7 +556,7 @@
         "USGS.InstantaneousValues.WaterDepth": {
           "name": "WaterDepth",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS water depth data. Parameter code 72199.",
+          "description": "A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.WaterDepth"
@@ -575,7 +580,7 @@
         "USGS.InstantaneousValues.EquipmentStatus": {
           "name": "EquipmentStatus",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS equipment alarm status data. Parameter code 99235.",
+          "description": "A equipment status event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.EquipmentStatus"
@@ -599,7 +604,7 @@
         "USGS.InstantaneousValues.TidallyFilteredDischarge": {
           "name": "TidallyFilteredDischarge",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS tidally filtered discharge data. Parameter code 72137.",
+          "description": "A tidally filtered discharge event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.TidallyFilteredDischarge"
@@ -623,7 +628,7 @@
         "USGS.InstantaneousValues.WaterVelocity": {
           "name": "WaterVelocity",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS water velocity data. Parameter code 72254.",
+          "description": "A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries instantaneous water observations such as gauge height, discharge, and temperature when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.WaterVelocity"
@@ -647,7 +652,7 @@
         "USGS.InstantaneousValues.EstuaryElevationNGVD29": {
           "name": "EstuaryElevationNGVD29",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS estuary or ocean water surface elevation above NGVD 1929, feet. Parameter code 62619.",
+          "description": "A estuary elevation n g v d29 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.EstuaryElevationNGVD29"
@@ -671,7 +676,7 @@
         "USGS.InstantaneousValues.LakeElevationNAVD88": {
           "name": "LakeElevationNAVD88",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS lake or reservoir water surface elevation above NAVD 1988, feet. Parameter code 62615.",
+          "description": "A lake elevation n a v d88 event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.LakeElevationNAVD88"
@@ -695,7 +700,7 @@
         "USGS.InstantaneousValues.Salinity": {
           "name": "Salinity",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS salinity data. Parameter code 00480.",
+          "description": "A salinity event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.Salinity"
@@ -719,7 +724,7 @@
         "USGS.InstantaneousValues.GateOpening": {
           "name": "GateOpening",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS gate opening data. Parameter code 45592.",
+          "description": "A gate opening event from the U.S. Geological Survey (USGS) Water Services API. It represents source data for United States streamgages and other monitoring sites as published by the upstream feed.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.InstantaneousValues.GateOpening"
@@ -740,10 +745,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/USGS.InstantaneousValues.jstruct/schemas/USGS.InstantaneousValues.GateOpening"
         }
-      }
+      },
+      "description": "Events from USGS Instantaneous Values covering United States streamgages and other monitoring sites and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "USGS.Sites.mqtt": {
-      "description": "MQTT/5.0 transport variants for USGS site metadata. Topics are retained QoS-1 site info leaves under hydro/us/usgs/usgs-iv/{site_no}/info. The manifest intentionally uses existing schema field names site_no and parameter_cd rather than adding aliases.",
+      "description": "MQTT 5 variant of the USGS Instantaneous Values events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "USGS.Sites.mqtt.Site": {
           "name": "Site",
@@ -759,7 +765,7 @@
       }
     },
     "USGS.SiteTimeseries.mqtt": {
-      "description": "MQTT/5.0 transport variants for USGS site timeseries metadata. Retained QoS-1 leaves use existing schema fields site_no, parameter_cd, and timeseries_cd to preserve the Kafka identity axes.",
+      "description": "MQTT 5 variant of the USGS Instantaneous Values events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "USGS.SiteTimeseries.mqtt.SiteTimeseries": {
           "name": "SiteTimeseries",
@@ -775,7 +781,7 @@
       }
     },
     "USGS.InstantaneousValues.mqtt": {
-      "description": "MQTT/5.0 transport variants for USGS instantaneous values. Retained QoS-1 latest-observation leaves use existing schema fields site_no, parameter_cd, and timeseries_cd to avoid collapsing independent USGS time series; message expiry limits stale latest values.",
+      "description": "MQTT 5 variant of the USGS Instantaneous Values events. It carries the same station and measurement semantics as the source events, with MQTT topics arranged for source, water body, and station subscriptions where the manifest defines those segments.",
       "messages": {
         "USGS.InstantaneousValues.mqtt.OtherParameter": {
           "name": "OtherParameter",
@@ -1090,69 +1096,69 @@
                         "properties": {
                           "agency_cd": {
                             "type": "string",
-                            "description": "Agency code."
+                            "description": "USGS or partner agency code for the site. Combined with `site_no`, it forms the stable site identity used in CloudEvents subjects and transport keys."
                           },
                           "site_no": {
                             "type": "string",
-                            "description": "USGS site number."
+                            "description": "USGS site number within the agency. Combined with `agency_cd`, it uniquely identifies the monitoring location."
                           },
                           "station_nm": {
                             "type": "string",
-                            "description": "Station name."
+                            "description": "Human-readable site name published by USGS. Use `agency_cd` and `site_no` for stable joins because names can change."
                           },
                           "site_tp_cd": {
                             "type": "string",
-                            "description": "Site type code."
+                            "description": "USGS site-type code describing the kind of monitoring location, such as stream, lake, well, or atmospheric site."
                           },
                           "lat_va": {
                             "type": "string",
-                            "description": "DMS latitude."
+                            "description": "Latitude in degrees-minutes-seconds text as published by USGS."
                           },
                           "long_va": {
                             "type": "string",
-                            "description": "DMS longitude."
+                            "description": "Longitude in degrees-minutes-seconds text as published by USGS."
                           },
                           "dec_lat_va": {
                             "type": "float",
                             "default": null,
-                            "description": "Decimal latitude."
+                            "description": "Latitude in decimal degrees when USGS provides decimal coordinates."
                           },
                           "dec_long_va": {
                             "type": "float",
                             "default": null,
-                            "description": "Decimal longitude."
+                            "description": "Longitude in decimal degrees when USGS provides decimal coordinates."
                           },
                           "coord_meth_cd": {
                             "type": "string",
-                            "description": "Latitude-longitude method code."
+                            "description": "USGS method code describing how the latitude and longitude were determined."
                           },
                           "coord_acy_cd": {
                             "type": "string",
-                            "description": "Coordinate accuracy code."
+                            "description": "USGS accuracy code for the published coordinates."
                           },
                           "coord_datum_cd": {
                             "type": "string",
-                            "description": "Latitude-longitude datum code."
+                            "description": "Horizontal datum code for the degrees-minutes-seconds coordinates."
                           },
                           "dec_coord_datum_cd": {
                             "type": "string",
-                            "description": "Decimal latitude-longitude datum code."
+                            "description": "Horizontal datum code for the decimal coordinates."
                           },
                           "district_cd": {
                             "type": "string",
-                            "description": "District code."
+                            "description": "USGS district code responsible for or associated with the site."
                           },
                           "state_cd": {
                             "type": "string",
-                            "description": "State code."
+                            "description": "FIPS state code for the site location."
                           },
                           "county_cd": {
                             "type": "string",
-                            "description": "County code."
+                            "description": "FIPS county code for the site location."
                           },
                           "country_cd": {
                             "type": "string",
-                            "description": "Country code."
+                            "description": "Country code for the site location."
                           },
                           "land_net_ds": {
                             "type": "string",
@@ -1187,7 +1193,7 @@
                           },
                           "huc_cd": {
                             "type": "string",
-                            "description": "Hydrologic unit code."
+                            "description": "Hydrologic Unit Code identifying the watershed containing the site."
                           },
                           "basin_cd": {
                             "type": "string",
@@ -1199,7 +1205,7 @@
                           },
                           "instruments_cd": {
                             "type": "string",
-                            "description": "Flags for instruments at site."
+                            "description": "USGS code summarizing the instrumentation installed at the site."
                           },
                           "construction_dt": {
                             "type": "string",
@@ -1223,15 +1229,15 @@
                           },
                           "tz_cd": {
                             "type": "string",
-                            "description": "Time Zone abbreviation."
+                            "description": "Time-zone code used for local timestamps at the site."
                           },
                           "local_time_fg": {
                             "type": "boolean",
-                            "description": "Site honors Daylight Savings Time flag."
+                            "description": "Flag indicating whether timestamps are reported in the site local time zone."
                           },
                           "reliability_cd": {
                             "type": "string",
-                            "description": "Data reliability code."
+                            "description": "USGS reliability code describing the expected reliability of the site data."
                           },
                           "gw_file_cd": {
                             "type": "string",
@@ -1265,7 +1271,7 @@
                           },
                           "project_no": {
                             "type": "string",
-                            "description": "Project number."
+                            "description": "USGS project number associated with the site, when provided."
                           }
                         },
                         "required": [
@@ -1305,7 +1311,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reference details for one monitoring station or site in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1361,7 +1368,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reference details for one monitoring station or site in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1638,7 +1646,8 @@
                     "doc": "Project number.",
                     "type": "string"
                   }
-                ]
+                ],
+                "description": "Reference details for one monitoring station or site in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1682,7 +1691,8 @@
                     "doc": "Description.",
                     "type": "string"
                   }
-                ]
+                ],
+                "description": "Reference details for one monitoring station or site in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1753,7 +1763,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for other parameter events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1820,7 +1831,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for precipitation events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1887,7 +1899,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -1954,7 +1967,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2021,7 +2035,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2088,7 +2103,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for dissolved oxygen events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2155,7 +2171,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for p h events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2222,7 +2239,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for specific conductance events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2289,7 +2307,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for turbidity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2356,7 +2375,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for wind speed events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2423,7 +2443,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for wind direction events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2490,7 +2511,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for relative humidity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2557,7 +2579,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for barometric pressure events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2624,7 +2647,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2691,7 +2715,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for turbidity f n u events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2758,7 +2783,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for f d o m events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2825,7 +2851,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Reservoir status record from the USGS Instantaneous Values source."
               }
             }
           }
@@ -2892,7 +2919,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for lake elevation n g v d29 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -2959,7 +2987,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for water depth events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3014,7 +3043,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for equipment status events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3081,7 +3111,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3148,7 +3179,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for water velocity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3215,7 +3247,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for estuary elevation n g v d29 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3282,7 +3315,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for lake elevation n a v d88 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3349,7 +3383,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for salinity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3416,7 +3451,8 @@
                       }
                     }
                   }
-                }
+                },
+                "description": "Payload record for gate opening events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3484,7 +3520,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for other parameter events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3549,7 +3586,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for precipitation events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3614,7 +3652,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3679,7 +3718,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3743,7 +3783,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3807,7 +3848,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for dissolved oxygen events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3871,7 +3913,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for p h events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -3936,7 +3979,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for specific conductance events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4000,7 +4044,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for turbidity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4064,7 +4109,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for wind speed events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4128,7 +4174,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for wind direction events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4192,7 +4239,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for relative humidity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4256,7 +4304,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for barometric pressure events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4320,7 +4369,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4384,7 +4434,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for turbidity f n u events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4448,7 +4499,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for f d o m events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4512,7 +4564,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Reservoir status record from the USGS Instantaneous Values source."
               }
             }
           }
@@ -4576,7 +4629,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for lake elevation n g v d29 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4640,7 +4694,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for water depth events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4687,7 +4742,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for equipment status events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4751,7 +4807,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Measurement payload for observations in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4815,7 +4872,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for water velocity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4879,7 +4937,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for estuary elevation n g v d29 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -4943,7 +5002,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for lake elevation n a v d88 events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -5007,7 +5067,8 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for salinity events in the USGS Instantaneous Values source."
               }
             }
           }
@@ -5071,12 +5132,18 @@
                     "type": "string",
                     "doc": "{\"description\": \"Timeseries code.\"}"
                   }
-                ]
+                ],
+                "description": "Payload record for gate opening events in the USGS Instantaneous Values source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "USGS Instantaneous Values publishes instantaneous water observations such as gauge height, discharge, and temperature from the U.S. Geological Survey (USGS) Water Services API for United States streamgages and other monitoring sites. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for USGS Instantaneous Values, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/usgs-nwis-wq/EVENTS.md
+++ b/usgs-nwis-wq/EVENTS.md
@@ -1,12 +1,12 @@
 # USGS NWIS Water Quality - Continuous Water Quality Sensor Data Events
 
-**usgs-nwis-wq** is a bridge that polls the [USGS Water Services](https://waterservices.usgs.gov/) Instantaneous Values Service API for continuous water quality sensor readings from over 3,000 monitoring sites across the United States. The bridge focuses specifically on water quality parameters: dissolved oxygen, pH, water temperature, specific conductance, turbidity, and nitrate.
+USGS NWIS Water Quality publishes continuous water-quality sensor readings from the U.S. Geological Survey (USGS) Water Services API for United States water-quality monitoring sites. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
+- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
 - **Identity:** `{site_number}`, `{site_number}/{parameter_code}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `USGS.WaterQuality.Sites.MonitoringSite`
 
 #### What it tells you
 
-USGS water quality monitoring site reference data. Describes a physical monitoring location equipped with continuous water quality sensors. USGS water quality monitoring site.
+A reference record for one United States water-quality monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.
 
 #### Identity
 
@@ -65,7 +65,7 @@ null
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
 
 ### Water Quality Reading
 
@@ -73,7 +73,7 @@ CloudEvents type: `USGS.WaterQuality.Readings.WaterQualityReading`
 
 #### What it tells you
 
-A single water quality observation from a USGS continuous monitoring sensor, including dissolved oxygen, pH, water temperature, specific conductance, turbidity, and nitrate readings. A single water quality observation from a USGS continuous monitoring sensor. The USGS Instantaneous Values Service returns time series of sensor readings in WaterML 2.0 JSON format.
+A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries continuous water-quality sensor readings when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/usgs-nwis-wq/xreg/usgs_nwis_wq.xreg.json
+++ b/usgs-nwis-wq/xreg/usgs_nwis_wq.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/USGS.WaterQuality.Sites"
-      ]
+      ],
+      "description": "Kafka producer endpoint for USGS NWIS Water Quality CloudEvents on the `usgs-nwis-wq` topic keyed by `{site_number}`."
     },
     "USGS.WaterQuality.Readings.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/USGS.WaterQuality.Readings"
-      ]
+      ],
+      "description": "Kafka producer endpoint for USGS NWIS Water Quality CloudEvents on the `usgs-nwis-wq` topic keyed by `{site_number}/{parameter_code}`."
     }
   },
   "messagegroups": {
@@ -49,7 +51,7 @@
         "USGS.WaterQuality.Sites.MonitoringSite": {
           "name": "MonitoringSite",
           "envelope": "CloudEvents/1.0",
-          "description": "USGS water quality monitoring site reference data. Describes a physical monitoring location equipped with continuous water quality sensors.",
+          "description": "A reference record for one United States water-quality monitoring site published by the U.S. Geological Survey (USGS) Water Services API. It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.WaterQuality.Sites.MonitoringSite"
@@ -66,14 +68,15 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/USGS.WaterQuality.Sites.jstruct/schemas/USGS.WaterQuality.Sites.MonitoringSite"
         }
-      }
+      },
+      "description": "Events from USGS NWIS Water Quality covering United States water-quality monitoring sites and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     },
     "USGS.WaterQuality.Readings": {
       "messages": {
         "USGS.WaterQuality.Readings.WaterQualityReading": {
           "name": "WaterQualityReading",
           "envelope": "CloudEvents/1.0",
-          "description": "A single water quality observation from a USGS continuous monitoring sensor, including dissolved oxygen, pH, water temperature, specific conductance, turbidity, and nitrate readings.",
+          "description": "A current measurement from the U.S. Geological Survey (USGS) Water Services API for one monitoring site. It carries continuous water-quality sensor readings when the upstream feed reports a new or refreshed value.",
           "envelopemetadata": {
             "type": {
               "value": "USGS.WaterQuality.Readings.WaterQualityReading"
@@ -90,7 +93,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/USGS.WaterQuality.Readings.jstruct/schemas/USGS.WaterQuality.Readings.WaterQualityReading"
         }
-      }
+      },
+      "description": "Events from USGS NWIS Water Quality covering United States water-quality monitoring sites and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -125,32 +129,50 @@
                   },
                   {
                     "name": "latitude",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Decimal latitude of the monitoring site in the WGS84 (EPSG:4326) coordinate reference system."
                   },
                   {
                     "name": "longitude",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Decimal longitude of the monitoring site in the WGS84 (EPSG:4326) coordinate reference system."
                   },
                   {
                     "name": "site_type",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "USGS site type code indicating the category of the monitoring location. Common values include 'ST' (stream), 'LK' (lake), 'GW' (groundwater), 'ES' (estuary)."
                   },
                   {
                     "name": "state_code",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Two-digit FIPS state code for the state or territory where the site is located (e.g. '24' for Maryland)."
                   },
                   {
                     "name": "county_code",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Five-digit FIPS county code for the county where the site is located (e.g. '24031' for Montgomery County, MD)."
                   },
                   {
                     "name": "huc_code",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Hydrologic Unit Code (HUC) identifying the watershed or drainage basin containing the site."
                   }
                 ]
@@ -196,7 +218,10 @@
                   },
                   {
                     "name": "value",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Numeric sensor reading for the parameter at the given date_time. Null when the sensor did not return a valid numeric value (e.g. equipment malfunction, ice-affected, or the USGS noDataValue sentinel -999999.0)."
                   },
                   {
@@ -206,7 +231,10 @@
                   },
                   {
                     "name": "qualifier",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "USGS data qualifier code indicating the quality or status of the reading. Common values: 'P' (provisional), 'A' (approved), 'e' (estimated). Null when no qualifier is provided."
                   },
                   {
@@ -221,5 +249,10 @@
         }
       }
     }
+  },
+  "description": "USGS NWIS Water Quality publishes continuous water-quality sensor readings from the U.S. Geological Survey (USGS) Water Services API for United States water-quality monitoring sites. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for USGS NWIS Water Quality, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/waterinfo-vmm/EVENTS.md
+++ b/waterinfo-vmm/EVENTS.md
@@ -1,6 +1,6 @@
 # Waterinfo VMM (Belgium/Flanders) Water Level Bridge Events
 
-This project bridges water level data from the Belgian [Waterinfo.be](https://waterinfo.vlaanderen.be/) KIWIS API (VMM provider) to Apache Kafka, emitting CloudEvents.
+Waterinfo VMM publishes water level observations from Waterinfo.be and the Flemish Environment Agency (VMM) for Flemish water monitoring locations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,11 +38,11 @@ CloudEvents type: `BE.Vlaanderen.Waterinfo.VMM.Station`
 
 #### What it tells you
 
-This event carries station data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record for one Flemish water monitoring location published by Waterinfo.be and the Flemish Environment Agency (VMM). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events. Reference details for one monitoring station or site in the Waterinfo VMM source.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_no}`. `{station_no}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_no}`. `{station_no}` is provider-supplied station no value for this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -54,15 +54,15 @@ Each event identifies the real-world resource with `{station_no}`. `{station_no}
 
 `Station` payloads are JSON object. Required fields: `station_no`, `station_name`, `station_latitude`, `station_longitude`.
 
-- **`station_no`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`station_id`** (string, optional): No description provided.
-- **`station_latitude`** (double, required): No description provided.
-- **`station_longitude`** (double, required): No description provided.
-- **`river_name`** (string or null, optional): No description provided.
-- **`stationparameter_name`** (string or null, optional): No description provided.
-- **`ts_id`** (string or null, optional): No description provided.
-- **`ts_unitname`** (string or null, optional): No description provided.
+- **`station_no`** (string, required): Provider-supplied station no value for this record.
+- **`station_name`** (string, required): Human-readable name of the monitoring station.
+- **`station_id`** (string, optional): Stable identifier assigned by the upstream provider for the monitoring station or site.
+- **`station_latitude`** (double, required): Provider-supplied station latitude value for this record.
+- **`station_longitude`** (double, required): Provider-supplied station longitude value for this record.
+- **`river_name`** (string or null, optional): Name of the river or watercourse observed at the station.
+- **`stationparameter_name`** (string or null, optional): Human-readable name of the stationparameter.
+- **`ts_id`** (string or null, optional): Stable identifier assigned by the upstream provider for the ts.
+- **`ts_unitname`** (string or null, optional): Provider-supplied ts unitname value for this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -91,11 +91,11 @@ CloudEvents type: `BE.Vlaanderen.Waterinfo.VMM.WaterLevelReading`
 
 #### What it tells you
 
-This event carries water level reading data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current measurement from Waterinfo.be and the Flemish Environment Agency (VMM) for one monitoring site. It carries water level observations when the upstream feed reports a new or refreshed value. WaterLevelReading
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_no}`. `{station_no}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_no}`. `{station_no}` is provider-supplied station no value for this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -107,13 +107,13 @@ Each event identifies the real-world resource with `{station_no}`. `{station_no}
 
 `Water Level Reading` payloads are JSON object. Required fields: `ts_id`, `station_no`, `timestamp`, `value`.
 
-- **`ts_id`** (string, required): No description provided.
-- **`station_no`** (string, required): No description provided.
-- **`station_name`** (string, optional): No description provided.
-- **`timestamp`** (datetime, required): No description provided.
-- **`value`** (double, required): No description provided.
-- **`unit_name`** (string, optional): No description provided.
-- **`parameter_name`** (string, optional): No description provided.
+- **`ts_id`** (string, required): Stable identifier assigned by the upstream provider for the ts.
+- **`station_no`** (string, required): Provider-supplied station no value for this record.
+- **`station_name`** (string, optional): Human-readable name of the monitoring station.
+- **`timestamp`** (datetime, required): Time when the provider recorded or published the observation.
+- **`value`** (double, required): Measured value reported by the upstream provider.
+- **`unit_name`** (string, optional): Human-readable name of the unit.
+- **`parameter_name`** (string, optional): Plain-language name of the measured parameter.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/waterinfo-vmm/xreg/waterinfo_vmm.xreg.json
+++ b/waterinfo-vmm/xreg/waterinfo_vmm.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/BE.Vlaanderen.Waterinfo.VMM"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Waterinfo VMM CloudEvents on the `waterinfo-vmm` topic keyed by `{station_no}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/BE.Vlaanderen.Waterinfo.VMM.jstruct/schemas/BE.Vlaanderen.Waterinfo.VMM.Station"
+          "dataschemauri": "#/schemagroups/BE.Vlaanderen.Waterinfo.VMM.jstruct/schemas/BE.Vlaanderen.Waterinfo.VMM.Station",
+          "description": "A reference record for one Flemish water monitoring location published by Waterinfo.be and the Flemish Environment Agency (VMM). It fires when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events."
         },
         "BE.Vlaanderen.Waterinfo.VMM.WaterLevelReading": {
           "name": "WaterLevelReading",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/BE.Vlaanderen.Waterinfo.VMM.jstruct/schemas/BE.Vlaanderen.Waterinfo.VMM.WaterLevelReading"
+          "dataschemauri": "#/schemagroups/BE.Vlaanderen.Waterinfo.VMM.jstruct/schemas/BE.Vlaanderen.Waterinfo.VMM.WaterLevelReading",
+          "description": "A current measurement from Waterinfo.be and the Flemish Environment Agency (VMM) for one monitoring site. It carries water level observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Waterinfo VMM covering Flemish water monitoring locations and their current measurements. Use the reference records to identify stations and the measurement records for the latest observations."
     }
   },
   "schemagroups": {
@@ -86,35 +90,56 @@
                 "name": "Station",
                 "properties": {
                   "station_no": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied station no value for this record."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the monitoring station or site."
                   },
                   "station_latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied station latitude value for this record."
                   },
                   "station_longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider-supplied station longitude value for this record."
                   },
                   "river_name": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the river or watercourse observed at the station."
                   },
                   "stationparameter_name": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable name of the stationparameter."
                   },
                   "ts_id": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Stable identifier assigned by the upstream provider for the ts."
                   },
                   "ts_unitname": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Provider-supplied ts unitname value for this record."
                   }
                 },
                 "$id": "https://example.com/schemas/BE/Vlaanderen/Waterinfo/VMM/Station",
-                "description": "Station"
+                "description": "Reference details for one monitoring station or site in the Waterinfo VMM source."
               }
             }
           }
@@ -138,25 +163,32 @@
                 "name": "WaterLevelReading",
                 "properties": {
                   "ts_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the ts."
                   },
                   "station_no": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider-supplied station no value for this record."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the monitoring station."
                   },
                   "timestamp": {
-                    "type": "datetime"
+                    "type": "datetime",
+                    "description": "Time when the provider recorded or published the observation."
                   },
                   "value": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Measured value reported by the upstream provider."
                   },
                   "unit_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the unit."
                   },
                   "parameter_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Plain-language name of the measured parameter."
                   }
                 },
                 "$id": "https://example.com/schemas/BE/Vlaanderen/Waterinfo/VMM/WaterLevelReading",
@@ -179,7 +211,7 @@
               "schema": {
                 "type": "record",
                 "name": "Station",
-                "doc": "Station",
+                "doc": "Reference details for one monitoring station or site in the Waterinfo VMM source.",
                 "fields": [
                   {
                     "name": "station_no",
@@ -238,7 +270,8 @@
                     "default": null
                   }
                 ],
-                "namespace": "BE.Vlaanderen.Waterinfo.VMM"
+                "namespace": "BE.Vlaanderen.Waterinfo.VMM",
+                "description": "Reference details for one monitoring station or site in the Waterinfo VMM source."
               }
             }
           }
@@ -253,7 +286,7 @@
               "schema": {
                 "type": "record",
                 "name": "WaterLevelReading",
-                "doc": "WaterLevelReading",
+                "doc": "Measurement payload for observations in the Waterinfo VMM source.",
                 "fields": [
                   {
                     "name": "ts_id",
@@ -299,12 +332,18 @@
                     "default": null
                   }
                 ],
-                "namespace": "BE.Vlaanderen.Waterinfo.VMM"
+                "namespace": "BE.Vlaanderen.Waterinfo.VMM",
+                "description": "Measurement payload for observations in the Waterinfo VMM source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Waterinfo VMM publishes water level observations from Waterinfo.be and the Flemish Environment Agency (VMM) for Flemish water monitoring locations. These events let consumers build real-time monitoring, alerting, and operational dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Waterinfo VMM, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites xRegistry descriptions for Batch A hydro/water sources so generated EVENTS.md pages lead with source semantics.
- Updates registry, messagegroup, endpoint, message, and JsonStructure schema/field descriptions only.
- Regenerates EVENTS.md for each touched source.

## Validation
- Regenerated each Batch A source with `pwsh .\tools\generate-events-md.ps1 -Source <source>`.
- Rubber-duck technical-writer review signed off on PegelOnline, Hub'Eau Hydrométrie, and USGS IV samples after iteration.

## Sources
bafu-hydro, smhi-hydro, nve-hydro, pegelonline, chmi-hydro, rws-waterwebservices, hubeau-hydrometrie, ireland-opw-waterlevel, imgw-hydro, syke-hydro, usgs-iv, usgs-nwis-wq, canada-eccc-wateroffice, cdec-reservoirs, german-waters, uk-ea-flood-monitoring, waterinfo-vmm, nepal-bipad-hydrology.