### PR TITLE
docs(xreg): improve descriptions — batch B weather/air-quality

### DIFF
--- a/canada-aqhi/EVENTS.md
+++ b/canada-aqhi/EVENTS.md
@@ -1,6 +1,6 @@
 # Canada AQHI Bridge Events
 
-This source bridges the Canadian Air Quality Health Index (AQHI) program from Environment and Climate Change Canada into Kafka as structured JSON [CloudEvents](https://cloudevents.io/).
+Canada AQHI publishes air-quality health index observations and forecasts from Environment and Climate Change Canada (ECCC) for Canadian Air Quality Health Index communities. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `ca.gc.weather.aqhi.Community`
 
 #### What it tells you
 
-Reference data for a Canadian Air Quality Health Index reporting community, including its stable CGNDB identifier and current upstream feed URLs. Reference record for an AQHI community from the official ECCC AQHI city lists. It links the public community name and province code to the CGNDB key and current XML feeds used by the bridge.
+Reference data for a Canadian Air Quality Health Index reporting community, including its stable CGNDB identifier and current upstream feed URLs.
 
 #### Identity
 
@@ -87,7 +87,7 @@ CloudEvents type: `ca.gc.weather.aqhi.Observation`
 
 #### What it tells you
 
-Latest AQHI observation for a reporting community. Observations are published hourly and may include decimal AQHI values. The value reflects short-term health risk from air pollution and may be null when the upstream feed has not published a value yet.
+Latest AQHI observation for a reporting community. Observations are published hourly and may include decimal AQHI values.
 
 #### Identity
 
@@ -141,7 +141,7 @@ CloudEvents type: `ca.gc.weather.aqhi.Forecast`
 
 #### What it tells you
 
-Public AQHI forecast for one of the four standard Canadian forecast periods published for an AQHI community. Public AQHI forecast for a community and one of the four standard forecast periods published by ECCC.
+Public AQHI forecast for one of the four standard Canadian forecast periods published for an AQHI community.
 
 #### Identity
 

--- a/canada-aqhi/xreg/canada-aqhi.xreg.json
+++ b/canada-aqhi/xreg/canada-aqhi.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/ca.gc.weather.aqhi"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Canada AQHI CloudEvents on the `canada-aqhi` topic keyed by `{province}/{community_name}`."
     }
   },
   "messagegroups": {
@@ -85,7 +86,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/ca.gc.weather.aqhi.jstruct/schemas/ca.gc.weather.aqhi.Forecast"
         }
-      }
+      },
+      "description": "Events from Canada AQHI covering Canadian Air Quality Health Index communities. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -111,7 +113,7 @@
                           "Community": {
                             "name": "Community",
                             "type": "object",
-                            "description": "Reference record for an AQHI community from the official ECCC AQHI city lists. It links the public community name and province code to the CGNDB key and current XML feeds used by the bridge.",
+                            "description": "Reference data for a Canadian Air Quality Health Index reporting community, including its stable CGNDB identifier and current upstream feed URLs.",
                             "properties": {
                               "province": {
                                 "type": "string",
@@ -191,7 +193,7 @@
                           "Observation": {
                             "name": "Observation",
                             "type": "object",
-                            "description": "Latest AQHI observation for a reporting community. The value reflects short-term health risk from air pollution and may be null when the upstream feed has not published a value yet.",
+                            "description": "Latest AQHI observation for a reporting community. Observations are published hourly and may include decimal AQHI values.",
                             "properties": {
                               "province": {
                                 "type": "string",
@@ -267,7 +269,7 @@
                           "Forecast": {
                             "name": "Forecast",
                             "type": "object",
-                            "description": "Public AQHI forecast for a community and one of the four standard forecast periods published by ECCC.",
+                            "description": "Public AQHI forecast for one of the four standard Canadian forecast periods published for an AQHI community.",
                             "properties": {
                               "province": {
                                 "type": "string",
@@ -371,27 +373,32 @@
                   {
                     "name": "province",
                     "type": "string",
-                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community."
+                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "community_name",
                     "type": "string",
-                    "doc": "English AQHI community name as published by Environment and Climate Change Canada."
+                    "doc": "English AQHI community name as published by Environment and Climate Change Canada.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Canada AQHI source."
                   },
                   {
                     "name": "cgndb_code",
                     "type": "string",
-                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds."
+                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "Latitude of the AQHI community reference point in WGS84 decimal degrees."
+                    "doc": "Latitude of the AQHI community reference point in WGS84 decimal degrees.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "Longitude of the AQHI community reference point in WGS84 decimal degrees."
+                    "doc": "Longitude of the AQHI community reference point in WGS84 decimal degrees.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "observation_url",
@@ -400,7 +407,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Current XML observation feed URL for the AQHI community, or null when observations are not distributed for that community."
+                    "doc": "Current XML observation feed URL for the AQHI community, or null when observations are not distributed for that community.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "forecast_url",
@@ -409,9 +417,11 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Current XML forecast feed URL for the AQHI community, or null when a public forecast feed is not available."
+                    "doc": "Current XML forecast feed URL for the AQHI community, or null when a public forecast feed is not available.",
+                    "description": "Forecast payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the Canada AQHI source."
               }
             }
           }
@@ -432,22 +442,26 @@
                   {
                     "name": "province",
                     "type": "string",
-                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community."
+                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "community_name",
                     "type": "string",
-                    "doc": "English AQHI community name as published by Environment and Climate Change Canada."
+                    "doc": "English AQHI community name as published by Environment and Climate Change Canada.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Canada AQHI source."
                   },
                   {
                     "name": "cgndb_code",
                     "type": "string",
-                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds."
+                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "observation_datetime",
                     "type": "string",
-                    "doc": "UTC timestamp of the AQHI observation in ISO 8601 format."
+                    "doc": "UTC timestamp of the AQHI observation in ISO 8601 format.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "aqhi",
@@ -456,14 +470,17 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Observed AQHI value for the community. Observation feeds publish AQHI with decimal precision."
+                    "doc": "Observed AQHI value for the community. Observation feeds publish AQHI with decimal precision.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "aqhi_category",
                     "type": "string",
-                    "doc": "Public AQHI health-risk category derived from the AQHI value."
+                    "doc": "Public AQHI health-risk category derived from the AQHI value.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
               }
             }
           }
@@ -484,37 +501,44 @@
                   {
                     "name": "province",
                     "type": "string",
-                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community."
+                    "doc": "Two-letter Canadian province or territory abbreviation resolved for the AQHI community.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "community_name",
                     "type": "string",
-                    "doc": "English AQHI community name as published by Environment and Climate Change Canada."
+                    "doc": "English AQHI community name as published by Environment and Climate Change Canada.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Canada AQHI source."
                   },
                   {
                     "name": "cgndb_code",
                     "type": "string",
-                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds."
+                    "doc": "Five-character CGNDB community identifier published by Natural Resources Canada and referenced by ECCC AQHI feeds.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "publication_datetime",
                     "type": "string",
-                    "doc": "UTC timestamp at which the public AQHI forecast bulletin was issued."
+                    "doc": "UTC timestamp at which the public AQHI forecast bulletin was issued.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "forecast_date",
                     "type": "string",
-                    "doc": "Forecast target date expressed as YYYYMMDD."
+                    "doc": "Forecast target date expressed as YYYYMMDD.",
+                    "description": "Forecast payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "forecast_period",
                     "type": "int",
-                    "doc": "AQHI public forecast period number: 1 Today, 2 Tonight, 3 Tomorrow, 4 Tomorrow Night."
+                    "doc": "AQHI public forecast period number: 1 Today, 2 Tonight, 3 Tomorrow, 4 Tomorrow Night.",
+                    "description": "Forecast payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "forecast_period_label",
                     "type": "string",
-                    "doc": "English public label for the AQHI forecast period."
+                    "doc": "English public label for the AQHI forecast period.",
+                    "description": "Forecast payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "aqhi",
@@ -523,19 +547,27 @@
                       "int"
                     ],
                     "default": null,
-                    "doc": "Forecast AQHI value for the forecast period. Public forecasts are published as whole numbers."
+                    "doc": "Forecast AQHI value for the forecast period. Public forecasts are published as whole numbers.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   },
                   {
                     "name": "aqhi_category",
                     "type": "string",
-                    "doc": "Public AQHI health-risk category derived from the forecast AQHI value."
+                    "doc": "Public AQHI health-risk category derived from the forecast AQHI value.",
+                    "description": "Measurement payload for air-quality health index observations and forecasts in the Canada AQHI source."
                   }
-                ]
+                ],
+                "description": "Forecast payload for air-quality health index observations and forecasts in the Canada AQHI source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Canada AQHI publishes air-quality health index observations and forecasts from Environment and Climate Change Canada (ECCC) for Canadian Air Quality Health Index communities. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Canada AQHI, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/defra-aurn/EVENTS.md
+++ b/defra-aurn/EVENTS.md
@@ -1,6 +1,6 @@
 # Defra AURN Bridge Usage Guide Events
 
-This bridge polls the UK Defra Automatic Urban and Rural Network (AURN) SOS Timeseries API and republishes station metadata, timeseries metadata, and fresh hourly observations to Kafka as CloudEvents in structured JSON mode.
+DEFRA AURN publishes pollutant concentration measurements from the UK Department for Environment, Food and Rural Affairs Automatic Urban and Rural Network for UK air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `uk.gov.defra.aurn.Station`
 
 #### What it tells you
 
-Reference metadata for a Defra AURN monitoring station entry as published by the 52°North SOS Timeseries API stations collection. Metadata for a Defra AURN monitoring station as returned by GET /stations. The bridge flattens the GeoJSON feature into a payload with the station identifier, the upstream display label, and WGS84 latitude and longitude values taken from geometry.coordinates[0] and geometry.coordinates[1], because this API returns coordinates in latitude, longitude order.
+Reference metadata for a Defra AURN monitoring station entry as published by the 52°North SOS Timeseries API stations collection.
 
 #### Identity
 
@@ -81,7 +81,7 @@ CloudEvents type: `uk.gov.defra.aurn.Timeseries`
 
 #### What it tells you
 
-Reference metadata for a Defra AURN station and pollutant timeseries combination, including linked station coordinates and pollutant taxonomy identifiers. Reference metadata for a Defra AURN station and pollutant timeseries combination, assembled from GET /timeseries/{id}?expanded=true. The payload preserves the stable timeseries identifier, linked station metadata, unit of measurement, and pollutant taxonomy references published in parameters.phenomenon and parameters.category.
+Reference metadata for a Defra AURN station and pollutant timeseries combination, including linked station coordinates and pollutant taxonomy identifiers.
 
 #### Identity
 
@@ -138,7 +138,7 @@ CloudEvents type: `uk.gov.defra.aurn.Observation`
 
 #### What it tells you
 
-Hourly or near-hourly Defra AURN observation value for a single timeseries, emitted from the getData endpoint for the most recent two-hour polling window. Observation value from GET /timeseries/{id}/getData. The bridge converts the upstream Unix millisecond timestamp to an ISO 8601 UTC timestamp string and republishes the measurement value together with the timeseries identifier and unit of measurement from the reference metadata.
+Hourly or near-hourly Defra AURN observation value for a single timeseries, emitted from the getData endpoint for the most recent two-hour polling window.
 
 #### Identity
 

--- a/defra-aurn/xreg/defra_aurn.xreg.json
+++ b/defra-aurn/xreg/defra_aurn.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/uk.gov.defra.aurn.Stations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DEFRA AURN CloudEvents on the `defra-aurn` topic keyed by `{station_id}`."
     },
     "uk.gov.defra.aurn.Timeseries.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/uk.gov.defra.aurn.Timeseries"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DEFRA AURN CloudEvents on the `defra-aurn` topic keyed by `{timeseries_id}`."
     }
   },
   "messagegroups": {
@@ -65,7 +67,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/uk.gov.defra.aurn.jstruct/schemas/uk.gov.defra.aurn.Station"
         }
-      }
+      },
+      "description": "Events from DEFRA AURN covering UK air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "uk.gov.defra.aurn.Timeseries": {
       "messages": {
@@ -107,7 +110,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/uk.gov.defra.aurn.jstruct/schemas/uk.gov.defra.aurn.Observation"
         }
-      }
+      },
+      "description": "Events from DEFRA AURN covering UK air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -133,7 +137,7 @@
                           "Station": {
                             "name": "Station",
                             "type": "object",
-                            "description": "Metadata for a Defra AURN monitoring station as returned by GET /stations. The bridge flattens the GeoJSON feature into a payload with the station identifier, the upstream display label, and WGS84 latitude and longitude values taken from geometry.coordinates[0] and geometry.coordinates[1], because this API returns coordinates in latitude, longitude order.",
+                            "description": "Reference metadata for a Defra AURN monitoring station entry as published by the 52°North SOS Timeseries API stations collection.",
                             "properties": {
                               "station_id": {
                                 "type": "string",
@@ -197,7 +201,7 @@
                           "Timeseries": {
                             "name": "Timeseries",
                             "type": "object",
-                            "description": "Reference metadata for a Defra AURN station and pollutant timeseries combination, assembled from GET /timeseries/{id}?expanded=true. The payload preserves the stable timeseries identifier, linked station metadata, unit of measurement, and pollutant taxonomy references published in parameters.phenomenon and parameters.category.",
+                            "description": "Reference metadata for a Defra AURN station and pollutant timeseries combination, including linked station coordinates and pollutant taxonomy identifiers.",
                             "properties": {
                               "timeseries_id": {
                                 "type": "string",
@@ -311,7 +315,7 @@
                           "Observation": {
                             "name": "Observation",
                             "type": "object",
-                            "description": "Observation value from GET /timeseries/{id}/getData. The bridge converts the upstream Unix millisecond timestamp to an ISO 8601 UTC timestamp string and republishes the measurement value together with the timeseries identifier and unit of measurement from the reference metadata.",
+                            "description": "Hourly or near-hourly Defra AURN observation value for a single timeseries, emitted from the getData endpoint for the most recent two-hour polling window.",
                             "properties": {
                               "timeseries_id": {
                                 "type": "string",
@@ -370,24 +374,29 @@
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Stable numeric monitoring station identifier from properties.id."
+                    "doc": "Stable numeric monitoring station identifier from properties.id.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the DEFRA AURN source."
                   },
                   {
                     "name": "label",
                     "type": "string",
-                    "doc": "Upstream station label from properties.label."
+                    "doc": "Upstream station label from properties.label.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "WGS84 latitude in decimal degrees from geometry.coordinates[0]."
+                    "doc": "WGS84 latitude in decimal degrees from geometry.coordinates[0].",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "WGS84 longitude in decimal degrees from geometry.coordinates[1]."
+                    "doc": "WGS84 longitude in decimal degrees from geometry.coordinates[1].",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the DEFRA AURN source."
               }
             }
           }
@@ -408,27 +417,32 @@
                   {
                     "name": "timeseries_id",
                     "type": "string",
-                    "doc": "Stable numeric timeseries identifier from id."
+                    "doc": "Stable numeric timeseries identifier from id.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "label",
                     "type": "string",
-                    "doc": "Descriptive label from the timeseries label field."
+                    "doc": "Descriptive label from the timeseries label field.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "uom",
                     "type": "string",
-                    "doc": "Unit of measurement string from the timeseries uom field."
+                    "doc": "Unit of measurement string from the timeseries uom field.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Stable station identifier from station.properties.id."
+                    "doc": "Stable station identifier from station.properties.id.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the DEFRA AURN source."
                   },
                   {
                     "name": "station_label",
                     "type": "string",
-                    "doc": "Station display label from station.properties.label."
+                    "doc": "Station display label from station.properties.label.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the DEFRA AURN source."
                   },
                   {
                     "name": "latitude",
@@ -437,7 +451,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Nullable WGS84 latitude in decimal degrees from station.geometry.coordinates[0]."
+                    "doc": "Nullable WGS84 latitude in decimal degrees from station.geometry.coordinates[0].",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "longitude",
@@ -446,7 +461,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Nullable WGS84 longitude in decimal degrees from station.geometry.coordinates[1]."
+                    "doc": "Nullable WGS84 longitude in decimal degrees from station.geometry.coordinates[1].",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "phenomenon_id",
@@ -455,7 +471,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Nullable pollutant phenomenon identifier from parameters.phenomenon.id."
+                    "doc": "Nullable pollutant phenomenon identifier from parameters.phenomenon.id.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "phenomenon_label",
@@ -464,7 +481,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Nullable pollutant label from parameters.phenomenon.label."
+                    "doc": "Nullable pollutant label from parameters.phenomenon.label.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "category_id",
@@ -473,7 +491,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Nullable category identifier from parameters.category.id."
+                    "doc": "Nullable category identifier from parameters.category.id.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "category_label",
@@ -482,9 +501,11 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Nullable category label from parameters.category.label."
+                    "doc": "Nullable category label from parameters.category.label.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
               }
             }
           }
@@ -505,12 +526,14 @@
                   {
                     "name": "timeseries_id",
                     "type": "string",
-                    "doc": "Stable numeric timeseries identifier for the series that produced this observation."
+                    "doc": "Stable numeric timeseries identifier for the series that produced this observation.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "timestamp",
                     "type": "string",
-                    "doc": "Observation timestamp encoded as an ISO 8601 UTC string."
+                    "doc": "Observation timestamp encoded as an ISO 8601 UTC string.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "value",
@@ -519,19 +542,27 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Measured pollutant concentration or other reported numeric reading."
+                    "doc": "Measured pollutant concentration or other reported numeric reading.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   },
                   {
                     "name": "uom",
                     "type": "string",
-                    "doc": "Unit of measurement for the observation."
+                    "doc": "Unit of measurement for the observation.",
+                    "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the DEFRA AURN source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "DEFRA AURN publishes pollutant concentration measurements from the UK Department for Environment, Food and Rural Affairs Automatic Urban and Rural Network for UK air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for DEFRA AURN, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/dwd-pollenflug/EVENTS.md
+++ b/dwd-pollenflug/EVENTS.md
@@ -1,6 +1,6 @@
 # DWD Pollenflug (German Pollen Forecast) Bridge Events
 
-**DWD Pollenflug Bridge** polls the Deutscher Wetterdienst (DWD) pollen forecast API for the latest daily pollen forecasts across Germany and sends them to a Kafka topic as CloudEvents. The tool tracks the `last_update` timestamp from the API to avoid sending duplicate forecasts.
+DWD Pollenflug publishes pollen exposure forecasts by region and plant type from Germany's Deutscher Wetterdienst (DWD) for German pollen forecast regions. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `DE.DWD.Pollenflug.Region`
 
 #### What it tells you
 
-Reference data for a DWD pollen forecast region or sub-region. Germany is divided into 11 main regions, some of which are subdivided into 2–4 sub-regions for a total of 27 forecast areas. Emitted at bridge startup so downstream consumers can correlate forecast events with region metadata.
+A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -73,7 +73,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Pollen Forecast
 
@@ -81,7 +81,7 @@ CloudEvents type: `DE.DWD.Pollenflug.PollenForecast`
 
 #### What it tells you
 
-Daily pollen forecast for a single German region or sub-region, published by the Deutscher Wetterdienst (DWD). Contains intensity values for eight pollen types across three forecast days (today, tomorrow, day after tomorrow). Intensity is on a scale from 0 (no load) to 3 (high load) with intermediate half-step ranges such as '0-1', '1-2', '2-3'.
+A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries pollen exposure forecasts by region and plant type for the period published by the upstream source.
 
 #### Identity
 

--- a/dwd-pollenflug/xreg/dwd_pollenflug.xreg.json
+++ b/dwd-pollenflug/xreg/dwd_pollenflug.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.DWD.Pollenflug"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DWD Pollenflug CloudEvents on the `dwd-pollenflug` topic keyed by `{region_id}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Pollenflug.jstruct/schemas/DE.DWD.Pollenflug.Region"
+          "dataschemauri": "#/schemagroups/DE.DWD.Pollenflug.jstruct/schemas/DE.DWD.Pollenflug.Region",
+          "description": "A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "DE.DWD.Pollenflug.PollenForecast": {
           "name": "PollenForecast",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Pollenflug.jstruct/schemas/DE.DWD.Pollenflug.PollenForecast"
+          "dataschemauri": "#/schemagroups/DE.DWD.Pollenflug.jstruct/schemas/DE.DWD.Pollenflug.PollenForecast",
+          "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries pollen exposure forecasts by region and plant type for the period published by the upstream source."
         }
-      }
+      },
+      "description": "Events from DWD Pollenflug covering German pollen forecast regions. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -79,7 +83,7 @@
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Pollenflug/Region",
                 "type": "object",
                 "name": "Region",
-                "description": "Reference data for a DWD pollen forecast region or sub-region. Germany is divided into 11 main regions, some of which are subdivided into 2–4 sub-regions for a total of 27 forecast areas. Emitted at bridge startup so downstream consumers can correlate forecast events with region metadata.",
+                "description": "A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events.",
                 "required": [
                   "region_id",
                   "region_name"
@@ -124,7 +128,7 @@
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Pollenflug/PollenForecast",
                 "type": "object",
                 "name": "PollenForecast",
-                "description": "Daily pollen forecast for a single German region or sub-region, published by the Deutscher Wetterdienst (DWD). Contains intensity values for eight pollen types across three forecast days (today, tomorrow, day after tomorrow). Intensity is on a scale from 0 (no load) to 3 (high load) with intermediate half-step ranges such as '0-1', '1-2', '2-3'. The bridge maps the German pollen names from the upstream API to English equivalents.",
+                "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries pollen exposure forecasts by region and plant type for the period published by the upstream source.",
                 "required": [
                   "region_id",
                   "region_name",
@@ -402,5 +406,10 @@
         }
       }
     }
+  },
+  "description": "DWD Pollenflug publishes pollen exposure forecasts by region and plant type from Germany's Deutscher Wetterdienst (DWD) for German pollen forecast regions. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for DWD Pollenflug, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/dwd/EVENTS.md
+++ b/dwd/EVENTS.md
@@ -1,12 +1,12 @@
 # DWD Open Data Bridge Usage Guide Events
 
-**DWD Open Data Bridge** polls the [Deutscher Wetterdienst (DWD) Climate Data Center](https://opendata.dwd.de/) open-data file server for weather observations, station metadata, and weather alerts from ~1,450 stations across Germany. The data is forwarded to a Kafka topic as [CloudEvents](https://cloudevents.io/) in JSON format.
+DWD Weather publishes weather observations, warnings, and forecast product updates from Germany's Deutscher Wetterdienst (DWD) for German weather stations, alerts, radar, and forecast products. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 13 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 3 reference/catalog event types and 10 telemetry event types.
+- **Reference vs telemetry:** 1 reference/catalog event type and 12 telemetry event types.
 - **Identity:** `{station_id}`, `{identifier}`, `{file_url}` identifies the resource each event is about.
 - **Operations:** The bridge documentation mentions ETag-aware polling, so consumers should expect unchanged upstream responses to be skipped.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,11 +38,11 @@ CloudEvents type: `DE.DWD.CDC.StationMetadata`
 
 #### What it tells you
 
-This event carries station metadata data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -54,14 +54,14 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Station Metadata` payloads are JSON object. Required fields: `station_id`, `station_name`, `latitude`, `longitude`, `elevation`.
 
-- **`station_id`** (string, required): No description provided.
-- **`station_name`** (string, required): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`elevation`** (double, required): No description provided.
-- **`state`** (string, optional): No description provided.
-- **`from_date`** (string, optional): No description provided.
-- **`to_date`** (string, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`station_name`** (string, required): Human-readable name of the station or monitoring site.
+- **`latitude`** (double, required): Latitude of the station or site in WGS 84 coordinates.
+- **`longitude`** (double, required): Longitude of the station or site in WGS 84 coordinates.
+- **`elevation`** (double, required): Elevation of the station above mean sea level or the provider datum.
+- **`state`** (string, optional): State, province, or administrative region for the station or area.
+- **`from_date`** (string, optional): Start date when the station, product, or metadata record is valid.
+- **`to_date`** (string, optional): End date when the station, product, or metadata record is valid, when known.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -81,7 +81,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Air Temperature10 Min
 
@@ -89,11 +89,11 @@ CloudEvents type: `DE.DWD.CDC.AirTemperature10Min`
 
 #### What it tells you
 
-This event carries air temperature10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -105,14 +105,14 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Air Temperature10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`pressure_station_level`** (double, optional): No description provided.
-- **`air_temperature_2m`** (double, optional): No description provided.
-- **`air_temperature_5cm`** (double, optional): No description provided.
-- **`relative_humidity`** (double, optional): No description provided.
-- **`dew_point_temperature`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`pressure_station_level`** (double, optional): Reference details for a station, monitoring site, or reporting area in the DWD Weather source.
+- **`air_temperature_2m`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_5cm`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`relative_humidity`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`dew_point_temperature`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -132,7 +132,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Precipitation10 Min
 
@@ -140,11 +140,11 @@ CloudEvents type: `DE.DWD.CDC.Precipitation10Min`
 
 #### What it tells you
 
-This event carries precipitation10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -156,11 +156,11 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Precipitation10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`precipitation_height`** (double, optional): No description provided.
-- **`precipitation_indicator`** (int32, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`precipitation_height`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`precipitation_indicator`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -177,7 +177,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Wind10 Min
 
@@ -185,11 +185,11 @@ CloudEvents type: `DE.DWD.CDC.Wind10Min`
 
 #### What it tells you
 
-This event carries wind10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -201,11 +201,11 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Wind10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`wind_speed`** (double, optional): No description provided.
-- **`wind_direction`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_speed`** (double, optional): Wind speed reported by the station.
+- **`wind_direction`** (double, optional): Wind direction reported by the station.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -222,7 +222,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Solar10 Min
 
@@ -230,11 +230,11 @@ CloudEvents type: `DE.DWD.CDC.Solar10Min`
 
 #### What it tells you
 
-This event carries solar10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -246,13 +246,13 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Solar10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`global_radiation`** (double, optional): No description provided.
-- **`sunshine_duration`** (double, optional): No description provided.
-- **`diffuse_radiation`** (double, optional): No description provided.
-- **`longwave_radiation`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`global_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`sunshine_duration`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`diffuse_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`longwave_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -271,7 +271,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Hourly Observation
 
@@ -279,11 +279,11 @@ CloudEvents type: `DE.DWD.CDC.HourlyObservation`
 
 #### What it tells you
 
-This event carries hourly observation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -295,12 +295,12 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Hourly Observation` payloads are JSON object. Required fields: `station_id`, `timestamp`, `parameter`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`parameter`** (string, required): No description provided.
-- **`value`** (double, optional): No description provided.
-- **`unit`** (string, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`parameter`** (string, required): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`value`** (double, optional): Measured or forecast value reported by the upstream provider.
+- **`unit`** (string, optional): Unit used for the reported value.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -326,11 +326,11 @@ CloudEvents type: `DE.DWD.CDC.ExtremeWind10Min`
 
 #### What it tells you
 
-This event carries extreme wind10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -342,12 +342,12 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Extreme Wind10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`wind_speed_maximum`** (double, optional): No description provided.
-- **`wind_speed_minimum`** (double, optional): No description provided.
-- **`wind_direction_at_maximum`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_speed_maximum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_speed_minimum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_direction_at_maximum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -365,7 +365,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Extreme Temperature10 Min
 
@@ -373,11 +373,11 @@ CloudEvents type: `DE.DWD.CDC.ExtremeTemperature10Min`
 
 #### What it tells you
 
-This event carries extreme temperature10 min data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
-Each event identifies the real-world resource with `{station_id}`. `{station_id}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{station_id}`. `{station_id}` is stable identifier assigned by the upstream provider for the station or monitoring site. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -389,11 +389,11 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 
 `Extreme Temperature10 Min` payloads are JSON object. Required fields: `station_id`, `timestamp`.
 
-- **`station_id`** (string, required): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`quality_level`** (int32, optional): No description provided.
-- **`air_temperature_maximum_2m`** (double, optional): No description provided.
-- **`air_temperature_minimum_5cm`** (double, optional): No description provided.
+- **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
+- **`timestamp`** (string, required): Time when the provider recorded or published the value.
+- **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_maximum_2m`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_minimum_5cm`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -410,7 +410,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Alert
 
@@ -418,11 +418,11 @@ CloudEvents type: `DE.DWD.Weather.Alert`
 
 #### What it tells you
 
-This event carries alert data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A weather or environmental alert from Germany's Deutscher Wetterdienst (DWD). It fires when the upstream source publishes or updates a warning that may affect the covered area.
 
 #### Identity
 
-Each event identifies the real-world resource with `{identifier}`. `{identifier}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{identifier}`. `{identifier}` is measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -434,22 +434,22 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 
 `Alert` payloads are JSON object. Required fields: `identifier`, `sender`, `sent`, `severity`, `event`.
 
-- **`identifier`** (string, required): No description provided.
-- **`sender`** (string, required): No description provided.
-- **`sent`** (string, required): No description provided.
-- **`status`** (string, optional): No description provided.
-- **`msg_type`** (string, optional): No description provided.
-- **`severity`** (string, required): No description provided.
-- **`urgency`** (string, optional): No description provided.
-- **`certainty`** (string, optional): No description provided.
-- **`event`** (string, required): No description provided.
-- **`headline`** (string, optional): No description provided.
-- **`description`** (string, optional): No description provided.
-- **`effective`** (string, optional): No description provided.
-- **`onset`** (string, optional): No description provided.
-- **`expires`** (string, optional): No description provided.
-- **`area_desc`** (string, optional): No description provided.
-- **`geocodes`** (string, optional): No description provided.
+- **`identifier`** (string, required): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`sender`** (string, required): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`sent`** (string, required): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`status`** (string, optional): Provider status value for the station, product, warning, or measurement.
+- **`msg_type`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`severity`** (string, required): Provider severity level for a warning or alert.
+- **`urgency`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`certainty`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`event`** (string, required): Provider event type, warning type, or product event category.
+- **`headline`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`description`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`effective`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`onset`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`expires`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`area_desc`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`geocodes`** (string, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -485,7 +485,7 @@ CloudEvents type: `DE.DWD.Radar.RadarProductCatalog`
 
 #### What it tells you
 
-Reference (catalog) event describing a single DWD radar composite product family. One event is emitted per product directory the first time the bridge observes it, so consumers can build a catalog of available products and the URLs from which their files can be discovered.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -518,7 +518,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Radar File Product
 
@@ -526,7 +526,7 @@ CloudEvents type: `DE.DWD.Radar.RadarFileProduct`
 
 #### What it tells you
 
-Telemetry-style event announcing that a single DWD radar composite product file has appeared or been updated on the Open Data server. The event carries enough metadata to fetch the file directly via an unauthenticated HTTPS GET against file_url; it does not embed the file payload.
+A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -563,7 +563,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Forecast Model Catalog
 
@@ -571,7 +571,7 @@ CloudEvents type: `DE.DWD.Forecast.ForecastModelCatalog`
 
 #### What it tells you
 
-Reference (catalog) event describing a single NWP forecast model family published by DWD Open Data. One event is emitted per model the first time the bridge observes it, so consumers can build a catalog of available models and the URLs from which their forecast files can be discovered.
+A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source.
 
 #### Identity
 
@@ -612,7 +612,7 @@ CloudEvents type: `DE.DWD.Forecast.IconD2ForecastFile`
 
 #### What it tells you
 
-Telemetry-style event announcing that a single ICON-D2 GRIB2 forecast file has appeared or been updated on the DWD Open Data server. The event carries enough metadata to fetch the file directly via an unauthenticated HTTPS GET against file_url; it does not embed the file payload.
+A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source.
 
 #### Identity
 

--- a/dwd/xreg/dwd.xreg.json
+++ b/dwd/xreg/dwd.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.DWD.CDC"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DWD Weather CloudEvents on the `dwd` topic keyed by `{station_id}`."
     },
     "DE.DWD.Weather.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.DWD.Weather"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DWD Weather CloudEvents on the `dwd` topic keyed by `{identifier}`."
     },
     "DE.DWD.Radar.Kafka": {
       "usage": [
@@ -61,7 +63,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.DWD.Radar"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DWD Weather CloudEvents on the `dwd` topic keyed by `{file_url}`."
     },
     "DE.DWD.Forecast.Kafka": {
       "usage": [
@@ -82,7 +85,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.DWD.Forecast"
-      ]
+      ],
+      "description": "Kafka producer endpoint for DWD Weather CloudEvents on the `dwd` topic keyed by `{file_url}`."
     }
   },
   "messagegroups": {
@@ -104,7 +108,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.StationMetadata"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.StationMetadata",
+          "description": "A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "DE.DWD.CDC.AirTemperature10Min": {
           "name": "AirTemperature10Min",
@@ -122,7 +127,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.AirTemperature10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.AirTemperature10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.Precipitation10Min": {
           "name": "Precipitation10Min",
@@ -140,7 +146,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Precipitation10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Precipitation10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.Wind10Min": {
           "name": "Wind10Min",
@@ -158,7 +165,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Wind10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Wind10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.Solar10Min": {
           "name": "Solar10Min",
@@ -176,7 +184,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Solar10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Solar10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.HourlyObservation": {
           "name": "HourlyObservation",
@@ -194,7 +203,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.HourlyObservation"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.HourlyObservation",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.ExtremeWind10Min": {
           "name": "ExtremeWind10Min",
@@ -212,7 +222,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.ExtremeWind10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.ExtremeWind10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.CDC.ExtremeTemperature10Min": {
           "name": "ExtremeTemperature10Min",
@@ -230,9 +241,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.ExtremeTemperature10Min"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.ExtremeTemperature10Min",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from DWD Weather covering German weather stations, alerts, radar, and forecast products. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "DE.DWD.Weather": {
       "messages": {
@@ -252,9 +265,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.Weather.Alert"
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.Weather.Alert",
+          "description": "A weather or environmental alert from Germany's Deutscher Wetterdienst (DWD). It fires when the upstream source publishes or updates a warning that may affect the covered area."
         }
-      }
+      },
+      "description": "Events from DWD Weather covering German weather stations, alerts, radar, and forecast products. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "DE.DWD.Radar": {
       "messages": {
@@ -274,7 +289,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Radar.jstruct/schemas/DE.DWD.Radar.RadarProductCatalog"
+          "dataschemauri": "#/schemagroups/DE.DWD.Radar.jstruct/schemas/DE.DWD.Radar.RadarProductCatalog",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         },
         "DE.DWD.Radar.RadarFileProduct": {
           "name": "RadarFileProduct",
@@ -292,9 +308,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Radar.jstruct/schemas/DE.DWD.Radar.RadarFileProduct"
+          "dataschemauri": "#/schemagroups/DE.DWD.Radar.jstruct/schemas/DE.DWD.Radar.RadarFileProduct",
+          "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from DWD Weather covering German weather stations, alerts, radar, and forecast products. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "DE.DWD.Forecast": {
       "messages": {
@@ -314,7 +332,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Forecast.jstruct/schemas/DE.DWD.Forecast.ForecastModelCatalog"
+          "dataschemauri": "#/schemagroups/DE.DWD.Forecast.jstruct/schemas/DE.DWD.Forecast.ForecastModelCatalog",
+          "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source."
         },
         "DE.DWD.Forecast.IconD2ForecastFile": {
           "name": "IconD2ForecastFile",
@@ -332,9 +351,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.DWD.Forecast.jstruct/schemas/DE.DWD.Forecast.IconD2ForecastFile"
+          "dataschemauri": "#/schemagroups/DE.DWD.Forecast.jstruct/schemas/DE.DWD.Forecast.IconD2ForecastFile",
+          "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source."
         }
-      }
+      },
+      "description": "Events from DWD Weather covering German weather stations, alerts, radar, and forecast products. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -363,32 +384,40 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "station_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the station or monitoring site."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the station or site in WGS 84 coordinates."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the station or site in WGS 84 coordinates."
                   },
                   "elevation": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Elevation of the station above mean sea level or the provider datum."
                   },
                   "state": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "State, province, or administrative region for the station or area."
                   },
                   "from_date": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Start date when the station, product, or metadata record is valid."
                   },
                   "to_date": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "End date when the station, product, or metadata record is valid, when known."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/StationMetadata",
-                "description": "StationMetadata"
+                "description": "A reference record published by Germany's Deutscher Wetterdienst (DWD). It lets consumers label, group, and route the live measurement or forecast events."
               }
             }
           }
@@ -413,53 +442,61 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "pressure_station_level": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "PP_10"
-                    }
+                    },
+                    "description": "Reference details for a station, monitoring site, or reporting area in the DWD Weather source."
                   },
                   "air_temperature_2m": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "TT_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_5cm": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "TM5_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "relative_humidity": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "RF_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "dew_point_temperature": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "TD_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/AirTemperature10Min",
-                "description": "AirTemperature10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -484,35 +521,40 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "precipitation_height": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "RWS_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "precipitation_indicator": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "RWS_IND_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Precipitation10Min",
-                "description": "Precipitation10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -537,35 +579,40 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "FF_10"
-                    }
+                    },
+                    "description": "Wind speed reported by the station."
                   },
                   "wind_direction": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "DD_10"
-                    }
+                    },
+                    "description": "Wind direction reported by the station."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Wind10Min",
-                "description": "Wind10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -590,47 +637,54 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "global_radiation": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "GS_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "sunshine_duration": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "SD_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "diffuse_radiation": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "DS_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "longwave_radiation": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "LS_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/Solar10Min",
-                "description": "Solar10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -656,32 +710,38 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "parameter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "value": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Measured or forecast value reported by the upstream provider."
                   },
                   "unit": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Unit used for the reported value."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/HourlyObservation",
-                "description": "HourlyObservation"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -706,56 +766,72 @@
                 "name": "Alert",
                 "properties": {
                   "identifier": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "sender": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "sent": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "status": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider status value for the station, product, warning, or measurement."
                   },
                   "msg_type": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "severity": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider severity level for a warning or alert."
                   },
                   "urgency": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "certainty": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "event": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider event type, warning type, or product event category."
                   },
                   "headline": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "effective": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "onset": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "expires": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "area_desc": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "geocodes": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/DE/DWD/Weather.schema.json",
-                "description": "Alert"
+                "description": "A weather or environmental alert from Germany's Deutscher Wetterdienst (DWD). It fires when the upstream source publishes or updates a warning that may affect the covered area."
               }
             }
           }
@@ -780,41 +856,47 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed_maximum": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "FX_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed_minimum": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "FNX_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_direction_at_maximum": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "DX_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/ExtremeWind10Min",
-                "description": "ExtremeWind10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -839,35 +921,40 @@
                     "type": "string",
                     "altnames": {
                       "lang:de": "STATIONS_ID"
-                    }
+                    },
+                    "description": "Stable identifier assigned by the upstream provider for the station or monitoring site."
                   },
                   "timestamp": {
                     "type": "string",
                     "altnames": {
                       "lang:de": "MESS_DATUM"
-                    }
+                    },
+                    "description": "Time when the provider recorded or published the value."
                   },
                   "quality_level": {
                     "type": "int32",
                     "altnames": {
                       "lang:de": "QN"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_maximum_2m": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "TX_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_minimum_5cm": {
                     "type": "double",
                     "altnames": {
                       "lang:de": "TN_10"
-                    }
+                    },
+                    "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   }
                 },
                 "$id": "https://example.com/schemas/DE/DWD/CDC/ExtremeTemperature10Min",
-                "description": "ExtremeTemperature10Min"
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -906,7 +993,7 @@
                   }
                 },
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Radar/RadarProductCatalog",
-                "description": "Reference (catalog) event describing a single DWD radar composite product family. One event is emitted per product directory the first time the bridge observes it, so consumers can build a catalog of available products and the URLs from which their files can be discovered."
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -954,7 +1041,7 @@
                   }
                 },
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Radar/RadarFileProduct",
-                "description": "Telemetry-style event announcing that a single DWD radar composite product file has appeared or been updated on the Open Data server. The event carries enough metadata to fetch the file directly via an unauthenticated HTTPS GET against file_url; it does not embed the file payload."
+                "description": "A current environmental measurement from Germany's Deutscher Wetterdienst (DWD). It carries weather observations, warnings, and forecast product updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -993,7 +1080,7 @@
                   }
                 },
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Forecast/ForecastModelCatalog",
-                "description": "Reference (catalog) event describing a single NWP forecast model family published by DWD Open Data. One event is emitted per model the first time the bridge observes it, so consumers can build a catalog of available models and the URLs from which their forecast files can be discovered."
+                "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source."
               }
             }
           }
@@ -1076,12 +1163,17 @@
                   }
                 },
                 "$id": "https://opendata.dwd.de/schemas/DE/DWD/Forecast/IconD2ForecastFile",
-                "description": "Telemetry-style event announcing that a single ICON-D2 GRIB2 forecast file has appeared or been updated on the DWD Open Data server. The event carries enough metadata to fetch the file directly via an unauthenticated HTTPS GET against file_url; it does not embed the file payload."
+                "description": "A forecast from Germany's Deutscher Wetterdienst (DWD) for one area or station. It carries weather observations, warnings, and forecast product updates for the period published by the upstream source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "DWD Weather publishes weather observations, warnings, and forecast product updates from Germany's Deutscher Wetterdienst (DWD) for German weather stations, alerts, radar, and forecast products. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for DWD Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/environment-canada/EVENTS.md
+++ b/environment-canada/EVENTS.md
@@ -1,12 +1,12 @@
 # Environment Canada Weather Observation Bridge Events
 
-This bridge fetches real-time Surface Weather Observations (SWOB) from [Environment and Climate Change Canada (ECCC)](https://api.weather.gc.ca/) via the OGC API and emits them as CloudEvents into Apache Kafka or Azure Event Hubs.
+Environment Canada Weather publishes current weather observations from Environment and Climate Change Canada (ECCC) for Canadian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{msc_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `CA.Gov.ECCC.Weather.Station`
 
 #### What it tells you
 
-Reference data for an Environment Canada SWOB weather station. Stations are identified by their MSC ID (Meteorological Service of Canada identifier) and include WMO synoptic IDs where available.
+A reference record published by Environment and Climate Change Canada (ECCC). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -87,7 +87,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Weather Observation
 
@@ -95,7 +95,7 @@ CloudEvents type: `CA.Gov.ECCC.Weather.WeatherObservation`
 
 #### What it tells you
 
-Weather observation from an Environment Canada SWOB station. Fields are extracted from the verbose SWOB-ML record (200+ raw fields). The core meteorological parameters retained include temperature, humidity, dew point, pressure (station and sea-level), wind, precipitation, visibility, snow depth, cloud cover, pressure tendency, and 24-hour temperature extremes.
+A current environmental measurement from Environment and Climate Change Canada (ECCC). It carries current weather observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/environment-canada/xreg/environment_canada.xreg.json
+++ b/environment-canada/xreg/environment_canada.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "CA.Gov.ECCC.Weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,10 @@
           "key": "{msc_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/CA.Gov.ECCC.Weather"]
+      "messagegroups": [
+        "#/messagegroups/CA.Gov.ECCC.Weather"
+      ],
+      "description": "Kafka producer endpoint for Environment Canada Weather CloudEvents on the `environment-canada` topic keyed by `{msc_id}`."
     }
   },
   "messagegroups": {
@@ -25,25 +30,42 @@
           "name": "Station",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "CA.Gov.ECCC.Weather.Station"},
-            "source": {"value": "https://api.weather.gc.ca"},
-            "subject": {"value": "{msc_id}", "type": "uritemplate"}
+            "type": {
+              "value": "CA.Gov.ECCC.Weather.Station"
+            },
+            "source": {
+              "value": "https://api.weather.gc.ca"
+            },
+            "subject": {
+              "value": "{msc_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Weather.jstruct/schemas/CA.Gov.ECCC.Weather.Station"
+          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Weather.jstruct/schemas/CA.Gov.ECCC.Weather.Station",
+          "description": "A reference record published by Environment and Climate Change Canada (ECCC). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "CA.Gov.ECCC.Weather.WeatherObservation": {
           "name": "WeatherObservation",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "CA.Gov.ECCC.Weather.WeatherObservation"},
-            "source": {"value": "https://api.weather.gc.ca"},
-            "subject": {"value": "{msc_id}", "type": "uritemplate"}
+            "type": {
+              "value": "CA.Gov.ECCC.Weather.WeatherObservation"
+            },
+            "source": {
+              "value": "https://api.weather.gc.ca"
+            },
+            "subject": {
+              "value": "{msc_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Weather.jstruct/schemas/CA.Gov.ECCC.Weather.WeatherObservation"
+          "dataschemauri": "#/schemagroups/CA.Gov.ECCC.Weather.jstruct/schemas/CA.Gov.ECCC.Weather.WeatherObservation",
+          "description": "A current environmental measurement from Environment and Climate Change Canada (ECCC). It carries current weather observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Environment Canada Weather covering Canadian weather stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -61,8 +83,11 @@
                 "$id": "https://api.weather.gc.ca/schemas/CA/Gov/ECCC/Weather/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference data for an Environment Canada SWOB weather station. Stations are identified by their MSC ID (Meteorological Service of Canada identifier) and include WMO synoptic IDs where available.",
-                "required": ["msc_id", "name"],
+                "description": "A reference record published by Environment and Climate Change Canada (ECCC). It lets consumers label, group, and route the live measurement or forecast events.",
+                "required": [
+                  "msc_id",
+                  "name"
+                ],
                 "properties": {
                   "msc_id": {
                     "type": "string",
@@ -77,7 +102,10 @@
                     "description": "IATA station code, e.g. 'CYYZ' for Toronto Pearson."
                   },
                   "wmo_id": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "WMO synoptic station identifier, e.g. 71624 for Toronto Pearson. Null for stations without a WMO assignment."
                   },
                   "province_territory": {
@@ -97,19 +125,28 @@
                     "description": "Station type: 'AUTO' for automatic, 'MAN' for manual, or combination."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the station in decimal degrees.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the station in decimal degrees.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "elevation": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Station elevation above sea level in meters.",
                     "unit": "m",
                     "symbol": "m"
@@ -131,8 +168,12 @@
                 "$id": "https://api.weather.gc.ca/schemas/CA/Gov/ECCC/Weather/WeatherObservation",
                 "type": "object",
                 "name": "WeatherObservation",
-                "description": "Weather observation from an Environment Canada SWOB station. Fields are extracted from the verbose SWOB-ML record (200+ raw fields). The core meteorological parameters retained include temperature, humidity, dew point, pressure (station and sea-level), wind, precipitation, visibility, snow depth, cloud cover, pressure tendency, and 24-hour temperature extremes.",
-                "required": ["msc_id", "station_name", "observation_time"],
+                "description": "A current environmental measurement from Environment and Climate Change Canada (ECCC). It carries current weather observations when the upstream feed reports a new or refreshed value.",
+                "required": [
+                  "msc_id",
+                  "station_name",
+                  "observation_time"
+                ],
                 "properties": {
                   "msc_id": {
                     "type": "string",
@@ -147,127 +188,206 @@
                     "description": "Observation timestamp in UTC from the obs_date_tm field."
                   },
                   "air_temperature": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Instantaneous air temperature from the air_temp field.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "dew_point": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Dew point temperature from the dwpt_temp field.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "relative_humidity": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Relative humidity from the rel_hum field.",
                     "unit": "percent",
                     "symbol": "%"
                   },
                   "station_pressure": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Station-level atmospheric pressure from the stn_pres field.",
                     "unit": "hPa",
                     "symbol": "hPa"
                   },
                   "wind_speed": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average wind speed at 10m over the last 1 minute from avg_wnd_spd_10m_pst1mt.",
                     "unit": "km/h",
                     "symbol": "km/h"
                   },
                   "wind_direction": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Average wind direction at 10m over the last 1 minute from avg_wnd_dir_10m_pst1mt, in degrees clockwise from true north.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "wind_gust": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum wind speed at 10m in the last 1 minute from max_wnd_spd_10m_pst1mt.",
                     "unit": "km/h",
                     "symbol": "km/h"
                   },
                   "precipitation_1hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Total precipitation in the last hour from pcpn_amt_pst1hr.",
                     "unit": "mm",
                     "symbol": "mm"
                   },
                   "mean_sea_level_pressure": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Mean sea-level pressure (MSLP) from the mslp field. Available on synoptic and hourly reporting stations. Null on minutely auto-only stations.",
                     "unit": "hPa",
                     "symbol": "hPa",
-                    "altnames": {"json": "mslp"}
+                    "altnames": {
+                      "json": "mslp"
+                    }
                   },
                   "visibility": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Horizontal visibility from the vis field. Primarily available on staffed and NAV CANADA stations.",
                     "unit": "km",
                     "symbol": "km",
-                    "altnames": {"json": "vis"}
+                    "altnames": {
+                      "json": "vis"
+                    }
                   },
                   "snow_depth": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Snow depth on the ground from the snw_dpth field. Available on stations equipped with ultrasonic snow depth sensors.",
                     "unit": "cm",
                     "symbol": "cm",
-                    "altnames": {"json": "snw_dpth"}
+                    "altnames": {
+                      "json": "snw_dpth"
+                    }
                   },
                   "total_cloud_cover": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Total cloud amount code from the tot_cld_amt field. Reports cloud cover in tenths (0-10) or oktas depending on reporting convention. Available on staffed and select automated stations.",
-                    "altnames": {"json": "tot_cld_amt"}
+                    "altnames": {
+                      "json": "tot_cld_amt"
+                    }
                   },
                   "pressure_tendency_3hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Change in station pressure over the preceding 3 hours from pres_tend_amt_pst3hrs. Positive values indicate rising pressure.",
                     "unit": "hPa",
                     "symbol": "hPa",
-                    "altnames": {"json": "pres_tend_amt_pst3hrs"}
+                    "altnames": {
+                      "json": "pres_tend_amt_pst3hrs"
+                    }
                   },
                   "max_temperature_24hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum air temperature in the past 24 hours from max_air_temp_pst24hrs.",
                     "unit": "Cel",
                     "symbol": "°C",
-                    "altnames": {"json": "max_air_temp_pst24hrs"}
+                    "altnames": {
+                      "json": "max_air_temp_pst24hrs"
+                    }
                   },
                   "min_temperature_24hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Minimum air temperature in the past 24 hours from min_air_temp_pst24hrs.",
                     "unit": "Cel",
                     "symbol": "°C",
-                    "altnames": {"json": "min_air_temp_pst24hrs"}
+                    "altnames": {
+                      "json": "min_air_temp_pst24hrs"
+                    }
                   },
                   "wind_speed_1hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average wind speed at 10m over the past hour from avg_wnd_spd_10m_pst1hr.",
                     "unit": "km/h",
                     "symbol": "km/h",
-                    "altnames": {"json": "avg_wnd_spd_10m_pst1hr"}
+                    "altnames": {
+                      "json": "avg_wnd_spd_10m_pst1hr"
+                    }
                   },
                   "wind_gust_1hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum wind speed at 10m in the past hour from max_wnd_spd_10m_pst1hr.",
                     "unit": "km/h",
                     "symbol": "km/h",
-                    "altnames": {"json": "max_wnd_spd_10m_pst1hr"}
+                    "altnames": {
+                      "json": "max_wnd_spd_10m_pst1hr"
+                    }
                   },
                   "precipitation_24hr": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Total precipitation in the past 24 hours from pcpn_amt_pst24hrs.",
                     "unit": "mm",
                     "symbol": "mm",
-                    "altnames": {"json": "pcpn_amt_pst24hrs"}
+                    "altnames": {
+                      "json": "pcpn_amt_pst24hrs"
+                    }
                   },
                   "altimeter_setting": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Altimeter setting from the altmetr_setng field. Used in aviation.",
                     "unit": "[in_i'Hg]",
                     "symbol": "inHg",
-                    "altnames": {"json": "altmetr_setng"}
+                    "altnames": {
+                      "json": "altmetr_setng"
+                    }
                   }
                 }
               }
@@ -276,5 +396,10 @@
         }
       }
     }
+  },
+  "description": "Environment Canada Weather publishes current weather observations from Environment and Climate Change Canada (ECCC) for Canadian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Environment Canada Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/fmi-finland/EVENTS.md
+++ b/fmi-finland/EVENTS.md
@@ -1,6 +1,6 @@
 # FMI Finland Air Quality Bridge Events
 
-This bridge polls the Finnish Meteorological Institute (FMI) open OGC WFS service for hourly air quality observations and republishes them as structured CloudEvents to Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams.
+FMI Finland Weather publishes weather observations from the Finnish Meteorological Institute (FMI) for Finnish weather observation stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `fi.fmi.opendata.airquality.Station`
 
 #### What it tells you
 
-Reference data for a Finnish Meteorological Institute air quality monitoring station. Reference data for an FMI air quality monitoring station. The station identifier is the FMI station identifier (fmisid).
+Reference data for a Finnish Meteorological Institute air quality monitoring station.
 
 #### Identity
 
@@ -83,7 +83,7 @@ CloudEvents type: `fi.fmi.opendata.airquality.Observation`
 
 #### What it tells you
 
-Hourly air quality observation aggregated per station and timestamp from FMI OGC WFS simple query results. Hourly FMI air quality observation aggregated per station and observation timestamp from the urban::observations::airquality::hourly::simple stored query. Each event combines all supported pollutant and index parameters published for the station and hour.
+Hourly air quality observation aggregated per station and timestamp from FMI OGC WFS simple query results.
 
 #### Identity
 

--- a/fmi-finland/xreg/fmi-finland.xreg.json
+++ b/fmi-finland/xreg/fmi-finland.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.fmi.opendata.airquality"
-      ]
+      ],
+      "description": "Kafka producer endpoint for FMI Finland Weather CloudEvents on the `fmi-finland-airquality` topic keyed by `{fmisid}`."
     }
   },
   "messagegroups": {
@@ -65,7 +66,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/fi.fmi.opendata.airquality.jstruct/schemas/fi.fmi.opendata.airquality.Observation"
         }
-      }
+      },
+      "description": "Events from FMI Finland Weather covering Finnish weather observation stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -91,7 +93,7 @@
                           "Station": {
                             "name": "Station",
                             "type": "object",
-                            "description": "Reference data for an FMI air quality monitoring station. The station identifier is the FMI station identifier (fmisid). Municipality is taken from the WFS station metadata region name, and coordinates are the representative point published by FMI.",
+                            "description": "Reference data for a Finnish Meteorological Institute air quality monitoring station.",
                             "properties": {
                               "fmisid": {
                                 "type": "string",
@@ -310,7 +312,7 @@
                           "Observation": {
                             "name": "Observation",
                             "type": "object",
-                            "description": "Hourly FMI air quality observation aggregated per station and observation timestamp from the urban::observations::airquality::hourly::simple stored query. Each event combines all supported pollutant and index parameters published for the station and hour.",
+                            "description": "Hourly air quality observation aggregated per station and timestamp from FMI OGC WFS simple query results.",
                             "properties": {
                               "fmisid": {
                                 "type": "string",
@@ -445,22 +447,26 @@
                   {
                     "name": "fmisid",
                     "type": "string",
-                    "doc": "Stable FMI station identifier (fmisid) used as the Kafka key and CloudEvents subject."
+                    "doc": "Stable FMI station identifier (fmisid) used as the Kafka key and CloudEvents subject.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "station_name",
                     "type": "string",
-                    "doc": "Air quality station name from the FMI station metadata."
+                    "doc": "Air quality station name from the FMI station metadata.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the FMI Finland Weather source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "WGS84 latitude of the station representative point in decimal degrees."
+                    "doc": "WGS84 latitude of the station representative point in decimal degrees.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "WGS84 longitude of the station representative point in decimal degrees."
+                    "doc": "WGS84 longitude of the station representative point in decimal degrees.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "municipality",
@@ -469,9 +475,11 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Municipality or region name from the station metadata if available."
+                    "doc": "Municipality or region name from the station metadata if available.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the FMI Finland Weather source."
               }
             }
           }
@@ -492,17 +500,20 @@
                   {
                     "name": "fmisid",
                     "type": "string",
-                    "doc": "Stable FMI station identifier (fmisid) for the observing station."
+                    "doc": "Stable FMI station identifier (fmisid) for the observing station.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "station_name",
                     "type": "string",
-                    "doc": "Station name resolved from station metadata or, if metadata lookup fails, the station identifier string."
+                    "doc": "Station name resolved from station metadata or, if metadata lookup fails, the station identifier string.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the FMI Finland Weather source."
                   },
                   {
                     "name": "observation_time",
                     "type": "string",
-                    "doc": "Observation timestamp in UTC, formatted as an ISO-8601 instant such as 2024-01-15T13:00:00Z."
+                    "doc": "Observation timestamp in UTC, formatted as an ISO-8601 instant such as 2024-01-15T13:00:00Z.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "aqindex",
@@ -511,7 +522,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Finnish Air Quality Index 1-hour average."
+                    "doc": "Finnish Air Quality Index 1-hour average.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "pm10_ug_m3",
@@ -520,7 +532,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "PM10 particulate matter concentration 1-hour average in micrograms per cubic meter."
+                    "doc": "PM10 particulate matter concentration 1-hour average in micrograms per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "pm2_5_ug_m3",
@@ -529,7 +542,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "PM2.5 particulate matter concentration 1-hour average in micrograms per cubic meter."
+                    "doc": "PM2.5 particulate matter concentration 1-hour average in micrograms per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "no2_ug_m3",
@@ -538,7 +552,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Nitrogen dioxide concentration 1-hour average in micrograms per cubic meter."
+                    "doc": "Nitrogen dioxide concentration 1-hour average in micrograms per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "o3_ug_m3",
@@ -547,7 +562,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Ozone concentration 1-hour average in micrograms per cubic meter."
+                    "doc": "Ozone concentration 1-hour average in micrograms per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "so2_ug_m3",
@@ -556,7 +572,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Sulfur dioxide concentration 1-hour average in micrograms per cubic meter."
+                    "doc": "Sulfur dioxide concentration 1-hour average in micrograms per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   },
                   {
                     "name": "co_mg_m3",
@@ -565,14 +582,21 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Carbon monoxide concentration 1-hour average in milligrams per cubic meter."
+                    "doc": "Carbon monoxide concentration 1-hour average in milligrams per cubic meter.",
+                    "description": "Measurement payload for weather observations in the FMI Finland Weather source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for weather observations in the FMI Finland Weather source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "FMI Finland Weather publishes weather observations from the Finnish Meteorological Institute (FMI) for Finnish weather observation stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for FMI Finland Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/geosphere-austria/EVENTS.md
+++ b/geosphere-austria/EVENTS.md
@@ -1,6 +1,6 @@
 # GeoSphere Austria — TAWES Weather Observations Events
 
-This bridge polls 10-minute weather observations from the [GeoSphere Austria](https://geosphere.at) TAWES (Teilautomatische Wetterstationen) automatic station network and emits them as CloudEvents into Apache Kafka.
+GeoSphere Austria Weather publishes weather observations from GeoSphere Austria for Austrian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `at.geosphere.tawes.WeatherStation`
 
 #### What it tells you
 
-Reference data for a GeoSphere Austria TAWES automatic weather station, including location, elevation, and federal state. Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID.
+Reference data for a GeoSphere Austria TAWES automatic weather station, including location, elevation, and federal state.
 
 #### Identity
 
@@ -85,7 +85,7 @@ CloudEvents type: `at.geosphere.tawes.WeatherObservation`
 
 #### What it tells you
 
-10-minute weather observation from a GeoSphere Austria TAWES station, including temperature, humidity, precipitation, wind, pressure, sunshine duration, and global radiation. 10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters.
+10-minute weather observation from a GeoSphere Austria TAWES station, including temperature, humidity, precipitation, wind, pressure, sunshine duration, and global radiation.
 
 #### Identity
 

--- a/geosphere-austria/xreg/geosphere-austria.xreg.json
+++ b/geosphere-austria/xreg/geosphere-austria.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/at.geosphere.tawes"
-      ]
+      ],
+      "description": "Kafka producer endpoint for GeoSphere Austria Weather CloudEvents on the `geosphere-austria-tawes` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -65,7 +66,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/at.geosphere.tawes.jstruct/schemas/at.geosphere.tawes.WeatherObservation"
         }
-      }
+      },
+      "description": "Events from GeoSphere Austria Weather covering Austrian weather stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -90,7 +92,7 @@
                         "WeatherStation": {
                           "name": "WeatherStation",
                           "type": "object",
-                          "description": "Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID. Metadata is sourced from the TAWES v1 10-minute current dataset metadata endpoint.",
+                          "description": "Reference data for a GeoSphere Austria TAWES automatic weather station, including location, elevation, and federal state.",
                           "properties": {
                             "station_id": {
                               "type": "string",
@@ -120,7 +122,10 @@
                               "symbol": "m"
                             },
                             "state": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Austrian federal state (Bundesland) where the station is located, for example 'Wien', 'Tirol', 'Steiermark'. Sourced from the GeoSphere metadata 'state' field. Null when the metadata does not include a state."
                             }
                           },
@@ -148,7 +153,10 @@
                               "description": "Observation timestamp in UTC from the GeoSphere API 'timestamps' array, formatted as an ISO-8601 instant such as '2024-01-15T13:00:00+00:00'."
                             },
                             "temperature": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Air temperature (Lufttemperatur) in degrees Celsius over the 10-minute interval, from the GeoSphere TL parameter. Null when the station does not report this parameter.",
                               "unit": "degree Celsius",
                               "symbol": "°C",
@@ -157,7 +165,10 @@
                               }
                             },
                             "humidity": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Relative humidity (Relative Feuchte) as a percentage over the 10-minute interval, from the GeoSphere RF parameter. Null when not reported.",
                               "unit": "percent",
                               "symbol": "%",
@@ -166,7 +177,10 @@
                               }
                             },
                             "precipitation": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Precipitation (Niederschlag) in millimeters accumulated during the 10-minute interval, from the GeoSphere RR parameter. Null when not reported.",
                               "unit": "millimeter",
                               "symbol": "mm",
@@ -175,7 +189,10 @@
                               }
                             },
                             "wind_direction": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Wind direction (Windrichtung) in degrees over the 10-minute interval, from the GeoSphere DD parameter. 0 indicates north, 90 east, 180 south, 270 west. Null when not reported.",
                               "unit": "degree",
                               "symbol": "°",
@@ -184,7 +201,10 @@
                               }
                             },
                             "wind_speed": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Wind speed (Windgeschwindigkeit) in meters per second over the 10-minute interval, from the GeoSphere FF parameter. Null when not reported.",
                               "unit": "meter per second",
                               "symbol": "m/s",
@@ -193,7 +213,10 @@
                               }
                             },
                             "pressure": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Atmospheric pressure (Luftdruck) in hectopascals at station level over the 10-minute interval, from the GeoSphere P parameter. Null when not reported.",
                               "unit": "hectopascal",
                               "symbol": "hPa",
@@ -202,7 +225,10 @@
                               }
                             },
                             "sunshine_duration": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Sunshine duration (Sonnenscheindauer) in seconds during the 10-minute interval, from the GeoSphere SO parameter. Null when the station does not have a sunshine sensor (has_sunshine=false) or the value is missing.",
                               "unit": "second",
                               "symbol": "s",
@@ -211,7 +237,10 @@
                               }
                             },
                             "global_radiation": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Global radiation (Globalstrahlung) in watts per square meter during the 10-minute interval, from the GeoSphere GLOW parameter. Null when the station does not have a radiation sensor (has_global_radiation=false) or the value is missing.",
                               "unit": "watt per square meter",
                               "symbol": "W/m²",
@@ -290,7 +319,10 @@
                               "symbol": "m"
                             },
                             "state": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Austrian federal state (Bundesland) where the station is located, for example 'Wien', 'Tirol', 'Steiermark'. Sourced from the GeoSphere metadata 'state' field. Null when the metadata does not include a state."
                             }
                           },
@@ -306,7 +338,7 @@
                         "WeatherObservation": {
                           "name": "WeatherObservation",
                           "type": "object",
-                          "description": "10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters. Values are null when the station does not report a parameter or the measurement is missing for the current interval.",
+                          "description": "10-minute weather observation from a GeoSphere Austria TAWES station, including temperature, humidity, precipitation, wind, pressure, sunshine duration, and global radiation.",
                           "properties": {
                             "station_id": {
                               "type": "string",
@@ -318,7 +350,10 @@
                               "description": "Observation timestamp in UTC from the GeoSphere API 'timestamps' array, formatted as an ISO-8601 instant such as '2024-01-15T13:00:00+00:00'."
                             },
                             "temperature": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Air temperature (Lufttemperatur) in degrees Celsius over the 10-minute interval, from the GeoSphere TL parameter. Null when the station does not report this parameter.",
                               "unit": "degree Celsius",
                               "symbol": "°C",
@@ -327,7 +362,10 @@
                               }
                             },
                             "humidity": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Relative humidity (Relative Feuchte) as a percentage over the 10-minute interval, from the GeoSphere RF parameter. Null when not reported.",
                               "unit": "percent",
                               "symbol": "%",
@@ -336,7 +374,10 @@
                               }
                             },
                             "precipitation": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Precipitation (Niederschlag) in millimeters accumulated during the 10-minute interval, from the GeoSphere RR parameter. Null when not reported.",
                               "unit": "millimeter",
                               "symbol": "mm",
@@ -345,7 +386,10 @@
                               }
                             },
                             "wind_direction": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Wind direction (Windrichtung) in degrees over the 10-minute interval, from the GeoSphere DD parameter. 0 indicates north, 90 east, 180 south, 270 west. Null when not reported.",
                               "unit": "degree",
                               "symbol": "°",
@@ -354,7 +398,10 @@
                               }
                             },
                             "wind_speed": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Wind speed (Windgeschwindigkeit) in meters per second over the 10-minute interval, from the GeoSphere FF parameter. Null when not reported.",
                               "unit": "meter per second",
                               "symbol": "m/s",
@@ -363,7 +410,10 @@
                               }
                             },
                             "pressure": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Atmospheric pressure (Luftdruck) in hectopascals at station level over the 10-minute interval, from the GeoSphere P parameter. Null when not reported.",
                               "unit": "hectopascal",
                               "symbol": "hPa",
@@ -372,7 +422,10 @@
                               }
                             },
                             "sunshine_duration": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Sunshine duration (Sonnenscheindauer) in seconds during the 10-minute interval, from the GeoSphere SO parameter. Null when the station does not have a sunshine sensor (has_sunshine=false) or the value is missing.",
                               "unit": "second",
                               "symbol": "s",
@@ -381,7 +434,10 @@
                               }
                             },
                             "global_radiation": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Global radiation (Globalstrahlung) in watts per square meter during the 10-minute interval, from the GeoSphere GLOW parameter. Null when the station does not have a radiation sensor (has_global_radiation=false) or the value is missing.",
                               "unit": "watt per square meter",
                               "symbol": "W/m²",
@@ -431,35 +487,45 @@
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Stable GeoSphere Austria numeric station identifier."
+                    "doc": "Stable GeoSphere Austria numeric station identifier.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "station_name",
                     "type": "string",
-                    "doc": "Station name from the GeoSphere metadata."
+                    "doc": "Station name from the GeoSphere metadata.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "WGS84 latitude of the station in decimal degrees."
+                    "doc": "WGS84 latitude of the station in decimal degrees.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "WGS84 longitude of the station in decimal degrees."
+                    "doc": "WGS84 longitude of the station in decimal degrees.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "altitude",
                     "type": "double",
-                    "doc": "Station altitude above sea level in meters."
+                    "doc": "Station altitude above sea level in meters.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "state",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "default": null,
-                    "doc": "Austrian federal state (Bundesland) where the station is located."
+                    "doc": "Austrian federal state (Bundesland) where the station is located.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the GeoSphere Austria Weather source."
               }
             }
           }
@@ -480,67 +546,107 @@
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "GeoSphere Austria numeric station identifier for the observing station."
+                    "doc": "GeoSphere Austria numeric station identifier for the observing station.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "observation_time",
                     "type": "string",
-                    "doc": "Observation timestamp in UTC from the GeoSphere API timestamps array."
+                    "doc": "Observation timestamp in UTC from the GeoSphere API timestamps array.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "temperature",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Air temperature in degrees Celsius over the 10-minute interval."
+                    "doc": "Air temperature in degrees Celsius over the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "humidity",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Relative humidity as a percentage over the 10-minute interval."
+                    "doc": "Relative humidity as a percentage over the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "precipitation",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Precipitation in millimeters accumulated during the 10-minute interval."
+                    "doc": "Precipitation in millimeters accumulated during the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "wind_direction",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Wind direction in degrees over the 10-minute interval."
+                    "doc": "Wind direction in degrees over the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "wind_speed",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Wind speed in meters per second over the 10-minute interval."
+                    "doc": "Wind speed in meters per second over the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "pressure",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Atmospheric pressure in hectopascals at station level."
+                    "doc": "Atmospheric pressure in hectopascals at station level.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "sunshine_duration",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Sunshine duration in seconds during the 10-minute interval."
+                    "doc": "Sunshine duration in seconds during the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   },
                   {
                     "name": "global_radiation",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "default": null,
-                    "doc": "Global radiation in watts per square meter during the 10-minute interval."
+                    "doc": "Global radiation in watts per square meter during the 10-minute interval.",
+                    "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for weather observations in the GeoSphere Austria Weather source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "GeoSphere Austria Weather publishes weather observations from GeoSphere Austria for Austrian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for GeoSphere Austria Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/gios-poland/EVENTS.md
+++ b/gios-poland/EVENTS.md
@@ -1,6 +1,6 @@
 # GIOŚ Poland Air Quality Poller Events
 
-**GIOŚ Poland Air Quality Poller** polls the Polish Chief Inspectorate of Environmental Protection (GIOŚ) air quality API for station metadata, sensor reference data, hourly measurements, and air quality index values, and sends them to a Kafka topic as CloudEvents. The tool tracks previously seen measurement timestamps per sensor to avoid sending duplicates.
+GIOŚ Poland Air Quality publishes sensor readings and air-quality index values from Poland's Chief Inspectorate of Environmental Protection (GIOŚ) for Polish air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `pl.gov.gios.airquality.Station`
 
 #### What it tells you
 
-Reference data for a GIOŚ air quality monitoring station, including its geographic location, city, commune, district, and voivodeship. Reference record for a GIOŚ air quality monitoring station in Poland. Contains the station identifier, code, name, WGS84 coordinates, and administrative location (city, commune, district, voivodeship, street).
+Reference data for a GIOŚ air quality monitoring station, including its geographic location, city, commune, district, and voivodeship.
 
 #### Identity
 
@@ -95,7 +95,7 @@ CloudEvents type: `pl.gov.gios.airquality.Sensor`
 
 #### What it tells you
 
-Reference data for a sensor (measurement point) installed at a GIOŚ station, identifying the pollutant it measures. Reference record for a sensor installed at a GIOŚ air quality station. Identifies the specific pollutant being measured (e.g.
+Reference data for a sensor (measurement point) installed at a GIOŚ station, identifying the pollutant it measures.
 
 #### Identity
 
@@ -142,7 +142,7 @@ CloudEvents type: `pl.gov.gios.airquality.Measurement`
 
 #### What it tells you
 
-Hourly air quality measurement from a single sensor, reporting the concentration of the monitored pollutant in µg/m³. Hourly air quality measurement from a GIOŚ sensor. Reports the pollutant concentration in µg/m³ at a specific timestamp.
+Hourly air quality measurement from a single sensor, reporting the concentration of the monitored pollutant in µg/m³.
 
 #### Identity
 
@@ -187,7 +187,7 @@ CloudEvents type: `pl.gov.gios.airquality.AirQualityIndex`
 
 #### What it tells you
 
-Current Polish Air Quality Index for a station, including the overall index and sub-indices for individual pollutants (SO₂, NO₂, PM10, PM2.5, O₃). Current Polish Air Quality Index (Indeks Jakości Powietrza) for a GIOŚ monitoring station. Includes the overall index value and category plus sub-indices for SO₂, NO₂, PM10, PM2.5, and O₃.
+Current Polish Air Quality Index for a station, including the overall index and sub-indices for individual pollutants (SO₂, NO₂, PM10, PM2.5, O₃).
 
 #### Identity
 

--- a/gios-poland/xreg/gios_poland.xreg.json
+++ b/gios-poland/xreg/gios_poland.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/pl.gov.gios.airquality"
-      ]
+      ],
+      "description": "Kafka producer endpoint for GIOŚ Poland Air Quality CloudEvents on the `gios-poland` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -101,7 +102,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/pl.gov.gios.airquality.jstruct/schemas/pl.gov.gios.airquality.AirQualityIndex"
         }
-      }
+      },
+      "description": "Events from GIOŚ Poland Air Quality covering Polish air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -137,44 +139,68 @@
                     "description": "Human-readable name of the monitoring station, typically including city and street. Mapped from 'Nazwa stacji'."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Latitude of the station in decimal degrees north (WGS84). Mapped from 'WGS84 φ N'.",
                     "unit": "deg",
                     "symbol": "°N"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Longitude of the station in decimal degrees east (WGS84). Mapped from 'WGS84 λ E'.",
                     "unit": "deg",
                     "symbol": "°E"
                   },
                   "city_id": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Numeric identifier of the city where the station is located. Mapped from 'Identyfikator miasta'."
                   },
                   "city_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the city where the station is located. Mapped from 'Nazwa miasta'."
                   },
                   "commune": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the commune (gmina) where the station is located. Mapped from 'Gmina'."
                   },
                   "district": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the district (powiat) where the station is located. Mapped from 'Powiat'."
                   },
                   "voivodeship": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the voivodeship (province) where the station is located, in uppercase Polish. Mapped from 'Województwo'."
                   },
                   "street": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Street address of the station, if available. Mapped from 'Ulica'."
                   }
                 },
                 "$id": "https://api.gios.gov.pl/schemas/pl/gov/gios/airquality/Station",
-                "description": "Reference record for a GIOŚ air quality monitoring station in Poland. Contains the station identifier, code, name, WGS84 coordinates, and administrative location (city, commune, district, voivodeship, street). Fields are mapped from the Polish-language GIOŚ REST API /station/findAll endpoint."
+                "description": "Reference data for a GIOŚ air quality monitoring station, including its geographic location, city, commune, district, and voivodeship."
               }
             }
           }
@@ -210,7 +236,10 @@
                     "description": "Polish-language name of the measured pollutant, e.g. 'pył zawieszony PM10', 'dwutlenek azotu'. Mapped from 'Wskaźnik'."
                   },
                   "parameter_formula": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Chemical formula of the measured pollutant, e.g. 'PM10', 'NO2', 'SO2', 'O3', 'CO', 'C6H6', 'PM2.5'. Mapped from 'Wskaźnik - wzór'."
                   },
                   "parameter_code": {
@@ -218,12 +247,15 @@
                     "description": "Short code identifying the pollutant parameter, e.g. 'PM10', 'NO2'. Mapped from 'Wskaźnik - kod'."
                   },
                   "parameter_id": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Numeric identifier of the pollutant parameter in the GIOŚ system. Mapped from 'Id wskaźnika'."
                   }
                 },
                 "$id": "https://api.gios.gov.pl/schemas/pl/gov/gios/airquality/Sensor",
-                "description": "Reference record for a sensor installed at a GIOŚ air quality station. Identifies the specific pollutant being measured (e.g. PM10, NO₂, O₃) along with the sensor and station identifiers. Fields are mapped from the Polish-language /station/sensors/{stationId} endpoint."
+                "description": "Reference data for a sensor (measurement point) installed at a GIOŚ station, identifying the pollutant it measures."
               }
             }
           }
@@ -263,14 +295,17 @@
                     "description": "Measurement timestamp in local Polish time (ISO 8601 format). Mapped from 'Data'."
                   },
                   "value": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Measured pollutant concentration. Unit: micrograms per cubic meter (µg/m³). Null when the measurement is missing or invalid. Mapped from 'Wartość'.",
                     "unit": "ug/m3",
                     "symbol": "µg/m³"
                   }
                 },
                 "$id": "https://api.gios.gov.pl/schemas/pl/gov/gios/airquality/Measurement",
-                "description": "Hourly air quality measurement from a GIOŚ sensor. Reports the pollutant concentration in µg/m³ at a specific timestamp. The measurement may be null when data is missing or under validation. Fields are mapped from the Polish-language /data/getData/{sensorId} endpoint."
+                "description": "Hourly air quality measurement from a single sensor, reporting the concentration of the monitored pollutant in µg/m³."
               }
             }
           }
@@ -300,113 +335,193 @@
                     "description": "Timestamp when the overall index was calculated (ISO 8601 in local Polish time). Mapped from 'Data wykonania obliczeń indeksu'."
                   },
                   "index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Overall air quality index value: 0=Bardzo dobry (Very good), 1=Dobry (Good), 2=Umiarkowany (Moderate), 3=Dostateczny (Sufficient), 4=Zły (Bad), 5=Bardzo zły (Very bad). Mapped from 'Wartość indeksu'."
                   },
                   "index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name of the overall index, e.g. 'Bardzo dobry', 'Dobry', 'Umiarkowany'. Mapped from 'Nazwa kategorii indeksu'."
                   },
                   "source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source measurement data used for the overall index calculation. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika st'."
                   },
                   "so2_calculation_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp when the SO₂ sub-index was calculated. Mapped from 'Data wykonania obliczeń indeksu dla wskaźnika SO2'."
                   },
                   "so2_index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "SO₂ sub-index value (0–5 scale). Mapped from 'Wartość indeksu dla wskaźnika SO2'."
                   },
                   "so2_index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name for the SO₂ sub-index. Mapped from 'Nazwa kategorii indeksu dla wskażnika SO2'."
                   },
                   "so2_source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source data used for the SO₂ sub-index. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika SO2'."
                   },
                   "no2_calculation_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp when the NO₂ sub-index was calculated. Mapped from 'Data wykonania obliczeń indeksu dla wskaźnika NO2'."
                   },
                   "no2_index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "NO₂ sub-index value (0–5 scale). Mapped from 'Wartość indeksu dla wskaźnika NO2'."
                   },
                   "no2_index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name for the NO₂ sub-index. Mapped from 'Nazwa kategorii indeksu dla wskażnika NO2'."
                   },
                   "no2_source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source data used for the NO₂ sub-index. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika NO2'."
                   },
                   "pm10_calculation_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp when the PM10 sub-index was calculated. Mapped from 'Data wykonania obliczeń indeksu dla wskaźnika PM10'."
                   },
                   "pm10_index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "PM10 sub-index value (0–5 scale). Mapped from 'Wartość indeksu dla wskaźnika PM10'."
                   },
                   "pm10_index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name for the PM10 sub-index. Mapped from 'Nazwa kategorii indeksu dla wskażnika PM10'."
                   },
                   "pm10_source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source data used for the PM10 sub-index. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika PM10'."
                   },
                   "pm25_calculation_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp when the PM2.5 sub-index was calculated. Mapped from 'Data wykonania obliczeń indeksu dla wskaźnika PM2.5'."
                   },
                   "pm25_index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "PM2.5 sub-index value (0–5 scale). Mapped from 'Wartość indeksu dla wskaźnika PM2.5'."
                   },
                   "pm25_index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name for the PM2.5 sub-index. Mapped from 'Nazwa kategorii indeksu dla wskażnika PM2.5'."
                   },
                   "pm25_source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source data used for the PM2.5 sub-index. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika PM2.5'."
                   },
                   "o3_calculation_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp when the O₃ sub-index was calculated. Mapped from 'Data wykonania obliczeń indeksu dla wskaźnika O3'."
                   },
                   "o3_index_value": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "O₃ sub-index value (0–5 scale). Mapped from 'Wartość indeksu dla wskaźnika O3'."
                   },
                   "o3_index_category": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Polish-language category name for the O₃ sub-index. Mapped from 'Nazwa kategorii indeksu dla wskażnika O3'."
                   },
                   "o3_source_data_timestamp": {
-                    "type": ["datetime", "null"],
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Timestamp of the source data used for the O₃ sub-index. Mapped from 'Data danych źródłowych, z których policzono wartość indeksu dla wskaźnika O3'."
                   },
                   "overall_status": {
-                    "type": ["boolean", "null"],
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
                     "description": "Whether the overall air quality index is currently valid for this station. Mapped from 'Status indeksu ogólnego dla stacji pomiarowej'."
                   },
                   "critical_pollutant_code": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Code of the pollutant that determined the overall index value, e.g. 'OZON', 'PM10'. Mapped from 'Kod zanieczyszczenia krytycznego'."
                   }
                 },
                 "$id": "https://api.gios.gov.pl/schemas/pl/gov/gios/airquality/AirQualityIndex",
-                "description": "Current Polish Air Quality Index (Indeks Jakości Powietrza) for a GIOŚ monitoring station. Includes the overall index value and category plus sub-indices for SO₂, NO₂, PM10, PM2.5, and O₃. Each sub-index uses a 0–5 scale: 0=Bardzo dobry (Very good), 1=Dobry (Good), 2=Umiarkowany (Moderate), 3=Dostateczny (Sufficient), 4=Zły (Bad), 5=Bardzo zły (Very bad). Fields are mapped from the Polish-language /aqindex/getIndex/{stationId} endpoint."
+                "description": "Current Polish Air Quality Index for a station, including the overall index and sub-indices for individual pollutants (SO₂, NO₂, PM10, PM2.5, O₃)."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "GIOŚ Poland Air Quality publishes sensor readings and air-quality index values from Poland's Chief Inspectorate of Environmental Protection (GIOŚ) for Polish air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for GIOŚ Poland Air Quality, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/hko-hong-kong/EVENTS.md
+++ b/hko-hong-kong/EVENTS.md
@@ -1,12 +1,12 @@
 # HKO Hong Kong Weather Observation Bridge Events
 
-This bridge fetches real-time weather observations from the [Hong Kong Observatory (HKO)](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) and emits them as CloudEvents into Apache Kafka or Azure Event Hubs.
+Hong Kong Observatory Weather publishes weather observations from the Hong Kong Observatory for Hong Kong weather observation locations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{place_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `HK.Gov.HKO.Weather.Station`
 
 #### What it tells you
 
-Reference data for a HKO weather observation place. Places include automatic weather stations (temperature), rainfall reporting districts, and special measurement locations (humidity at HKO headquarters, UV index at King's Park).
+A reference record published by the Hong Kong Observatory. It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -71,7 +71,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Weather Observation
 
@@ -79,7 +79,7 @@ CloudEvents type: `HK.Gov.HKO.Weather.WeatherObservation`
 
 #### What it tells you
 
-Current weather observation for a HKO place from the rhrread endpoint. Temperature from automatic weather stations, rainfall from district-level rain gauges, humidity from HKO headquarters, UV index from King's Park. Fields are null when the place does not report that data type.
+A current environmental measurement from the Hong Kong Observatory. It carries weather observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/hko-hong-kong/xreg/hko_hong_kong.xreg.json
+++ b/hko-hong-kong/xreg/hko_hong_kong.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "HK.Gov.HKO.Weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,10 @@
           "key": "{place_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/HK.Gov.HKO.Weather"]
+      "messagegroups": [
+        "#/messagegroups/HK.Gov.HKO.Weather"
+      ],
+      "description": "Kafka producer endpoint for Hong Kong Observatory Weather CloudEvents on the `hko-hong-kong` topic keyed by `{place_id}`."
     }
   },
   "messagegroups": {
@@ -25,25 +30,42 @@
           "name": "Station",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "HK.Gov.HKO.Weather.Station"},
-            "source": {"value": "https://data.weather.gov.hk"},
-            "subject": {"value": "{place_id}", "type": "uritemplate"}
+            "type": {
+              "value": "HK.Gov.HKO.Weather.Station"
+            },
+            "source": {
+              "value": "https://data.weather.gov.hk"
+            },
+            "subject": {
+              "value": "{place_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/HK.Gov.HKO.Weather.jstruct/schemas/HK.Gov.HKO.Weather.Station"
+          "dataschemauri": "#/schemagroups/HK.Gov.HKO.Weather.jstruct/schemas/HK.Gov.HKO.Weather.Station",
+          "description": "A reference record published by the Hong Kong Observatory. It lets consumers label, group, and route the live measurement or forecast events."
         },
         "HK.Gov.HKO.Weather.WeatherObservation": {
           "name": "WeatherObservation",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "HK.Gov.HKO.Weather.WeatherObservation"},
-            "source": {"value": "https://data.weather.gov.hk"},
-            "subject": {"value": "{place_id}", "type": "uritemplate"}
+            "type": {
+              "value": "HK.Gov.HKO.Weather.WeatherObservation"
+            },
+            "source": {
+              "value": "https://data.weather.gov.hk"
+            },
+            "subject": {
+              "value": "{place_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/HK.Gov.HKO.Weather.jstruct/schemas/HK.Gov.HKO.Weather.WeatherObservation"
+          "dataschemauri": "#/schemagroups/HK.Gov.HKO.Weather.jstruct/schemas/HK.Gov.HKO.Weather.WeatherObservation",
+          "description": "A current environmental measurement from the Hong Kong Observatory. It carries weather observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Hong Kong Observatory Weather covering Hong Kong weather observation locations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -61,8 +83,12 @@
                 "$id": "https://data.weather.gov.hk/schemas/HK/Gov/HKO/Weather/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference data for a HKO weather observation place. Places include automatic weather stations (temperature), rainfall reporting districts, and special measurement locations (humidity at HKO headquarters, UV index at King's Park).",
-                "required": ["place_id", "name", "data_types"],
+                "description": "A reference record published by the Hong Kong Observatory. It lets consumers label, group, and route the live measurement or forecast events.",
+                "required": [
+                  "place_id",
+                  "name",
+                  "data_types"
+                ],
                 "properties": {
                   "place_id": {
                     "type": "string",
@@ -93,8 +119,12 @@
                 "$id": "https://data.weather.gov.hk/schemas/HK/Gov/HKO/Weather/WeatherObservation",
                 "type": "object",
                 "name": "WeatherObservation",
-                "description": "Current weather observation for a HKO place from the rhrread endpoint. Temperature from automatic weather stations, rainfall from district-level rain gauges, humidity from HKO headquarters, UV index from King's Park. Fields are null when the place does not report that data type.",
-                "required": ["place_id", "place_name", "observation_time"],
+                "description": "A current environmental measurement from the Hong Kong Observatory. It carries weather observations when the upstream feed reports a new or refreshed value.",
+                "required": [
+                  "place_id",
+                  "place_name",
+                  "observation_time"
+                ],
                 "properties": {
                   "place_id": {
                     "type": "string",
@@ -109,30 +139,45 @@
                     "description": "ISO 8601 timestamp of the observation including Hong Kong timezone offset (+08:00), from the updateTime field."
                   },
                   "temperature": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Air temperature from automatic weather stations.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "rainfall_max": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum rainfall in the past hour from district-level rain gauges.",
                     "unit": "mm",
                     "symbol": "mm"
                   },
                   "humidity": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Relative humidity, currently only from Hong Kong Observatory headquarters.",
                     "unit": "percent",
                     "symbol": "%"
                   },
                   "uv_index": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "UV index during the past hour, currently only from King's Park.",
                     "unit": "1"
                   },
                   "uv_description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "HKO descriptive UV level: 'low', 'moderate', 'high', 'very high', 'extreme'."
                   }
                 }
@@ -142,5 +187,10 @@
         }
       }
     }
+  },
+  "description": "Hong Kong Observatory Weather publishes weather observations from the Hong Kong Observatory for Hong Kong weather observation locations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Hong Kong Observatory Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/hongkong-epd/EVENTS.md
+++ b/hongkong-epd/EVENTS.md
@@ -1,12 +1,12 @@
 # Hong Kong EPD AQHI Bridge Events
 
-MQTT/5.0 transport variants of the HK EPD AQHI CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under air-quality/hk/epd/hongkong-epd/{district}/{station_id}/... The {district} placeholder is the Hong Kong 18-district administrative area where the station is located, normalized to lowercase snake_case.
+Hong Kong EPD Air Quality publishes air-quality health index and pollutant measurements from Hong Kong's Environmental Protection Department for Hong Kong air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types (4 transport bindings in the manifest).
 - **Transports:** KAFKA, MQTT/5.0
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{station_id}` identifies the resource each event is about.
 - **Operations:** The checked-in guide documents a default polling interval of 3600 seconds.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -52,7 +52,7 @@ CloudEvents type: `HK.Gov.EPD.AQHI.Station`
 
 #### What it tells you
 
-Reference data for a Hong Kong EPD AQHI monitoring station. The EPD operates a network of General Stations and Roadside Stations across Hong Kong. Station coordinates are derived from the EPD station map.
+A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -92,7 +92,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity. MQTT may retain the latest copy so late subscribers can build local context immediately.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Aqhireading
 
@@ -100,7 +100,7 @@ CloudEvents type: `HK.Gov.EPD.AQHI.AQHIReading`
 
 #### What it tells you
 
-Air Quality Health Index (AQHI) reading for a Hong Kong EPD monitoring station. AQHI quantifies health risk from air pollution on a scale of 1 to 10+ and is calculated from concentrations of nitrogen dioxide, sulphur dioxide, ozone, and PM2.5. Published hourly by the EPD.
+A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health index and pollutant measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/hongkong-epd/xreg/hongkong_epd.xreg.json
+++ b/hongkong-epd/xreg/hongkong_epd.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "HK.Gov.EPD.AQHI.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,10 +17,15 @@
           "key": "{station_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/HK.Gov.EPD.AQHI"]
+      "messagegroups": [
+        "#/messagegroups/HK.Gov.EPD.AQHI"
+      ],
+      "description": "Kafka producer endpoint for Hong Kong EPD Air Quality CloudEvents on the `hongkong-epd-aqhi` topic keyed by `{station_id}`."
     },
     "HK.Gov.EPD.AQHI.Mqtt": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "MQTT/5.0",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -32,7 +39,10 @@
           }
         ]
       },
-      "messagegroups": ["#/messagegroups/HK.Gov.EPD.AQHI.mqtt"]
+      "messagegroups": [
+        "#/messagegroups/HK.Gov.EPD.AQHI.mqtt"
+      ],
+      "description": "MQTT 5 producer endpoint for Hong Kong EPD Air Quality CloudEvents using the source topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -54,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/HK.Gov.EPD.AQHI.jstruct/schemas/HK.Gov.EPD.AQHI.Station"
+          "dataschemauri": "#/schemagroups/HK.Gov.EPD.AQHI.jstruct/schemas/HK.Gov.EPD.AQHI.Station",
+          "description": "A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and route the live measurement or forecast events."
         },
         "HK.Gov.EPD.AQHI.AQHIReading": {
           "name": "AQHIReading",
@@ -72,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/HK.Gov.EPD.AQHI.jstruct/schemas/HK.Gov.EPD.AQHI.AQHIReading"
+          "dataschemauri": "#/schemagroups/HK.Gov.EPD.AQHI.jstruct/schemas/HK.Gov.EPD.AQHI.AQHIReading",
+          "description": "A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health index and pollutant measurements when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Hong Kong EPD Air Quality covering Hong Kong air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "HK.Gov.EPD.AQHI.mqtt": {
-      "description": "MQTT/5.0 transport variants of the HK EPD AQHI CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under air-quality/hk/epd/hongkong-epd/{district}/{station_id}/... The {district} placeholder is the Hong Kong 18-district administrative area where the station is located, normalized to lowercase snake_case.",
+      "description": "MQTT 5 variant of the Hong Kong EPD Air Quality events. It carries the same source semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "HK.Gov.EPD.AQHI.mqtt.Station": {
           "name": "Station",
@@ -117,7 +130,7 @@
                 "$id": "https://www.aqhi.gov.hk/schemas/HK/Gov/EPD/AQHI/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference data for a Hong Kong EPD AQHI monitoring station. The EPD operates a network of General Stations and Roadside Stations across Hong Kong. Station coordinates are derived from the EPD station map.",
+                "description": "A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and route the live measurement or forecast events.",
                 "required": [
                   "station_id",
                   "station_name",
@@ -180,7 +193,7 @@
                 "$id": "https://www.aqhi.gov.hk/schemas/HK/Gov/EPD/AQHI/AQHIReading",
                 "type": "object",
                 "name": "AQHIReading",
-                "description": "Air Quality Health Index (AQHI) reading for a Hong Kong EPD monitoring station. AQHI quantifies health risk from air pollution on a scale of 1 to 10+ and is calculated from concentrations of nitrogen dioxide, sulphur dioxide, ozone, and PM2.5. Published hourly by the EPD.",
+                "description": "A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health index and pollutant measurements when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "station_id",
                   "station_name",
@@ -240,5 +253,10 @@
         }
       }
     }
+  },
+  "description": "Hong Kong EPD Air Quality publishes air-quality health index and pollutant measurements from Hong Kong's Environmental Protection Department for Hong Kong air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Hong Kong EPD Air Quality, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/irceline-belgium/EVENTS.md
+++ b/irceline-belgium/EVENTS.md
@@ -1,12 +1,12 @@
 # IRCELINE Belgium Events
 
-This source bridges the IRCELINE Belgium 52°North SOS Timeseries API into Kafka as CloudEvents. It covers Belgium's interregional air-quality monitoring network and emits both reference data and hourly telemetry into a single topic.
+IRCELINE Belgium Air Quality publishes pollutant concentration and air-quality measurements from Belgium's IRCELINE interregional environment agency for Belgian air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 3 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 2 telemetry event types.
+- **Reference vs telemetry:** 0 reference/catalog event types and 3 telemetry event types.
 - **Identity:** `{station_id}`, `{timeseries_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `be.irceline.Station`
 
 #### What it tells you
 
-Reference data describing one IRCELINE monitoring station from the GET /stations collection. The bridge maps the upstream GeoJSON feature to stable English field names and ignores the third coordinate element, which is the literal string 'NaN' in the live payloads.
+A reference record published by Belgium's IRCELINE interregional environment agency. It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -73,7 +73,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Timeseries
 
@@ -81,7 +81,7 @@ CloudEvents type: `be.irceline.Timeseries`
 
 #### What it tells you
 
-Reference data for a single IRCELINE timeseries from GET /timeseries or GET /timeseries/{id}?expanded=true. Each timeseries combines a stable numeric timeseries identifier with a station, a phenomenon/category pair, the published unit of measurement, and optional statusIntervals that describe threshold bands used by IRCELINE for display and air-quality interpretation.
+A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -139,7 +139,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Observation
 
@@ -147,7 +147,7 @@ CloudEvents type: `be.irceline.Observation`
 
 #### What it tells you
 
-Telemetry measurement for a single IRCELINE timeseries from GET /timeseries/{id}/getData. The upstream payload returns Unix timestamps in milliseconds and numeric values that may be null; the bridge converts the timestamp to an ISO 8601 UTC string and carries the unit from the timeseries metadata.
+A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/irceline-belgium/xreg/irceline_belgium.xreg.json
+++ b/irceline-belgium/xreg/irceline_belgium.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.irceline.Stations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for IRCELINE Belgium Air Quality CloudEvents on the `irceline-belgium` topic keyed by `{station_id}`."
     },
     "be.irceline.Timeseries.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.irceline.Timeseries"
-      ]
+      ],
+      "description": "Kafka producer endpoint for IRCELINE Belgium Air Quality CloudEvents on the `irceline-belgium` topic keyed by `{timeseries_id}`."
     }
   },
   "messagegroups": {
@@ -62,9 +64,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Station"
+          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Station",
+          "description": "A reference record published by Belgium's IRCELINE interregional environment agency. It lets consumers label, group, and route the live measurement or forecast events."
         }
-      }
+      },
+      "description": "Events from IRCELINE Belgium Air Quality covering Belgian air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "be.irceline.Timeseries": {
       "messages": {
@@ -84,7 +88,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Timeseries"
+          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Timeseries",
+          "description": "A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value."
         },
         "be.irceline.Observation": {
           "name": "Observation",
@@ -102,9 +107,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Observation"
+          "dataschemauri": "#/schemagroups/be.irceline.jstruct/schemas/be.irceline.Observation",
+          "description": "A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from IRCELINE Belgium Air Quality covering Belgian air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -124,7 +131,7 @@
                 "name": "Station",
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Reference data describing one IRCELINE monitoring station from the GET /stations collection. The bridge maps the upstream GeoJSON feature to stable English field names and ignores the third coordinate element, which is the literal string 'NaN' in the live payloads.",
+                "description": "A reference record published by Belgium's IRCELINE interregional environment agency. It lets consumers label, group, and route the live measurement or forecast events.",
                 "required": [
                   "station_id",
                   "label",
@@ -184,7 +191,7 @@
                 "name": "Timeseries",
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Reference data for a single IRCELINE timeseries from GET /timeseries or GET /timeseries/{id}?expanded=true. Each timeseries combines a stable numeric timeseries identifier with a station, a phenomenon/category pair, the published unit of measurement, and optional statusIntervals that describe threshold bands used by IRCELINE for display and air-quality interpretation.",
+                "description": "A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value.",
                 "definitions": {
                   "StatusInterval": {
                     "name": "StatusInterval",
@@ -236,7 +243,8 @@
                     "items": {
                       "type": {
                         "$ref": "#/definitions/StatusInterval"
-                      }
+                      },
+                      "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                     }
                   }
                 },
@@ -380,7 +388,7 @@
                 "name": "Observation",
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Telemetry measurement for a single IRCELINE timeseries from GET /timeseries/{id}/getData. The upstream payload returns Unix timestamps in milliseconds and numeric values that may be null; the bridge converts the timestamp to an ISO 8601 UTC string and carries the unit from the timeseries metadata.",
+                "description": "A current environmental measurement from Belgium's IRCELINE interregional environment agency. It carries pollutant concentration and air-quality measurements when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "timeseries_id",
                   "timestamp",
@@ -446,24 +454,29 @@
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Stable numeric station identifier from properties.id."
+                    "doc": "Stable numeric station identifier from properties.id.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "label",
                     "type": "string",
-                    "doc": "Human-readable station label from properties.label."
+                    "doc": "Human-readable station label from properties.label.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "Latitude in decimal degrees north from GeoJSON coordinates[1]."
+                    "doc": "Latitude in decimal degrees north from GeoJSON coordinates[1].",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "Longitude in decimal degrees east from GeoJSON coordinates[0]."
+                    "doc": "Longitude in decimal degrees east from GeoJSON coordinates[0].",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the IRCELINE Belgium Air Quality source."
               }
             }
           }
@@ -485,27 +498,32 @@
                   {
                     "name": "timeseries_id",
                     "type": "string",
-                    "doc": "Stable numeric timeseries identifier from id."
+                    "doc": "Stable numeric timeseries identifier from id.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "label",
                     "type": "string",
-                    "doc": "Descriptive upstream timeseries label."
+                    "doc": "Descriptive upstream timeseries label.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "uom",
                     "type": "string",
-                    "doc": "Published unit of measurement."
+                    "doc": "Published unit of measurement.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "station_id",
                     "type": "string",
-                    "doc": "Linked numeric station identifier from station.properties.id."
+                    "doc": "Linked numeric station identifier from station.properties.id.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "station_label",
                     "type": "string",
-                    "doc": "Linked station label from station.properties.label."
+                    "doc": "Linked station label from station.properties.label.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "latitude",
@@ -514,7 +532,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Linked station latitude from station.geometry.coordinates[1]."
+                    "doc": "Linked station latitude from station.geometry.coordinates[1].",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "longitude",
@@ -523,7 +542,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Linked station longitude from station.geometry.coordinates[0]."
+                    "doc": "Linked station longitude from station.geometry.coordinates[0].",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "phenomenon_id",
@@ -532,7 +552,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Measured phenomenon identifier from parameters.phenomenon.id."
+                    "doc": "Measured phenomenon identifier from parameters.phenomenon.id.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "phenomenon_label",
@@ -541,7 +562,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Measured phenomenon label from parameters.phenomenon.label."
+                    "doc": "Measured phenomenon label from parameters.phenomenon.label.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "category_id",
@@ -550,7 +572,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Category identifier from parameters.category.id."
+                    "doc": "Category identifier from parameters.category.id.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "category_label",
@@ -559,7 +582,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Category label from parameters.category.label."
+                    "doc": "Category label from parameters.category.label.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "status_intervals",
@@ -597,9 +621,11 @@
                       }
                     ],
                     "default": null,
-                    "doc": "Optional ordered array of status interval bands from the expanded timeseries metadata."
+                    "doc": "Optional ordered array of status interval bands from the expanded timeseries metadata.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
               }
             }
           }
@@ -621,12 +647,14 @@
                   {
                     "name": "timeseries_id",
                     "type": "string",
-                    "doc": "Stable numeric timeseries identifier."
+                    "doc": "Stable numeric timeseries identifier.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "timestamp",
                     "type": "string",
-                    "doc": "Observation timestamp in ISO 8601 UTC form."
+                    "doc": "Observation timestamp in ISO 8601 UTC form.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "value",
@@ -635,19 +663,27 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "Measured value from the IRCELINE getData response."
+                    "doc": "Measured value from the IRCELINE getData response.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   },
                   {
                     "name": "uom",
                     "type": "string",
-                    "doc": "Published unit of measurement copied from the parent timeseries."
+                    "doc": "Published unit of measurement copied from the parent timeseries.",
+                    "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration and air-quality measurements in the IRCELINE Belgium Air Quality source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "IRCELINE Belgium Air Quality publishes pollutant concentration and air-quality measurements from Belgium's IRCELINE interregional environment agency for Belgian air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for IRCELINE Belgium Air Quality, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/kmi-belgium/EVENTS.md
+++ b/kmi-belgium/EVENTS.md
@@ -1,12 +1,12 @@
 # KMI Belgium Weather Observation Bridge Events
 
-This bridge fetches real-time automatic weather station observations from the [Royal Meteorological Institute of Belgium (KMI/RMI)](https://opendata.meteo.be/) and emits them as CloudEvents into Apache Kafka or Azure Event Hubs.
+KMI Belgium Weather publishes weather observations from the Royal Meteorological Institute of Belgium (KMI/IRM) for Belgian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{station_code}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `BE.Gov.KMI.Weather.Station`
 
 #### What it tells you
 
-Reference metadata for a KMI/RMI automatic weather station derived from the latest aws:aws_10min observation features published through the public WFS service.
+A reference record published by the Royal Meteorological Institute of Belgium (KMI/IRM). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -71,7 +71,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Weather Observation
 
@@ -79,7 +79,7 @@ CloudEvents type: `BE.Gov.KMI.Weather.WeatherObservation`
 
 #### What it tells you
 
-Ten-minute automatic weather station observation from the KMI/RMI aws:aws_10min feed, containing precipitation, temperature, wind, humidity, pressure, radiation, and soil measurements.
+A current environmental measurement from the Royal Meteorological Institute of Belgium (KMI/IRM). It carries weather observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/kmi-belgium/xreg/kmi_belgium.xreg.json
+++ b/kmi-belgium/xreg/kmi_belgium.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "BE.Gov.KMI.Weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,10 @@
           "key": "{station_code}"
         }
       },
-      "messagegroups": ["#/messagegroups/BE.Gov.KMI.Weather"]
+      "messagegroups": [
+        "#/messagegroups/BE.Gov.KMI.Weather"
+      ],
+      "description": "Kafka producer endpoint for KMI Belgium Weather CloudEvents on the `kmi-belgium` topic keyed by `{station_code}`."
     }
   },
   "messagegroups": {
@@ -25,25 +30,42 @@
           "name": "Station",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "BE.Gov.KMI.Weather.Station"},
-            "source": {"value": "https://opendata.meteo.be"},
-            "subject": {"value": "{station_code}", "type": "uritemplate"}
+            "type": {
+              "value": "BE.Gov.KMI.Weather.Station"
+            },
+            "source": {
+              "value": "https://opendata.meteo.be"
+            },
+            "subject": {
+              "value": "{station_code}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/BE.Gov.KMI.Weather.jstruct/schemas/BE.Gov.KMI.Weather.Station"
+          "dataschemauri": "#/schemagroups/BE.Gov.KMI.Weather.jstruct/schemas/BE.Gov.KMI.Weather.Station",
+          "description": "A reference record published by the Royal Meteorological Institute of Belgium (KMI/IRM). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "BE.Gov.KMI.Weather.WeatherObservation": {
           "name": "WeatherObservation",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "BE.Gov.KMI.Weather.WeatherObservation"},
-            "source": {"value": "https://opendata.meteo.be"},
-            "subject": {"value": "{station_code}", "type": "uritemplate"}
+            "type": {
+              "value": "BE.Gov.KMI.Weather.WeatherObservation"
+            },
+            "source": {
+              "value": "https://opendata.meteo.be"
+            },
+            "subject": {
+              "value": "{station_code}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/BE.Gov.KMI.Weather.jstruct/schemas/BE.Gov.KMI.Weather.WeatherObservation"
+          "dataschemauri": "#/schemagroups/BE.Gov.KMI.Weather.jstruct/schemas/BE.Gov.KMI.Weather.WeatherObservation",
+          "description": "A current environmental measurement from the Royal Meteorological Institute of Belgium (KMI/IRM). It carries weather observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from KMI Belgium Weather covering Belgian weather stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -61,8 +83,12 @@
                 "$id": "https://opendata.meteo.be/schemas/BE/Gov/KMI/Weather/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference metadata for a KMI/RMI automatic weather station derived from the latest aws:aws_10min observation features published through the public WFS service.",
-                "required": ["station_code", "latitude", "longitude"],
+                "description": "A reference record published by the Royal Meteorological Institute of Belgium (KMI/IRM). It lets consumers label, group, and route the live measurement or forecast events.",
+                "required": [
+                  "station_code",
+                  "latitude",
+                  "longitude"
+                ],
                 "properties": {
                   "station_code": {
                     "type": "string",
@@ -97,8 +123,11 @@
                 "$id": "https://opendata.meteo.be/schemas/BE/Gov/KMI/Weather/WeatherObservation",
                 "type": "object",
                 "name": "WeatherObservation",
-                "description": "Ten-minute automatic weather station observation from the KMI/RMI aws:aws_10min feed, containing precipitation, temperature, wind, humidity, pressure, radiation, and soil measurements.",
-                "required": ["station_code", "observation_time"],
+                "description": "A current environmental measurement from the Royal Meteorological Institute of Belgium (KMI/IRM). It carries weather observations when the upstream feed reports a new or refreshed value.",
+                "required": [
+                  "station_code",
+                  "observation_time"
+                ],
                 "properties": {
                   "station_code": {
                     "type": "string",
@@ -109,103 +138,154 @@
                     "description": "Observation timestamp in UTC from the feature property `timestamp`."
                   },
                   "precip_quantity": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Precipitation quantity reported for the 10-minute observation period.",
                     "unit": "mm",
                     "symbol": "mm"
                   },
                   "temp_dry_shelter_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average air temperature measured in the 2 m dry shelter during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_grass_pt100_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average grass-level temperature measured by the Pt100 sensor during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_soil_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average soil surface temperature during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_soil_avg_5cm": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average soil temperature measured at 5 cm depth during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_soil_avg_10cm": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average soil temperature measured at 10 cm depth during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_soil_avg_20cm": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average soil temperature measured at 20 cm depth during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "temp_soil_avg_50cm": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average soil temperature measured at 50 cm depth during the observation period.",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "wind_speed_10m": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Wind speed measured at 10 m above ground level.",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "wind_speed_avg_30m": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average wind speed measured at 30 m above ground level.",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "wind_direction": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Wind direction in degrees from which the wind is blowing.",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "wind_gusts_speed": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum wind gust speed observed during the 10-minute period.",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "humidity_rel_shelter_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average relative humidity measured in the shelter during the observation period.",
                     "unit": "percent",
                     "symbol": "%"
                   },
                   "pressure": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Station-level atmospheric pressure reported by the automatic weather station.",
                     "unit": "hPa",
                     "symbol": "hPa"
                   },
                   "sun_duration": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Sunshine duration accumulated during the 10-minute observation period.",
                     "unit": "min",
                     "symbol": "min"
                   },
                   "short_wave_from_sky_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average downward shortwave radiation from the sky during the observation period.",
                     "unit": "W/m2",
                     "symbol": "W/m²"
                   },
                   "sun_int_avg": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average direct sunshine intensity during the observation period.",
                     "unit": "W/m2",
                     "symbol": "W/m²"
@@ -217,5 +297,10 @@
         }
       }
     }
+  },
+  "description": "KMI Belgium Weather publishes weather observations from the Royal Meteorological Institute of Belgium (KMI/IRM) for Belgian weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for KMI Belgium Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/laqn-london/EVENTS.md
+++ b/laqn-london/EVENTS.md
@@ -1,6 +1,6 @@
 # LAQN London Air Quality Network Events
 
-The LAQN London Air Quality Network bridge polls the public LAQN API operated by King's College London and emits structured JSON CloudEvents to Kafka. It keeps the upstream split intact: site metadata, species metadata, hourly site measurements, and Daily Air Quality Index bulletin records.
+London Air Quality Network publishes pollutant concentration measurements from the London Air Quality Network for London air-quality monitoring sites. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `uk.kcl.laqn.Site`
 
 #### What it tells you
 
-LAQN monitoring site reference data, including stable site identity, operator information, and WGS84 coordinates. Reference description of a London Air Quality Network monitoring site, including its stable code, operator metadata, and WGS84 coordinates.
+LAQN monitoring site reference data, including stable site identity, operator information, and WGS84 coordinates.
 
 #### Identity
 
@@ -104,7 +104,7 @@ CloudEvents type: `uk.kcl.laqn.Measurement`
 
 #### What it tells you
 
-LAQN hourly pollutant measurement for a site and species at a GMT timestamp. Hourly air quality measurement for a LAQN site and pollutant species at a GMT timestamp.
+LAQN hourly pollutant measurement for a site and species at a GMT timestamp.
 
 #### Identity
 
@@ -147,7 +147,7 @@ CloudEvents type: `uk.kcl.laqn.DailyIndex`
 
 #### What it tells you
 
-LAQN Daily Air Quality Index (DAQI) for a site and pollutant, published as the latest London-wide bulletin. Daily Air Quality Index bulletin record for a LAQN site and pollutant species within the latest London-wide index publication.
+LAQN Daily Air Quality Index (DAQI) for a site and pollutant, published as the latest London-wide bulletin.
 
 #### Identity
 
@@ -204,7 +204,7 @@ CloudEvents type: `uk.kcl.laqn.Species`
 
 #### What it tells you
 
-LAQN pollutant reference data, including descriptive text and health guidance for a pollutant code. Reference description of a LAQN pollutant species, including explanatory text and health impact guidance.
+LAQN pollutant reference data, including descriptive text and health guidance for a pollutant code.
 
 #### Identity
 

--- a/laqn-london/xreg/laqn_london.xreg.json
+++ b/laqn-london/xreg/laqn_london.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/uk.kcl.laqn"
-      ]
+      ],
+      "description": "Kafka producer endpoint for London Air Quality Network CloudEvents on the `laqn-london` topic keyed by `{site_code}`."
     },
     "uk.kcl.laqn.species.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/uk.kcl.laqn.species"
-      ]
+      ],
+      "description": "Kafka producer endpoint for London Air Quality Network CloudEvents on the `laqn-london` topic keyed by `{species_code}`."
     }
   },
   "messagegroups": {
@@ -103,7 +105,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/uk.kcl.laqn.jstruct/schemas/uk.kcl.laqn.DailyIndex"
         }
-      }
+      },
+      "description": "Events from London Air Quality Network covering London air-quality monitoring sites. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "uk.kcl.laqn.species": {
       "messages": {
@@ -126,7 +129,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/uk.kcl.laqn.jstruct/schemas/uk.kcl.laqn.Species"
         }
-      }
+      },
+      "description": "Events from London Air Quality Network covering London air-quality monitoring sites. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -151,7 +155,7 @@
                         "Site": {
                           "name": "Site",
                           "type": "object",
-                          "description": "Reference description of a London Air Quality Network monitoring site, including its stable code, operator metadata, and WGS84 coordinates.",
+                          "description": "LAQN monitoring site reference data, including stable site identity, operator information, and WGS84 coordinates.",
                           "properties": {
                             "site_code": {
                               "type": "string",
@@ -290,7 +294,7 @@
                         "Species": {
                           "name": "Species",
                           "type": "object",
-                          "description": "Reference description of a LAQN pollutant species, including explanatory text and health impact guidance.",
+                          "description": "LAQN pollutant reference data, including descriptive text and health guidance for a pollutant code.",
                           "properties": {
                             "species_code": {
                               "type": "string",
@@ -363,7 +367,7 @@
                         "Measurement": {
                           "name": "Measurement",
                           "type": "object",
-                          "description": "Hourly air quality measurement for a LAQN site and pollutant species at a GMT timestamp.",
+                          "description": "LAQN hourly pollutant measurement for a site and species at a GMT timestamp.",
                           "properties": {
                             "site_code": {
                               "type": "string",
@@ -428,7 +432,7 @@
                         "DailyIndex": {
                           "name": "DailyIndex",
                           "type": "object",
-                          "description": "Daily Air Quality Index bulletin record for a LAQN site and pollutant species within the latest London-wide index publication.",
+                          "description": "LAQN Daily Air Quality Index (DAQI) for a site and pollutant, published as the latest London-wide bulletin.",
                           "properties": {
                             "site_code": {
                               "type": "string",
@@ -522,27 +526,32 @@
                   {
                     "name": "site_code",
                     "type": "string",
-                    "doc": "Stable LAQN site code that identifies the monitoring site, such as BX1."
+                    "doc": "Stable LAQN site code that identifies the monitoring site, such as BX1.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
                   },
                   {
                     "name": "site_name",
                     "type": "string",
-                    "doc": "Human-readable LAQN site name published for the monitoring site."
+                    "doc": "Human-readable LAQN site name published for the monitoring site.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
                   },
                   {
                     "name": "site_type",
                     "type": "string",
-                    "doc": "Site classification published by LAQN, such as Suburban, Kerbside, Roadside, Urban Background, Industrial, Rural, or other."
+                    "doc": "Site classification published by LAQN, such as Suburban, Kerbside, Roadside, Urban Background, Industrial, Rural, or other.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
                   },
                   {
                     "name": "local_authority_code",
                     "type": "string",
-                    "doc": "Stable local authority code associated with the site in the LAQN reference data."
+                    "doc": "Stable local authority code associated with the site in the LAQN reference data.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "local_authority_name",
                     "type": "string",
-                    "doc": "Human-readable local authority name associated with the site in the LAQN reference data."
+                    "doc": "Human-readable local authority name associated with the site in the LAQN reference data.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "latitude",
@@ -551,7 +560,8 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "WGS84 latitude of the monitoring site in decimal degrees, or null when the upstream site record leaves the coordinate blank."
+                    "doc": "WGS84 latitude of the monitoring site in decimal degrees, or null when the upstream site record leaves the coordinate blank.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "longitude",
@@ -560,12 +570,14 @@
                       "double"
                     ],
                     "default": null,
-                    "doc": "WGS84 longitude of the monitoring site in decimal degrees, or null when the upstream site record leaves the coordinate blank."
+                    "doc": "WGS84 longitude of the monitoring site in decimal degrees, or null when the upstream site record leaves the coordinate blank.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "date_opened",
                     "type": "string",
-                    "doc": "Date and time when the site opened, as published by LAQN in YYYY-MM-DD HH:MM:SS format."
+                    "doc": "Date and time when the site opened, as published by LAQN in YYYY-MM-DD HH:MM:SS format.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "date_closed",
@@ -574,19 +586,23 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Date and time when the site closed in YYYY-MM-DD HH:MM:SS format, or null when the site is still active and no closure date is published."
+                    "doc": "Date and time when the site closed in YYYY-MM-DD HH:MM:SS format, or null when the site is still active and no closure date is published.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "data_owner",
                     "type": "string",
-                    "doc": "Organisation listed by LAQN as the owner of the site's data."
+                    "doc": "Organisation listed by LAQN as the owner of the site's data.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "data_manager",
                     "type": "string",
-                    "doc": "Organisation listed by LAQN as the manager of the monitoring site data."
+                    "doc": "Organisation listed by LAQN as the manager of the monitoring site data.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
               }
             }
           }
@@ -607,29 +623,35 @@
                   {
                     "name": "species_code",
                     "type": "string",
-                    "doc": "Stable LAQN pollutant code, such as NO2, PM10, PM25, O3, SO2, or CO."
+                    "doc": "Stable LAQN pollutant code, such as NO2, PM10, PM25, O3, SO2, or CO.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "species_name",
                     "type": "string",
-                    "doc": "Human-readable pollutant name published by LAQN for the pollutant code."
+                    "doc": "Human-readable pollutant name published by LAQN for the pollutant code.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "description",
                     "type": "string",
-                    "doc": "LAQN explanatory description of the pollutant and how it is formed or encountered."
+                    "doc": "LAQN explanatory description of the pollutant and how it is formed or encountered.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "health_effect",
                     "type": "string",
-                    "doc": "LAQN health effect guidance describing the health impacts associated with exposure to the pollutant."
+                    "doc": "LAQN health effect guidance describing the health impacts associated with exposure to the pollutant.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "link",
                     "type": "string",
-                    "doc": "HTTP URL to the LAQN or LondonAir guidance page with more detailed information about the pollutant."
+                    "doc": "HTTP URL to the LAQN or LondonAir guidance page with more detailed information about the pollutant.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
               }
             }
           }
@@ -650,24 +672,29 @@
                   {
                     "name": "site_code",
                     "type": "string",
-                    "doc": "Stable LAQN site code for the monitoring site that produced the measurement."
+                    "doc": "Stable LAQN site code for the monitoring site that produced the measurement.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
                   },
                   {
                     "name": "species_code",
                     "type": "string",
-                    "doc": "Stable LAQN pollutant code for the measured species."
+                    "doc": "Stable LAQN pollutant code for the measured species.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "measurement_date_gmt",
                     "type": "string",
-                    "doc": "Measurement timestamp in GMT, encoded by LAQN as YYYY-MM-DD HH:MM:SS."
+                    "doc": "Measurement timestamp in GMT, encoded by LAQN as YYYY-MM-DD HH:MM:SS.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "value",
                     "type": "double",
-                    "doc": "Measured pollutant concentration as a decimal number. The bridge omits records for timestamps where the upstream API reports an empty value."
+                    "doc": "Measured pollutant concentration as a decimal number. The bridge omits records for timestamps where the upstream API reports an empty value.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
               }
             }
           }
@@ -688,39 +715,51 @@
                   {
                     "name": "site_code",
                     "type": "string",
-                    "doc": "Stable LAQN site code for the monitoring site to which the daily index applies."
+                    "doc": "Stable LAQN site code for the monitoring site to which the daily index applies.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the London Air Quality Network source."
                   },
                   {
                     "name": "bulletin_date",
                     "type": "string",
-                    "doc": "Bulletin date and time published by LAQN for the daily index, encoded as YYYY-MM-DD HH:MM:SS."
+                    "doc": "Bulletin date and time published by LAQN for the daily index, encoded as YYYY-MM-DD HH:MM:SS.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "species_code",
                     "type": "string",
-                    "doc": "Stable LAQN pollutant code for the species to which the daily index applies."
+                    "doc": "Stable LAQN pollutant code for the species to which the daily index applies.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "air_quality_index",
                     "type": "int",
-                    "doc": "LAQN Daily Air Quality Index value from 1 to 10."
+                    "doc": "LAQN Daily Air Quality Index value from 1 to 10.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "air_quality_band",
                     "type": "string",
-                    "doc": "Textual Daily Air Quality Index band published by LAQN: Low, Moderate, High, or Very High."
+                    "doc": "Textual Daily Air Quality Index band published by LAQN: Low, Moderate, High, or Very High.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   },
                   {
                     "name": "index_source",
                     "type": "string",
-                    "doc": "Origin of the daily index published by LAQN, typically Measurement or Forecast."
+                    "doc": "Origin of the daily index published by LAQN, typically Measurement or Forecast.",
+                    "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the London Air Quality Network source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "London Air Quality Network publishes pollutant concentration measurements from the London Air Quality Network for London air-quality monitoring sites. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for London Air Quality Network, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/luchtmeetnet-nl/EVENTS.md
+++ b/luchtmeetnet-nl/EVENTS.md
@@ -1,6 +1,6 @@
 # Luchtmeetnet Netherlands Air Quality Bridge Events
 
-This source bridges the public Dutch **Luchtmeetnet** API into Apache Kafka compatible brokers as structured JSON CloudEvents. It emits both slowly changing reference data and hourly telemetry so downstream consumers can reconstruct air quality context and measurements over time without making their own side calls.
+Luchtmeetnet NL publishes pollutant concentration measurements from the Dutch national air-quality monitoring network for Dutch air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `nl.rivm.luchtmeetnet.Station`
 
 #### What it tells you
 
-Luchtmeetnet station metadata with location, operator, coordinates, and the formulas measured at the station. Metadata for a Luchtmeetnet measuring station, combining the station list resource with the station detail resource so downstream consumers can interpret later measurements and LKI values in temporal context.
+Luchtmeetnet station metadata with location, operator, coordinates, and the formulas measured at the station.
 
 #### Identity
 
@@ -95,7 +95,7 @@ CloudEvents type: `nl.rivm.luchtmeetnet.Measurement`
 
 #### What it tells you
 
-Hourly Luchtmeetnet measurement for a station and component formula. Hourly Luchtmeetnet measurement for a station and a single component formula. The API returns the latest values on page 1 and orders the series by measurement time.
+Hourly Luchtmeetnet measurement for a station and component formula.
 
 #### Identity
 
@@ -138,7 +138,7 @@ CloudEvents type: `nl.rivm.luchtmeetnet.LKI`
 
 #### What it tells you
 
-Hourly Dutch Luchtkwaliteitsindex value for a station. Hourly Dutch national air quality index value for a station. The LKI scale runs from 1 to 11, where lower values indicate better air quality.
+Hourly Dutch Luchtkwaliteitsindex value for a station.
 
 #### Identity
 
@@ -179,7 +179,7 @@ CloudEvents type: `nl.rivm.luchtmeetnet.components.Component`
 
 #### What it tells you
 
-Reference definition for a monitored component formula in the Luchtmeetnet network. Reference definition for a Luchtmeetnet monitored component formula as returned by the component catalog endpoint.
+Reference definition for a monitored component formula in the Luchtmeetnet network.
 
 #### Identity
 

--- a/luchtmeetnet-nl/xreg/luchtmeetnet_nl.xreg.json
+++ b/luchtmeetnet-nl/xreg/luchtmeetnet_nl.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/nl.rivm.luchtmeetnet"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Luchtmeetnet NL CloudEvents on the `luchtmeetnet-nl` topic keyed by `{station_number}`."
     },
     "nl.rivm.luchtmeetnet.components.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/nl.rivm.luchtmeetnet.components"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Luchtmeetnet NL CloudEvents on the `luchtmeetnet-nl` topic keyed by `{formula}`."
     }
   },
   "messagegroups": {
@@ -103,7 +105,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/nl.rivm.luchtmeetnet.jstruct/schemas/nl.rivm.luchtmeetnet.LKI"
         }
-      }
+      },
+      "description": "Events from Luchtmeetnet NL covering Dutch air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "nl.rivm.luchtmeetnet.components": {
       "messages": {
@@ -126,7 +129,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/nl.rivm.luchtmeetnet.jstruct/schemas/nl.rivm.luchtmeetnet.components.Component"
         }
-      }
+      },
+      "description": "Events from Luchtmeetnet NL covering Dutch air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -151,7 +155,7 @@
                         "Station": {
                           "name": "Station",
                           "type": "object",
-                          "description": "Metadata for a Luchtmeetnet measuring station, combining the station list resource with the station detail resource so downstream consumers can interpret later measurements and LKI values in temporal context.",
+                          "description": "Luchtmeetnet station metadata with location, operator, coordinates, and the formulas measured at the station.",
                           "properties": {
                             "station_number": {
                               "type": "string",
@@ -244,7 +248,7 @@
                         "Measurement": {
                           "name": "Measurement",
                           "type": "object",
-                          "description": "Hourly Luchtmeetnet measurement for a station and a single component formula. The API returns the latest values on page 1 and orders the series by measurement time.",
+                          "description": "Hourly Luchtmeetnet measurement for a station and component formula.",
                           "properties": {
                             "station_number": {
                               "type": "string",
@@ -298,7 +302,7 @@
                         "LKI": {
                           "name": "LKI",
                           "type": "object",
-                          "description": "Hourly Dutch national air quality index value for a station. The LKI scale runs from 1 to 11, where lower values indicate better air quality.",
+                          "description": "Hourly Dutch Luchtkwaliteitsindex value for a station.",
                           "properties": {
                             "station_number": {
                               "type": "string",
@@ -348,7 +352,7 @@
                           "Component": {
                             "name": "Component",
                             "type": "object",
-                            "description": "Reference definition for a Luchtmeetnet monitored component formula as returned by the component catalog endpoint.",
+                            "description": "Reference definition for a monitored component formula in the Luchtmeetnet network.",
                             "properties": {
                               "formula": {
                                 "type": "string",
@@ -398,22 +402,26 @@
                   {
                     "name": "station_number",
                     "type": "string",
-                    "doc": "Stable Luchtmeetnet station code, such as NL01491, used in station, measurement, and LKI requests."
+                    "doc": "Stable Luchtmeetnet station code, such as NL01491, used in station, measurement, and LKI requests.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "location",
                     "type": "string",
-                    "doc": "Human-readable station location label published by Luchtmeetnet."
+                    "doc": "Human-readable station location label published by Luchtmeetnet.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "type",
                     "type": "string",
-                    "doc": "Station classification returned by the detail endpoint, for example Traffic, Industrial, Background, or Regional."
+                    "doc": "Station classification returned by the detail endpoint, for example Traffic, Industrial, Background, or Regional.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "organisation",
                     "type": "string",
-                    "doc": "Organisation operating or publishing the station in the Luchtmeetnet network, such as RIVM or a regional environmental agency."
+                    "doc": "Organisation operating or publishing the station in the Luchtmeetnet network, such as RIVM or a regional environmental agency.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "municipality",
@@ -422,7 +430,8 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Municipality name for the station location when present in the detail response; null when the API does not provide one."
+                    "doc": "Municipality name for the station location when present in the detail response; null when the API does not provide one.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "province",
@@ -431,22 +440,26 @@
                       "string"
                     ],
                     "default": null,
-                    "doc": "Province name for the station location when present in the detail response; null when the API omits it."
+                    "doc": "Province name for the station location when present in the detail response; null when the API omits it.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "longitude",
                     "type": "double",
-                    "doc": "Longitude of the station in WGS84 decimal degrees, taken from geometry.coordinates[0]."
+                    "doc": "Longitude of the station in WGS84 decimal degrees, taken from geometry.coordinates[0].",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "latitude",
                     "type": "double",
-                    "doc": "Latitude of the station in WGS84 decimal degrees, taken from geometry.coordinates[1]."
+                    "doc": "Latitude of the station in WGS84 decimal degrees, taken from geometry.coordinates[1].",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "year_start",
                     "type": "string",
-                    "doc": "Year in which the station became operational according to the detail response. The upstream can return an empty string when the start year is not populated."
+                    "doc": "Year in which the station became operational according to the detail response. The upstream can return an empty string when the start year is not populated.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "components",
@@ -454,9 +467,11 @@
                       "type": "array",
                       "items": "string"
                     },
-                    "doc": "Ordered list of formula codes measured at the station, as returned by the station detail endpoint."
+                    "doc": "Ordered list of formula codes measured at the station, as returned by the station detail endpoint.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   }
-                ]
+                ],
+                "description": "Reference details for one station, monitoring site, or forecast area in the Luchtmeetnet NL source."
               }
             }
           }
@@ -477,24 +492,29 @@
                   {
                     "name": "station_number",
                     "type": "string",
-                    "doc": "Stable Luchtmeetnet station code identifying where the measurement was taken."
+                    "doc": "Stable Luchtmeetnet station code identifying where the measurement was taken.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "formula",
                     "type": "string",
-                    "doc": "Component formula code identifying what was measured, for example NO2, O3, PM10, or FN."
+                    "doc": "Component formula code identifying what was measured, for example NO2, O3, PM10, or FN.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "value",
                     "type": "double",
-                    "doc": "Numeric measurement value published by the API for the station and formula at the given timestamp."
+                    "doc": "Numeric measurement value published by the API for the station and formula at the given timestamp.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "timestamp_measured",
                     "type": "string",
-                    "doc": "Timestamp at which the value was measured, encoded as an ISO 8601 date-time string with timezone offset."
+                    "doc": "Timestamp at which the value was measured, encoded as an ISO 8601 date-time string with timezone offset.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
               }
             }
           }
@@ -515,19 +535,23 @@
                   {
                     "name": "station_number",
                     "type": "string",
-                    "doc": "Stable Luchtmeetnet station code identifying the station for which the LKI value was calculated."
+                    "doc": "Stable Luchtmeetnet station code identifying the station for which the LKI value was calculated.",
+                    "description": "Reference details for one station, monitoring site, or forecast area in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "value",
                     "type": "int",
-                    "doc": "Luchtkwaliteitsindex value on the Dutch 1 to 11 scale."
+                    "doc": "Luchtkwaliteitsindex value on the Dutch 1 to 11 scale.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "timestamp_measured",
                     "type": "string",
-                    "doc": "Timestamp for the hourly LKI value, encoded as an ISO 8601 date-time string with timezone offset."
+                    "doc": "Timestamp for the hourly LKI value, encoded as an ISO 8601 date-time string with timezone offset.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
               }
             }
           }
@@ -548,24 +572,33 @@
                   {
                     "name": "formula",
                     "type": "string",
-                    "doc": "Stable component formula code used in measurement queries and in station component lists, such as NO2, PM25, O3, or BCWB."
+                    "doc": "Stable component formula code used in measurement queries and in station component lists, such as NO2, PM25, O3, or BCWB.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "name_nl",
                     "type": "string",
-                    "doc": "Dutch display name for the component from the component catalog."
+                    "doc": "Dutch display name for the component from the component catalog.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   },
                   {
                     "name": "name_en",
                     "type": "string",
-                    "doc": "English display name for the component from the component catalog."
+                    "doc": "English display name for the component from the component catalog.",
+                    "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
                   }
-                ]
+                ],
+                "description": "Measurement payload for pollutant concentration measurements in the Luchtmeetnet NL source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Luchtmeetnet NL publishes pollutant concentration measurements from the Dutch national air-quality monitoring network for Dutch air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Luchtmeetnet NL, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/singapore-nea/EVENTS.md
+++ b/singapore-nea/EVENTS.md
@@ -1,12 +1,12 @@
 # Singapore NEA Weather and Air Quality Bridge Events
 
-This bridge fetches real-time weather observations and regional air quality data from the [Singapore National Environment Agency (NEA)](https://data.gov.sg/datasets?topics=environment) and emits them as CloudEvents into Apache Kafka or Azure Event Hubs.
+Singapore NEA Environment publishes weather observations, air-quality readings, and environmental indexes from Singapore's National Environment Agency (NEA) for Singapore weather and air-quality regions and stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 5 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 4 telemetry event types.
+- **Reference vs telemetry:** 0 reference/catalog event types and 5 telemetry event types.
 - **Identity:** `{station_id}`, `{region}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `SG.Gov.NEA.Weather.Station`
 
 #### What it tells you
 
-Reference data for a Singapore NEA weather observation station. Stations are identified by a stable device ID (e.g. S109) and include location coordinates.
+A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -77,7 +77,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Weather Observation
 
@@ -85,7 +85,7 @@ CloudEvents type: `SG.Gov.NEA.Weather.WeatherObservation`
 
 #### What it tells you
 
-Real-time weather observation from a Singapore NEA station assembled from multiple endpoints. Temperature updates every minute, rainfall every 5 minutes, humidity and wind every minute. Fields are null when the station does not report that parameter.
+A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -136,7 +136,7 @@ CloudEvents type: `SG.Gov.NEA.AirQuality.Region`
 
 #### What it tells you
 
-Reference data for a Singapore NEA air quality monitoring region. NEA divides Singapore into five geographic regions for PSI and PM2.5 reporting.
+A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -169,7 +169,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Psireading
 
@@ -177,7 +177,7 @@ CloudEvents type: `SG.Gov.NEA.AirQuality.PSIReading`
 
 #### What it tells you
 
-Pollutant Standards Index (PSI) reading for a Singapore NEA air quality region. PSI is a composite index calculated from six pollutant sub-indices. Published hourly by the NEA via data.gov.sg.
+A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -242,7 +242,7 @@ CloudEvents type: `SG.Gov.NEA.AirQuality.PM25Reading`
 
 #### What it tells you
 
-Hourly PM2.5 concentration reading for a Singapore NEA air quality region. Fine particulate matter with aerodynamic diameter less than or equal to 2.5 micrometres. Published hourly by NEA.
+A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/singapore-nea/xreg/singapore_nea.xreg.json
+++ b/singapore-nea/xreg/singapore_nea.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "SG.Gov.NEA.Weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,10 +17,15 @@
           "key": "{station_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/SG.Gov.NEA.Weather"]
+      "messagegroups": [
+        "#/messagegroups/SG.Gov.NEA.Weather"
+      ],
+      "description": "Kafka producer endpoint for Singapore NEA Environment CloudEvents on the `singapore-nea` topic keyed by `{station_id}`."
     },
     "SG.Gov.NEA.AirQuality.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -32,7 +39,10 @@
           "key": "{region}"
         }
       },
-      "messagegroups": ["#/messagegroups/SG.Gov.NEA.AirQuality"]
+      "messagegroups": [
+        "#/messagegroups/SG.Gov.NEA.AirQuality"
+      ],
+      "description": "Kafka producer endpoint for Singapore NEA Environment CloudEvents on the `singapore-nea-airquality` topic keyed by `{region}`."
     }
   },
   "messagegroups": {
@@ -54,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SG.Gov.NEA.Weather.jstruct/schemas/SG.Gov.NEA.Weather.Station"
+          "dataschemauri": "#/schemagroups/SG.Gov.NEA.Weather.jstruct/schemas/SG.Gov.NEA.Weather.Station",
+          "description": "A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "SG.Gov.NEA.Weather.WeatherObservation": {
           "name": "WeatherObservation",
@@ -72,9 +83,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SG.Gov.NEA.Weather.jstruct/schemas/SG.Gov.NEA.Weather.WeatherObservation"
+          "dataschemauri": "#/schemagroups/SG.Gov.NEA.Weather.jstruct/schemas/SG.Gov.NEA.Weather.WeatherObservation",
+          "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Singapore NEA Environment covering Singapore weather and air-quality regions and stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "SG.Gov.NEA.AirQuality": {
       "messages": {
@@ -94,7 +107,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.Region"
+          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.Region",
+          "description": "A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "SG.Gov.NEA.AirQuality.PSIReading": {
           "name": "PSIReading",
@@ -112,7 +126,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.PSIReading"
+          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.PSIReading",
+          "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value."
         },
         "SG.Gov.NEA.AirQuality.PM25Reading": {
           "name": "PM25Reading",
@@ -130,9 +145,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.PM25Reading"
+          "dataschemauri": "#/schemagroups/SG.Gov.NEA.AirQuality.jstruct/schemas/SG.Gov.NEA.AirQuality.PM25Reading",
+          "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Singapore NEA Environment covering Singapore weather and air-quality regions and stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -150,7 +167,7 @@
                 "$id": "https://api.data.gov.sg/schemas/SG/Gov/NEA/Weather/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference data for a Singapore NEA weather observation station. Stations are identified by a stable device ID (e.g. S109) and include location coordinates. The data_types field indicates which parameters this station reports.",
+                "description": "A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events.",
                 "required": [
                   "station_id",
                   "name",
@@ -203,7 +220,7 @@
                 "$id": "https://api.data.gov.sg/schemas/SG/Gov/NEA/Weather/WeatherObservation",
                 "type": "object",
                 "name": "WeatherObservation",
-                "description": "Real-time weather observation from a Singapore NEA station assembled from multiple endpoints. Temperature updates every minute, rainfall every 5 minutes, humidity and wind every minute. Fields are null when the station does not report that parameter.",
+                "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "station_id",
                   "station_name",
@@ -288,7 +305,7 @@
                 "$id": "https://api.data.gov.sg/schemas/SG/Gov/NEA/AirQuality/Region",
                 "type": "object",
                 "name": "Region",
-                "description": "Reference data for a Singapore NEA air quality monitoring region. NEA divides Singapore into five geographic regions for PSI and PM2.5 reporting.",
+                "description": "A reference record published by Singapore's National Environment Agency (NEA). It lets consumers label, group, and route the live measurement or forecast events.",
                 "required": [
                   "region",
                   "latitude",
@@ -335,7 +352,7 @@
                 "$id": "https://api.data.gov.sg/schemas/SG/Gov/NEA/AirQuality/PSIReading",
                 "type": "object",
                 "name": "PSIReading",
-                "description": "Pollutant Standards Index (PSI) reading for a Singapore NEA air quality region. PSI is a composite index calculated from six pollutant sub-indices. Published hourly by the NEA via data.gov.sg.",
+                "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "region",
                   "timestamp",
@@ -487,7 +504,7 @@
                 "$id": "https://api.data.gov.sg/schemas/SG/Gov/NEA/AirQuality/PM25Reading",
                 "type": "object",
                 "name": "PM25Reading",
-                "description": "Hourly PM2.5 concentration reading for a Singapore NEA air quality region. Fine particulate matter with aerodynamic diameter less than or equal to 2.5 micrometres. Published hourly by NEA.",
+                "description": "A current environmental measurement from Singapore's National Environment Agency (NEA). It carries weather observations, air-quality readings, and environmental indexes when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "region",
                   "timestamp",
@@ -531,5 +548,10 @@
         }
       }
     }
+  },
+  "description": "Singapore NEA Environment publishes weather observations, air-quality readings, and environmental indexes from Singapore's National Environment Agency (NEA) for Singapore weather and air-quality regions and stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Singapore NEA Environment, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/smhi-weather/EVENTS.md
+++ b/smhi-weather/EVENTS.md
@@ -1,12 +1,12 @@
 # SMHI Weather Observation Bridge Events
 
-This bridge fetches real-time meteorological observations from the [Swedish Meteorological and Hydrological Institute (SMHI)](https://opendata.smhi.se/apidocs/metobs/) and emits them as CloudEvents into Apache Kafka or Azure Event Hubs.
+SMHI Weather publishes weather observations from the Swedish Meteorological and Hydrological Institute (SMHI) for Swedish weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{station_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -38,7 +38,7 @@ CloudEvents type: `SE.Gov.SMHI.Weather.Station`
 
 #### What it tells you
 
-Reference metadata for a SMHI meteorological observation station. Stations report hourly surface observations of temperature, wind, pressure, humidity, precipitation, and other parameters across Sweden.
+A reference record published by the Swedish Meteorological and Hydrological Institute (SMHI). It lets consumers label, group, and route the live measurement or forecast events.
 
 #### Identity
 
@@ -81,7 +81,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Weather Observation
 
@@ -89,7 +89,7 @@ CloudEvents type: `SE.Gov.SMHI.Weather.WeatherObservation`
 
 #### What it tells you
 
-Hourly weather observation from a SMHI meteorological station. Multi-parameter observations are assembled from the per-parameter latest-hour API endpoints. Each record contains the most recent values for temperature, wind, pressure, humidity, precipitation, visibility, cloud cover, irradiance, and present weather.
+A current environmental measurement from the Swedish Meteorological and Hydrological Institute (SMHI). It carries weather observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/smhi-weather/xreg/smhi_weather.xreg.json
+++ b/smhi-weather/xreg/smhi_weather.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "SE.Gov.SMHI.Weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,7 +17,10 @@
           "key": "{station_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/SE.Gov.SMHI.Weather"]
+      "messagegroups": [
+        "#/messagegroups/SE.Gov.SMHI.Weather"
+      ],
+      "description": "Kafka producer endpoint for SMHI Weather CloudEvents on the `smhi-weather` topic keyed by `{station_id}`."
     }
   },
   "messagegroups": {
@@ -25,25 +30,42 @@
           "name": "Station",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "SE.Gov.SMHI.Weather.Station"},
-            "source": {"value": "https://opendata-download-metobs.smhi.se"},
-            "subject": {"value": "{station_id}", "type": "uritemplate"}
+            "type": {
+              "value": "SE.Gov.SMHI.Weather.Station"
+            },
+            "source": {
+              "value": "https://opendata-download-metobs.smhi.se"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Weather.jstruct/schemas/SE.Gov.SMHI.Weather.Station"
+          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Weather.jstruct/schemas/SE.Gov.SMHI.Weather.Station",
+          "description": "A reference record published by the Swedish Meteorological and Hydrological Institute (SMHI). It lets consumers label, group, and route the live measurement or forecast events."
         },
         "SE.Gov.SMHI.Weather.WeatherObservation": {
           "name": "WeatherObservation",
           "envelope": "CloudEvents/1.0",
           "envelopemetadata": {
-            "type": {"value": "SE.Gov.SMHI.Weather.WeatherObservation"},
-            "source": {"value": "https://opendata-download-metobs.smhi.se"},
-            "subject": {"value": "{station_id}", "type": "uritemplate"}
+            "type": {
+              "value": "SE.Gov.SMHI.Weather.WeatherObservation"
+            },
+            "source": {
+              "value": "https://opendata-download-metobs.smhi.se"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Weather.jstruct/schemas/SE.Gov.SMHI.Weather.WeatherObservation"
+          "dataschemauri": "#/schemagroups/SE.Gov.SMHI.Weather.jstruct/schemas/SE.Gov.SMHI.Weather.WeatherObservation",
+          "description": "A current environmental measurement from the Swedish Meteorological and Hydrological Institute (SMHI). It carries weather observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from SMHI Weather covering Swedish weather stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -61,8 +83,13 @@
                 "$id": "https://opendata-download-metobs.smhi.se/schemas/SE/Gov/SMHI/Weather/Station",
                 "type": "object",
                 "name": "Station",
-                "description": "Reference metadata for a SMHI meteorological observation station. Stations report hourly surface observations of temperature, wind, pressure, humidity, precipitation, and other parameters across Sweden.",
-                "required": ["station_id", "name", "latitude", "longitude"],
+                "description": "A reference record published by the Swedish Meteorological and Hydrological Institute (SMHI). It lets consumers label, group, and route the live measurement or forecast events.",
+                "required": [
+                  "station_id",
+                  "name",
+                  "latitude",
+                  "longitude"
+                ],
                 "properties": {
                   "station_id": {
                     "type": "string",
@@ -119,8 +146,12 @@
                 "$id": "https://opendata-download-metobs.smhi.se/schemas/SE/Gov/SMHI/Weather/WeatherObservation",
                 "type": "object",
                 "name": "WeatherObservation",
-                "description": "Hourly weather observation from a SMHI meteorological station. Multi-parameter observations are assembled from the per-parameter latest-hour API endpoints. Each record contains the most recent values for temperature, wind, pressure, humidity, precipitation, visibility, cloud cover, irradiance, and present weather.",
-                "required": ["station_id", "station_name", "observation_time"],
+                "description": "A current environmental measurement from the Swedish Meteorological and Hydrological Institute (SMHI). It carries weather observations when the upstream feed reports a new or refreshed value.",
+                "required": [
+                  "station_id",
+                  "station_name",
+                  "observation_time"
+                ],
                 "properties": {
                   "station_id": {
                     "type": "string",
@@ -135,89 +166,134 @@
                     "description": "Timestamp of the observation in UTC, derived from the SMHI epoch millisecond value."
                   },
                   "air_temperature": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Instantaneous air temperature, reported hourly (SMHI parameter 1).",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "wind_gust": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum wind gust speed, reported hourly (SMHI parameter 21).",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "dew_point": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Dew point temperature, reported hourly (SMHI parameter 39).",
                     "unit": "Cel",
                     "symbol": "°C"
                   },
                   "air_pressure": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Atmospheric pressure reduced to mean sea level, reported hourly (SMHI parameter 9).",
                     "unit": "hPa",
                     "symbol": "hPa"
                   },
                   "relative_humidity": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Relative humidity as a percentage, reported hourly (SMHI parameter 6).",
                     "unit": "percent",
                     "symbol": "%"
                   },
                   "precipitation_last_hour": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Total precipitation in the last hour, reported hourly (SMHI parameter 7).",
                     "unit": "mm",
                     "symbol": "mm"
                   },
                   "wind_direction": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Wind direction in degrees from which the wind is blowing, measured at 10 m height, reported hourly (SMHI parameter 3).",
                     "unit": "degree",
                     "symbol": "°"
                   },
                   "wind_speed": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Mean wind speed over 10 minutes measured at 10 m height, reported hourly (SMHI parameter 4).",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "max_wind_speed": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Maximum of 10-minute mean wind speed during the hour, measured at 10 m height (SMHI parameter 25).",
                     "unit": "m/s",
                     "symbol": "m/s"
                   },
                   "visibility": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Horizontal visibility, reported hourly (SMHI parameter 12).",
                     "unit": "km",
                     "symbol": "km"
                   },
                   "total_cloud_cover": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Total cloud cover in oktas (eighths of sky covered), reported hourly (SMHI parameter 16).",
                     "unit": "okta",
                     "symbol": "okta"
                   },
                   "present_weather": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "WMO present weather code (ww table 4677) describing current weather phenomena at the time of observation (SMHI parameter 13). Values range from 0 (clear) to 99 (thunderstorm with hail)."
                   },
                   "sunshine_duration": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Duration of sunshine during the last hour in seconds (SMHI parameter 10).",
                     "unit": "s",
                     "symbol": "s"
                   },
                   "global_irradiance": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Global solar irradiance (direct + diffuse), average over the hour, measured by pyranometer (SMHI parameter 11).",
                     "unit": "W/m2",
                     "symbol": "W/m²"
                   },
                   "precipitation_intensity": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Instantaneous precipitation intensity measured by optical or weighing gauge (SMHI parameter 38).",
                     "unit": "mm/h",
                     "symbol": "mm/h"
@@ -233,5 +309,10 @@
         }
       }
     }
+  },
+  "description": "SMHI Weather publishes weather observations from the Swedish Meteorological and Hydrological Institute (SMHI) for Swedish weather stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for SMHI Weather, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/uba-airdata/EVENTS.md
+++ b/uba-airdata/EVENTS.md
@@ -1,6 +1,6 @@
 # UBA Germany Air Quality Bridge Events
 
-This source bridges the Umweltbundesamt (UBA) `air_data/v3` API into Apache Kafka compatible brokers as structured JSON CloudEvents.
+UBA Airdata publishes pollutant concentration measurements from the Austrian Umweltbundesamt air-quality data service for Austrian air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `de.uba.airdata.Station`
 
 #### What it tells you
 
-Reference data for a UBA air quality monitoring station, including geographic position, station environment, and the denormalized monitoring network metadata published by the UBA air_data/v3 station catalog. Reference data for a station in the Umweltbundesamt air_data/v3 station catalog. The station payload describes the UBA station identifier, official station code, station naming, active period, WGS84 coordinates, the denormalized federal state monitoring network, and the station environment classification.
+Reference data for a UBA air quality monitoring station, including geographic position, station environment, and the denormalized monitoring network metadata published by the UBA air_data/v3 station catalog.
 
 #### Identity
 
@@ -109,7 +109,7 @@ CloudEvents type: `de.uba.airdata.Measure`
 
 #### What it tells you
 
-Hourly one-hour-average air quality measurement for a UBA monitoring station and pollutant component as returned by the air_data/v3 measures endpoint. Hourly air quality measurement record from the UBA air_data/v3 measures endpoint. The upstream API returns measurements grouped by station and measurement start time for a requested component and averaging scope.
+Hourly one-hour-average air quality measurement for a UBA monitoring station and pollutant component as returned by the air_data/v3 measures endpoint.
 
 #### Identity
 
@@ -158,7 +158,7 @@ CloudEvents type: `de.uba.airdata.components.Component`
 
 #### What it tells you
 
-Reference data for an air pollutant component published by the UBA air_data/v3 components catalog, including the stable numeric component identifier, code, symbol, unit, and English display name. Reference data for a pollutant component from the UBA air_data/v3 components catalog. Each component defines the stable numeric component identifier, short code, published symbol, published unit string, and English display name.
+Reference data for an air pollutant component published by the UBA air_data/v3 components catalog, including the stable numeric component identifier, code, symbol, unit, and English display name.
 
 #### Identity
 

--- a/uba-airdata/xreg/uba_airdata.xreg.json
+++ b/uba-airdata/xreg/uba_airdata.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/de.uba.airdata"
-      ]
+      ],
+      "description": "Kafka producer endpoint for UBA Airdata CloudEvents on the `uba-airdata` topic keyed by `{station_id}`."
     },
     "de.uba.airdata.components.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/de.uba.airdata.components"
-      ]
+      ],
+      "description": "Kafka producer endpoint for UBA Airdata CloudEvents on the `uba-airdata` topic keyed by `{component_id}`."
     }
   },
   "messagegroups": {
@@ -86,7 +88,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/de.uba.airdata.jstruct/schemas/de.uba.airdata.Measure"
         }
-      }
+      },
+      "description": "Events from UBA Airdata covering Austrian air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "de.uba.airdata.components": {
       "messages": {
@@ -110,7 +113,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/de.uba.airdata.jstruct/schemas/de.uba.airdata.components.Component"
         }
-      }
+      },
+      "description": "Events from UBA Airdata covering Austrian air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     }
   },
   "schemagroups": {
@@ -135,7 +139,7 @@
                         "Station": {
                           "name": "Station",
                           "type": "object",
-                          "description": "Reference data for a station in the Umweltbundesamt air_data/v3 station catalog. The station payload describes the UBA station identifier, official station code, station naming, active period, WGS84 coordinates, the denormalized federal state monitoring network, and the station environment classification.",
+                          "description": "Reference data for a UBA air quality monitoring station, including geographic position, station environment, and the denormalized monitoring network metadata published by the UBA air_data/v3 station catalog.",
                           "properties": {
                             "station_id": {
                               "type": "int32",
@@ -273,7 +277,7 @@
                         "Measure": {
                           "name": "Measure",
                           "type": "object",
-                          "description": "Hourly air quality measurement record from the UBA air_data/v3 measures endpoint. The upstream API returns measurements grouped by station and measurement start time for a requested component and averaging scope.",
+                          "description": "Hourly one-hour-average air quality measurement for a UBA monitoring station and pollutant component as returned by the air_data/v3 measures endpoint.",
                           "properties": {
                             "station_id": {
                               "type": "int32",
@@ -345,7 +349,7 @@
                           "Component": {
                             "name": "Component",
                             "type": "object",
-                            "description": "Reference data for a pollutant component from the UBA air_data/v3 components catalog. Each component defines the stable numeric component identifier, short code, published symbol, published unit string, and English display name.",
+                            "description": "Reference data for an air pollutant component published by the UBA air_data/v3 components catalog, including the stable numeric component identifier, code, symbol, unit, and English display name.",
                             "properties": {
                               "component_id": {
                                 "type": "int32",
@@ -387,5 +391,10 @@
         }
       }
     }
+  },
+  "description": "UBA Airdata publishes pollutant concentration measurements from the Austrian Umweltbundesamt air-quality data service for Austrian air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for UBA Airdata, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/wallonia-issep/EVENTS.md
+++ b/wallonia-issep/EVENTS.md
@@ -1,12 +1,12 @@
 # Wallonia ISSeP Events
 
-MQTT/5.0 transport variants of the ISSeP Wallonia air quality CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under aq/be/wallonia/wallonia-issep/{configuration_id}/... The bridge publishes sensor configuration info and observations per configuration_id.
+Wallonia ISSeP Air Quality publishes pollutant concentration measurements from Wallonia's Institut Scientifique de Service Public (ISSeP) for Walloon air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.
 
 ## At a glance
 
 - **Event types:** 2 documented event types (4 transport bindings in the manifest).
 - **Transports:** KAFKA, MQTT/5.0
-- **Reference vs telemetry:** 1 reference/catalog event type and 1 telemetry event type.
+- **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{configuration_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
@@ -52,7 +52,7 @@ CloudEvents type: `be.issep.airquality.SensorConfiguration`
 
 #### What it tells you
 
-Reference data for one ISSeP Wallonia air quality sensor configuration. Each id_configuration identifies a deployed sensor unit. The bridge emits this event at startup for each distinct configuration seen in the data records.
+A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -84,7 +84,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity. MQTT may retain the latest copy so late subscribers can build local context immediately.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Observation
 
@@ -92,7 +92,7 @@ CloudEvents type: `be.issep.airquality.Observation`
 
 #### What it tells you
 
-Air quality observation from one ISSeP Wallonia sensor at a specific moment in time. Includes raw electrochemical gas readings, calibrated ppb and µg/m³ values, particulate matter concentrations, environmental parameters, reference station comparisons, and quality status flags. Negative raw values (e.g.
+A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/wallonia-issep/xreg/wallonia_issep.xreg.json
+++ b/wallonia-issep/xreg/wallonia_issep.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.issep.airquality.Sensors"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Wallonia ISSeP Air Quality CloudEvents on the `wallonia-issep` topic keyed by `{configuration_id}`."
     },
     "be.issep.airquality.Sensors.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.issep.airquality.Sensors.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Wallonia ISSeP Air Quality CloudEvents using the source topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/be.issep.airquality.jstruct/schemas/be.issep.airquality.SensorConfiguration"
+          "dataschemauri": "#/schemagroups/be.issep.airquality.jstruct/schemas/be.issep.airquality.SensorConfiguration",
+          "description": "A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value."
         },
         "be.issep.airquality.Observation": {
           "name": "Observation",
@@ -80,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/be.issep.airquality.jstruct/schemas/be.issep.airquality.Observation"
+          "dataschemauri": "#/schemagroups/be.issep.airquality.jstruct/schemas/be.issep.airquality.Observation",
+          "description": "A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Wallonia ISSeP Air Quality covering Walloon air-quality monitoring stations. Reference records identify stations, sites, or areas; measurement and forecast records carry the current source data."
     },
     "be.issep.airquality.Sensors.mqtt": {
-      "description": "MQTT/5.0 transport variants of the ISSeP Wallonia air quality CloudEvents, mapping each message to a retained, QoS-1 Unified Namespace topic under aq/be/wallonia/wallonia-issep/{configuration_id}/... The bridge publishes sensor configuration info and observations per configuration_id.",
+      "description": "MQTT 5 variant of the Wallonia ISSeP Air Quality events. It carries the same source semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "be.issep.airquality.Sensors.mqtt.SensorConfiguration": {
           "name": "SensorConfiguration",
@@ -127,7 +132,7 @@
                 "name": "SensorConfiguration",
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Reference data for one ISSeP Wallonia air quality sensor configuration. Each id_configuration identifies a deployed sensor unit. The bridge emits this event at startup for each distinct configuration seen in the data records.",
+                "description": "A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "configuration_id",
                   "province"
@@ -164,7 +169,7 @@
                 "name": "Observation",
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Air quality observation from one ISSeP Wallonia sensor at a specific moment in time. Includes raw electrochemical gas readings, calibrated ppb and µg/m³ values, particulate matter concentrations, environmental parameters, reference station comparisons, and quality status flags. Negative raw values (e.g. no2=-4) are valid sensor readings and must not be filtered.",
+                "description": "A current environmental measurement from Wallonia's Institut Scientifique de Service Public (ISSeP). It carries pollutant concentration measurements when the upstream feed reports a new or refreshed value.",
                 "required": [
                   "configuration_id",
                   "moment",
@@ -613,5 +618,10 @@
         }
       }
     }
+  },
+  "description": "Wallonia ISSeP Air Quality publishes pollutant concentration measurements from Wallonia's Institut Scientifique de Service Public (ISSeP) for Walloon air-quality monitoring stations. These events help consumers build monitoring, alerting, analytics, and dashboards without polling the upstream API directly.",
+  "documentation": {
+    "description": "Source documentation for Wallonia ISSeP Air Quality, including upstream API context and bridge deployment notes.",
+    "url": "README.md"
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites xRegistry descriptions for Batch B weather and air-quality sources.
- Updates only human-facing descriptions and regenerated EVENTS.md outputs.
- Keeps source schemas, identifiers, topics, and CloudEvents metadata unchanged.

## Validation
- Regenerated each Batch B source with `pwsh .\tools\generate-events-md.ps1 -Source <source>`.
- Spot-checked generated DWD, Canada AQHI, and HKO EVENTS.md openings and first event entries for reader-facing prose.

## Sources
canada-aqhi, defra-aurn, dwd, dwd-pollenflug, environment-canada, fmi-finland, geosphere-austria, gios-poland, hko-hong-kong, hongkong-epd, irceline-belgium, kmi-belgium, laqn-london, luchtmeetnet-nl, singapore-nea, smhi-weather, uba-airdata, wallonia-issep.