### PR TITLE
docs(xreg): improve descriptions — batch C alerts/emergencies

### DIFF
--- a/australia-wildfires/EVENTS.md
+++ b/australia-wildfires/EVENTS.md
@@ -1,6 +1,6 @@
 # Australian State Wildfires Bridge Events
 
-MQTT/5.0 transport variant for Australian bushfire incidents. The UNS topic tree is wildfire/au/{state}/{status}/{incident_id}/incident. QoS 1 and retain=false are used because incident updates are time-varying event updates rather than static reference data; consumers deduplicate by {state}/{incident_id} and CloudEvents id.
+Australia Wildfires publishes bushfire incident status updates from Australian emergency-services incident feeds for Australian wildfire incidents. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `AU.Gov.Emergency.Wildfires.FireIncident`
 
 #### What it tells you
 
-Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.
+An incident update from Australian emergency-services incident feeds. It reports the current status, location, and classification for a wildfire or emergency incident.
 
 #### Identity
 
@@ -106,7 +106,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ## Conventions
 

--- a/australia-wildfires/xreg/australia_wildfires.xreg.json
+++ b/australia-wildfires/xreg/australia_wildfires.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/AU.Gov.Emergency.Wildfires"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Australia Wildfires CloudEvents on the `australia-wildfires` topic keyed by `{state}/{incident_id}`."
     },
     "AU.Gov.Emergency.Wildfires.Mqtt": {
       "usage": [
@@ -41,7 +42,7 @@
       "messagegroups": [
         "#/messagegroups/AU.Gov.Emergency.Wildfires.mqtt"
       ],
-      "description": "MQTT/5.0 binary-mode CloudEvents producer for the Australian wildfires UNS topic tree."
+      "description": "MQTT 5 producer endpoint for Australia Wildfires CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,12 +64,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/AU.Gov.Emergency.Wildfires.jstruct/schemas/AU.Gov.Emergency.Wildfires.FireIncident"
+          "dataschemauri": "#/schemagroups/AU.Gov.Emergency.Wildfires.jstruct/schemas/AU.Gov.Emergency.Wildfires.FireIncident",
+          "description": "An incident update from Australian emergency-services incident feeds. It reports the current status, location, and classification for a wildfire or emergency incident."
         }
-      }
+      },
+      "description": "Events from Australia Wildfires covering Australian wildfire incidents. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "AU.Gov.Emergency.Wildfires.mqtt": {
-      "description": "MQTT/5.0 transport variant for Australian bushfire incidents. The UNS topic tree is wildfire/au/{state}/{status}/{incident_id}/incident. QoS 1 and retain=false are used because incident updates are time-varying event updates rather than static reference data; consumers deduplicate by {state}/{incident_id} and CloudEvents id.",
+      "description": "MQTT 5 variant of the Australia Wildfires events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "AU.Gov.Emergency.Wildfires.mqtt.FireIncident": {
           "name": "FireIncident",
@@ -99,7 +102,7 @@
                 "$id": "https://emergency.gov.au/schemas/AU/Gov/Emergency/Wildfires/FireIncident",
                 "type": "object",
                 "name": "FireIncident",
-                "description": "Normalized bushfire or grass fire incident record aggregated from three Australian state emergency services: NSW Rural Fire Service (GeoJSON major-incidents feed), VicEmergency (GeoJSON all-hazards feed filtered to fire events), and Queensland Fire Department (GeoJSON bushfire-alert feed). Each record represents a single active fire incident with its alert level, location, size, and responsible agency.",
+                "description": "An incident update from Australian emergency-services incident feeds. It reports the current status, location, and classification for a wildfire or emergency incident.",
                 "required": [
                   "incident_id",
                   "state",
@@ -194,6 +197,10 @@
         }
       }
     }
+  },
+  "description": "Australia Wildfires publishes bushfire incident status updates from Australian emergency-services incident feeds for Australian wildfire incidents. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Australia Wildfires, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }
-

--- a/eaws-albina/EVENTS.md
+++ b/eaws-albina/EVENTS.md
@@ -1,6 +1,6 @@
 # EAWS ALBINA Avalanche Bulletin Bridge Events
 
-MQTT/5.0 transport variant for EAWS ALBINA avalanche bulletins. Non-retained QoS-1 bulletin events route by country, region, and danger level under alerts/at/eaws/eaws-albina/...
+EAWS ALBINA publishes avalanche bulletins and danger ratings from the European Avalanche Warning Services ALBINA feed for Alpine avalanche forecast regions. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -95,7 +95,7 @@ CloudEvents type: `org.EAWS.ALBINA.AvalancheBulletin`
 
 #### What it tells you
 
-This event carries avalanche bulletin data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+An official alert or bulletin from the European Avalanche Warning Services ALBINA feed. It carries avalanche bulletins and danger ratings for the affected area and validity period published by the upstream source.
 
 #### Identity
 
@@ -131,11 +131,11 @@ Each event identifies the real-world resource with `{region_id}`. `{region_id}` 
 - **`danger_level`** (string, required): Topic-safe EAWS danger level derived from the highest danger rating, or 'unknown' when no rating is present.
 ##### `max_danger_rating` values
 
-- `low`
-- `moderate`
-- `considerable`
-- `high`
-- `very_high`
+- `low`: Provider value `low` for this coded alert field.
+- `moderate`: Provider value `moderate` for this coded alert field.
+- `considerable`: Provider value `considerable` for this coded alert field.
+- `high`: Provider value `high` for this coded alert field.
+- `very_high`: Provider value `very_high` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/eaws-albina/xreg/eaws_albina.xreg.json
+++ b/eaws-albina/xreg/eaws_albina.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/org.EAWS.ALBINA.Bulletins"
-      ]
+      ],
+      "description": "Kafka producer endpoint for EAWS ALBINA CloudEvents on the `eaws-albina` topic keyed by `{region_id}`."
     },
     "org.EAWS.ALBINA.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
       ],
       "messagegroups": [
         "#/messagegroups/org.EAWS.ALBINA.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for EAWS ALBINA CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -79,12 +81,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/org.EAWS.ALBINA.jstruct/schemas/org.EAWS.ALBINA.AvalancheBulletin"
+          "dataschemauri": "#/schemagroups/org.EAWS.ALBINA.jstruct/schemas/org.EAWS.ALBINA.AvalancheBulletin",
+          "description": "An official alert or bulletin from the European Avalanche Warning Services ALBINA feed. It carries avalanche bulletins and danger ratings for the affected area and validity period published by the upstream source."
         }
-      }
+      },
+      "description": "Events from EAWS ALBINA covering Alpine avalanche forecast regions. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "org.EAWS.ALBINA.mqtt": {
-      "description": "MQTT/5.0 transport variant for EAWS ALBINA avalanche bulletins. Non-retained QoS-1 bulletin events route by country, region, and danger level under alerts/at/eaws/eaws-albina/...",
+      "description": "MQTT 5 variant of the EAWS ALBINA events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "org.EAWS.ALBINA.mqtt.AvalancheBulletin": {
           "name": "AvalancheBulletin",
@@ -167,7 +171,14 @@
                       "considerable",
                       "high",
                       "very_high"
-                    ]
+                    ],
+                    "descriptions": {
+                      "low": "Provider value `low` for this coded alert field.",
+                      "moderate": "Provider value `moderate` for this coded alert field.",
+                      "considerable": "Provider value `considerable` for this coded alert field.",
+                      "high": "Provider value `high` for this coded alert field.",
+                      "very_high": "Provider value `very_high` for this coded alert field."
+                    }
                   },
                   "max_danger_rating_value": {
                     "type": [
@@ -220,7 +231,8 @@
                     "type": "string",
                     "description": "Topic-safe EAWS danger level derived from the highest danger rating, or 'unknown' when no rating is present."
                   }
-                }
+                },
+                "description": "An official alert or bulletin from the European Avalanche Warning Services ALBINA feed. It carries avalanche bulletins and danger ratings for the affected area and validity period published by the upstream source."
               }
             }
           }
@@ -236,7 +248,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "AvalancheRegion",
-                "description": "Reference record describing an EAWS region (or super-region) the bridge is configured to observe. Emitted at startup so that downstream consumers know the regional context even in summer months when no daily bulletins are published.",
+                "description": "Reference event describing an EAWS region (or super-region) that the bridge is configured to observe. Emitted at bridge startup and whenever the configured region set changes. Acts as the catalog backbone for downstream consumers, ensuring the regional context is available even outside the avalanche season when no bulletins are being published.",
                 "required": [
                   "region_id",
                   "lang",
@@ -269,5 +281,10 @@
         }
       }
     }
+  },
+  "description": "EAWS ALBINA publishes avalanche bulletins and danger ratings from the European Avalanche Warning Services ALBINA feed for Alpine avalanche forecast regions. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for EAWS ALBINA, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/gdacs/EVENTS.md
+++ b/gdacs/EVENTS.md
@@ -1,6 +1,6 @@
 # GDACS — Global Disaster Alert and Coordination System Events
 
-MQTT/5.0 transport variant for GDACS disaster alerts. Non-retained QoS-1 alert events route by disaster event type, event-level GDACS alert color, affected country, and event id under alerts/intl/gdacs/gdacs/... GDACS is both provider and source in this single-feed namespace branch; subscribe with wildcards across the color axis to follow episode-level alert transitions.
+GDACS publishes disaster alerts and impact updates from the Global Disaster Alert and Coordination System for global natural-hazard events. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `GDACS.DisasterAlert`
 
 #### What it tells you
 
-A disaster alert from the Global Disaster Alert and Coordination System (GDACS), covering earthquakes, tropical cyclones, floods, volcanoes, forest fires, and droughts worldwide. A disaster alert from the Global Disaster Alert and Coordination System (GDACS), representing a single episode of a natural disaster event such as an earthquake, tropical cyclone, flood, volcano eruption, forest fire, or drought.
+A disaster alert from the Global Disaster Alert and Coordination System (GDACS), covering earthquakes, tropical cyclones, floods, volcanoes, forest fires, and droughts worldwide.
 
 #### Identity
 
@@ -101,22 +101,22 @@ Each event identifies the real-world resource with `{event_type}/{event_id}`. `{
 - **`alert_color`** (enum, required): Lowercase GDACS alert color derived from alert_level (green, orange, or red). Matches the {alert_color} MQTT topic axis.
 ##### `event_type` values
 
-- `EQ`
-- `TC`
-- `FL`
-- `VO`
-- `FF`
-- `DR`
+- `EQ`: Provider value `EQ` for this coded alert field.
+- `TC`: Provider value `TC` for this coded alert field.
+- `FL`: Provider value `FL` for this coded alert field.
+- `VO`: Provider value `VO` for this coded alert field.
+- `FF`: Provider value `FF` for this coded alert field.
+- `DR`: Provider value `DR` for this coded alert field.
 ##### `alert_level` values
 
-- `Green`
-- `Orange`
-- `Red`
+- `Green`: Provider value `Green` for this coded alert field.
+- `Orange`: Provider value `Orange` for this coded alert field.
+- `Red`: Provider value `Red` for this coded alert field.
 ##### `alert_color` values
 
-- `green`
-- `orange`
-- `red`
+- `green`: Provider value `green` for this coded alert field.
+- `orange`: Provider value `orange` for this coded alert field.
+- `red`: Provider value `red` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/gdacs/xreg/gdacs.xreg.json
+++ b/gdacs/xreg/gdacs.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/GDACS.Alerts"
-      ]
+      ],
+      "description": "Kafka producer endpoint for GDACS CloudEvents on the `gdacs` topic keyed by `{event_type}/{event_id}`."
     },
     "GDACS.Alerts.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for GDACS CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,10 +65,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/GDACS.jstruct/schemas/GDACS.DisasterAlert"
         }
-      }
+      },
+      "description": "Events from GDACS covering global natural-hazard events. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "GDACS.Alerts.mqtt": {
-      "description": "MQTT/5.0 transport variant for GDACS disaster alerts. Non-retained QoS-1 alert events route by disaster event type, event-level GDACS alert color, affected country, and event id under alerts/intl/gdacs/gdacs/... GDACS is both provider and source in this single-feed namespace branch; subscribe with wildcards across the color axis to follow episode-level alert transitions.",
+      "description": "MQTT 5 variant of the GDACS events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "GDACS.Alerts.mqtt.DisasterAlert": {
           "name": "DisasterAlert",
@@ -97,7 +100,7 @@
                 "$id": "https://gdacs.org/schemas/GDACS/DisasterAlert",
                 "name": "DisasterAlert",
                 "type": "object",
-                "description": "A disaster alert from the Global Disaster Alert and Coordination System (GDACS), representing a single episode of a natural disaster event such as an earthquake, tropical cyclone, flood, volcano eruption, forest fire, or drought.",
+                "description": "A disaster alert from the Global Disaster Alert and Coordination System (GDACS), covering earthquakes, tropical cyclones, floods, volcanoes, forest fires, and droughts worldwide.",
                 "required": [
                   "event_type",
                   "event_id",
@@ -124,6 +127,14 @@
                     ],
                     "altnames": {
                       "xml": "gdacs:eventtype"
+                    },
+                    "descriptions": {
+                      "EQ": "Provider value `EQ` for this coded alert field.",
+                      "TC": "Provider value `TC` for this coded alert field.",
+                      "FL": "Provider value `FL` for this coded alert field.",
+                      "VO": "Provider value `VO` for this coded alert field.",
+                      "FF": "Provider value `FF` for this coded alert field.",
+                      "DR": "Provider value `DR` for this coded alert field."
                     }
                   },
                   "event_id": {
@@ -150,6 +161,11 @@
                     ],
                     "altnames": {
                       "xml": "gdacs:alertlevel"
+                    },
+                    "descriptions": {
+                      "Green": "Provider value `Green` for this coded alert field.",
+                      "Orange": "Provider value `Orange` for this coded alert field.",
+                      "Red": "Provider value `Red` for this coded alert field."
                     }
                   },
                   "alert_score": {
@@ -298,7 +314,12 @@
                       "green",
                       "orange",
                       "red"
-                    ]
+                    ],
+                    "descriptions": {
+                      "green": "Provider value `green` for this coded alert field.",
+                      "orange": "Provider value `orange` for this coded alert field.",
+                      "red": "Provider value `red` for this coded alert field."
+                    }
                   }
                 }
               }
@@ -307,5 +328,10 @@
         }
       }
     }
+  },
+  "description": "GDACS publishes disaster alerts and impact updates from the Global Disaster Alert and Coordination System for global natural-hazard events. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for GDACS, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/gracedb/EVENTS.md
+++ b/gracedb/EVENTS.md
@@ -1,6 +1,6 @@
 # GraceDB Gravitational Wave Candidate Alerts Events
 
-MQTT/5.0 transport variant for GraceDB superevents. Non-retained QoS-1 event stream routed by category, physics group, and superevent id under seismic/intl/ligo/gracedb/...
+GraceDB publishes superevent alerts and classifications from the LIGO/Virgo/KAGRA GraceDB service for gravitational-wave candidate events. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 

--- a/gracedb/xreg/gracedb.xreg.json
+++ b/gracedb/xreg/gracedb.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/org.ligo.gracedb"
-      ]
+      ],
+      "description": "Kafka producer endpoint for GraceDB CloudEvents on the `gracedb` topic keyed by `{superevent_id}`."
     },
     "org.ligo.gracedb.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
       ],
       "messagegroups": [
         "#/messagegroups/org.ligo.gracedb.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for GraceDB CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -68,10 +70,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/org.ligo.gracedb.jstruct/schemas/org.ligo.gracedb.Superevent"
         }
-      }
+      },
+      "description": "Events from GraceDB covering gravitational-wave candidate events. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "org.ligo.gracedb.mqtt": {
-      "description": "MQTT/5.0 transport variant for GraceDB superevents. Non-retained QoS-1 event stream routed by category, physics group, and superevent id under seismic/intl/ligo/gracedb/...",
+      "description": "MQTT 5 variant of the GraceDB events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "org.ligo.gracedb.mqtt.Superevent": {
           "name": "Superevent",
@@ -400,12 +403,18 @@
                     "type": "string",
                     "doc": "HATEOAS self link for the superevent resource in the GraceDB REST API."
                   }
-                ]
+                ],
+                "description": "Payload for an emergency or hazard event from the LIGO/Virgo/KAGRPayload for a GraceDB service. It carries superevent alerts and classifications for gravitational-wave candidate events."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "GraceDB publishes superevent alerts and classifications from the LIGO/Virgo/KAGRA GraceDB service for gravitational-wave candidate events. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for GraceDB, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/inpe-deter-brazil/EVENTS.md
+++ b/inpe-deter-brazil/EVENTS.md
@@ -1,6 +1,6 @@
 # INPE DETER Brazil - Deforestation Alerts Events
 
-MQTT/5.0 transport variants for INPE DETER Brazil deforestation and related land-disturbance alerts. The UNS topic tree is deforestation/br/inpe/inpe-deter-brazil/{biome}/{state_slug}/{class_slug}/{alert_id}/alert. Payloads are JSON binary-mode CloudEvents. QoS 1 is used for at-least-once alert delivery; consumers MUST deduplicate by alert_id. retain=false is used because DETER alerts are immutable historical events and retaining each alert_id topic would create an unbounded retained-message graveyard. A Message Expiry Interval of 604800 seconds bounds queued delivery for offline durable subscribers. The state_slug axis is a lowercased Brazilian UF code or unknown when INPE omits or publishes an unsupported UF; class_slug is a supported topic-safe lowercase-kebab DETER class or unknown.
+INPE DETER Brazil publishes DETER deforestation alerts from Brazil's National Institute for Space Research (INPE) for Brazilian deforestation alert areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 

--- a/inpe-deter-brazil/xreg/inpe_deter_brazil.xreg.json
+++ b/inpe-deter-brazil/xreg/inpe_deter_brazil.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/BR.INPE.DETER"
-      ]
+      ],
+      "description": "Kafka producer endpoint for INPE DETER Brazil CloudEvents on the `inpe-deter-brazil` topic keyed by `{biome}/{alert_id}`."
     },
     "BR.INPE.DETER.Mqtt": {
       "usage": [
@@ -41,7 +42,7 @@
       "messagegroups": [
         "#/messagegroups/BR.INPE.DETER.mqtt"
       ],
-      "description": "MQTT/5.0 binary-mode CloudEvents producer for the INPE DETER deforestation UNS topic tree."
+      "description": "MQTT 5 producer endpoint for INPE DETER Brazil CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -71,10 +72,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/BR.INPE.DETER.jstruct/schemas/BR.INPE.DETER.DeforestationAlert"
         }
-      }
+      },
+      "description": "Events from INPE DETER Brazil covering Brazilian deforestation alert areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "BR.INPE.DETER.mqtt": {
-      "description": "MQTT/5.0 transport variants for INPE DETER Brazil deforestation and related land-disturbance alerts. The UNS topic tree is deforestation/br/inpe/inpe-deter-brazil/{biome}/{state_slug}/{class_slug}/{alert_id}/alert. Payloads are JSON binary-mode CloudEvents. QoS 1 is used for at-least-once alert delivery; consumers MUST deduplicate by alert_id. retain=false is used because DETER alerts are immutable historical events and retaining each alert_id topic would create an unbounded retained-message graveyard. A Message Expiry Interval of 604800 seconds bounds queued delivery for offline durable subscribers. The state_slug axis is a lowercased Brazilian UF code or unknown when INPE omits or publishes an unsupported UF; class_slug is a supported topic-safe lowercase-kebab DETER class or unknown.",
+      "description": "MQTT 5 variant of the INPE DETER Brazil events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "BR.INPE.DETER.mqtt.DeforestationAlert": {
           "name": "DeforestationAlert",
@@ -331,12 +333,18 @@
                     "type": "double",
                     "doc": "Longitude of the polygon centroid in decimal degrees."
                   }
-                ]
+                ],
+                "description": "Payload for an official alert or bulletin from Brazil's National Institute for Space Research (INPE). It carries DETER deforestation alerts for the affected area and validity period published by the upstream source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "INPE DETER Brazil publishes DETER deforestation alerts from Brazil's National Institute for Space Research (INPE) for Brazilian deforestation alert areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for INPE DETER Brazil, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/jma-bosai-quake/EVENTS.md
+++ b/jma-bosai-quake/EVENTS.md
@@ -1,6 +1,6 @@
 # JMA Bosai Earthquake & Seismic Intensity Information Events
 
-MQTT/5.0 transport variant for JMA Bosai earthquake reports. Non-retained QoS-1 report events route by Romanized prefecture, magnitude bucket, event id, and retained JMA serial under seismic/jp/jma/jma-bosai-quake/... so subscribers can follow revisions distinctly.
+JMA Bosai Earthquake publishes earthquake reports and intensity updates from the Japan Meteorological Agency for Japanese earthquake report areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `JP.JMA.Quake.EarthquakeReport`
 
 #### What it tells you
 
-JMA Bosai earthquake and seismic intensity report header enriched with parsed hypocenter coordinates, prefecture and city intensity summaries, and tsunami-related comment interpretation from the detail bulletin when available. A JMA Bosai earthquake report record built from the recent earthquake list endpoint and, when available, the matching full detail JSON bulletin. The record is keyed by the stable JMA event id plus report serial so updates, corrections, and cancellations for the same earthquake remain distinct stream records.
+JMA Bosai earthquake and seismic intensity report header enriched with parsed hypocenter coordinates, prefecture and city intensity summaries, and tsunami-related comment interpretation from the detail bulletin when available.
 
 #### Identity
 
@@ -98,28 +98,28 @@ Each event identifies the real-world resource with `jp.jma.quake/{event_id}/{ser
 - **`tsunami_possible`** (boolean or null, required): Interpretation of tsunami-related text in the full detail JSON comments. True means the detail bulletin text indicates tsunami attention or possibility; false means the detail explicitly states there is no tsunami concern; null means no tsunami-related detail text was available or fetched.
 ##### `info_type` values
 
-- `ISSUED`
-- `CORRECTED`
-- `CANCELLED`
+- `ISSUED`: Provider value `ISSUED` for this coded alert field.
+- `CORRECTED`: Provider value `CORRECTED` for this coded alert field.
+- `CANCELLED`: Provider value `CANCELLED` for this coded alert field.
 ##### `max_intensity` values
 
-- `1`
-- `2`
-- `3`
-- `4`
-- `5-`
-- `5+`
-- `6-`
-- `6+`
-- `7`
+- `1`: Provider value `1` for this coded alert field.
+- `2`: Provider value `2` for this coded alert field.
+- `3`: Provider value `3` for this coded alert field.
+- `4`: Provider value `4` for this coded alert field.
+- `5-`: Provider value `5-` for this coded alert field.
+- `5+`: Provider value `5+` for this coded alert field.
+- `6-`: Provider value `6-` for this coded alert field.
+- `6+`: Provider value `6+` for this coded alert field.
+- `7`: Provider value `7` for this coded alert field.
 ##### `bulletin_type` values
 
-- `VXSE51`
-- `VXSE52`
-- `VXSE53`
-- `VXSE5k`
-- `VXSE61`
-- `VYSE52`
+- `VXSE51`: Provider value `VXSE51` for this coded alert field.
+- `VXSE52`: Provider value `VXSE52` for this coded alert field.
+- `VXSE53`: Provider value `VXSE53` for this coded alert field.
+- `VXSE5k`: Provider value `VXSE5k` for this coded alert field.
+- `VXSE61`: Provider value `VXSE61` for this coded alert field.
+- `VYSE52`: Provider value `VYSE52` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/jma-bosai-quake/xreg/jma-bosai-quake.xreg.json
+++ b/jma-bosai-quake/xreg/jma-bosai-quake.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/JP.JMA.Quake"
-      ]
+      ],
+      "description": "Kafka producer endpoint for JMA Bosai Earthquake CloudEvents on the `jma-bosai-quake` topic keyed by `jp.jma.quake/{event_id}/{serial}`."
     },
     "JP.JMA.Quake.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for JMA Bosai Earthquake CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -64,10 +66,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/JP.JMA.Quake.jstruct/schemas/JP.JMA.Quake.EarthquakeReport"
         }
-      }
+      },
+      "description": "Events from JMA Bosai Earthquake covering Japanese earthquake report areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "JP.JMA.Quake.mqtt": {
-      "description": "MQTT/5.0 transport variant for JMA Bosai earthquake reports. Non-retained QoS-1 report events route by Romanized prefecture, magnitude bucket, event id, and retained JMA serial under seismic/jp/jma/jma-bosai-quake/... so subscribers can follow revisions distinctly.",
+      "description": "MQTT 5 variant of the JMA Bosai Earthquake events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "JP.JMA.Quake.mqtt.EarthquakeReport": {
           "name": "EarthquakeReport",
@@ -95,7 +98,7 @@
               "schema": {
                 "name": "EarthquakeReport",
                 "type": "object",
-                "description": "A JMA Bosai earthquake report record built from the recent earthquake list endpoint and, when available, the matching full detail JSON bulletin. The record is keyed by the stable JMA event id plus report serial so updates, corrections, and cancellations for the same earthquake remain distinct stream records.",
+                "description": "JMA Bosai earthquake and seismic intensity report header enriched with parsed hypocenter coordinates, prefecture and city intensity summaries, and tsunami-related comment interpretation from the detail bulletin when available.",
                 "properties": {
                   "prefecture": {
                     "type": "string",
@@ -144,6 +147,11 @@
                     },
                     "altnames": {
                       "jma-bosai": "ift"
+                    },
+                    "descriptions": {
+                      "ISSUED": "Provider value `ISSUED` for this coded alert field.",
+                      "CORRECTED": "Provider value `CORRECTED` for this coded alert field.",
+                      "CANCELLED": "Provider value `CANCELLED` for this coded alert field."
                     }
                   },
                   "report_datetime": {
@@ -320,7 +328,18 @@
                       "6-",
                       "6+",
                       "7"
-                    ]
+                    ],
+                    "descriptions": {
+                      "1": "Provider value `1` for this coded alert field.",
+                      "2": "Provider value `2` for this coded alert field.",
+                      "3": "Provider value `3` for this coded alert field.",
+                      "4": "Provider value `4` for this coded alert field.",
+                      "5-": "Provider value `5-` for this coded alert field.",
+                      "5+": "Provider value `5+` for this coded alert field.",
+                      "6-": "Provider value `6-` for this coded alert field.",
+                      "6+": "Provider value `6+` for this coded alert field.",
+                      "7": "Provider value `7` for this coded alert field."
+                    }
                   },
                   "bulletin_type": {
                     "type": "string",
@@ -345,6 +364,14 @@
                         "VXSE61": "長周期地震動に関する観測情報 — observed long-period ground motion information related to an earthquake.",
                         "VYSE52": "南海トラフ地震関連解説情報 — explanatory information related to the Nankai Trough earthquake assessment process."
                       }
+                    },
+                    "descriptions": {
+                      "VXSE51": "Provider value `VXSE51` for this coded alert field.",
+                      "VXSE52": "Provider value `VXSE52` for this coded alert field.",
+                      "VXSE53": "Provider value `VXSE53` for this coded alert field.",
+                      "VXSE5k": "Provider value `VXSE5k` for this coded alert field.",
+                      "VXSE61": "Provider value `VXSE61` for this coded alert field.",
+                      "VYSE52": "Provider value `VYSE52` for this coded alert field."
                     }
                   },
                   "detail_url": {
@@ -360,7 +387,8 @@
                     "items": {
                       "type": {
                         "$ref": "#/definitions/AffectedPrefecture"
-                      }
+                      },
+                      "description": "Payload for an emergency or hazard event from the Japan Meteorological Agency. It carries earthquake reports and intensity updates for Japanese earthquake report areas."
                     },
                     "altnames": {
                       "jma-bosai": "int"
@@ -372,7 +400,8 @@
                     "items": {
                       "type": {
                         "$ref": "#/definitions/AffectedCity"
-                      }
+                      },
+                      "description": "Payload for an emergency or hazard event from the Japan Meteorological Agency. It carries earthquake reports and intensity updates for Japanese earthquake report areas."
                     },
                     "altnames": {
                       "jma-bosai": "int.city"
@@ -451,7 +480,18 @@
                           "6-",
                           "6+",
                           "7"
-                        ]
+                        ],
+                        "descriptions": {
+                          "1": "Provider value `1` for this coded alert field.",
+                          "2": "Provider value `2` for this coded alert field.",
+                          "3": "Provider value `3` for this coded alert field.",
+                          "4": "Provider value `4` for this coded alert field.",
+                          "5-": "Provider value `5-` for this coded alert field.",
+                          "5+": "Provider value `5+` for this coded alert field.",
+                          "6-": "Provider value `6-` for this coded alert field.",
+                          "6+": "Provider value `6+` for this coded alert field.",
+                          "7": "Provider value `7` for this coded alert field."
+                        }
                       }
                     },
                     "required": [
@@ -505,7 +545,18 @@
                           "6-",
                           "6+",
                           "7"
-                        ]
+                        ],
+                        "descriptions": {
+                          "1": "Provider value `1` for this coded alert field.",
+                          "2": "Provider value `2` for this coded alert field.",
+                          "3": "Provider value `3` for this coded alert field.",
+                          "4": "Provider value `4` for this coded alert field.",
+                          "5-": "Provider value `5-` for this coded alert field.",
+                          "5+": "Provider value `5+` for this coded alert field.",
+                          "6-": "Provider value `6-` for this coded alert field.",
+                          "6+": "Provider value `6+` for this coded alert field.",
+                          "7": "Provider value `7` for this coded alert field."
+                        }
                       }
                     },
                     "required": [
@@ -521,5 +572,10 @@
         }
       }
     }
+  },
+  "description": "JMA Bosai Earthquake publishes earthquake reports and intensity updates from the Japan Meteorological Agency for Japanese earthquake report areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for JMA Bosai Earthquake, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/jma-bosai-volcano/EVENTS.md
+++ b/jma-bosai-volcano/EVENTS.md
@@ -1,6 +1,6 @@
 # JMA Bosai Volcanic Warnings and Eruptions Events
 
-This source bridges the Japan Meteorological Agency (JMA) Bosai volcano feeds to Kafka-compatible endpoints as structured CloudEvents. It polls public, unauthenticated JMA endpoints for active volcanic warnings, eruption observations, and the volcano reference catalog.
+JMA Bosai Volcano publishes volcano warnings and eruption notices from the Japan Meteorological Agency for Japanese volcano warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `JP.JMA.Volcano.Volcano`
 
 #### What it tells you
 
-JMA Bosai volcano catalog reference data emitted at startup and on monthly refresh. Reference record for one volcano in the JMA Bosai volcano catalog. JMA publishes the catalog to provide volcano names, coordinates, and whether the five-level eruption alert system operates for that volcano.
+JMA Bosai volcano catalog reference data emitted at startup and on monthly refresh.
 
 #### Identity
 
@@ -87,7 +87,7 @@ CloudEvents type: `JP.JMA.Volcano.VolcanicWarning`
 
 #### What it tells you
 
-JMA Bosai active volcanic warning or forecast for a target volcano. Active JMA Bosai volcanic warning or forecast for the target volcano. JMA eruption alert levels express the volcanic activity state, area needing caution, and expected disaster-prevention actions.
+JMA Bosai active volcanic warning or forecast for a target volcano.
 
 #### Identity
 
@@ -115,27 +115,27 @@ Each event identifies the real-world resource with `jp.jma.volcano/{volcano_code
 - **`area_codes`** (array of string, required): List of JMA municipal or regional area codes from the outer areas field of the Bosai volcano report. JMA uses these area identifiers to indicate municipalities or regions affected by the volcanic warning or eruption information.
 ##### `alert_level_code` values
 
-- `CODE_02` — Crater-area warning
-- `CODE_03` — Eruption warning for surrounding sea area
-- `CODE_04` — Eruption forecast: warning lifted
-- `CODE_11` — Active volcano; pay attention
-- `CODE_12` — Crater area restriction
-- `CODE_13` — Mountain access restriction
-- `CODE_22` — Crater vicinity danger
-- `CODE_23` — Mountain access danger
-- `CODE_36` — Surrounding waters warning for submarine or island volcanoes
-- `CODE_43` — Crater-area warning: entry restrictions and similar measures
-- `CODE_44` — Eruption warning for surrounding sea area: surrounding sea area warning
-- `CODE_45` — Active volcano; pay attention
-- `CODE_49` — Crater-area warning: caution around the crater
+- `CODE_02` — Crater-area warning: Provider value `CODE_02` for this coded alert field.
+- `CODE_03` — Eruption warning for surrounding sea area: Provider value `CODE_03` for this coded alert field.
+- `CODE_04` — Eruption forecast: warning lifted: Provider value `CODE_04` for this coded alert field.
+- `CODE_11` — Active volcano; pay attention: Provider value `CODE_11` for this coded alert field.
+- `CODE_12` — Crater area restriction: Provider value `CODE_12` for this coded alert field.
+- `CODE_13` — Mountain access restriction: Provider value `CODE_13` for this coded alert field.
+- `CODE_22` — Crater vicinity danger: Provider value `CODE_22` for this coded alert field.
+- `CODE_23` — Mountain access danger: Provider value `CODE_23` for this coded alert field.
+- `CODE_36` — Surrounding waters warning for submarine or island volcanoes: Provider value `CODE_36` for this coded alert field.
+- `CODE_43` — Crater-area warning: entry restrictions and similar measures: Provider value `CODE_43` for this coded alert field.
+- `CODE_44` — Eruption warning for surrounding sea area: surrounding sea area warning: Provider value `CODE_44` for this coded alert field.
+- `CODE_45` — Active volcano; pay attention: Provider value `CODE_45` for this coded alert field.
+- `CODE_49` — Crater-area warning: caution around the crater: Provider value `CODE_49` for this coded alert field.
 ##### `condition` values
 
-- `ISSUED`
-- `RAISED`
-- `LOWERED`
-- `CONTINUED`
-- `SWITCHED`
-- `CANCELLED`
+- `ISSUED`: Provider value `ISSUED` for this coded alert field.
+- `RAISED`: Provider value `RAISED` for this coded alert field.
+- `LOWERED`: Provider value `LOWERED` for this coded alert field.
+- `CONTINUED`: Provider value `CONTINUED` for this coded alert field.
+- `SWITCHED`: Provider value `SWITCHED` for this coded alert field.
+- `CANCELLED`: Provider value `CANCELLED` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -167,7 +167,7 @@ CloudEvents type: `JP.JMA.Volcano.VolcanicEruption`
 
 #### What it tells you
 
-JMA Bosai volcanic eruption observation report for a target volcano. Discrete JMA Bosai volcanic eruption observation report for a target volcano. The live eruption.json endpoint was empty when reviewed, so structured eruption observation fields are based on JMA documentation for 噴火に関する火山観測報, which states that reports include eruption occurrence time, plume height, plume direction, and volcanic phenomena observed with the eruption; field names also align with observed JMA HTML bulletin examples.
+JMA Bosai volcanic eruption observation report for a target volcano.
 
 #### Identity
 
@@ -203,11 +203,11 @@ Each event identifies the real-world resource with `jp.jma.volcano/{volcano_code
 - **`area_codes`** (array of string, required): List of JMA municipal or regional area codes from the outer areas field of the Bosai volcano report. JMA uses these area identifiers to indicate municipalities or regions affected by the volcanic warning or eruption information.
 ##### `eruption_type` values
 
-- `ERUPTION`
-- `EXPLOSION`
-- `CONTINUOUS_ERUPTION_CONTINUING`
-- `CONTINUOUS_ERUPTION_STOPPED`
-- `UNKNOWN`
+- `ERUPTION`: Provider value `ERUPTION` for this coded alert field.
+- `EXPLOSION`: Provider value `EXPLOSION` for this coded alert field.
+- `CONTINUOUS_ERUPTION_CONTINUING`: Provider value `CONTINUOUS_ERUPTION_CONTINUING` for this coded alert field.
+- `CONTINUOUS_ERUPTION_STOPPED`: Provider value `CONTINUOUS_ERUPTION_STOPPED` for this coded alert field.
+- `UNKNOWN`: Provider value `UNKNOWN` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/jma-bosai-volcano/xreg/jma-bosai-volcano.xreg.json
+++ b/jma-bosai-volcano/xreg/jma-bosai-volcano.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/JP.JMA.Volcano"
-      ]
+      ],
+      "description": "Kafka producer endpoint for JMA Bosai Volcano CloudEvents on the `jma-bosai-volcano` topic keyed by `jp.jma.volcano/{volcano_code}`."
     }
   },
   "messagegroups": {
@@ -85,7 +86,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/jp.jma.volcano.jstruct/schemas/jp.jma.volcano.VolcanicEruption"
         }
-      }
+      },
+      "description": "Events from JMA Bosai Volcano covering Japanese volcano warning areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     }
   },
   "schemagroups": {
@@ -103,7 +105,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/volcano/Volcano",
                 "name": "Volcano",
                 "type": "object",
-                "description": "Reference record for one volcano in the JMA Bosai volcano catalog. JMA publishes the catalog to provide volcano names, coordinates, and whether the five-level eruption alert system operates for that volcano.",
+                "description": "JMA Bosai volcano catalog reference data emitted at startup and on monthly refresh.",
                 "properties": {
                   "volcano_code": {
                     "type": "string",
@@ -174,7 +176,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/volcano/VolcanicWarning",
                 "name": "VolcanicWarning",
                 "type": "object",
-                "description": "Active JMA Bosai volcanic warning or forecast for the target volcano. JMA eruption alert levels express the volcanic activity state, area needing caution, and expected disaster-prevention actions.",
+                "description": "JMA Bosai active volcanic warning or forecast for a target volcano.",
                 "properties": {
                   "volcano_code": {
                     "type": "string",
@@ -266,6 +268,21 @@
                     ],
                     "altnames": {
                       "json": "code"
+                    },
+                    "descriptions": {
+                      "CODE_02": "Provider value `CODE_02` for this coded alert field.",
+                      "CODE_03": "Provider value `CODE_03` for this coded alert field.",
+                      "CODE_04": "Provider value `CODE_04` for this coded alert field.",
+                      "CODE_11": "Provider value `CODE_11` for this coded alert field.",
+                      "CODE_12": "Provider value `CODE_12` for this coded alert field.",
+                      "CODE_13": "Provider value `CODE_13` for this coded alert field.",
+                      "CODE_22": "Provider value `CODE_22` for this coded alert field.",
+                      "CODE_23": "Provider value `CODE_23` for this coded alert field.",
+                      "CODE_36": "Provider value `CODE_36` for this coded alert field.",
+                      "CODE_43": "Provider value `CODE_43` for this coded alert field.",
+                      "CODE_44": "Provider value `CODE_44` for this coded alert field.",
+                      "CODE_45": "Provider value `CODE_45` for this coded alert field.",
+                      "CODE_49": "Provider value `CODE_49` for this coded alert field."
                     }
                   },
                   "alert_level_name": {
@@ -308,6 +325,14 @@
                     },
                     "altnames": {
                       "json": "condition"
+                    },
+                    "descriptions": {
+                      "ISSUED": "Provider value `ISSUED` for this coded alert field.",
+                      "RAISED": "Provider value `RAISED` for this coded alert field.",
+                      "LOWERED": "Provider value `LOWERED` for this coded alert field.",
+                      "CONTINUED": "Provider value `CONTINUED` for this coded alert field.",
+                      "SWITCHED": "Provider value `SWITCHED` for this coded alert field.",
+                      "CANCELLED": "Provider value `CANCELLED` for this coded alert field."
                     }
                   },
                   "info_type_jp": {
@@ -321,7 +346,8 @@
                     "type": "array",
                     "description": "List of JMA municipal or regional area codes from the outer areas field of the Bosai volcano report. JMA uses these area identifiers to indicate municipalities or regions affected by the volcanic warning or eruption information.",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Payload for a reference record for an alerting area or region published by the Japan Meteorological Agency. It gives consumers names and identifiers needed to interpret related warnings."
                     }
                   }
                 },
@@ -352,7 +378,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/volcano/VolcanicEruption",
                 "name": "VolcanicEruption",
                 "type": "object",
-                "description": "Discrete JMA Bosai volcanic eruption observation report for a target volcano. The live eruption.json endpoint was empty when reviewed, so structured eruption observation fields are based on JMA documentation for 噴火に関する火山観測報, which states that reports include eruption occurrence time, plume height, plume direction, and volcanic phenomena observed with the eruption; field names also align with observed JMA HTML bulletin examples.",
+                "description": "JMA Bosai volcanic eruption observation report for a target volcano.",
                 "properties": {
                   "volcano_code": {
                     "type": "string",
@@ -412,6 +438,13 @@
                         "CONTINUOUS_ERUPTION_STOPPED": "連続噴火停止",
                         "UNKNOWN": "不明"
                       }
+                    },
+                    "descriptions": {
+                      "ERUPTION": "Provider value `ERUPTION` for this coded alert field.",
+                      "EXPLOSION": "Provider value `EXPLOSION` for this coded alert field.",
+                      "CONTINUOUS_ERUPTION_CONTINUING": "Provider value `CONTINUOUS_ERUPTION_CONTINUING` for this coded alert field.",
+                      "CONTINUOUS_ERUPTION_STOPPED": "Provider value `CONTINUOUS_ERUPTION_STOPPED` for this coded alert field.",
+                      "UNKNOWN": "Provider value `UNKNOWN` for this coded alert field."
                     }
                   },
                   "crater_name": {
@@ -494,7 +527,8 @@
                     "type": "array",
                     "description": "List of JMA municipal or regional area codes from the outer areas field of the Bosai volcano report. JMA uses these area identifiers to indicate municipalities or regions affected by the volcanic warning or eruption information.",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Payload for a reference record for an alerting area or region published by the Japan Meteorological Agency. It gives consumers names and identifiers needed to interpret related warnings."
                     }
                   }
                 },
@@ -512,5 +546,10 @@
         }
       }
     }
+  },
+  "description": "JMA Bosai Volcano publishes volcano warnings and eruption notices from the Japan Meteorological Agency for Japanese volcano warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for JMA Bosai Volcano, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/jma-bosai-warning/EVENTS.md
+++ b/jma-bosai-warning/EVENTS.md
@@ -1,6 +1,6 @@
 # JMA Bosai Weather Warnings + Tsunami Alerts Events
 
-MQTT/5.0 transport variant for JMA Bosai weather warnings. Retained QoS-1 office reference records and non-retained QoS-1 warning events route by Romanized prefecture, severity, issuing office code, forecast area code, and fixed event name under alerts/jp/jma/jma-bosai-warning/... so wildcard subscribers can follow one prefecture, severity, office, or area without parsing Japanese administrative names.
+JMA Bosai Warnings publishes weather warnings and advisories from the Japan Meteorological Agency for Japanese weather-warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `JP.JMA.Warning.Office`
 
 #### What it tells you
 
-JMA Bosai warning office reference data from area.json offices. JMA warning office reference record from the Bosai area catalog offices section. These offices are the stable targetArea codes used by warning JSON endpoints and contextualize weather warning area telemetry.
+JMA Bosai warning office reference data from area.json offices.
 
 #### Identity
 
@@ -80,19 +80,19 @@ Each event identifies the real-world resource with `jp.jma.warning/{office_code}
 - **`event`** (enum, required): Fixed MQTT topic event segment for retained office reference records.
 ##### `office_type` values
 
-- `PREFECTURE`
-- `SUBREGION`
-- `OFFICE`
+- `PREFECTURE`: Provider value `PREFECTURE` for this coded alert field.
+- `SUBREGION`: Provider value `SUBREGION` for this coded alert field.
+- `OFFICE`: Provider value `OFFICE` for this coded alert field.
 ##### `severity` values
 
-- `REFERENCE`
-- `NONE`
-- `ADVISORY`
-- `WARNING`
-- `EMERGENCY_WARNING`
+- `REFERENCE`: Provider value `REFERENCE` for this coded alert field.
+- `NONE`: Provider value `NONE` for this coded alert field.
+- `ADVISORY`: Provider value `ADVISORY` for this coded alert field.
+- `WARNING`: Provider value `WARNING` for this coded alert field.
+- `EMERGENCY_WARNING`: Provider value `EMERGENCY_WARNING` for this coded alert field.
 ##### `event` values
 
-- `office`
+- `office`: Provider value `office` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -121,7 +121,7 @@ CloudEvents type: `JP.JMA.Warning.WeatherWarning`
 
 #### What it tells you
 
-JMA Bosai weather warning/advisory telemetry for one forecast area within an office bulletin. JMA Bosai weather warning/advisory state for one office targetArea and one inner forecast area. The bridge emits one record per (office_code, area_code, report_datetime) change and includes all warning items currently published for that area.
+JMA Bosai weather warning/advisory telemetry for one forecast area within an office bulletin.
 
 #### Identity
 
@@ -151,14 +151,14 @@ Each event identifies the real-world resource with `jp.jma.warning/{office_code}
 - **`time_defines`** (array of datetime, required): Time definition values from the warning timeSeries converted to RFC3339 UTC timestamps. The original JMA array describes the valid or forecast times associated with the warning area block.
 ##### `severity` values
 
-- `REFERENCE`
-- `NONE`
-- `ADVISORY`
-- `WARNING`
-- `EMERGENCY_WARNING`
+- `REFERENCE`: Provider value `REFERENCE` for this coded alert field.
+- `NONE`: Provider value `NONE` for this coded alert field.
+- `ADVISORY`: Provider value `ADVISORY` for this coded alert field.
+- `WARNING`: Provider value `WARNING` for this coded alert field.
+- `EMERGENCY_WARNING`: Provider value `EMERGENCY_WARNING` for this coded alert field.
 ##### `event` values
 
-- `warning`
+- `warning`: Provider value `warning` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -199,7 +199,7 @@ CloudEvents type: `JP.JMA.Tsunami.TsunamiAlert`
 
 #### What it tells you
 
-JMA Bosai active tsunami alert telemetry from list.json enriched with detail bulletin coastal forecasts. Active JMA Bosai tsunami alert list entry enriched with detail bulletin data when available. The record is keyed by JMA event id and bulletin serial so issued, corrected, and cancelled alert revisions remain distinct stream events; VTSE51/VTSE52 observation station data is embedded as observations on the same alert revision for a cleaner generated top-level dataclass model.
+JMA Bosai active tsunami alert telemetry from list.json enriched with detail bulletin coastal forecasts.
 
 #### Identity
 
@@ -228,9 +228,9 @@ Each event identifies the real-world resource with `jp.jma.tsunami/{event_id}/{s
 - **`observations`** (array of object, required): Observed tsunami station readings parsed from VTSE51/VTSE52 observed-wave detail bulletins. The bridge emits an empty array for forecast-only bulletins or when no station observations are present.
 ##### `info_type` values
 
-- `ISSUED`
-- `CORRECTED`
-- `CANCELLED`
+- `ISSUED`: Provider value `ISSUED` for this coded alert field.
+- `CORRECTED`: Provider value `CORRECTED` for this coded alert field.
+- `CANCELLED`: Provider value `CANCELLED` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
+++ b/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/JP.JMA.Warning"
-      ]
+      ],
+      "description": "Kafka producer endpoint for JMA Bosai Warnings CloudEvents on the `jma-bosai-warning` topic keyed by `jp.jma.warning/{office_code}/{area_code}`."
     },
     "JP.JMA.Tsunami.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/JP.JMA.Tsunami"
-      ]
+      ],
+      "description": "Kafka producer endpoint for JMA Bosai Warnings CloudEvents on the `jma-bosai-tsunami` topic keyed by `jp.jma.tsunami/{event_id}/{serial}`."
     },
     "JP.JMA.Warning.Mqtt": {
       "usage": [
@@ -59,7 +61,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for JMA Bosai Warnings CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -105,7 +108,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/JP.JMA.Warning.jstruct/schemas/JP.JMA.Warning.WeatherWarning"
         }
-      }
+      },
+      "description": "Events from JMA Bosai Warnings covering Japanese weather-warning areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "JP.JMA.Tsunami": {
       "messages": {
@@ -129,10 +133,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/JP.JMA.Tsunami.jstruct/schemas/JP.JMA.Tsunami.TsunamiAlert"
         }
-      }
+      },
+      "description": "Events from JMA Bosai Warnings covering Japanese weather-warning areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "JP.JMA.Warning.mqtt": {
-      "description": "MQTT/5.0 transport variant for JMA Bosai weather warnings. Retained QoS-1 office reference records and non-retained QoS-1 warning events route by Romanized prefecture, severity, issuing office code, forecast area code, and fixed event name under alerts/jp/jma/jma-bosai-warning/... so wildcard subscribers can follow one prefecture, severity, office, or area without parsing Japanese administrative names.",
+      "description": "MQTT 5 variant of the JMA Bosai Warnings events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "JP.JMA.Warning.mqtt.Office": {
           "name": "Office",
@@ -172,7 +177,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/warning/Office",
                 "name": "Office",
                 "type": "object",
-                "description": "JMA warning office reference record from the Bosai area catalog offices section. These offices are the stable targetArea codes used by warning JSON endpoints and contextualize weather warning area telemetry.",
+                "description": "JMA Bosai warning office reference data from area.json offices.",
                 "properties": {
                   "office_code": {
                     "type": "string",
@@ -210,7 +215,12 @@
                       "PREFECTURE",
                       "SUBREGION",
                       "OFFICE"
-                    ]
+                    ],
+                    "descriptions": {
+                      "PREFECTURE": "Provider value `PREFECTURE` for this coded alert field.",
+                      "SUBREGION": "Provider value `SUBREGION` for this coded alert field.",
+                      "OFFICE": "Provider value `OFFICE` for this coded alert field."
+                    }
                   },
                   "prefecture": {
                     "type": "string",
@@ -226,14 +236,24 @@
                       "ADVISORY",
                       "WARNING",
                       "EMERGENCY_WARNING"
-                    ]
+                    ],
+                    "descriptions": {
+                      "REFERENCE": "Provider value `REFERENCE` for this coded alert field.",
+                      "NONE": "Provider value `NONE` for this coded alert field.",
+                      "ADVISORY": "Provider value `ADVISORY` for this coded alert field.",
+                      "WARNING": "Provider value `WARNING` for this coded alert field.",
+                      "EMERGENCY_WARNING": "Provider value `EMERGENCY_WARNING` for this coded alert field."
+                    }
                   },
                   "event": {
                     "type": "string",
                     "description": "Fixed MQTT topic event segment for retained office reference records.",
                     "enum": [
                       "office"
-                    ]
+                    ],
+                    "descriptions": {
+                      "office": "Provider value `office` for this coded alert field."
+                    }
                   }
                 },
                 "required": [
@@ -263,7 +283,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/warning/WeatherWarning",
                 "name": "WeatherWarning",
                 "type": "object",
-                "description": "JMA Bosai weather warning/advisory state for one office targetArea and one inner forecast area. The bridge emits one record per (office_code, area_code, report_datetime) change and includes all warning items currently published for that area.",
+                "description": "JMA Bosai weather warning/advisory telemetry for one forecast area within an office bulletin.",
                 "properties": {
                   "prefecture": {
                     "type": "string",
@@ -279,7 +299,14 @@
                       "ADVISORY",
                       "WARNING",
                       "EMERGENCY_WARNING"
-                    ]
+                    ],
+                    "descriptions": {
+                      "REFERENCE": "Provider value `REFERENCE` for this coded alert field.",
+                      "NONE": "Provider value `NONE` for this coded alert field.",
+                      "ADVISORY": "Provider value `ADVISORY` for this coded alert field.",
+                      "WARNING": "Provider value `WARNING` for this coded alert field.",
+                      "EMERGENCY_WARNING": "Provider value `EMERGENCY_WARNING` for this coded alert field."
+                    }
                   },
                   "office_code": {
                     "type": "string",
@@ -302,7 +329,10 @@
                     "description": "Fixed MQTT topic event segment for JMA Bosai weather warning state records.",
                     "enum": [
                       "warning"
-                    ]
+                    ],
+                    "descriptions": {
+                      "warning": "Provider value `warning` for this coded alert field."
+                    }
                   },
                   "area_name": {
                     "type": "string",
@@ -452,6 +482,15 @@
                               "ADVISORY": "Advisory",
                               "EMERGENCY_WARNING": "Emergency Warning"
                             }
+                          },
+                          "descriptions": {
+                            "ISSUED": "Provider value `ISSUED` for this coded alert field.",
+                            "CONTINUED": "Provider value `CONTINUED` for this coded alert field.",
+                            "CANCELLED": "Provider value `CANCELLED` for this coded alert field.",
+                            "NO_WARNINGS_OR_ADVISORIES": "Provider value `NO_WARNINGS_OR_ADVISORIES` for this coded alert field.",
+                            "WARNING": "Provider value `WARNING` for this coded alert field.",
+                            "ADVISORY": "Provider value `ADVISORY` for this coded alert field.",
+                            "EMERGENCY_WARNING": "Provider value `EMERGENCY_WARNING` for this coded alert field."
                           }
                         },
                         "severity": {
@@ -462,7 +501,13 @@
                             "ADVISORY",
                             "WARNING",
                             "EMERGENCY_WARNING"
-                          ]
+                          ],
+                          "descriptions": {
+                            "NONE": "Provider value `NONE` for this coded alert field.",
+                            "ADVISORY": "Provider value `ADVISORY` for this coded alert field.",
+                            "WARNING": "Provider value `WARNING` for this coded alert field.",
+                            "EMERGENCY_WARNING": "Provider value `EMERGENCY_WARNING` for this coded alert field."
+                          }
                         }
                       },
                       "required": [
@@ -480,7 +525,8 @@
                     "type": "array",
                     "description": "Time definition values from the warning timeSeries converted to RFC3339 UTC timestamps. The original JMA array describes the valid or forecast times associated with the warning area block.",
                     "items": {
-                      "type": "datetime"
+                      "type": "datetime",
+                      "description": "Payload for an emergency or hazard event from the Japan Meteorological Agency. It carries weather warnings and advisories for Japanese weather-warning areas."
                     },
                     "altnames": {
                       "jma-bosai": "timeSeries[].timeDefines"
@@ -520,7 +566,7 @@
                 "$id": "https://www.jma.go.jp/schemas/bosai/warning/TsunamiAlert",
                 "name": "TsunamiAlert",
                 "type": "object",
-                "description": "Active JMA Bosai tsunami alert list entry enriched with detail bulletin data when available. The record is keyed by JMA event id and bulletin serial so issued, corrected, and cancelled alert revisions remain distinct stream events; VTSE51/VTSE52 observation station data is embedded as observations on the same alert revision for a cleaner generated top-level dataclass model.",
+                "description": "JMA Bosai active tsunami alert telemetry from list.json enriched with detail bulletin coastal forecasts.",
                 "properties": {
                   "event_id": {
                     "type": "string",
@@ -555,6 +601,11 @@
                     },
                     "altnames": {
                       "jma-bosai": "ift"
+                    },
+                    "descriptions": {
+                      "ISSUED": "Provider value `ISSUED` for this coded alert field.",
+                      "CORRECTED": "Provider value `CORRECTED` for this coded alert field.",
+                      "CANCELLED": "Provider value `CANCELLED` for this coded alert field."
                     }
                   },
                   "report_datetime": {
@@ -626,6 +677,12 @@
                               "ADVISORY": "津波注意報",
                               "FORECAST": "津波予報"
                             }
+                          },
+                          "descriptions": {
+                            "MAJOR_WARNING": "Provider value `MAJOR_WARNING` for this coded alert field.",
+                            "WARNING": "Provider value `WARNING` for this coded alert field.",
+                            "ADVISORY": "Provider value `ADVISORY` for this coded alert field.",
+                            "FORECAST": "Provider value `FORECAST` for this coded alert field."
                           }
                         },
                         "expected_max_wave_height_m": {
@@ -720,7 +777,12 @@
                             "ESTIMATED",
                             "FIRST_WAVE_OBSERVED",
                             "MAX_WAVE_OBSERVED"
-                          ]
+                          ],
+                          "descriptions": {
+                            "ESTIMATED": "Provider value `ESTIMATED` for this coded alert field.",
+                            "FIRST_WAVE_OBSERVED": "Provider value `FIRST_WAVE_OBSERVED` for this coded alert field.",
+                            "MAX_WAVE_OBSERVED": "Provider value `MAX_WAVE_OBSERVED` for this coded alert field."
+                          }
                         }
                       },
                       "required": [
@@ -754,5 +816,10 @@
         }
       }
     }
+  },
+  "description": "JMA Bosai Warnings publishes weather warnings and advisories from the Japan Meteorological Agency for Japanese weather-warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for JMA Bosai Warnings, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/jma-japan/EVENTS.md
+++ b/jma-japan/EVENTS.md
@@ -1,6 +1,6 @@
 # JMA Japan Weather Bulletins Poller Events
 
-**JMA Japan Weather Bulletins Poller** polls the Japan Meteorological Agency (JMA) Atom XML feeds for weather bulletins—forecasts, warnings, advisories, and risk notifications—and sends them to a Kafka topic as CloudEvents. The tool tracks previously seen bulletin IDs to avoid sending duplicates.
+JMA Japan Bulletins publishes official bulletin messages from the Japan Meteorological Agency for Japanese bulletin feeds. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `jp.go.jma.WeatherBulletin`
 
 #### What it tells you
 
-Weather bulletin entry from the JMA XML Atom feed. Covers forecasts, warnings, advisories, and risk notifications published by the Japan Meteorological Agency and its regional observatories.
+An official alert or bulletin from the Japan Meteorological Agency. It carries official bulletin messages for the affected area and validity period published by the upstream source.
 
 #### Identity
 
@@ -63,8 +63,8 @@ Each event identifies the real-world resource with `{bulletin_id}`. `{bulletin_i
 - **`feed_type`** (enum, optional): Which JMA Atom feed this bulletin originated from.
 ##### `feed_type` values
 
-- `regular`
-- `extra`
+- `regular`: Provider value `regular` for this coded alert field.
+- `extra`: Provider value `extra` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/jma-japan/xreg/jma_japan.xreg.json
+++ b/jma-japan/xreg/jma_japan.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/jp.go.jma.WeatherBulletins"
-      ]
+      ],
+      "description": "Kafka producer endpoint for JMA Japan Bulletins CloudEvents on the `jma-japan` topic keyed by `{bulletin_id}`."
     }
   },
   "messagegroups": {
@@ -41,9 +42,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/jp.go.jma.jstruct/schemas/jp.go.jma.WeatherBulletin"
+          "dataschemauri": "#/schemagroups/jp.go.jma.jstruct/schemas/jp.go.jma.WeatherBulletin",
+          "description": "An official alert or bulletin from the Japan Meteorological Agency. It carries official bulletin messages for the affected area and validity period published by the upstream source."
         }
-      }
+      },
+      "description": "Events from JMA Japan Bulletins covering Japanese bulletin feeds. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     }
   },
   "schemagroups": {
@@ -75,7 +78,10 @@
                     "description": "Title of the weather bulletin in Japanese, e.g. '気象特別警報・警報・注意報' (Special weather warnings/advisories)."
                   },
                   "author": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Issuing authority name in Japanese, e.g. '気象庁' (JMA) or a regional observatory name like '松江地方気象台'."
                   },
                   "updated": {
@@ -83,11 +89,17 @@
                     "description": "UTC timestamp when the bulletin was last updated."
                   },
                   "link": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "URL to the full XML document for this bulletin on the JMA data server."
                   },
                   "content": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Brief text summary of the bulletin content in Japanese."
                   },
                   "feed_type": {
@@ -96,16 +108,25 @@
                     "enum": [
                       "regular",
                       "extra"
-                    ]
+                    ],
+                    "descriptions": {
+                      "regular": "Provider value `regular` for this coded alert field.",
+                      "extra": "Provider value `extra` for this coded alert field."
+                    }
                   }
                 },
                 "$id": "https://www.data.jma.go.jp/schemas/jp/go/jma/WeatherBulletin",
-                "description": "Weather bulletin entry from the JMA XML Atom feed. Covers forecasts, warnings, advisories, and risk notifications published by the Japan Meteorological Agency and its regional observatories."
+                "description": "An official alert or bulletin from the Japan Meteorological Agency. It carries official bulletin messages for the affected area and validity period published by the upstream source."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "JMA Japan Bulletins publishes official bulletin messages from the Japan Meteorological Agency for Japanese bulletin feeds. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for JMA Japan Bulletins, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/meteoalarm/EVENTS.md
+++ b/meteoalarm/EVENTS.md
@@ -1,6 +1,6 @@
 # Meteoalarm European Weather Warnings Bridge Events
 
-MQTT/5.0 transport variant for Meteoalarm CAP weather warnings. Non-retained QoS-1 warning events route by country feed slug, native CAP severity, normalized Meteoalarm awareness type, and CAP identifier under alerts/intl/meteoalarm/meteoalarm/... The awareness_type axis is derived from the Meteoalarm awareness_type parameter label and normalized for MQTT topic safety.
+Meteoalarm publishes official weather warnings from the European Meteoalarm network for European warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `Meteoalarm.WeatherWarning`
 
 #### What it tells you
 
-A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and hazard types. A severe weather warning from the EUMETNET Meteoalarm system.
+A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and hazard types.
 
 #### Identity
 
@@ -97,58 +97,58 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`awareness_type_raw`** (string, optional): Raw Meteoalarm awareness_type parameter value as provided by CAP, for example "2; Snow/Ice".
 ##### `status` values
 
-- `Actual`
-- `Exercise`
-- `System`
-- `Test`
-- `Draft`
+- `Actual`: Provider value `Actual` for this coded alert field.
+- `Exercise`: Provider value `Exercise` for this coded alert field.
+- `System`: Provider value `System` for this coded alert field.
+- `Test`: Provider value `Test` for this coded alert field.
+- `Draft`: Provider value `Draft` for this coded alert field.
 ##### `msg_type` values
 
-- `Alert`
-- `Update`
-- `Cancel`
-- `Ack`
-- `Error`
+- `Alert`: Provider value `Alert` for this coded alert field.
+- `Update`: Provider value `Update` for this coded alert field.
+- `Cancel`: Provider value `Cancel` for this coded alert field.
+- `Ack`: Provider value `Ack` for this coded alert field.
+- `Error`: Provider value `Error` for this coded alert field.
 ##### `scope` values
 
-- `Public`
-- `Restricted`
-- `Private`
+- `Public`: Provider value `Public` for this coded alert field.
+- `Restricted`: Provider value `Restricted` for this coded alert field.
+- `Private`: Provider value `Private` for this coded alert field.
 ##### `category` values
 
-- `Met`
-- `Geo`
-- `Safety`
-- `Security`
-- `Rescue`
-- `Fire`
-- `Health`
-- `Env`
-- `Transport`
-- `Infra`
-- `CBRNE`
-- `Other`
+- `Met`: Provider value `Met` for this coded alert field.
+- `Geo`: Provider value `Geo` for this coded alert field.
+- `Safety`: Provider value `Safety` for this coded alert field.
+- `Security`: Provider value `Security` for this coded alert field.
+- `Rescue`: Provider value `Rescue` for this coded alert field.
+- `Fire`: Provider value `Fire` for this coded alert field.
+- `Health`: Provider value `Health` for this coded alert field.
+- `Env`: Provider value `Env` for this coded alert field.
+- `Transport`: Provider value `Transport` for this coded alert field.
+- `Infra`: Provider value `Infra` for this coded alert field.
+- `CBRNE`: Provider value `CBRNE` for this coded alert field.
+- `Other`: Provider value `Other` for this coded alert field.
 ##### `severity` values
 
-- `Extreme`
-- `Severe`
-- `Moderate`
-- `Minor`
-- `Unknown`
+- `Extreme`: Provider value `Extreme` for this coded alert field.
+- `Severe`: Provider value `Severe` for this coded alert field.
+- `Moderate`: Provider value `Moderate` for this coded alert field.
+- `Minor`: Provider value `Minor` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `urgency` values
 
-- `Immediate`
-- `Expected`
-- `Future`
-- `Past`
-- `Unknown`
+- `Immediate`: Provider value `Immediate` for this coded alert field.
+- `Expected`: Provider value `Expected` for this coded alert field.
+- `Future`: Provider value `Future` for this coded alert field.
+- `Past`: Provider value `Past` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `certainty` values
 
-- `Observed`
-- `Likely`
-- `Possible`
-- `Unlikely`
-- `Unknown`
+- `Observed`: Provider value `Observed` for this coded alert field.
+- `Likely`: Provider value `Likely` for this coded alert field.
+- `Possible`: Provider value `Possible` for this coded alert field.
+- `Unlikely`: Provider value `Unlikely` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/meteoalarm/xreg/meteoalarm.xreg.json
+++ b/meteoalarm/xreg/meteoalarm.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/Meteoalarm.Warnings"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Meteoalarm CloudEvents on the `meteoalarm` topic keyed by `{identifier}`."
     },
     "Meteoalarm.Warnings.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Meteoalarm CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,10 +65,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/Meteoalarm.jstruct/schemas/Meteoalarm.WeatherWarning"
         }
-      }
+      },
+      "description": "Events from Meteoalarm covering European warning areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "Meteoalarm.Warnings.mqtt": {
-      "description": "MQTT/5.0 transport variant for Meteoalarm CAP weather warnings. Non-retained QoS-1 warning events route by country feed slug, native CAP severity, normalized Meteoalarm awareness type, and CAP identifier under alerts/intl/meteoalarm/meteoalarm/... The awareness_type axis is derived from the Meteoalarm awareness_type parameter label and normalized for MQTT topic safety.",
+      "description": "MQTT 5 variant of the Meteoalarm events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "Meteoalarm.Warnings.mqtt.WeatherWarning": {
           "name": "WeatherWarning",
@@ -97,7 +100,7 @@
                 "$id": "https://meteoalarm.org/schemas/Meteoalarm/WeatherWarning",
                 "name": "WeatherWarning",
                 "type": "object",
-                "description": "A severe weather warning from the EUMETNET Meteoalarm system. Contains CAP-structured alert data with awareness level and type, geographic area with EMMA/NUTS geocodes, and multilingual info blocks.",
+                "description": "A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and hazard types.",
                 "required": [
                   "identifier",
                   "sender",
@@ -135,7 +138,14 @@
                       "System",
                       "Test",
                       "Draft"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Actual": "Provider value `Actual` for this coded alert field.",
+                      "Exercise": "Provider value `Exercise` for this coded alert field.",
+                      "System": "Provider value `System` for this coded alert field.",
+                      "Test": "Provider value `Test` for this coded alert field.",
+                      "Draft": "Provider value `Draft` for this coded alert field."
+                    }
                   },
                   "msg_type": {
                     "type": "string",
@@ -149,6 +159,13 @@
                     ],
                     "altnames": {
                       "json": "msgType"
+                    },
+                    "descriptions": {
+                      "Alert": "Provider value `Alert` for this coded alert field.",
+                      "Update": "Provider value `Update` for this coded alert field.",
+                      "Cancel": "Provider value `Cancel` for this coded alert field.",
+                      "Ack": "Provider value `Ack` for this coded alert field.",
+                      "Error": "Provider value `Error` for this coded alert field."
                     }
                   },
                   "scope": {
@@ -158,7 +175,12 @@
                       "Public",
                       "Restricted",
                       "Private"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Public": "Provider value `Public` for this coded alert field.",
+                      "Restricted": "Provider value `Restricted` for this coded alert field.",
+                      "Private": "Provider value `Private` for this coded alert field."
+                    }
                   },
                   "country": {
                     "type": "string",
@@ -184,7 +206,21 @@
                       "Infra",
                       "CBRNE",
                       "Other"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Met": "Provider value `Met` for this coded alert field.",
+                      "Geo": "Provider value `Geo` for this coded alert field.",
+                      "Safety": "Provider value `Safety` for this coded alert field.",
+                      "Security": "Provider value `Security` for this coded alert field.",
+                      "Rescue": "Provider value `Rescue` for this coded alert field.",
+                      "Fire": "Provider value `Fire` for this coded alert field.",
+                      "Health": "Provider value `Health` for this coded alert field.",
+                      "Env": "Provider value `Env` for this coded alert field.",
+                      "Transport": "Provider value `Transport` for this coded alert field.",
+                      "Infra": "Provider value `Infra` for this coded alert field.",
+                      "CBRNE": "Provider value `CBRNE` for this coded alert field.",
+                      "Other": "Provider value `Other` for this coded alert field."
+                    }
                   },
                   "severity": {
                     "type": "string",
@@ -195,7 +231,14 @@
                       "Moderate",
                       "Minor",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Extreme": "Provider value `Extreme` for this coded alert field.",
+                      "Severe": "Provider value `Severe` for this coded alert field.",
+                      "Moderate": "Provider value `Moderate` for this coded alert field.",
+                      "Minor": "Provider value `Minor` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "urgency": {
                     "type": "string",
@@ -206,7 +249,14 @@
                       "Future",
                       "Past",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Immediate": "Provider value `Immediate` for this coded alert field.",
+                      "Expected": "Provider value `Expected` for this coded alert field.",
+                      "Future": "Provider value `Future` for this coded alert field.",
+                      "Past": "Provider value `Past` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "certainty": {
                     "type": "string",
@@ -217,7 +267,14 @@
                       "Possible",
                       "Unlikely",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Observed": "Provider value `Observed` for this coded alert field.",
+                      "Likely": "Provider value `Likely` for this coded alert field.",
+                      "Possible": "Provider value `Possible` for this coded alert field.",
+                      "Unlikely": "Provider value `Unlikely` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "headline": {
                     "type": "string",
@@ -282,5 +339,10 @@
         }
       }
     }
+  },
+  "description": "Meteoalarm publishes official weather warnings from the European Meteoalarm network for European warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Meteoalarm, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/nifc-usa-wildfires/EVENTS.md
+++ b/nifc-usa-wildfires/EVENTS.md
@@ -1,6 +1,6 @@
 # NIFC USA Wildfires - Active Wildfire Incident Feed Events
 
-**NIFC-USA-Wildfires** is a tool designed to interact with the [National Interagency Fire Center (NIFC)](https://www.nifc.gov/) ArcGIS Feature Service to fetch active wildfire incident data from the USA. The tool can list recent incidents or continuously poll the API to send wildfire events to a Kafka topic.
+NIFC USA Wildfires publishes wildfire incident status records from the U.S. National Interagency Fire Center for U.S. wildfire incidents. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 

--- a/nifc-usa-wildfires/xreg/nifc_usa_wildfires.xreg.json
+++ b/nifc-usa-wildfires/xreg/nifc_usa_wildfires.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/Gov.NIFC.Wildfires"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NIFC USA Wildfires CloudEvents on the `nifc-usa-wildfires` topic keyed by `{irwin_id}`."
     }
   },
   "messagegroups": {
@@ -49,7 +50,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/Gov.NIFC.Wildfires.jstruct/schemas/Gov.NIFC.Wildfires.WildfireIncident"
         }
-      }
+      },
+      "description": "Events from NIFC USA Wildfires covering U.S. wildfire incidents. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     }
   },
   "schemagroups": {
@@ -85,107 +87,185 @@
                               "description": "The name assigned to the wildfire incident (e.g. 'Pinnacle', 'Backbone')."
                             },
                             "unique_fire_identifier": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Unique fire identifier string assigned by the dispatching agency (e.g. '2025-ORRSF-000389'). May be null for incidents not yet assigned."
                             },
                             "incident_type_category": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Category of the incident type: WF (Wildfire), RX (Prescribed Fire), or other NWCG-defined categories."
                             },
                             "incident_type_kind": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Kind of incident from NWCG classification (e.g. 'FI' for Fire)."
                             },
                             "fire_discovery_datetime": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Date and time when the fire was first discovered, in ISO 8601 format. Converted from ArcGIS epoch milliseconds."
                             },
                             "daily_acres": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Most recently reported fire size in acres from the daily situation report."
                             },
                             "calculated_acres": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "GIS-calculated fire area in acres, derived from perimeter mapping when available."
                             },
                             "discovery_acres": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Size of the fire in acres at the time of initial discovery."
                             },
                             "percent_contained": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Percentage of the fire perimeter that is contained (0-100). Null if not reported."
                             },
                             "poo_state": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "US state or territory where the point of origin is located, as a two-letter code prefixed with 'US-' (e.g. 'US-OR', 'US-CA')."
                             },
                             "poo_county": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "County where the point of origin of the fire is located (e.g. 'Curry', 'Kings')."
                             },
                             "latitude": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Latitude of the fire incident point of origin in decimal degrees (WGS 84)."
                             },
                             "longitude": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Longitude of the fire incident point of origin in decimal degrees (WGS 84)."
                             },
                             "fire_cause": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "General cause of the fire (e.g. 'Natural', 'Human', 'Undetermined')."
                             },
                             "fire_cause_general": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Specific fire cause category when known (e.g. 'Lightning', 'Arson', 'Equipment Use')."
                             },
                             "gacc": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Geographic Area Coordination Center responsible for the incident (e.g. 'NWCC', 'OSCC', 'EACC'). GACCs coordinate wildfire management resources across regions."
                             },
                             "total_incident_personnel": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Total number of personnel assigned to the incident including all resources."
                             },
                             "incident_management_organization": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Name or type of the incident management organization or team managing the fire."
                             },
                             "fire_mgmt_complexity": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Complexity level of the fire management effort, typically a Type designation (e.g. 'Type 1' for the most complex)."
                             },
                             "residences_destroyed": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Number of residential structures destroyed by the fire."
                             },
                             "other_structures_destroyed": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Number of non-residential structures (outbuildings, commercial, etc.) destroyed by the fire."
                             },
                             "injuries": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Number of injuries reported in connection with the incident."
                             },
                             "fatalities": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Number of fatalities reported in connection with the incident."
                             },
                             "containment_datetime": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Date and time the fire was fully contained, in ISO 8601 format. Null if not yet contained."
                             },
                             "control_datetime": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Date and time the fire was declared under control, in ISO 8601 format. Null if not yet controlled."
                             },
                             "fire_out_datetime": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Date and time the fire was declared out, in ISO 8601 format. Null if the fire is still active."
                             },
                             "final_acres": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Final fire size in acres after the fire is declared out."
                             },
                             "modified_on_datetime": {
@@ -237,132 +317,210 @@
                   },
                   {
                     "name": "unique_fire_identifier",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Unique fire identifier string assigned by the dispatching agency."
                   },
                   {
                     "name": "incident_type_category",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Category of the incident type: WF (Wildfire), RX (Prescribed Fire), etc."
                   },
                   {
                     "name": "incident_type_kind",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Kind of incident from NWCG classification."
                   },
                   {
                     "name": "fire_discovery_datetime",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Date and time when the fire was first discovered, in ISO 8601 format."
                   },
                   {
                     "name": "daily_acres",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Most recently reported fire size in acres from the daily situation report."
                   },
                   {
                     "name": "calculated_acres",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "GIS-calculated fire area in acres."
                   },
                   {
                     "name": "discovery_acres",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Size of the fire in acres at the time of initial discovery."
                   },
                   {
                     "name": "percent_contained",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Percentage of the fire perimeter that is contained (0-100)."
                   },
                   {
                     "name": "poo_state",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "US state where the point of origin is located."
                   },
                   {
                     "name": "poo_county",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "County where the point of origin of the fire is located."
                   },
                   {
                     "name": "latitude",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Latitude of the fire incident point of origin in decimal degrees (WGS 84)."
                   },
                   {
                     "name": "longitude",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Longitude of the fire incident point of origin in decimal degrees (WGS 84)."
                   },
                   {
                     "name": "fire_cause",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "General cause of the fire."
                   },
                   {
                     "name": "fire_cause_general",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Specific fire cause category when known."
                   },
                   {
                     "name": "gacc",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Geographic Area Coordination Center responsible for the incident."
                   },
                   {
                     "name": "total_incident_personnel",
-                    "type": ["int", "null"],
+                    "type": [
+                      "int",
+                      "null"
+                    ],
                     "doc": "Total number of personnel assigned to the incident."
                   },
                   {
                     "name": "incident_management_organization",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Name or type of the incident management organization."
                   },
                   {
                     "name": "fire_mgmt_complexity",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Complexity level of the fire management effort."
                   },
                   {
                     "name": "residences_destroyed",
-                    "type": ["int", "null"],
+                    "type": [
+                      "int",
+                      "null"
+                    ],
                     "doc": "Number of residential structures destroyed by the fire."
                   },
                   {
                     "name": "other_structures_destroyed",
-                    "type": ["int", "null"],
+                    "type": [
+                      "int",
+                      "null"
+                    ],
                     "doc": "Number of non-residential structures destroyed by the fire."
                   },
                   {
                     "name": "injuries",
-                    "type": ["int", "null"],
+                    "type": [
+                      "int",
+                      "null"
+                    ],
                     "doc": "Number of injuries reported in connection with the incident."
                   },
                   {
                     "name": "fatalities",
-                    "type": ["int", "null"],
+                    "type": [
+                      "int",
+                      "null"
+                    ],
                     "doc": "Number of fatalities reported in connection with the incident."
                   },
                   {
                     "name": "containment_datetime",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Date and time the fire was fully contained, in ISO 8601 format."
                   },
                   {
                     "name": "control_datetime",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Date and time the fire was declared under control, in ISO 8601 format."
                   },
                   {
                     "name": "fire_out_datetime",
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "doc": "Date and time the fire was declared out, in ISO 8601 format."
                   },
                   {
                     "name": "final_acres",
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "doc": "Final fire size in acres after the fire is declared out."
                   },
                   {
@@ -370,12 +528,18 @@
                     "type": "string",
                     "doc": "Date and time when the incident record was last modified in the IRWIN system, in ISO 8601 format."
                   }
-                ]
+                ],
+                "description": "Payload for an incident update from the U.S. National Interagency Fire Center. It reports the current status, location, and classification for a wildfire or emergency incident."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "NIFC USA Wildfires publishes wildfire incident status records from the U.S. National Interagency Fire Center for U.S. wildfire incidents. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for NIFC USA Wildfires, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/nina-bbk/EVENTS.md
+++ b/nina-bbk/EVENTS.md
@@ -1,6 +1,6 @@
 # NINA/BBK German Civil Protection Warnings Bridge Events
 
-MQTT/5.0 transport variant for Germany NINA/BBK CAP warnings. Non-retained QoS-1 warning events route by German federal state, native CAP severity, and warning id under alerts/de/nina/nina-bbk/... The state axis is derived from CAP area administrative codes (warnVerwaltungsbereiche) with sender-code fallback.
+NINA BBK publishes civil-protection warnings from Germany's Federal Office of Civil Protection and Disaster Assistance (BBK) for German warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -96,66 +96,66 @@ Each event identifies the real-world resource with `{warning_id}`. `{warning_id}
 - **`state`** (string, required): German federal-state slug derived from CAP area administrative codes (warnVerwaltungsbereiche), with sender-code fallback. Matches the {state} MQTT topic axis.
 ##### `provider` values
 
-- `mowas`
-- `katwarn`
-- `biwapp`
-- `dwd`
-- `lhp`
-- `police`
+- `mowas`: Provider value `mowas` for this coded alert field.
+- `katwarn`: Provider value `katwarn` for this coded alert field.
+- `biwapp`: Provider value `biwapp` for this coded alert field.
+- `dwd`: Provider value `dwd` for this coded alert field.
+- `lhp`: Provider value `lhp` for this coded alert field.
+- `police`: Provider value `police` for this coded alert field.
 ##### `status` values
 
-- `Actual`
-- `Exercise`
-- `System`
-- `Test`
-- `Draft`
+- `Actual`: Provider value `Actual` for this coded alert field.
+- `Exercise`: Provider value `Exercise` for this coded alert field.
+- `System`: Provider value `System` for this coded alert field.
+- `Test`: Provider value `Test` for this coded alert field.
+- `Draft`: Provider value `Draft` for this coded alert field.
 ##### `msg_type` values
 
-- `Alert`
-- `Update`
-- `Cancel`
-- `Ack`
-- `Error`
+- `Alert`: Provider value `Alert` for this coded alert field.
+- `Update`: Provider value `Update` for this coded alert field.
+- `Cancel`: Provider value `Cancel` for this coded alert field.
+- `Ack`: Provider value `Ack` for this coded alert field.
+- `Error`: Provider value `Error` for this coded alert field.
 ##### `scope` values
 
-- `Public`
-- `Restricted`
-- `Private`
+- `Public`: Provider value `Public` for this coded alert field.
+- `Restricted`: Provider value `Restricted` for this coded alert field.
+- `Private`: Provider value `Private` for this coded alert field.
 ##### `category` values
 
-- `Met`
-- `Geo`
-- `Safety`
-- `Security`
-- `Rescue`
-- `Fire`
-- `Health`
-- `Env`
-- `Transport`
-- `Infra`
-- `CBRNE`
-- `Other`
+- `Met`: Provider value `Met` for this coded alert field.
+- `Geo`: Provider value `Geo` for this coded alert field.
+- `Safety`: Provider value `Safety` for this coded alert field.
+- `Security`: Provider value `Security` for this coded alert field.
+- `Rescue`: Provider value `Rescue` for this coded alert field.
+- `Fire`: Provider value `Fire` for this coded alert field.
+- `Health`: Provider value `Health` for this coded alert field.
+- `Env`: Provider value `Env` for this coded alert field.
+- `Transport`: Provider value `Transport` for this coded alert field.
+- `Infra`: Provider value `Infra` for this coded alert field.
+- `CBRNE`: Provider value `CBRNE` for this coded alert field.
+- `Other`: Provider value `Other` for this coded alert field.
 ##### `severity` values
 
-- `Extreme`
-- `Severe`
-- `Moderate`
-- `Minor`
-- `Unknown`
+- `Extreme`: Provider value `Extreme` for this coded alert field.
+- `Severe`: Provider value `Severe` for this coded alert field.
+- `Moderate`: Provider value `Moderate` for this coded alert field.
+- `Minor`: Provider value `Minor` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `urgency` values
 
-- `Immediate`
-- `Expected`
-- `Future`
-- `Past`
-- `Unknown`
+- `Immediate`: Provider value `Immediate` for this coded alert field.
+- `Expected`: Provider value `Expected` for this coded alert field.
+- `Future`: Provider value `Future` for this coded alert field.
+- `Past`: Provider value `Past` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `certainty` values
 
-- `Observed`
-- `Likely`
-- `Possible`
-- `Unlikely`
-- `Unknown`
+- `Observed`: Provider value `Observed` for this coded alert field.
+- `Likely`: Provider value `Likely` for this coded alert field.
+- `Possible`: Provider value `Possible` for this coded alert field.
+- `Unlikely`: Provider value `Unlikely` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/nina-bbk/xreg/nina_bbk.xreg.json
+++ b/nina-bbk/xreg/nina_bbk.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NINA.Warnings"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NINA BBK CloudEvents on the `nina-bbk` topic keyed by `{warning_id}`."
     },
     "NINA.Warnings.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for NINA BBK CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,10 +65,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NINA.jstruct/schemas/NINA.CivilWarning"
         }
-      }
+      },
+      "description": "Events from NINA BBK covering German warning areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "NINA.Warnings.mqtt": {
-      "description": "MQTT/5.0 transport variant for Germany NINA/BBK CAP warnings. Non-retained QoS-1 warning events route by German federal state, native CAP severity, and warning id under alerts/de/nina/nina-bbk/... The state axis is derived from CAP area administrative codes (warnVerwaltungsbereiche) with sender-code fallback.",
+      "description": "MQTT 5 variant of the NINA BBK events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "NINA.Warnings.mqtt.CivilWarning": {
           "name": "CivilWarning",
@@ -97,7 +100,7 @@
                 "$id": "https://warnung.bund.de/schemas/NINA/CivilWarning",
                 "name": "CivilWarning",
                 "type": "object",
-                "description": "A civil protection warning from Germany's NINA/BBK system. Contains CAP-structured alert data with multi-language info blocks, BBK event codes, and German administrative area geocodes (Verwaltungsbereiche).",
+                "description": "A civil protection warning from Germany's NINA/BBK warning system. Aggregates warnings from MOWAS (federal), KATWARN (municipal), BIWAPP (municipal), DWD (weather service), LHP (flood centers), and police services. Each warning follows the CAP (Common Alerting Protocol) structure with multi-language support.",
                 "required": [
                   "warning_id",
                   "provider",
@@ -127,7 +130,15 @@
                       "dwd",
                       "lhp",
                       "police"
-                    ]
+                    ],
+                    "descriptions": {
+                      "mowas": "Provider value `mowas` for this coded alert field.",
+                      "katwarn": "Provider value `katwarn` for this coded alert field.",
+                      "biwapp": "Provider value `biwapp` for this coded alert field.",
+                      "dwd": "Provider value `dwd` for this coded alert field.",
+                      "lhp": "Provider value `lhp` for this coded alert field.",
+                      "police": "Provider value `police` for this coded alert field."
+                    }
                   },
                   "version": {
                     "type": "integer",
@@ -154,7 +165,14 @@
                       "System",
                       "Test",
                       "Draft"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Actual": "Provider value `Actual` for this coded alert field.",
+                      "Exercise": "Provider value `Exercise` for this coded alert field.",
+                      "System": "Provider value `System` for this coded alert field.",
+                      "Test": "Provider value `Test` for this coded alert field.",
+                      "Draft": "Provider value `Draft` for this coded alert field."
+                    }
                   },
                   "msg_type": {
                     "type": "string",
@@ -168,6 +186,13 @@
                     ],
                     "altnames": {
                       "json": "msgType"
+                    },
+                    "descriptions": {
+                      "Alert": "Provider value `Alert` for this coded alert field.",
+                      "Update": "Provider value `Update` for this coded alert field.",
+                      "Cancel": "Provider value `Cancel` for this coded alert field.",
+                      "Ack": "Provider value `Ack` for this coded alert field.",
+                      "Error": "Provider value `Error` for this coded alert field."
                     }
                   },
                   "scope": {
@@ -177,7 +202,12 @@
                       "Public",
                       "Restricted",
                       "Private"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Public": "Provider value `Public` for this coded alert field.",
+                      "Restricted": "Provider value `Restricted` for this coded alert field.",
+                      "Private": "Provider value `Private` for this coded alert field."
+                    }
                   },
                   "references": {
                     "type": "string",
@@ -207,7 +237,21 @@
                       "Infra",
                       "CBRNE",
                       "Other"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Met": "Provider value `Met` for this coded alert field.",
+                      "Geo": "Provider value `Geo` for this coded alert field.",
+                      "Safety": "Provider value `Safety` for this coded alert field.",
+                      "Security": "Provider value `Security` for this coded alert field.",
+                      "Rescue": "Provider value `Rescue` for this coded alert field.",
+                      "Fire": "Provider value `Fire` for this coded alert field.",
+                      "Health": "Provider value `Health` for this coded alert field.",
+                      "Env": "Provider value `Env` for this coded alert field.",
+                      "Transport": "Provider value `Transport` for this coded alert field.",
+                      "Infra": "Provider value `Infra` for this coded alert field.",
+                      "CBRNE": "Provider value `CBRNE` for this coded alert field.",
+                      "Other": "Provider value `Other` for this coded alert field."
+                    }
                   },
                   "severity": {
                     "type": "string",
@@ -218,7 +262,14 @@
                       "Moderate",
                       "Minor",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Extreme": "Provider value `Extreme` for this coded alert field.",
+                      "Severe": "Provider value `Severe` for this coded alert field.",
+                      "Moderate": "Provider value `Moderate` for this coded alert field.",
+                      "Minor": "Provider value `Minor` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "urgency": {
                     "type": "string",
@@ -229,7 +280,14 @@
                       "Future",
                       "Past",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Immediate": "Provider value `Immediate` for this coded alert field.",
+                      "Expected": "Provider value `Expected` for this coded alert field.",
+                      "Future": "Provider value `Future` for this coded alert field.",
+                      "Past": "Provider value `Past` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "certainty": {
                     "type": "string",
@@ -240,7 +298,14 @@
                       "Possible",
                       "Unlikely",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Observed": "Provider value `Observed` for this coded alert field.",
+                      "Likely": "Provider value `Likely` for this coded alert field.",
+                      "Possible": "Provider value `Possible` for this coded alert field.",
+                      "Unlikely": "Provider value `Unlikely` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "headline": {
                     "type": "string",
@@ -285,5 +350,10 @@
         }
       }
     }
+  },
+  "description": "NINA BBK publishes civil-protection warnings from Germany's Federal Office of Civil Protection and Disaster Assistance (BBK) for German warning areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for NINA BBK, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/nws-alerts/EVENTS.md
+++ b/nws-alerts/EVENTS.md
@@ -1,6 +1,6 @@
 # NWS CAP Weather Alerts Bridge Events
 
-MQTT/5.0 mirror of NWS CAP weather alerts, published into the Unified-Namespace topic tree 'alerts/us/noaa/nws-alerts/{state}/<severity>/{event_type}/{alert_id}/alert'. CAP severity is baked as one of five literal sub-tree partitions (minor, moderate, severe, extreme, unknown) so every template placeholder resolves from an enriched WeatherAlert schema field. Alerts are QoS-1 non-retained one-shot lifecycle events.
+NWS Alerts publishes CAP weather watches, warnings, advisories, and updates from the U.S. National Weather Service for U.S. weather alert areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `NWS.WeatherAlert`
 
 #### What it tells you
 
-A weather or non-weather alert from the US National Weather Service, distributed through the Integrated Public Alert and Warning System (IPAWS). Follows the CAP (Common Alerting Protocol) standard. A weather or non-weather alert from the US National Weather Service (NWS/NOAA).
+A weather or non-weather alert from the US National Weather Service, distributed through the Integrated Public Alert and Warning System (IPAWS). Follows the CAP (Common Alerting Protocol) standard.
 
 #### Identity
 
@@ -104,39 +104,39 @@ Each event identifies the real-world resource with `{alert_id}`. `{alert_id}` is
 - **`event_type`** (string, required): Lowercase kebab-case slug derived from the CAP event field for topic partitioning.
 ##### `status` values
 
-- `Actual`
-- `Exercise`
-- `System`
-- `Test`
-- `Draft`
+- `Actual`: Provider value `Actual` for this coded alert field.
+- `Exercise`: Provider value `Exercise` for this coded alert field.
+- `System`: Provider value `System` for this coded alert field.
+- `Test`: Provider value `Test` for this coded alert field.
+- `Draft`: Provider value `Draft` for this coded alert field.
 ##### `message_type` values
 
-- `Alert`
-- `Update`
-- `Cancel`
-- `Ack`
-- `Error`
+- `Alert`: Provider value `Alert` for this coded alert field.
+- `Update`: Provider value `Update` for this coded alert field.
+- `Cancel`: Provider value `Cancel` for this coded alert field.
+- `Ack`: Provider value `Ack` for this coded alert field.
+- `Error`: Provider value `Error` for this coded alert field.
 ##### `severity` values
 
-- `Extreme`
-- `Severe`
-- `Moderate`
-- `Minor`
-- `Unknown`
+- `Extreme`: Provider value `Extreme` for this coded alert field.
+- `Severe`: Provider value `Severe` for this coded alert field.
+- `Moderate`: Provider value `Moderate` for this coded alert field.
+- `Minor`: Provider value `Minor` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `certainty` values
 
-- `Observed`
-- `Likely`
-- `Possible`
-- `Unlikely`
-- `Unknown`
+- `Observed`: Provider value `Observed` for this coded alert field.
+- `Likely`: Provider value `Likely` for this coded alert field.
+- `Possible`: Provider value `Possible` for this coded alert field.
+- `Unlikely`: Provider value `Unlikely` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 ##### `urgency` values
 
-- `Immediate`
-- `Expected`
-- `Future`
-- `Past`
-- `Unknown`
+- `Immediate`: Provider value `Immediate` for this coded alert field.
+- `Expected`: Provider value `Expected` for this coded alert field.
+- `Future`: Provider value `Future` for this coded alert field.
+- `Past`: Provider value `Past` for this coded alert field.
+- `Unknown`: Provider value `Unknown` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/nws-alerts/xreg/nws_alerts.xreg.json
+++ b/nws-alerts/xreg/nws_alerts.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NWS.Alerts"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NWS Alerts CloudEvents on the `nws-alerts` topic keyed by `{alert_id}`."
     },
     "NWS.Alerts.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NWS.Alerts.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for NWS Alerts CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -65,10 +67,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NWS.jstruct/schemas/NWS.WeatherAlert"
         }
-      }
+      },
+      "description": "Events from NWS Alerts covering U.S. weather alert areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "NWS.Alerts.mqtt": {
-      "description": "MQTT/5.0 mirror of NWS CAP weather alerts, published into the Unified-Namespace topic tree 'alerts/us/noaa/nws-alerts/{state}/<severity>/{event_type}/{alert_id}/alert'. CAP severity is baked as one of five literal sub-tree partitions (minor, moderate, severe, extreme, unknown) so every template placeholder resolves from an enriched WeatherAlert schema field. Alerts are QoS-1 non-retained one-shot lifecycle events.",
+      "description": "MQTT 5 variant of the NWS Alerts events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "NWS.WeatherAlert.Minor.mqtt": {
           "name": "WeatherAlertMinor",
@@ -139,7 +142,7 @@
                 "$id": "https://api.weather.gov/schemas/NWS/WeatherAlert",
                 "name": "WeatherAlert",
                 "type": "object",
-                "description": "A weather or non-weather alert from the US National Weather Service (NWS/NOAA). Contains full CAP properties including severity, urgency, certainty, VTEC codes for event tracking, and UGC/SAME zone geocodes.",
+                "description": "A weather or non-weather alert from the US National Weather Service, distributed through the Integrated Public Alert and Warning System (IPAWS). Follows the CAP (Common Alerting Protocol) standard.",
                 "required": [
                   "alert_id",
                   "event",
@@ -204,7 +207,14 @@
                       "System",
                       "Test",
                       "Draft"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Actual": "Provider value `Actual` for this coded alert field.",
+                      "Exercise": "Provider value `Exercise` for this coded alert field.",
+                      "System": "Provider value `System` for this coded alert field.",
+                      "Test": "Provider value `Test` for this coded alert field.",
+                      "Draft": "Provider value `Draft` for this coded alert field."
+                    }
                   },
                   "message_type": {
                     "type": "string",
@@ -218,6 +228,13 @@
                     ],
                     "altnames": {
                       "json": "messageType"
+                    },
+                    "descriptions": {
+                      "Alert": "Provider value `Alert` for this coded alert field.",
+                      "Update": "Provider value `Update` for this coded alert field.",
+                      "Cancel": "Provider value `Cancel` for this coded alert field.",
+                      "Ack": "Provider value `Ack` for this coded alert field.",
+                      "Error": "Provider value `Error` for this coded alert field."
                     }
                   },
                   "category": {
@@ -233,7 +250,14 @@
                       "Moderate",
                       "Minor",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Extreme": "Provider value `Extreme` for this coded alert field.",
+                      "Severe": "Provider value `Severe` for this coded alert field.",
+                      "Moderate": "Provider value `Moderate` for this coded alert field.",
+                      "Minor": "Provider value `Minor` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "certainty": {
                     "type": "string",
@@ -244,7 +268,14 @@
                       "Possible",
                       "Unlikely",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Observed": "Provider value `Observed` for this coded alert field.",
+                      "Likely": "Provider value `Likely` for this coded alert field.",
+                      "Possible": "Provider value `Possible` for this coded alert field.",
+                      "Unlikely": "Provider value `Unlikely` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "urgency": {
                     "type": "string",
@@ -255,7 +286,14 @@
                       "Future",
                       "Past",
                       "Unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Immediate": "Provider value `Immediate` for this coded alert field.",
+                      "Expected": "Provider value `Expected` for this coded alert field.",
+                      "Future": "Provider value `Future` for this coded alert field.",
+                      "Past": "Provider value `Past` for this coded alert field.",
+                      "Unknown": "Provider value `Unknown` for this coded alert field."
+                    }
                   },
                   "event": {
                     "type": "string",
@@ -323,5 +361,10 @@
         }
       }
     }
+  },
+  "description": "NWS Alerts publishes CAP weather watches, warnings, advisories, and updates from the U.S. National Weather Service for U.S. weather alert areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for NWS Alerts, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/ptwc-tsunami/EVENTS.md
+++ b/ptwc-tsunami/EVENTS.md
@@ -1,6 +1,6 @@
 # PTWC/NTWC Tsunami Bulletins Bridge Events
 
-MQTT/5.0 transport variant for tsunami.gov PTWC/NTWC tsunami bulletins. Non-retained QoS-1 bulletin events route by basin, tsunami bulletin level, and bulletin id under alerts/intl/ptwc/ptwc-tsunami/... Basin is derived from the NOAA feed (PHEB=pacific, PAAQ=alaska); ptwc_level is the native bulletin category normalized to lowercase.
+PTWC Tsunami publishes tsunami bulletins from the Pacific Tsunami Warning Center for ocean basins and tsunami bulletin areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `PTWC.TsunamiBulletin`
 
 #### What it tells you
 
-A tsunami bulletin from the US National Tsunami Warning Center (NTWC) or the Pacific Tsunami Warning Center (PTWC). Bulletins indicate seismic events and their tsunami threat assessment, parsed from the NOAA Atom feeds at tsunami.gov. Contains seismic event details and tsunami threat assessment parsed from NOAA Atom feeds.
+A tsunami bulletin from the US National Tsunami Warning Center (NTWC) or the Pacific Tsunami Warning Center (PTWC). Bulletins indicate seismic events and their tsunami threat assessment, parsed from the NOAA Atom feeds at tsunami.gov.
 
 #### Identity
 
@@ -86,26 +86,26 @@ Each event identifies the real-world resource with `{bulletin_id}`. `{bulletin_i
 - **`ptwc_level`** (enum, required): Native tsunami bulletin category normalized to lowercase for MQTT routing. Matches the {ptwc_level} MQTT topic axis.
 ##### `feed` values
 
-- `PAAQ`
-- `PHEB`
+- `PAAQ`: Provider value `PAAQ` for this coded alert field.
+- `PHEB`: Provider value `PHEB` for this coded alert field.
 ##### `category` values
 
-- `Warning`
-- `Advisory`
-- `Watch`
-- `Information`
+- `Warning`: Provider value `Warning` for this coded alert field.
+- `Advisory`: Provider value `Advisory` for this coded alert field.
+- `Watch`: Provider value `Watch` for this coded alert field.
+- `Information`: Provider value `Information` for this coded alert field.
 ##### `basin` values
 
-- `pacific`
-- `alaska`
-- `unknown`
+- `pacific`: Provider value `pacific` for this coded alert field.
+- `alaska`: Provider value `alaska` for this coded alert field.
+- `unknown`: Provider value `unknown` for this coded alert field.
 ##### `ptwc_level` values
 
-- `warning`
-- `advisory`
-- `watch`
-- `information`
-- `unknown`
+- `warning`: Provider value `warning` for this coded alert field.
+- `advisory`: Provider value `advisory` for this coded alert field.
+- `watch`: Provider value `watch` for this coded alert field.
+- `information`: Provider value `information` for this coded alert field.
+- `unknown`: Provider value `unknown` for this coded alert field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/ptwc-tsunami/xreg/ptwc_tsunami.xreg.json
+++ b/ptwc-tsunami/xreg/ptwc_tsunami.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/PTWC.Bulletins"
-      ]
+      ],
+      "description": "Kafka producer endpoint for PTWC Tsunami CloudEvents on the `ptwc-tsunami` topic keyed by `{bulletin_id}`."
     },
     "PTWC.Bulletins.Mqtt": {
       "usage": [
@@ -38,7 +39,8 @@
         {
           "uri": "mqtt://localhost:1883"
         }
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for PTWC Tsunami CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,10 +65,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/PTWC.jstruct/schemas/PTWC.TsunamiBulletin"
         }
-      }
+      },
+      "description": "Events from PTWC Tsunami covering ocean basins and tsunami bulletin areas. Alert and incident records describe the current upstream hazard state and update when the provider changes that state."
     },
     "PTWC.Bulletins.mqtt": {
-      "description": "MQTT/5.0 transport variant for tsunami.gov PTWC/NTWC tsunami bulletins. Non-retained QoS-1 bulletin events route by basin, tsunami bulletin level, and bulletin id under alerts/intl/ptwc/ptwc-tsunami/... Basin is derived from the NOAA feed (PHEB=pacific, PAAQ=alaska); ptwc_level is the native bulletin category normalized to lowercase.",
+      "description": "MQTT 5 variant of the PTWC Tsunami events. It carries the same alert semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "PTWC.Bulletins.mqtt.TsunamiBulletin": {
           "name": "TsunamiBulletin",
@@ -97,7 +100,7 @@
                 "$id": "https://www.tsunami.gov/schemas/PTWC/TsunamiBulletin",
                 "name": "TsunamiBulletin",
                 "type": "object",
-                "description": "A tsunami bulletin from the US National Tsunami Warning Center (NTWC) or the Pacific Tsunami Warning Center (PTWC). Contains seismic event details and tsunami threat assessment parsed from NOAA Atom feeds.",
+                "description": "A tsunami bulletin from the US National Tsunami Warning Center (NTWC) or the Pacific Tsunami Warning Center (PTWC). Bulletins indicate seismic events and their tsunami threat assessment, parsed from the NOAA Atom feeds at tsunami.gov.",
                 "required": [
                   "bulletin_id",
                   "title",
@@ -117,7 +120,11 @@
                     "enum": [
                       "PAAQ",
                       "PHEB"
-                    ]
+                    ],
+                    "descriptions": {
+                      "PAAQ": "Provider value `PAAQ` for this coded alert field.",
+                      "PHEB": "Provider value `PHEB` for this coded alert field."
+                    }
                   },
                   "center": {
                     "type": "string",
@@ -147,7 +154,13 @@
                       "Advisory",
                       "Watch",
                       "Information"
-                    ]
+                    ],
+                    "descriptions": {
+                      "Warning": "Provider value `Warning` for this coded alert field.",
+                      "Advisory": "Provider value `Advisory` for this coded alert field.",
+                      "Watch": "Provider value `Watch` for this coded alert field.",
+                      "Information": "Provider value `Information` for this coded alert field."
+                    }
                   },
                   "magnitude": {
                     "type": "string",
@@ -176,7 +189,12 @@
                       "pacific",
                       "alaska",
                       "unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "pacific": "Provider value `pacific` for this coded alert field.",
+                      "alaska": "Provider value `alaska` for this coded alert field.",
+                      "unknown": "Provider value `unknown` for this coded alert field."
+                    }
                   },
                   "ptwc_level": {
                     "type": "string",
@@ -187,7 +205,14 @@
                       "watch",
                       "information",
                       "unknown"
-                    ]
+                    ],
+                    "descriptions": {
+                      "warning": "Provider value `warning` for this coded alert field.",
+                      "advisory": "Provider value `advisory` for this coded alert field.",
+                      "watch": "Provider value `watch` for this coded alert field.",
+                      "information": "Provider value `information` for this coded alert field.",
+                      "unknown": "Provider value `unknown` for this coded alert field."
+                    }
                   }
                 }
               }
@@ -196,5 +221,10 @@
         }
       }
     }
+  },
+  "description": "PTWC Tsunami publishes tsunami bulletins from the Pacific Tsunami Warning Center for ocean basins and tsunami bulletin areas. These events help consumers monitor hazards, route notifications, and correlate public-warning updates without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for PTWC Tsunami, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites xRegistry descriptions for Batch C alerts, emergencies, wildfire, seismic, and warning sources.
- Updates human-facing descriptions and regenerated EVENTS.md only.
- Keeps source schemas, identifiers, topics, and CloudEvents metadata unchanged.

## Validation
- Regenerated each Batch C source with `pwsh .\tools\generate-events-md.ps1 -Source <source>`.
- Spot-checked generated Meteoalarm and GraceDB EVENTS.md openings and first event entries.

## Sources
nws-alerts, meteoalarm, gdacs, eaws-albina, ptwc-tsunami, nina-bbk, australia-wildfires, gracedb, nifc-usa-wildfires, inpe-deter-brazil, jma-bosai-quake, jma-bosai-volcano, jma-bosai-warning, jma-japan.