### PR TITLE
docs(xreg): improve descriptions — batch D transport/mobility

### DIFF
--- a/aisstream/EVENTS.md
+++ b/aisstream/EVENTS.md
@@ -1,6 +1,6 @@
 # AISstream.io Bridge Usage Guide Events
 
-**AISstream.io Bridge** connects to the AISstream.io WebSocket API for real-time global AIS vessel tracking and forwards decoded messages to a Kafka topic as [CloudEvents](https://cloudevents.io/) in JSON format.
+AISStream publishes vessel position, voyage, safety, and static AIS messages from AISStream public AIS firehose for AIS-equipped vessels received by the AISStream network. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -51,7 +51,7 @@ CloudEvents type: `IO.AISstream.PositionReport`
 
 #### What it tells you
 
-This event carries position report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -67,23 +67,23 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Position Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`NavigationalStatus`** (int32, optional): No description provided.
-- **`RateOfTurn`** (int32, optional): No description provided.
-- **`Sog`** (double, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Cog`** (double, optional): No description provided.
-- **`TrueHeading`** (int32, optional): No description provided.
-- **`Timestamp`** (int32, optional): No description provided.
-- **`SpecialManoeuvreIndicator`** (int32, optional): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`CommunicationState`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`NavigationalStatus`** (int32, optional): Provider field for navigational status in this record.
+- **`RateOfTurn`** (int32, optional): Provider field for rate of turn in this record.
+- **`Sog`** (double, optional): Provider field for sog in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Cog`** (double, optional): Provider field for cog in this record.
+- **`TrueHeading`** (int32, optional): Provider field for true heading in this record.
+- **`Timestamp`** (int32, optional): Time when the provider recorded or published the update.
+- **`SpecialManoeuvreIndicator`** (int32, optional): Provider field for special manoeuvre indicator in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`CommunicationState`** (int32, optional): Provider field for communication state in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -120,7 +120,7 @@ CloudEvents type: `IO.AISstream.ShipStaticData`
 
 #### What it tells you
 
-This event carries ship static data data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -136,40 +136,40 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Ship Static Data` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`AisVersion`** (int32, optional): No description provided.
-- **`ImoNumber`** (int32, optional): No description provided.
-- **`CallSign`** (string, optional): No description provided.
-- **`Name`** (string, optional): No description provided.
-- **`Type`** (int32, optional): No description provided.
-- **`Dimension`** (object, optional): No description provided. See [Dimension](#payload-io-aisstream-shipstaticdata-dimension).
-- **`FixType`** (int32, optional): No description provided.
-- **`Eta`** (object, optional): No description provided. See [Eta](#payload-io-aisstream-shipstaticdata-eta).
-- **`MaximumStaticDraught`** (double, optional): No description provided.
-- **`Destination`** (string, optional): No description provided.
-- **`Dte`** (boolean, optional): No description provided.
-- **`Spare`** (boolean, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`AisVersion`** (int32, optional): Provider field for ais version in this record.
+- **`ImoNumber`** (int32, optional): Provider field for imo number in this record.
+- **`CallSign`** (string, optional): Provider field for call sign in this record.
+- **`Name`** (string, optional): Human-readable name of the resource.
+- **`Type`** (int32, optional): Provider field for type in this record.
+- **`Dimension`** (object, optional): Provider field for dimension in this record. See [Dimension](#payload-io-aisstream-shipstaticdata-dimension).
+- **`FixType`** (int32, optional): Provider field for fix type in this record.
+- **`Eta`** (object, optional): Provider field for eta in this record. See [Eta](#payload-io-aisstream-shipstaticdata-eta).
+- **`MaximumStaticDraught`** (double, optional): Provider field for maximum static draught in this record.
+- **`Destination`** (string, optional): Provider field for destination in this record.
+- **`Dte`** (boolean, optional): Provider field for dte in this record.
+- **`Spare`** (boolean, optional): Provider field for spare in this record.
 ##### Dimension
 <a id="payload-io-aisstream-shipstaticdata-dimension"></a>
 
-Nested record.
+Provider field for dimension in this record.
 
-- **`A`** (int32, required): No description provided.
-- **`B`** (int32, required): No description provided.
-- **`C`** (int32, required): No description provided.
-- **`D`** (int32, required): No description provided.
+- **`A`** (int32, required): Provider field for a in this record.
+- **`B`** (int32, required): Provider field for b in this record.
+- **`C`** (int32, required): Provider field for c in this record.
+- **`D`** (int32, required): Provider field for d in this record.
 ##### Eta
 <a id="payload-io-aisstream-shipstaticdata-eta"></a>
 
-Nested record.
+Provider field for eta in this record.
 
-- **`Month`** (int32, required): No description provided.
-- **`Day`** (int32, required): No description provided.
-- **`Hour`** (int32, required): No description provided.
-- **`Minute`** (int32, required): No description provided.
+- **`Month`** (int32, required): Provider field for month in this record.
+- **`Day`** (int32, required): Provider field for day in this record.
+- **`Hour`** (int32, required): Provider field for hour in this record.
+- **`Minute`** (int32, required): Provider field for minute in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -215,7 +215,7 @@ CloudEvents type: `IO.AISstream.StandardClassBPositionReport`
 
 #### What it tells you
 
-This event carries standard class bposition report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -231,28 +231,28 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Standard Class Bposition Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`Sog`** (double, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Cog`** (double, optional): No description provided.
-- **`TrueHeading`** (int32, optional): No description provided.
-- **`Timestamp`** (int32, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`ClassBUnit`** (boolean, optional): No description provided.
-- **`ClassBDisplay`** (boolean, optional): No description provided.
-- **`ClassBDsc`** (boolean, optional): No description provided.
-- **`ClassBBand`** (boolean, optional): No description provided.
-- **`ClassBMsg22`** (boolean, optional): No description provided.
-- **`AssignedMode`** (boolean, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`CommunicationStateIsItdma`** (boolean, optional): No description provided.
-- **`CommunicationState`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`Sog`** (double, optional): Provider field for sog in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Cog`** (double, optional): Provider field for cog in this record.
+- **`TrueHeading`** (int32, optional): Provider field for true heading in this record.
+- **`Timestamp`** (int32, optional): Time when the provider recorded or published the update.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`ClassBUnit`** (boolean, optional): Provider field for class b unit in this record.
+- **`ClassBDisplay`** (boolean, optional): Provider field for class b display in this record.
+- **`ClassBDsc`** (boolean, optional): Provider field for class b dsc in this record.
+- **`ClassBBand`** (boolean, optional): Provider field for class b band in this record.
+- **`ClassBMsg22`** (boolean, optional): Provider field for class b msg22 in this record.
+- **`AssignedMode`** (boolean, optional): Provider field for assigned mode in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`CommunicationStateIsItdma`** (boolean, optional): Provider field for communication state is itdma in this record.
+- **`CommunicationState`** (int32, optional): Provider field for communication state in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -294,7 +294,7 @@ CloudEvents type: `IO.AISstream.ExtendedClassBPositionReport`
 
 #### What it tells you
 
-This event carries extended class bposition report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -310,36 +310,36 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Extended Class Bposition Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`Sog`** (double, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Cog`** (double, optional): No description provided.
-- **`TrueHeading`** (int32, optional): No description provided.
-- **`Timestamp`** (int32, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`Name`** (string, optional): No description provided.
-- **`Type`** (int32, optional): No description provided.
-- **`Dimension`** (object, optional): No description provided. See [Dimension](#payload-io-aisstream-extendedclassbpositionreport-dimension).
-- **`FixType`** (int32, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`Dte`** (boolean, optional): No description provided.
-- **`AssignedMode`** (boolean, optional): No description provided.
-- **`Spare3`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`Sog`** (double, optional): Provider field for sog in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Cog`** (double, optional): Provider field for cog in this record.
+- **`TrueHeading`** (int32, optional): Provider field for true heading in this record.
+- **`Timestamp`** (int32, optional): Time when the provider recorded or published the update.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`Name`** (string, optional): Human-readable name of the resource.
+- **`Type`** (int32, optional): Provider field for type in this record.
+- **`Dimension`** (object, optional): Provider field for dimension in this record. See [Dimension](#payload-io-aisstream-extendedclassbpositionreport-dimension).
+- **`FixType`** (int32, optional): Provider field for fix type in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`Dte`** (boolean, optional): Provider field for dte in this record.
+- **`AssignedMode`** (boolean, optional): Provider field for assigned mode in this record.
+- **`Spare3`** (int32, optional): Provider field for spare3 in this record.
 ##### Dimension
 <a id="payload-io-aisstream-extendedclassbpositionreport-dimension"></a>
 
-Nested record.
+Provider field for dimension in this record.
 
-- **`A`** (int32, required): No description provided.
-- **`B`** (int32, required): No description provided.
-- **`C`** (int32, required): No description provided.
-- **`D`** (int32, required): No description provided.
+- **`A`** (int32, required): Provider field for a in this record.
+- **`B`** (int32, required): Provider field for b in this record.
+- **`C`** (int32, required): Provider field for c in this record.
+- **`D`** (int32, required): Provider field for d in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -385,7 +385,7 @@ CloudEvents type: `IO.AISstream.AidsToNavigationReport`
 
 #### What it tells you
 
-This event carries aids to navigation report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -401,34 +401,34 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Aids To Navigation Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Type`** (int32, optional): No description provided.
-- **`Name`** (string, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Dimension`** (object, optional): No description provided. See [Dimension](#payload-io-aisstream-aidstonavigationreport-dimension).
-- **`Fixtype`** (int32, optional): No description provided.
-- **`Timestamp`** (int32, optional): No description provided.
-- **`OffPosition`** (boolean, optional): No description provided.
-- **`AtoN`** (int32, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`VirtualAtoN`** (boolean, optional): No description provided.
-- **`AssignedMode`** (boolean, optional): No description provided.
-- **`Spare`** (boolean, optional): No description provided.
-- **`NameExtension`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Type`** (int32, optional): Provider field for type in this record.
+- **`Name`** (string, optional): Human-readable name of the resource.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Dimension`** (object, optional): Provider field for dimension in this record. See [Dimension](#payload-io-aisstream-aidstonavigationreport-dimension).
+- **`Fixtype`** (int32, optional): Provider field for fixtype in this record.
+- **`Timestamp`** (int32, optional): Time when the provider recorded or published the update.
+- **`OffPosition`** (boolean, optional): Provider field for off position in this record.
+- **`AtoN`** (int32, optional): Provider field for ato n in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`VirtualAtoN`** (boolean, optional): Provider field for virtual ato n in this record.
+- **`AssignedMode`** (boolean, optional): Provider field for assigned mode in this record.
+- **`Spare`** (boolean, optional): Provider field for spare in this record.
+- **`NameExtension`** (string, optional): Provider field for name extension in this record.
 ##### Dimension
 <a id="payload-io-aisstream-aidstonavigationreport-dimension"></a>
 
-Nested record.
+Provider field for dimension in this record.
 
-- **`A`** (int32, required): No description provided.
-- **`B`** (int32, required): No description provided.
-- **`C`** (int32, required): No description provided.
-- **`D`** (int32, required): No description provided.
+- **`A`** (int32, required): Provider field for a in this record.
+- **`B`** (int32, required): Provider field for b in this record.
+- **`C`** (int32, required): Provider field for c in this record.
+- **`D`** (int32, required): Provider field for d in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -472,7 +472,7 @@ CloudEvents type: `IO.AISstream.StaticDataReport`
 
 #### What it tells you
 
-This event carries static data report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -488,44 +488,44 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Static Data Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Reserved`** (int32, optional): No description provided.
-- **`PartNumber`** (boolean, optional): No description provided.
-- **`ReportA`** (object, optional): No description provided. See [ReportA](#payload-io-aisstream-staticdatareport-reporta).
-- **`ReportB`** (object, optional): No description provided. See [ReportB](#payload-io-aisstream-staticdatareport-reportb).
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Reserved`** (int32, optional): Provider field for reserved in this record.
+- **`PartNumber`** (boolean, optional): Provider field for part number in this record.
+- **`ReportA`** (object, optional): Provider field for report a in this record. See [ReportA](#payload-io-aisstream-staticdatareport-reporta).
+- **`ReportB`** (object, optional): Provider field for report b in this record. See [ReportB](#payload-io-aisstream-staticdatareport-reportb).
 ##### ReportA
 <a id="payload-io-aisstream-staticdatareport-reporta"></a>
 
-Nested record.
+Provider field for report a in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`Name`** (string, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Name`** (string, required): Human-readable name of the resource.
 ##### ReportB
 <a id="payload-io-aisstream-staticdatareport-reportb"></a>
 
-Nested record.
+Provider field for report b in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`ShipType`** (int32, optional): No description provided.
-- **`VendorIDName`** (string, optional): No description provided.
-- **`VenderIDModel`** (int32, optional): No description provided.
-- **`VenderIDSerial`** (int32, optional): No description provided.
-- **`CallSign`** (string, optional): No description provided.
-- **`Dimension`** (object, optional): No description provided. See [Dimension](#payload-io-aisstream-staticdatareport-reportb-dimension).
-- **`FixType`** (int32, optional): No description provided.
-- **`Spare`** (int32, optional): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`ShipType`** (int32, optional): Provider field for ship type in this record.
+- **`VendorIDName`** (string, optional): Provider field for vendor i d name in this record.
+- **`VenderIDModel`** (int32, optional): Provider field for vender i d model in this record.
+- **`VenderIDSerial`** (int32, optional): Provider field for vender i d serial in this record.
+- **`CallSign`** (string, optional): Provider field for call sign in this record.
+- **`Dimension`** (object, optional): Provider field for dimension in this record. See [Dimension](#payload-io-aisstream-staticdatareport-reportb-dimension).
+- **`FixType`** (int32, optional): Provider field for fix type in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
 ##### Dimension
 <a id="payload-io-aisstream-staticdatareport-dimension"></a>
 
-Nested record.
+Provider field for dimension in this record.
 
-- **`A`** (int32, required): No description provided.
-- **`B`** (int32, required): No description provided.
-- **`C`** (int32, required): No description provided.
-- **`D`** (int32, required): No description provided.
+- **`A`** (int32, required): Provider field for a in this record.
+- **`B`** (int32, required): Provider field for b in this record.
+- **`C`** (int32, required): Provider field for c in this record.
+- **`D`** (int32, required): Provider field for d in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -571,7 +571,7 @@ CloudEvents type: `IO.AISstream.BaseStationReport`
 
 #### What it tells you
 
-This event carries base station report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A reference record from AISStream public AIS firehose for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -587,24 +587,24 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Base Station Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`UtcYear`** (int32, optional): No description provided.
-- **`UtcMonth`** (int32, optional): No description provided.
-- **`UtcDay`** (int32, optional): No description provided.
-- **`UtcHour`** (int32, optional): No description provided.
-- **`UtcMinute`** (int32, optional): No description provided.
-- **`UtcSecond`** (int32, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`FixType`** (int32, optional): No description provided.
-- **`LongRangeEnable`** (boolean, optional): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`CommunicationState`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`UtcYear`** (int32, optional): Provider field for utc year in this record.
+- **`UtcMonth`** (int32, optional): Provider field for utc month in this record.
+- **`UtcDay`** (int32, optional): Provider field for utc day in this record.
+- **`UtcHour`** (int32, optional): Provider field for utc hour in this record.
+- **`UtcMinute`** (int32, optional): Provider field for utc minute in this record.
+- **`UtcSecond`** (int32, optional): Provider field for utc second in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`FixType`** (int32, optional): Provider field for fix type in this record.
+- **`LongRangeEnable`** (boolean, optional): Provider field for long range enable in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`CommunicationState`** (int32, optional): Provider field for communication state in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -642,7 +642,7 @@ CloudEvents type: `IO.AISstream.SafetyBroadcastMessage`
 
 #### What it tells you
 
-This event carries safety broadcast message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -658,12 +658,12 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Safety Broadcast Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Text`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Text`** (string, optional): Provider field for text in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -689,7 +689,7 @@ CloudEvents type: `IO.AISstream.StandardSearchAndRescueAircraftReport`
 
 #### What it tells you
 
-This event carries standard search and rescue aircraft report data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -705,25 +705,25 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Standard Search And Rescue Aircraft Report` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Altitude`** (int32, optional): No description provided.
-- **`Sog`** (double, optional): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Cog`** (double, optional): No description provided.
-- **`Timestamp`** (int32, optional): No description provided.
-- **`AltFromBaro`** (boolean, optional): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`Dte`** (boolean, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`AssignedMode`** (boolean, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`CommunicationStateIsItdma`** (boolean, optional): No description provided.
-- **`CommunicationState`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Altitude`** (int32, optional): Provider field for altitude in this record.
+- **`Sog`** (double, optional): Provider field for sog in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Cog`** (double, optional): Provider field for cog in this record.
+- **`Timestamp`** (int32, optional): Time when the provider recorded or published the update.
+- **`AltFromBaro`** (boolean, optional): Provider field for alt from baro in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`Dte`** (boolean, optional): Provider field for dte in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`AssignedMode`** (boolean, optional): Provider field for assigned mode in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`CommunicationStateIsItdma`** (boolean, optional): Provider field for communication state is itdma in this record.
+- **`CommunicationState`** (int32, optional): Provider field for communication state in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -762,7 +762,7 @@ CloudEvents type: `IO.AISstream.LongRangeAisBroadcastMessage`
 
 #### What it tells you
 
-This event carries long range ais broadcast message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A vehicle or vessel update from AISStream public AIS firehose. It reports the latest position, movement, identity, or voyage information available from the upstream feed.
 
 #### Identity
 
@@ -778,19 +778,19 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Long Range Ais Broadcast Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`, `Longitude`, `Latitude`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`PositionAccuracy`** (boolean, optional): No description provided.
-- **`Raim`** (boolean, optional): No description provided.
-- **`NavigationalStatus`** (int32, optional): No description provided.
-- **`Longitude`** (double, required): No description provided.
-- **`Latitude`** (double, required): No description provided.
-- **`Sog`** (double, optional): No description provided.
-- **`Cog`** (double, optional): No description provided.
-- **`PositionLatency`** (boolean, optional): No description provided.
-- **`Spare`** (boolean, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`PositionAccuracy`** (boolean, optional): Provider field for position accuracy in this record.
+- **`Raim`** (boolean, optional): Provider field for raim in this record.
+- **`NavigationalStatus`** (int32, optional): Provider field for navigational status in this record.
+- **`Longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`Sog`** (double, optional): Provider field for sog in this record.
+- **`Cog`** (double, optional): Provider field for cog in this record.
+- **`PositionLatency`** (boolean, optional): Provider field for position latency in this record.
+- **`Spare`** (boolean, optional): Provider field for spare in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -815,7 +815,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Addressed Safety Message
 
@@ -823,7 +823,7 @@ CloudEvents type: `IO.AISstream.AddressedSafetyMessage`
 
 #### What it tells you
 
-This event carries addressed safety message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -839,15 +839,15 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Addressed Safety Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Sequenceinteger`** (int32, optional): No description provided.
-- **`DestinationID`** (int32, optional): No description provided.
-- **`Retransmission`** (boolean, optional): No description provided.
-- **`Spare`** (boolean, optional): No description provided.
-- **`Text`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Sequenceinteger`** (int32, optional): Provider field for sequenceinteger in this record.
+- **`DestinationID`** (int32, optional): Provider field for destination i d in this record.
+- **`Retransmission`** (boolean, optional): Provider field for retransmission in this record.
+- **`Spare`** (boolean, optional): Provider field for spare in this record.
+- **`Text`** (string, optional): Provider field for text in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -876,7 +876,7 @@ CloudEvents type: `IO.AISstream.AddressedBinaryMessage`
 
 #### What it tells you
 
-This event carries addressed binary message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -892,24 +892,24 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Addressed Binary Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Sequenceinteger`** (int32, optional): No description provided.
-- **`DestinationID`** (int32, optional): No description provided.
-- **`Retransmission`** (boolean, optional): No description provided.
-- **`Spare`** (boolean, optional): No description provided.
-- **`ApplicationID`** (object, optional): No description provided. See [ApplicationID](#payload-io-aisstream-addressedbinarymessage-applicationid).
-- **`BinaryData`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Sequenceinteger`** (int32, optional): Provider field for sequenceinteger in this record.
+- **`DestinationID`** (int32, optional): Provider field for destination i d in this record.
+- **`Retransmission`** (boolean, optional): Provider field for retransmission in this record.
+- **`Spare`** (boolean, optional): Provider field for spare in this record.
+- **`ApplicationID`** (object, optional): Provider field for application i d in this record. See [ApplicationID](#payload-io-aisstream-addressedbinarymessage-applicationid).
+- **`BinaryData`** (string, optional): Provider field for binary data in this record.
 ##### ApplicationID
 <a id="payload-io-aisstream-addressedbinarymessage-applicationid"></a>
 
-Nested record.
+Provider field for application i d in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`DesignatedAreaCode`** (int32, required): No description provided.
-- **`FunctionIdentifier`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DesignatedAreaCode`** (int32, required): Provider field for designated area code in this record.
+- **`FunctionIdentifier`** (int32, required): Provider field for function identifier in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -943,7 +943,7 @@ CloudEvents type: `IO.AISstream.AssignedModeCommand`
 
 #### What it tells you
 
-This event carries assigned mode command data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -959,12 +959,12 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Assigned Mode Command` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Commands`** (map, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Commands`** (map, optional): Provider field for commands in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -990,7 +990,7 @@ CloudEvents type: `IO.AISstream.BinaryAcknowledge`
 
 #### What it tells you
 
-This event carries binary acknowledge data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1006,12 +1006,12 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Binary Acknowledge` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Destinations`** (map, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Destinations`** (map, optional): Provider field for destinations in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1037,7 +1037,7 @@ CloudEvents type: `IO.AISstream.BinaryBroadcastMessage`
 
 #### What it tells you
 
-This event carries binary broadcast message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1053,21 +1053,21 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Binary Broadcast Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`ApplicationID`** (object, optional): No description provided. See [ApplicationID](#payload-io-aisstream-binarybroadcastmessage-applicationid).
-- **`BinaryData`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`ApplicationID`** (object, optional): Provider field for application i d in this record. See [ApplicationID](#payload-io-aisstream-binarybroadcastmessage-applicationid).
+- **`BinaryData`** (string, optional): Provider field for binary data in this record.
 ##### ApplicationID
 <a id="payload-io-aisstream-binarybroadcastmessage-applicationid"></a>
 
-Nested record.
+Provider field for application i d in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`DesignatedAreaCode`** (int32, required): No description provided.
-- **`FunctionIdentifier`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DesignatedAreaCode`** (int32, required): Provider field for designated area code in this record.
+- **`FunctionIdentifier`** (int32, required): Provider field for function identifier in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1098,7 +1098,7 @@ CloudEvents type: `IO.AISstream.ChannelManagement`
 
 #### What it tells you
 
-This event carries channel management data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1114,40 +1114,40 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Channel Management` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`ChannelA`** (int32, optional): No description provided.
-- **`ChannelB`** (int32, optional): No description provided.
-- **`TxRxMode`** (int32, optional): No description provided.
-- **`LowPower`** (boolean, optional): No description provided.
-- **`Area`** (object, optional): No description provided. See [Area](#payload-io-aisstream-channelmanagement-area).
-- **`Unicast`** (object, optional): No description provided. See [Unicast](#payload-io-aisstream-channelmanagement-unicast).
-- **`IsAddressed`** (boolean, optional): No description provided.
-- **`BwA`** (boolean, optional): No description provided.
-- **`BwB`** (boolean, optional): No description provided.
-- **`TransitionalZoneSize`** (int32, optional): No description provided.
-- **`Spare4`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`ChannelA`** (int32, optional): Provider field for channel a in this record.
+- **`ChannelB`** (int32, optional): Provider field for channel b in this record.
+- **`TxRxMode`** (int32, optional): Provider field for tx rx mode in this record.
+- **`LowPower`** (boolean, optional): Provider field for low power in this record.
+- **`Area`** (object, optional): Provider field for area in this record. See [Area](#payload-io-aisstream-channelmanagement-area).
+- **`Unicast`** (object, optional): Provider field for unicast in this record. See [Unicast](#payload-io-aisstream-channelmanagement-unicast).
+- **`IsAddressed`** (boolean, optional): Provider field for is addressed in this record.
+- **`BwA`** (boolean, optional): Provider field for bw a in this record.
+- **`BwB`** (boolean, optional): Provider field for bw b in this record.
+- **`TransitionalZoneSize`** (int32, optional): Provider field for transitional zone size in this record.
+- **`Spare4`** (int32, optional): Provider field for spare4 in this record.
 ##### Area
 <a id="payload-io-aisstream-channelmanagement-area"></a>
 
-Nested record.
+Provider field for area in this record.
 
-- **`Longitude1`** (double, required): No description provided.
-- **`Latitude1`** (double, required): No description provided.
-- **`Longitude2`** (double, required): No description provided.
-- **`Latitude2`** (double, required): No description provided.
+- **`Longitude1`** (double, required): Provider field for longitude1 in this record.
+- **`Latitude1`** (double, required): Provider field for latitude1 in this record.
+- **`Longitude2`** (double, required): Provider field for longitude2 in this record.
+- **`Latitude2`** (double, required): Provider field for latitude2 in this record.
 ##### Unicast
 <a id="payload-io-aisstream-channelmanagement-unicast"></a>
 
-Nested record.
+Provider field for unicast in this record.
 
-- **`AddressStation1`** (int32, required): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`AddressStation2`** (int32, required): No description provided.
-- **`Spare3`** (int32, optional): No description provided.
+- **`AddressStation1`** (int32, required): Provider field for address station1 in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`AddressStation2`** (int32, required): Provider field for address station2 in this record.
+- **`Spare3`** (int32, optional): Provider field for spare3 in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1193,7 +1193,7 @@ CloudEvents type: `IO.AISstream.CoordinatedUTCInquiry`
 
 #### What it tells you
 
-This event carries coordinated utcinquiry data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1209,13 +1209,13 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Coordinated Utcinquiry` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`DestinationID`** (int32, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`DestinationID`** (int32, optional): Provider field for destination i d in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1242,7 +1242,7 @@ CloudEvents type: `IO.AISstream.DataLinkManagementMessage`
 
 #### What it tells you
 
-This event carries data link management message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1258,12 +1258,12 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Data Link Management Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Data`** (map, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Data`** (map, optional): Provider field for data in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1289,7 +1289,7 @@ CloudEvents type: `IO.AISstream.GnssBroadcastBinaryMessage`
 
 #### What it tells you
 
-This event carries gnss broadcast binary message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1305,15 +1305,15 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Gnss Broadcast Binary Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`Longitude`** (double, optional): No description provided.
-- **`Latitude`** (double, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`Data`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`Longitude`** (double, optional): Longitude of the resource in WGS 84 coordinates.
+- **`Latitude`** (double, optional): Latitude of the resource in WGS 84 coordinates.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`Data`** (string, optional): Provider field for data in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1342,7 +1342,7 @@ CloudEvents type: `IO.AISstream.GroupAssignmentCommand`
 
 #### What it tells you
 
-This event carries group assignment command data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1358,22 +1358,22 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Group Assignment Command` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`Longitude1`** (double, optional): No description provided.
-- **`Latitude1`** (double, optional): No description provided.
-- **`Longitude2`** (double, optional): No description provided.
-- **`Latitude2`** (double, optional): No description provided.
-- **`StationType`** (int32, optional): No description provided.
-- **`ShipType`** (int32, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`TxRxMode`** (int32, optional): No description provided.
-- **`ReportingInterval`** (int32, optional): No description provided.
-- **`QuietTime`** (int32, optional): No description provided.
-- **`Spare3`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`Longitude1`** (double, optional): Provider field for longitude1 in this record.
+- **`Latitude1`** (double, optional): Provider field for latitude1 in this record.
+- **`Longitude2`** (double, optional): Provider field for longitude2 in this record.
+- **`Latitude2`** (double, optional): Provider field for latitude2 in this record.
+- **`StationType`** (int32, optional): Provider field for station type in this record.
+- **`ShipType`** (int32, optional): Provider field for ship type in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`TxRxMode`** (int32, optional): Provider field for tx rx mode in this record.
+- **`ReportingInterval`** (int32, optional): Provider field for reporting interval in this record.
+- **`QuietTime`** (int32, optional): Provider field for quiet time in this record.
+- **`Spare3`** (int32, optional): Provider field for spare3 in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1409,7 +1409,7 @@ CloudEvents type: `IO.AISstream.Interrogation`
 
 #### What it tells you
 
-This event carries interrogation data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1425,43 +1425,43 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Interrogation` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`Station1Msg1`** (object, optional): No description provided. See [Station1Msg1](#payload-io-aisstream-interrogation-station1msg1).
-- **`Station1Msg2`** (object, optional): No description provided. See [Station1Msg2](#payload-io-aisstream-interrogation-station1msg2).
-- **`Station2`** (object, optional): No description provided. See [Station2](#payload-io-aisstream-interrogation-station2).
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`Station1Msg1`** (object, optional): Provider field for station1 msg1 in this record. See [Station1Msg1](#payload-io-aisstream-interrogation-station1msg1).
+- **`Station1Msg2`** (object, optional): Provider field for station1 msg2 in this record. See [Station1Msg2](#payload-io-aisstream-interrogation-station1msg2).
+- **`Station2`** (object, optional): Provider field for station2 in this record. See [Station2](#payload-io-aisstream-interrogation-station2).
 ##### Station1Msg1
 <a id="payload-io-aisstream-interrogation-station1msg1"></a>
 
-Nested record.
+Provider field for station1 msg1 in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`StationID`** (int32, required): No description provided.
-- **`MessageID`** (int32, required): No description provided.
-- **`SlotOffset`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`StationID`** (int32, required): Provider field for station i d in this record.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`SlotOffset`** (int32, required): Provider field for slot offset in this record.
 ##### Station1Msg2
 <a id="payload-io-aisstream-interrogation-station1msg2"></a>
 
-Nested record.
+Provider field for station1 msg2 in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`MessageID`** (int32, required): No description provided.
-- **`SlotOffset`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`SlotOffset`** (int32, required): Provider field for slot offset in this record.
 ##### Station2
 <a id="payload-io-aisstream-interrogation-station2"></a>
 
-Nested record.
+Provider field for station2 in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`StationID`** (int32, required): No description provided.
-- **`MessageID`** (int32, required): No description provided.
-- **`SlotOffset`** (int32, required): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`StationID`** (int32, required): Provider field for station i d in this record.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`SlotOffset`** (int32, required): Provider field for slot offset in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1506,7 +1506,7 @@ CloudEvents type: `IO.AISstream.MultiSlotBinaryMessage`
 
 #### What it tells you
 
-This event carries multi slot binary message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1522,27 +1522,27 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Multi Slot Binary Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`DestinationIDValid`** (boolean, optional): No description provided.
-- **`ApplicationIDValid`** (boolean, optional): No description provided.
-- **`DestinationID`** (int32, optional): No description provided.
-- **`Spare1`** (int32, optional): No description provided.
-- **`ApplicationID`** (object, optional): No description provided. See [ApplicationID](#payload-io-aisstream-multislotbinarymessage-applicationid).
-- **`Payload`** (string, optional): No description provided.
-- **`Spare2`** (int32, optional): No description provided.
-- **`CommunicationStateIsItdma`** (boolean, optional): No description provided.
-- **`CommunicationState`** (int32, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DestinationIDValid`** (boolean, optional): Provider field for destination i d valid in this record.
+- **`ApplicationIDValid`** (boolean, optional): Provider field for application i d valid in this record.
+- **`DestinationID`** (int32, optional): Provider field for destination i d in this record.
+- **`Spare1`** (int32, optional): Provider field for spare1 in this record.
+- **`ApplicationID`** (object, optional): Provider field for application i d in this record. See [ApplicationID](#payload-io-aisstream-multislotbinarymessage-applicationid).
+- **`Payload`** (string, optional): Provider field for payload in this record.
+- **`Spare2`** (int32, optional): Provider field for spare2 in this record.
+- **`CommunicationStateIsItdma`** (boolean, optional): Provider field for communication state is itdma in this record.
+- **`CommunicationState`** (int32, optional): Provider field for communication state in this record.
 ##### ApplicationID
 <a id="payload-io-aisstream-multislotbinarymessage-applicationid"></a>
 
-Nested record.
+Provider field for application i d in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`DesignatedAreaCode`** (int32, required): No description provided.
-- **`FunctionIdentifier`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DesignatedAreaCode`** (int32, required): Provider field for designated area code in this record.
+- **`FunctionIdentifier`** (int32, required): Provider field for function identifier in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1579,7 +1579,7 @@ CloudEvents type: `IO.AISstream.SingleSlotBinaryMessage`
 
 #### What it tells you
 
-This event carries single slot binary message data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1595,24 +1595,24 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Single Slot Binary Message` payloads are JSON object. Required fields: `MessageID`, `UserID`, `Valid`.
 
-- **`MessageID`** (int32, required): No description provided.
-- **`RepeatIndicator`** (int32, optional): No description provided.
-- **`UserID`** (int32, required): No description provided.
-- **`Valid`** (boolean, required): No description provided.
-- **`DestinationIDValid`** (boolean, optional): No description provided.
-- **`ApplicationIDValid`** (boolean, optional): No description provided.
-- **`DestinationID`** (int32, optional): No description provided.
-- **`Spare`** (int32, optional): No description provided.
-- **`ApplicationID`** (object, optional): No description provided. See [ApplicationID](#payload-io-aisstream-singleslotbinarymessage-applicationid).
-- **`Payload`** (string, optional): No description provided.
+- **`MessageID`** (int32, required): Provider field for message i d in this record.
+- **`RepeatIndicator`** (int32, optional): Provider field for repeat indicator in this record.
+- **`UserID`** (int32, required): Provider field for user i d in this record.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DestinationIDValid`** (boolean, optional): Provider field for destination i d valid in this record.
+- **`ApplicationIDValid`** (boolean, optional): Provider field for application i d valid in this record.
+- **`DestinationID`** (int32, optional): Provider field for destination i d in this record.
+- **`Spare`** (int32, optional): Provider field for spare in this record.
+- **`ApplicationID`** (object, optional): Provider field for application i d in this record. See [ApplicationID](#payload-io-aisstream-singleslotbinarymessage-applicationid).
+- **`Payload`** (string, optional): Provider field for payload in this record.
 ##### ApplicationID
 <a id="payload-io-aisstream-singleslotbinarymessage-applicationid"></a>
 
-Nested record.
+Provider field for application i d in this record.
 
-- **`Valid`** (boolean, required): No description provided.
-- **`DesignatedAreaCode`** (int32, required): No description provided.
-- **`FunctionIdentifier`** (int32, required): No description provided.
+- **`Valid`** (boolean, required): Provider field for valid in this record.
+- **`DesignatedAreaCode`** (int32, required): Provider field for designated area code in this record.
+- **`FunctionIdentifier`** (int32, required): Provider field for function identifier in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1646,7 +1646,7 @@ CloudEvents type: `IO.AISstream.mqtt.PositionReport`
 
 #### What it tells you
 
-Position report (Type 1/2/3/4/9/18/19/27) projected onto the UNS axes.
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1681,9 +1681,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`message_id`** (int32, required): Original ITU-R M.1371 message ID (1, 2, 3, 4, 9, 18, 19, or 27).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1720,7 +1720,7 @@ CloudEvents type: `IO.AISstream.mqtt.ShipStatic`
 
 #### What it tells you
 
-Static and voyage-related data (Type 5 ShipStaticData / Type 24 StaticDataReport).
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1756,9 +1756,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`message_id`** (int32, required): Original ITU-R M.1371 message ID (5 or 24).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1796,7 +1796,7 @@ CloudEvents type: `IO.AISstream.mqtt.AidToNavigation`
 
 #### What it tells you
 
-Aid-to-Navigation report (Type 21).
+A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.
 
 #### Identity
 
@@ -1827,9 +1827,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`message_id`** (int32, required): Original ITU-R M.1371 message ID (21).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/aisstream/xreg/aisstream.xreg.json
+++ b/aisstream/xreg/aisstream.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/IO.AISstream"
-      ]
+      ],
+      "description": "Kafka producer endpoint for AISStream CloudEvents on the `aisstream` topic keyed by `{mmsi}`."
     },
     "IO.AISstream.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/IO.AISstream.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for AISStream CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -62,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.PositionReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.PositionReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.ShipStaticData": {
           "name": "ShipStaticData",
@@ -80,7 +83,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ShipStaticData"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ShipStaticData",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.StandardClassBPositionReport": {
           "name": "StandardClassBPositionReport",
@@ -98,7 +102,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StandardClassBPositionReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StandardClassBPositionReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.ExtendedClassBPositionReport": {
           "name": "ExtendedClassBPositionReport",
@@ -116,7 +121,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ExtendedClassBPositionReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ExtendedClassBPositionReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.AidsToNavigationReport": {
           "name": "AidsToNavigationReport",
@@ -134,7 +140,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AidsToNavigationReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AidsToNavigationReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.StaticDataReport": {
           "name": "StaticDataReport",
@@ -152,7 +159,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StaticDataReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StaticDataReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.BaseStationReport": {
           "name": "BaseStationReport",
@@ -170,7 +178,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BaseStationReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BaseStationReport",
+          "description": "A reference record from AISStream public AIS firehose for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "IO.AISstream.SafetyBroadcastMessage": {
           "name": "SafetyBroadcastMessage",
@@ -188,7 +197,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.SafetyBroadcastMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.SafetyBroadcastMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.StandardSearchAndRescueAircraftReport": {
           "name": "StandardSearchAndRescueAircraftReport",
@@ -206,7 +216,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StandardSearchAndRescueAircraftReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.StandardSearchAndRescueAircraftReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.LongRangeAisBroadcastMessage": {
           "name": "LongRangeAisBroadcastMessage",
@@ -224,7 +235,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.LongRangeAisBroadcastMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.LongRangeAisBroadcastMessage",
+          "description": "A vehicle or vessel update from AISStream public AIS firehose. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
         },
         "IO.AISstream.AddressedSafetyMessage": {
           "name": "AddressedSafetyMessage",
@@ -242,7 +254,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AddressedSafetyMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AddressedSafetyMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.AddressedBinaryMessage": {
           "name": "AddressedBinaryMessage",
@@ -260,7 +273,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AddressedBinaryMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AddressedBinaryMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.AssignedModeCommand": {
           "name": "AssignedModeCommand",
@@ -278,7 +292,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AssignedModeCommand"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.AssignedModeCommand",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.BinaryAcknowledge": {
           "name": "BinaryAcknowledge",
@@ -296,7 +311,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BinaryAcknowledge"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BinaryAcknowledge",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.BinaryBroadcastMessage": {
           "name": "BinaryBroadcastMessage",
@@ -314,7 +330,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BinaryBroadcastMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.BinaryBroadcastMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.ChannelManagement": {
           "name": "ChannelManagement",
@@ -332,7 +349,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ChannelManagement"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.ChannelManagement",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.CoordinatedUTCInquiry": {
           "name": "CoordinatedUTCInquiry",
@@ -350,7 +368,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.CoordinatedUTCInquiry"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.CoordinatedUTCInquiry",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.DataLinkManagementMessage": {
           "name": "DataLinkManagementMessage",
@@ -368,7 +387,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.DataLinkManagementMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.DataLinkManagementMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.GnssBroadcastBinaryMessage": {
           "name": "GnssBroadcastBinaryMessage",
@@ -386,7 +406,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.GnssBroadcastBinaryMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.GnssBroadcastBinaryMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.GroupAssignmentCommand": {
           "name": "GroupAssignmentCommand",
@@ -404,7 +425,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.GroupAssignmentCommand"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.GroupAssignmentCommand",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.Interrogation": {
           "name": "Interrogation",
@@ -422,7 +444,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.Interrogation"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.Interrogation",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.MultiSlotBinaryMessage": {
           "name": "MultiSlotBinaryMessage",
@@ -440,7 +463,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.MultiSlotBinaryMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.MultiSlotBinaryMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.SingleSlotBinaryMessage": {
           "name": "SingleSlotBinaryMessage",
@@ -458,9 +482,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.SingleSlotBinaryMessage"
+          "dataschemauri": "#/schemagroups/IO.AISstream.jstruct/schemas/IO.AISstream.SingleSlotBinaryMessage",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         }
-      }
+      },
+      "description": "Events from AISStream covering AIS-equipped vessels received by the AISStream network. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "IO.AISstream.mqtt": {
       "envelope": "CloudEvents/1.0",
@@ -488,7 +514,8 @@
             "retain": false
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.PositionReport"
+          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.PositionReport",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.mqtt.ShipStatic": {
           "messageid": "IO.AISstream.mqtt.ShipStatic.mqtt",
@@ -513,7 +540,8 @@
             "retain": false
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.ShipStatic"
+          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.ShipStatic",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         },
         "IO.AISstream.mqtt.AidToNavigation": {
           "messageid": "IO.AISstream.mqtt.AidToNavigation.mqtt",
@@ -538,9 +566,11 @@
             "retain": false
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.AidToNavigation"
+          "dataschemauri": "#/schemagroups/IO.AISstream.mqtt.jstruct/schemas/IO.AISstream.mqtt.AidToNavigation",
+          "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
         }
-      }
+      },
+      "description": "MQTT 5 variant of the AISStream events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message."
     }
   },
   "schemagroups": {
@@ -566,58 +596,76 @@
                 "name": "PositionReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "NavigationalStatus": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for navigational status in this record."
                   },
                   "RateOfTurn": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for rate of turn in this record."
                   },
                   "Sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "TrueHeading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for true heading in this record."
                   },
                   "Timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "SpecialManoeuvreIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for special manoeuvre indicator in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "CommunicationState": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for communication state in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/PositionReport"
+                "$id": "https://example.com/schemas/IO/AISstream/PositionReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -640,31 +688,40 @@
                 "name": "ShipStaticData",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "AisVersion": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ais version in this record."
                   },
                   "ImoNumber": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for imo number in this record."
                   },
                   "CallSign": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for call sign in this record."
                   },
                   "Name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the resource."
                   },
                   "Type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for type in this record."
                   },
                   "Dimension": {
                     "type": "object",
@@ -677,21 +734,27 @@
                     "name": "Dimension",
                     "properties": {
                       "A": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for a in this record."
                       },
                       "B": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for b in this record."
                       },
                       "C": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for c in this record."
                       },
                       "D": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for d in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for dimension in this record."
                   },
                   "FixType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for fix type in this record."
                   },
                   "Eta": {
                     "type": "object",
@@ -704,33 +767,43 @@
                     "name": "Eta",
                     "properties": {
                       "Month": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for month in this record."
                       },
                       "Day": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for day in this record."
                       },
                       "Hour": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for hour in this record."
                       },
                       "Minute": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for minute in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for eta in this record."
                   },
                   "MaximumStaticDraught": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for maximum static draught in this record."
                   },
                   "Destination": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for destination in this record."
                   },
                   "Dte": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for dte in this record."
                   },
                   "Spare": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for spare in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/ShipStaticData"
+                "$id": "https://example.com/schemas/IO/AISstream/ShipStaticData",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -755,73 +828,96 @@
                 "name": "StandardClassBPositionReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "Sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "TrueHeading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for true heading in this record."
                   },
                   "Timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "ClassBUnit": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for class b unit in this record."
                   },
                   "ClassBDisplay": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for class b display in this record."
                   },
                   "ClassBDsc": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for class b dsc in this record."
                   },
                   "ClassBBand": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for class b band in this record."
                   },
                   "ClassBMsg22": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for class b msg22 in this record."
                   },
                   "AssignedMode": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for assigned mode in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "CommunicationStateIsItdma": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for communication state is itdma in this record."
                   },
                   "CommunicationState": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for communication state in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/StandardClassBPositionReport"
+                "$id": "https://example.com/schemas/IO/AISstream/StandardClassBPositionReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -846,49 +942,64 @@
                 "name": "ExtendedClassBPositionReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "Sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "TrueHeading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for true heading in this record."
                   },
                   "Timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "Name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the resource."
                   },
                   "Type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for type in this record."
                   },
                   "Dimension": {
                     "type": "object",
@@ -901,36 +1012,47 @@
                     "name": "Dimension",
                     "properties": {
                       "A": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for a in this record."
                       },
                       "B": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for b in this record."
                       },
                       "C": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for c in this record."
                       },
                       "D": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for d in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for dimension in this record."
                   },
                   "FixType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for fix type in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "Dte": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for dte in this record."
                   },
                   "AssignedMode": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for assigned mode in this record."
                   },
                   "Spare3": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare3 in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/ExtendedClassBPositionReport"
+                "$id": "https://example.com/schemas/IO/AISstream/ExtendedClassBPositionReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -955,31 +1077,40 @@
                 "name": "AidsToNavigationReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for type in this record."
                   },
                   "Name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the resource."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Dimension": {
                     "type": "object",
@@ -992,48 +1123,63 @@
                     "name": "Dimension",
                     "properties": {
                       "A": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for a in this record."
                       },
                       "B": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for b in this record."
                       },
                       "C": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for c in this record."
                       },
                       "D": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for d in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for dimension in this record."
                   },
                   "Fixtype": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for fixtype in this record."
                   },
                   "Timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "OffPosition": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for off position in this record."
                   },
                   "AtoN": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ato n in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "VirtualAtoN": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for virtual ato n in this record."
                   },
                   "AssignedMode": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for assigned mode in this record."
                   },
                   "Spare": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for spare in this record."
                   },
                   "NameExtension": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for name extension in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/AidsToNavigationReport"
+                "$id": "https://example.com/schemas/IO/AISstream/AidsToNavigationReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1056,22 +1202,28 @@
                 "name": "StaticDataReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Reserved": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for reserved in this record."
                   },
                   "PartNumber": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for part number in this record."
                   },
                   "ReportA": {
                     "type": "object",
@@ -1082,12 +1234,15 @@
                     "name": "ReportA",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "Name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Human-readable name of the resource."
                       }
-                    }
+                    },
+                    "description": "Provider field for report a in this record."
                   },
                   "ReportB": {
                     "type": "object",
@@ -1097,22 +1252,28 @@
                     "name": "ReportB",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "ShipType": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for ship type in this record."
                       },
                       "VendorIDName": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Provider field for vendor i d name in this record."
                       },
                       "VenderIDModel": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for vender i d model in this record."
                       },
                       "VenderIDSerial": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for vender i d serial in this record."
                       },
                       "CallSign": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Provider field for call sign in this record."
                       },
                       "Dimension": {
                         "type": "object",
@@ -1125,29 +1286,38 @@
                         "name": "Dimension",
                         "properties": {
                           "A": {
-                            "type": "int32"
+                            "type": "int32",
+                            "description": "Provider field for a in this record."
                           },
                           "B": {
-                            "type": "int32"
+                            "type": "int32",
+                            "description": "Provider field for b in this record."
                           },
                           "C": {
-                            "type": "int32"
+                            "type": "int32",
+                            "description": "Provider field for c in this record."
                           },
                           "D": {
-                            "type": "int32"
+                            "type": "int32",
+                            "description": "Provider field for d in this record."
                           }
-                        }
+                        },
+                        "description": "Provider field for dimension in this record."
                       },
                       "FixType": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for fix type in this record."
                       },
                       "Spare": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for report b in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/StaticDataReport"
+                "$id": "https://example.com/schemas/IO/AISstream/StaticDataReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1172,61 +1342,80 @@
                 "name": "BaseStationReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "UtcYear": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc year in this record."
                   },
                   "UtcMonth": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc month in this record."
                   },
                   "UtcDay": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc day in this record."
                   },
                   "UtcHour": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc hour in this record."
                   },
                   "UtcMinute": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc minute in this record."
                   },
                   "UtcSecond": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for utc second in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "FixType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for fix type in this record."
                   },
                   "LongRangeEnable": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for long range enable in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "CommunicationState": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for communication state in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/BaseStationReport"
+                "$id": "https://example.com/schemas/IO/AISstream/BaseStationReport",
+                "description": "A reference record from AISStream public AIS firehose for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           }
@@ -1249,25 +1438,32 @@
                 "name": "SafetyBroadcastMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Text": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for text in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/SafetyBroadcastMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/SafetyBroadcastMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1292,64 +1488,84 @@
                 "name": "StandardSearchAndRescueAircraftReport",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Altitude": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for altitude in this record."
                   },
                   "Sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "Timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "AltFromBaro": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for alt from baro in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "Dte": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for dte in this record."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "AssignedMode": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for assigned mode in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "CommunicationStateIsItdma": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for communication state is itdma in this record."
                   },
                   "CommunicationState": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for communication state in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/StandardSearchAndRescueAircraftReport"
+                "$id": "https://example.com/schemas/IO/AISstream/StandardSearchAndRescueAircraftReport",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1374,46 +1590,60 @@
                 "name": "LongRangeAisBroadcastMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "PositionAccuracy": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "Raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "NavigationalStatus": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for navigational status in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "Cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "PositionLatency": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for position latency in this record."
                   },
                   "Spare": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for spare in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/LongRangeAisBroadcastMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/LongRangeAisBroadcastMessage",
+                "description": "A vehicle or vessel update from AISStream public AIS firehose. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               }
             }
           }
@@ -1436,34 +1666,44 @@
                 "name": "AddressedSafetyMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Sequenceinteger": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for sequenceinteger in this record."
                   },
                   "DestinationID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for destination i d in this record."
                   },
                   "Retransmission": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for retransmission in this record."
                   },
                   "Spare": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for spare in this record."
                   },
                   "Text": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for text in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/AddressedSafetyMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/AddressedSafetyMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1486,28 +1726,36 @@
                 "name": "AddressedBinaryMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Sequenceinteger": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for sequenceinteger in this record."
                   },
                   "DestinationID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for destination i d in this record."
                   },
                   "Retransmission": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for retransmission in this record."
                   },
                   "Spare": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for spare in this record."
                   },
                   "ApplicationID": {
                     "type": "object",
@@ -1519,21 +1767,27 @@
                     "name": "ApplicationID",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "DesignatedAreaCode": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for designated area code in this record."
                       },
                       "FunctionIdentifier": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for function identifier in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for application i d in this record."
                   },
                   "BinaryData": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for binary data in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/AddressedBinaryMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/AddressedBinaryMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1556,28 +1810,35 @@
                 "name": "AssignedModeCommand",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Commands": {
                     "type": "map",
                     "values": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Provider field for commands in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/AssignedModeCommand"
+                "$id": "https://example.com/schemas/IO/AISstream/AssignedModeCommand",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1600,28 +1861,35 @@
                 "name": "BinaryAcknowledge",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Destinations": {
                     "type": "map",
                     "values": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Provider field for destinations in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/BinaryAcknowledge"
+                "$id": "https://example.com/schemas/IO/AISstream/BinaryAcknowledge",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1644,19 +1912,24 @@
                 "name": "BinaryBroadcastMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "ApplicationID": {
                     "type": "object",
@@ -1668,21 +1941,27 @@
                     "name": "ApplicationID",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "DesignatedAreaCode": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for designated area code in this record."
                       },
                       "FunctionIdentifier": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for function identifier in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for application i d in this record."
                   },
                   "BinaryData": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for binary data in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/BinaryBroadcastMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/BinaryBroadcastMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1705,31 +1984,40 @@
                 "name": "ChannelManagement",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "ChannelA": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for channel a in this record."
                   },
                   "ChannelB": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for channel b in this record."
                   },
                   "TxRxMode": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for tx rx mode in this record."
                   },
                   "LowPower": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for low power in this record."
                   },
                   "Area": {
                     "type": "object",
@@ -1742,18 +2030,23 @@
                     "name": "Area",
                     "properties": {
                       "Longitude1": {
-                        "type": "double"
+                        "type": "double",
+                        "description": "Provider field for longitude1 in this record."
                       },
                       "Latitude1": {
-                        "type": "double"
+                        "type": "double",
+                        "description": "Provider field for latitude1 in this record."
                       },
                       "Longitude2": {
-                        "type": "double"
+                        "type": "double",
+                        "description": "Provider field for longitude2 in this record."
                       },
                       "Latitude2": {
-                        "type": "double"
+                        "type": "double",
+                        "description": "Provider field for latitude2 in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for area in this record."
                   },
                   "Unicast": {
                     "type": "object",
@@ -1764,36 +2057,47 @@
                     "name": "Unicast",
                     "properties": {
                       "AddressStation1": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for address station1 in this record."
                       },
                       "Spare2": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare2 in this record."
                       },
                       "AddressStation2": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for address station2 in this record."
                       },
                       "Spare3": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare3 in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for unicast in this record."
                   },
                   "IsAddressed": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for is addressed in this record."
                   },
                   "BwA": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for bw a in this record."
                   },
                   "BwB": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for bw b in this record."
                   },
                   "TransitionalZoneSize": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for transitional zone size in this record."
                   },
                   "Spare4": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare4 in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/ChannelManagement"
+                "$id": "https://example.com/schemas/IO/AISstream/ChannelManagement",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1816,28 +2120,36 @@
                 "name": "CoordinatedUTCInquiry",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "DestinationID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for destination i d in this record."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/CoordinatedUTCInquiry"
+                "$id": "https://example.com/schemas/IO/AISstream/CoordinatedUTCInquiry",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1860,28 +2172,35 @@
                 "name": "DataLinkManagementMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Data": {
                     "type": "map",
                     "values": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Provider field for data in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/DataLinkManagementMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/DataLinkManagementMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1904,34 +2223,44 @@
                 "name": "GnssBroadcastBinaryMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "Longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "Latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "Data": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for data in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/GnssBroadcastBinaryMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/GnssBroadcastBinaryMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -1954,55 +2283,72 @@
                 "name": "GroupAssignmentCommand",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "Longitude1": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for longitude1 in this record."
                   },
                   "Latitude1": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for latitude1 in this record."
                   },
                   "Longitude2": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for longitude2 in this record."
                   },
                   "Latitude2": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for latitude2 in this record."
                   },
                   "StationType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for station type in this record."
                   },
                   "ShipType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ship type in this record."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "TxRxMode": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for tx rx mode in this record."
                   },
                   "ReportingInterval": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for reporting interval in this record."
                   },
                   "QuietTime": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for quiet time in this record."
                   },
                   "Spare3": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare3 in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/GroupAssignmentCommand"
+                "$id": "https://example.com/schemas/IO/AISstream/GroupAssignmentCommand",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -2025,19 +2371,24 @@
                 "name": "Interrogation",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "Station1Msg1": {
                     "type": "object",
@@ -2050,18 +2401,23 @@
                     "name": "Station1Msg1",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "StationID": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for station i d in this record."
                       },
                       "MessageID": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for message i d in this record."
                       },
                       "SlotOffset": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for slot offset in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for station1 msg1 in this record."
                   },
                   "Station1Msg2": {
                     "type": "object",
@@ -2073,18 +2429,23 @@
                     "name": "Station1Msg2",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "Spare": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare in this record."
                       },
                       "MessageID": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for message i d in this record."
                       },
                       "SlotOffset": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for slot offset in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for station1 msg2 in this record."
                   },
                   "Station2": {
                     "type": "object",
@@ -2097,27 +2458,35 @@
                     "name": "Station2",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "Spare1": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare1 in this record."
                       },
                       "StationID": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for station i d in this record."
                       },
                       "MessageID": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for message i d in this record."
                       },
                       "SlotOffset": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for slot offset in this record."
                       },
                       "Spare2": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for spare2 in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for station2 in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/Interrogation"
+                "$id": "https://example.com/schemas/IO/AISstream/Interrogation",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -2140,28 +2509,36 @@
                 "name": "MultiSlotBinaryMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "DestinationIDValid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for destination i d valid in this record."
                   },
                   "ApplicationIDValid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for application i d valid in this record."
                   },
                   "DestinationID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for destination i d in this record."
                   },
                   "Spare1": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare1 in this record."
                   },
                   "ApplicationID": {
                     "type": "object",
@@ -2173,30 +2550,39 @@
                     "name": "ApplicationID",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "DesignatedAreaCode": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for designated area code in this record."
                       },
                       "FunctionIdentifier": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for function identifier in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for application i d in this record."
                   },
                   "Payload": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for payload in this record."
                   },
                   "Spare2": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare2 in this record."
                   },
                   "CommunicationStateIsItdma": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for communication state is itdma in this record."
                   },
                   "CommunicationState": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for communication state in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/MultiSlotBinaryMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/MultiSlotBinaryMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -2219,28 +2605,36 @@
                 "name": "SingleSlotBinaryMessage",
                 "properties": {
                   "MessageID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for message i d in this record."
                   },
                   "RepeatIndicator": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for repeat indicator in this record."
                   },
                   "UserID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for user i d in this record."
                   },
                   "Valid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for valid in this record."
                   },
                   "DestinationIDValid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for destination i d valid in this record."
                   },
                   "ApplicationIDValid": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for application i d valid in this record."
                   },
                   "DestinationID": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for destination i d in this record."
                   },
                   "Spare": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for spare in this record."
                   },
                   "ApplicationID": {
                     "type": "object",
@@ -2252,21 +2646,27 @@
                     "name": "ApplicationID",
                     "properties": {
                       "Valid": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Provider field for valid in this record."
                       },
                       "DesignatedAreaCode": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for designated area code in this record."
                       },
                       "FunctionIdentifier": {
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Provider field for function identifier in this record."
                       }
-                    }
+                    },
+                    "description": "Provider field for application i d in this record."
                   },
                   "Payload": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for payload in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/IO/AISstream/SingleSlotBinaryMessage"
+                "$id": "https://example.com/schemas/IO/AISstream/SingleSlotBinaryMessage",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network."
               }
             }
           }
@@ -2287,7 +2687,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "PositionReport",
-                "description": "Position report (Type 1/2/3/4/9/18/19/27) projected onto the UNS axes.",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -2326,7 +2726,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "user_id": {
                     "type": "int32",
@@ -2393,7 +2798,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "ShipStatic",
-                "description": "Static and voyage-related data (Type 5 ShipStaticData / Type 24 StaticDataReport).",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -2432,7 +2837,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "user_id": {
                     "type": "int32",
@@ -2503,7 +2913,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "AidToNavigation",
-                "description": "Aid-to-Navigation report (Type 21).",
+                "description": "A transport update from AISStream public AIS firehose. It carries vessel position, voyage, safety, and static AIS messages for AIS-equipped vessels received by the AISStream network.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -2544,7 +2954,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "user_id": {
                     "type": "int32",
@@ -2586,5 +3001,10 @@
         }
       }
     }
+  },
+  "description": "AISStream publishes vessel position, voyage, safety, and static AIS messages from AISStream public AIS firehose for AIS-equipped vessels received by the AISStream network. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for AISStream, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/autobahn/EVENTS.md
+++ b/autobahn/EVENTS.md
@@ -1,6 +1,6 @@
 # German Autobahn Traffic Bridge Events
 
-MQTT/5.0 mirror of the DE.Autobahn CloudEvents, published into the Unified-Namespace topic tree 'traffic/de/autobahn/autobahn/{road}/{kind}/{identifier}/{state}'. {kind} (10 values) and {state} (appeared/updated/resolved) are literally baked per-message so xrcg can resolve every placeholder from schema fields. Lifecycle-event families (roadwork, short-term-roadwork, closure, entry-exit-closure, warning) are QoS-1 non-retained — they are state-change notifications, not LKV slots. Stable-object families (weight-limit-3-5, webcam, parking-lorry, electric-charging-station, strong-electric-charging-station) are QoS-1 retained so late subscribers see the current state of every known object; the bridge publishes an empty retained payload on `resolved` to clear the slot.
+Autobahn publishes road traffic incidents, closures, webcams, and travel information from Germany's Autobahn GmbH traffic APIs for German motorway segments, roadworks, closures, and traffic messages. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `DE.Autobahn.RoadworkAppeared`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -94,11 +94,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -149,7 +149,7 @@ CloudEvents type: `DE.Autobahn.RoadworkUpdated`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -191,11 +191,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -246,7 +246,7 @@ CloudEvents type: `DE.Autobahn.RoadworkResolved`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -288,11 +288,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -343,7 +343,7 @@ CloudEvents type: `DE.Autobahn.ShortTermRoadworkAppeared`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -385,11 +385,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -440,7 +440,7 @@ CloudEvents type: `DE.Autobahn.ShortTermRoadworkUpdated`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -482,11 +482,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -537,7 +537,7 @@ CloudEvents type: `DE.Autobahn.ShortTermRoadworkResolved`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -579,11 +579,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -634,7 +634,7 @@ CloudEvents type: `DE.Autobahn.WarningAppeared`
 
 #### What it tells you
 
-Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -680,7 +680,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`source_name`** (string or null, optional): source value from the Autobahn warning item that identifies the origin of the warning.
 ##### `display_type` values
 
-- `WARNING`
+- `WARNING`: Provider coded value `WARNING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -735,7 +735,7 @@ CloudEvents type: `DE.Autobahn.WarningUpdated`
 
 #### What it tells you
 
-Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -781,7 +781,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`source_name`** (string or null, optional): source value from the Autobahn warning item that identifies the origin of the warning.
 ##### `display_type` values
 
-- `WARNING`
+- `WARNING`: Provider coded value `WARNING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -836,7 +836,7 @@ CloudEvents type: `DE.Autobahn.WarningResolved`
 
 #### What it tells you
 
-Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -882,7 +882,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`source_name`** (string or null, optional): source value from the Autobahn warning item that identifies the origin of the warning.
 ##### `display_type` values
 
-- `WARNING`
+- `WARNING`: Provider coded value `WARNING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -937,7 +937,7 @@ CloudEvents type: `DE.Autobahn.ClosureAppeared`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -979,11 +979,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1034,7 +1034,7 @@ CloudEvents type: `DE.Autobahn.ClosureUpdated`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -1076,11 +1076,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1131,7 +1131,7 @@ CloudEvents type: `DE.Autobahn.ClosureResolved`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -1173,11 +1173,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1228,7 +1228,7 @@ CloudEvents type: `DE.Autobahn.EntryExitClosureAppeared`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -1270,11 +1270,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1325,7 +1325,7 @@ CloudEvents type: `DE.Autobahn.EntryExitClosureUpdated`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -1367,11 +1367,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1422,7 +1422,7 @@ CloudEvents type: `DE.Autobahn.EntryExitClosureResolved`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network. A transport update from Germany's Autobahn GmbH traffic APIs.
 
 #### Identity
 
@@ -1464,11 +1464,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1519,7 +1519,7 @@ CloudEvents type: `DE.Autobahn.WeightLimit35RestrictionAppeared`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -1561,11 +1561,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1616,7 +1616,7 @@ CloudEvents type: `DE.Autobahn.WeightLimit35RestrictionUpdated`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -1658,11 +1658,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1713,7 +1713,7 @@ CloudEvents type: `DE.Autobahn.WeightLimit35RestrictionResolved`
 
 #### What it tells you
 
-Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -1755,11 +1755,11 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ROADWORKS`
-- `SHORT_TERM_ROADWORKS`
-- `CLOSURE`
-- `CLOSURE_ENTRY_EXIT`
-- `WEIGHT_LIMIT_35`
+- `ROADWORKS`: Provider coded value `ROADWORKS` for this field.
+- `SHORT_TERM_ROADWORKS`: Provider coded value `SHORT_TERM_ROADWORKS` for this field.
+- `CLOSURE`: Provider coded value `CLOSURE` for this field.
+- `CLOSURE_ENTRY_EXIT`: Provider coded value `CLOSURE_ENTRY_EXIT` for this field.
+- `WEIGHT_LIMIT_35`: Provider coded value `WEIGHT_LIMIT_35` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1810,7 +1810,7 @@ CloudEvents type: `DE.Autobahn.ParkingLorryAppeared`
 
 #### What it tells you
 
-Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -1850,7 +1850,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`lorry_space_count`** (integer or null, optional): Number of lorry spaces parsed from description lines that contain LKW Stellplätze. Constraints: minimum `0`.
 ##### `display_type` values
 
-- `PARKING`
+- `PARKING`: Provider coded value `PARKING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1899,7 +1899,7 @@ CloudEvents type: `DE.Autobahn.ParkingLorryUpdated`
 
 #### What it tells you
 
-Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -1939,7 +1939,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`lorry_space_count`** (integer or null, optional): Number of lorry spaces parsed from description lines that contain LKW Stellplätze. Constraints: minimum `0`.
 ##### `display_type` values
 
-- `PARKING`
+- `PARKING`: Provider coded value `PARKING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1988,7 +1988,7 @@ CloudEvents type: `DE.Autobahn.ParkingLorryResolved`
 
 #### What it tells you
 
-Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -2028,7 +2028,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`lorry_space_count`** (integer or null, optional): Number of lorry spaces parsed from description lines that contain LKW Stellplätze. Constraints: minimum `0`.
 ##### `display_type` values
 
-- `PARKING`
+- `PARKING`: Provider coded value `PARKING` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2077,7 +2077,7 @@ CloudEvents type: `DE.Autobahn.ElectricChargingStationAppeared`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2116,8 +2116,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2163,7 +2163,7 @@ CloudEvents type: `DE.Autobahn.ElectricChargingStationUpdated`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2202,8 +2202,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2249,7 +2249,7 @@ CloudEvents type: `DE.Autobahn.ElectricChargingStationResolved`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2288,8 +2288,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2335,7 +2335,7 @@ CloudEvents type: `DE.Autobahn.StrongElectricChargingStationAppeared`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2374,8 +2374,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2421,7 +2421,7 @@ CloudEvents type: `DE.Autobahn.StrongElectricChargingStationUpdated`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2460,8 +2460,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2507,7 +2507,7 @@ CloudEvents type: `DE.Autobahn.StrongElectricChargingStationResolved`
 
 #### What it tells you
 
-Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station.
+A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -2546,8 +2546,8 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`footer_lines`** (array of string, optional): Footer lines from the Autobahn API footer array.
 ##### `display_type` values
 
-- `ELECTRIC_CHARGING_STATION`
-- `STRONG_ELECTRIC_CHARGING_STATION`
+- `ELECTRIC_CHARGING_STATION`: Provider coded value `ELECTRIC_CHARGING_STATION` for this field.
+- `STRONG_ELECTRIC_CHARGING_STATION`: Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2593,7 +2593,7 @@ CloudEvents type: `DE.Autobahn.WebcamAppeared`
 
 #### What it tells you
 
-Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -2632,7 +2632,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`stream_url`** (uri or null, optional): linkurl value from the Autobahn API webcam item for the linked stream or detail page.
 ##### `display_type` values
 
-- `WEBCAM`
+- `WEBCAM`: Provider coded value `WEBCAM` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2678,7 +2678,7 @@ CloudEvents type: `DE.Autobahn.WebcamUpdated`
 
 #### What it tells you
 
-Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -2717,7 +2717,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`stream_url`** (uri or null, optional): linkurl value from the Autobahn API webcam item for the linked stream or detail page.
 ##### `display_type` values
 
-- `WEBCAM`
+- `WEBCAM`: Provider coded value `WEBCAM` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2763,7 +2763,7 @@ CloudEvents type: `DE.Autobahn.WebcamResolved`
 
 #### What it tells you
 
-Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam.
+A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages.
 
 #### Identity
 
@@ -2802,7 +2802,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 - **`stream_url`** (uri or null, optional): linkurl value from the Autobahn API webcam item for the linked stream or detail page.
 ##### `display_type` values
 
-- `WEBCAM`
+- `WEBCAM`: Provider coded value `WEBCAM` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/autobahn/xreg/autobahn.xreg.json
+++ b/autobahn/xreg/autobahn.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.Autobahn"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Autobahn CloudEvents on the `autobahn` topic keyed by `{identifier}`."
     },
     "DE.Autobahn.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/DE.Autobahn.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Autobahn CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -66,7 +68,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.RoadworkUpdated": {
           "name": "RoadworkUpdated",
@@ -88,7 +91,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.RoadworkResolved": {
           "name": "RoadworkResolved",
@@ -110,7 +114,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.ShortTermRoadworkAppeared": {
           "name": "ShortTermRoadworkAppeared",
@@ -132,7 +137,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.ShortTermRoadworkUpdated": {
           "name": "ShortTermRoadworkUpdated",
@@ -154,7 +160,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.ShortTermRoadworkResolved": {
           "name": "ShortTermRoadworkResolved",
@@ -176,7 +183,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.WarningAppeared": {
           "name": "WarningAppeared",
@@ -198,7 +206,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WarningUpdated": {
           "name": "WarningUpdated",
@@ -220,7 +229,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WarningResolved": {
           "name": "WarningResolved",
@@ -242,7 +252,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.WarningEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.ClosureAppeared": {
           "name": "ClosureAppeared",
@@ -264,7 +275,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.ClosureUpdated": {
           "name": "ClosureUpdated",
@@ -286,7 +298,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.ClosureResolved": {
           "name": "ClosureResolved",
@@ -308,7 +321,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.EntryExitClosureAppeared": {
           "name": "EntryExitClosureAppeared",
@@ -330,7 +344,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.EntryExitClosureUpdated": {
           "name": "EntryExitClosureUpdated",
@@ -352,7 +367,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.EntryExitClosureResolved": {
           "name": "EntryExitClosureResolved",
@@ -374,7 +390,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A traffic or service situation update from Germany's Autobahn GmbH traffic APIs. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         },
         "DE.Autobahn.WeightLimit35RestrictionAppeared": {
           "name": "WeightLimit35RestrictionAppeared",
@@ -396,7 +413,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WeightLimit35RestrictionUpdated": {
           "name": "WeightLimit35RestrictionUpdated",
@@ -418,7 +436,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WeightLimit35RestrictionResolved": {
           "name": "WeightLimit35RestrictionResolved",
@@ -440,7 +459,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.RoadEvent",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.ParkingLorryAppeared": {
           "name": "ParkingLorryAppeared",
@@ -462,7 +482,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.ParkingLorryUpdated": {
           "name": "ParkingLorryUpdated",
@@ -484,7 +505,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.ParkingLorryResolved": {
           "name": "ParkingLorryResolved",
@@ -506,7 +528,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ParkingLorry",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.ElectricChargingStationAppeared": {
           "name": "ElectricChargingStationAppeared",
@@ -528,7 +551,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.ElectricChargingStationUpdated": {
           "name": "ElectricChargingStationUpdated",
@@ -550,7 +574,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.ElectricChargingStationResolved": {
           "name": "ElectricChargingStationResolved",
@@ -572,7 +597,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.StrongElectricChargingStationAppeared": {
           "name": "StrongElectricChargingStationAppeared",
@@ -594,7 +620,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.StrongElectricChargingStationUpdated": {
           "name": "StrongElectricChargingStationUpdated",
@@ -616,7 +643,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.StrongElectricChargingStationResolved": {
           "name": "StrongElectricChargingStationResolved",
@@ -638,7 +666,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.ChargingStation",
+          "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "DE.Autobahn.WebcamAppeared": {
           "name": "WebcamAppeared",
@@ -660,7 +689,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WebcamUpdated": {
           "name": "WebcamUpdated",
@@ -682,7 +712,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         },
         "DE.Autobahn.WebcamResolved": {
           "name": "WebcamResolved",
@@ -704,13 +735,15 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam"
+          "dataschemauri": "#/schemagroups/DE.Autobahn.jstruct/schemas/DE.Autobahn.Webcam",
+          "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
         }
-      }
+      },
+      "description": "Events from Autobahn covering German motorway segments, roadworks, closures, and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "DE.Autobahn.mqtt": {
       "messagegroupid": "DE.Autobahn.mqtt",
-      "description": "MQTT/5.0 mirror of the DE.Autobahn CloudEvents, published into the Unified-Namespace topic tree 'traffic/de/autobahn/autobahn/{road}/{kind}/{identifier}/{state}'. {kind} (10 values) and {state} (appeared/updated/resolved) are literally baked per-message so xrcg can resolve every placeholder from schema fields. Lifecycle-event families (roadwork, short-term-roadwork, closure, entry-exit-closure, warning) are QoS-1 non-retained — they are state-change notifications, not LKV slots. Stable-object families (weight-limit-3-5, webcam, parking-lorry, electric-charging-station, strong-electric-charging-station) are QoS-1 retained so late subscribers see the current state of every known object; the bridge publishes an empty retained payload on `resolved` to clear the slot.",
+      "description": "MQTT 5 variant of the Autobahn events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "DE.Autobahn.RoadworkAppeared.mqtt": {
           "messageid": "DE.Autobahn.RoadworkAppeared.mqtt",
@@ -1064,7 +1097,8 @@
                     "name": "StringList",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "description": "Reusable array of strings for Autobahn list-valued text and symbol fields."
                   }
@@ -1095,7 +1129,8 @@
                   "road_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "minItems": 1,
                     "uniqueItems": true,
@@ -1117,6 +1152,13 @@
                     "description": "Autobahn API display_type value that identifies the road-event subtype.",
                     "altnames": {
                       "autobahn-api": "display_type"
+                    },
+                    "descriptions": {
+                      "ROADWORKS": "Provider coded value `ROADWORKS` for this field.",
+                      "SHORT_TERM_ROADWORKS": "Provider coded value `SHORT_TERM_ROADWORKS` for this field.",
+                      "CLOSURE": "Provider coded value `CLOSURE` for this field.",
+                      "CLOSURE_ENTRY_EXIT": "Provider coded value `CLOSURE_ENTRY_EXIT` for this field.",
+                      "WEIGHT_LIMIT_35": "Provider coded value `WEIGHT_LIMIT_35` for this field."
                     }
                   },
                   "title": {
@@ -1304,7 +1346,7 @@
                     }
                   }
                 },
-                "description": "Normalized Autobahn road-event payload used for roadworks and closure-like items. Source pages: https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks and https://verkehr.autobahn.de/o/autobahn/A1/services/closure."
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -1325,7 +1367,8 @@
                     "name": "StringList",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "description": "Reusable array of strings for Autobahn list-valued text and symbol fields."
                   }
@@ -1356,7 +1399,8 @@
                   "road_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "minItems": 1,
                     "uniqueItems": true,
@@ -1374,6 +1418,9 @@
                     "description": "Autobahn API display_type for warning items.",
                     "altnames": {
                       "autobahn-api": "display_type"
+                    },
+                    "descriptions": {
+                      "WARNING": "Provider coded value `WARNING` for this field."
                     }
                   },
                   "title": {
@@ -1605,7 +1652,7 @@
                     }
                   }
                 },
-                "description": "Normalized Autobahn warning payload with delay and traffic source details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/warning."
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -1626,7 +1673,8 @@
                     "name": "StringList",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "description": "Reusable array of strings for Autobahn list-valued text and symbol fields."
                   }
@@ -1657,7 +1705,8 @@
                   "road_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "minItems": 1,
                     "uniqueItems": true,
@@ -1675,6 +1724,9 @@
                     "description": "Autobahn API display_type for lorry parking items.",
                     "altnames": {
                       "autobahn-api": "display_type"
+                    },
+                    "descriptions": {
+                      "PARKING": "Provider coded value `PARKING` for this field."
                     }
                   },
                   "title": {
@@ -1838,7 +1890,7 @@
                     "description": "Number of lorry spaces parsed from description lines that contain LKW Stellplätze."
                   }
                 },
-                "description": "Normalized Autobahn lorry parking payload with parsed amenity and space counts. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/parking_lorry."
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -1859,7 +1911,8 @@
                     "name": "StringList",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "description": "Reusable array of strings for Autobahn list-valued text and symbol fields."
                   }
@@ -1890,7 +1943,8 @@
                   "road_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "minItems": 1,
                     "uniqueItems": true,
@@ -1909,6 +1963,10 @@
                     "description": "Autobahn API display_type for charging-station items.",
                     "altnames": {
                       "autobahn-api": "display_type"
+                    },
+                    "descriptions": {
+                      "ELECTRIC_CHARGING_STATION": "Provider coded value `ELECTRIC_CHARGING_STATION` for this field.",
+                      "STRONG_ELECTRIC_CHARGING_STATION": "Provider coded value `STRONG_ELECTRIC_CHARGING_STATION` for this field."
                     }
                   },
                   "title": {
@@ -2056,7 +2114,7 @@
                     }
                   }
                 },
-                "description": "Normalized Autobahn charging-station payload with parsed address and charging point details. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/electric_charging_station."
+                "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           }
@@ -2077,7 +2135,8 @@
                     "name": "StringList",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "description": "Reusable array of strings for Autobahn list-valued text and symbol fields."
                   }
@@ -2108,7 +2167,8 @@
                   "road_ids": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
                     },
                     "minItems": 1,
                     "uniqueItems": true,
@@ -2126,6 +2186,9 @@
                     "description": "Autobahn API display_type for webcam items.",
                     "altnames": {
                       "autobahn-api": "display_type"
+                    },
+                    "descriptions": {
+                      "WEBCAM": "Provider coded value `WEBCAM` for this field."
                     }
                   },
                   "title": {
@@ -2281,7 +2344,7 @@
                     }
                   }
                 },
-                "description": "Normalized Autobahn webcam payload with operator and media URLs. Source page: https://verkehr.autobahn.de/o/autobahn/A1/services/webcam."
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -2481,7 +2544,8 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -2709,7 +2773,8 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -2889,7 +2954,8 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
@@ -3058,7 +3124,8 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A reference record from Germany's Autobahn GmbH traffic APIs for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           }
@@ -3227,12 +3294,18 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A transport update from Germany's Autobahn GmbH traffic APIs. It carries road traffic incidents, closures, webcams, and travel information for German motorway segments, roadworks, closures, and traffic messages."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Autobahn publishes road traffic incidents, closures, webcams, and travel information from Germany's Autobahn GmbH traffic APIs for German motorway segments, roadworks, closures, and traffic messages. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Autobahn, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/digitraffic-maritime/EVENTS.md
+++ b/digitraffic-maritime/EVENTS.md
@@ -1,12 +1,12 @@
 # Digitraffic Marine Bridge Usage Guide Events
 
-**Digitraffic Marine Bridge** connects to Finland's [Digitraffic](https://www.digitraffic.fi/) MQTT stream for real-time AIS vessel tracking and also polls Digitraffic's Port Call REST APIs for vessel visit and companion reference data. Both paths are forwarded to Kafka as [CloudEvents](https://cloudevents.io/) in JSON format.
+Digitraffic Maritime publishes maritime traffic and fairway updates from Fintraffic Digitraffic for Finnish maritime fairways and vessels. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
 - **Event types:** 5 documented event types.
 - **Transports:** KAFKA
-- **Reference vs telemetry:** 1 reference/catalog event type and 4 telemetry event types.
+- **Reference vs telemetry:** 0 reference/catalog event types and 5 telemetry event types.
 - **Identity:** `{mmsi}`, `{port_call_id}`, `{vessel_id}`, `{locode}` identifies the resource each event is about.
 - **Read next:** [Quick start](#quick-start--how-to-consume), [Event catalog](#event-catalog), [Conventions](#conventions), [Operational notes](#operational-notes), [References](#references).
 
@@ -37,11 +37,11 @@ CloudEvents type: `fi.digitraffic.marine.ais.VesselLocation`
 
 #### What it tells you
 
-AIS vessel position report from Digitraffic MQTT stream. Represents a decoded AIS message type 1/2/3/18/19 position update.
+A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -53,17 +53,17 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Vessel Location` payloads are JSON object. Required fields: `time`, `sog`, `cog`, `navStat`, `rot`, `posAcc`, `raim`, `heading`, `lon`, `lat`.
 
-- **`mmsi`** (int32, optional): No description provided.
-- **`time`** (int32, required): No description provided.
-- **`sog`** (double, required): No description provided.
-- **`cog`** (double, required): No description provided.
-- **`navStat`** (int32, required): No description provided.
-- **`rot`** (int32, required): No description provided.
-- **`posAcc`** (boolean, required): No description provided.
-- **`raim`** (boolean, required): No description provided.
-- **`heading`** (int32, required): No description provided.
-- **`lon`** (double, required): No description provided.
-- **`lat`** (double, required): No description provided.
+- **`mmsi`** (int32, optional): Provider field for mmsi in this record.
+- **`time`** (int32, required): Time when the provider recorded or published the update.
+- **`sog`** (double, required): Provider field for sog in this record.
+- **`cog`** (double, required): Provider field for cog in this record.
+- **`navStat`** (int32, required): Provider field for nav stat in this record.
+- **`rot`** (int32, required): Provider field for rot in this record.
+- **`posAcc`** (boolean, required): Provider field for pos acc in this record.
+- **`raim`** (boolean, required): Provider field for raim in this record.
+- **`heading`** (int32, required): Provider field for heading in this record.
+- **`lon`** (double, required): Provider field for lon in this record.
+- **`lat`** (double, required): Provider field for lat in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -94,11 +94,11 @@ CloudEvents type: `fi.digitraffic.marine.ais.VesselMetadata`
 
 #### What it tells you
 
-AIS vessel static and voyage data from Digitraffic MQTT stream. Represents decoded AIS message type 5/24 data.
+A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -110,20 +110,20 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Vessel Metadata` payloads are JSON object. Required fields: `timestamp`.
 
-- **`mmsi`** (int32, optional): No description provided.
-- **`timestamp`** (int32, required): No description provided.
-- **`name`** (string, optional): No description provided.
-- **`callSign`** (string, optional): No description provided.
-- **`imo`** (int32, optional): No description provided.
-- **`type`** (int32, optional): No description provided.
-- **`draught`** (int32, optional): No description provided.
-- **`eta`** (int32, optional): No description provided.
-- **`destination`** (string, optional): No description provided.
-- **`posType`** (int32, optional): No description provided.
-- **`refA`** (int32, optional): No description provided.
-- **`refB`** (int32, optional): No description provided.
-- **`refC`** (int32, optional): No description provided.
-- **`refD`** (int32, optional): No description provided.
+- **`mmsi`** (int32, optional): Provider field for mmsi in this record.
+- **`timestamp`** (int32, required): Time when the provider recorded or published the update.
+- **`name`** (string, optional): Human-readable name of the resource.
+- **`callSign`** (string, optional): Provider field for call sign in this record.
+- **`imo`** (int32, optional): Provider field for imo in this record.
+- **`type`** (int32, optional): Provider field for type in this record.
+- **`draught`** (int32, optional): Provider field for draught in this record.
+- **`eta`** (int32, optional): Provider field for eta in this record.
+- **`destination`** (string, optional): Provider field for destination in this record.
+- **`posType`** (int32, optional): Provider field for pos type in this record.
+- **`refA`** (int32, optional): Provider field for ref a in this record.
+- **`refB`** (int32, optional): Provider field for ref b in this record.
+- **`refC`** (int32, optional): Provider field for ref c in this record.
+- **`refD`** (int32, optional): Provider field for ref d in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -149,7 +149,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is reference/catalog data. Consumers should cache it and use it to interpret telemetry events that share the same identity.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Port Call
 
@@ -157,7 +157,7 @@ CloudEvents type: `fi.digitraffic.marine.portcall.PortCall`
 
 #### What it tells you
 
-Port call update from Digitraffic's Portnet-backed port-call API. Each event represents one vessel visit plan or update keyed by the Digitraffic port call identifier and carries the vessel identity, routing context, assigned agents, and berth-area timing details.
+A transport update from Fintraffic Digitraffic. It carries maritime traffic and fairway updates for Finnish maritime fairways and vessels.
 
 #### Identity
 
@@ -257,7 +257,7 @@ CloudEvents type: `fi.digitraffic.marine.portcall.VesselDetails`
 
 #### What it tells you
 
-Reference record from Digitraffic's Port Call vessel-details API. Each event represents the current known metadata for one vessel entity keyed by Digitraffic's stable vessel identifier and includes identity, construction, dimensions, registration, and contact details sourced from Portnet.
+A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed.
 
 #### Identity
 
@@ -388,7 +388,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Port Location
 
@@ -396,7 +396,7 @@ CloudEvents type: `fi.digitraffic.marine.portcall.PortLocation`
 
 #### What it tells you
 
-Reference record from Digitraffic's Port Call ports API. Each event represents one SafeSeaNet port location keyed by UN/LOCODE together with its point geometry, port-area definitions, and berth catalog from the same upstream snapshot.
+A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 

--- a/digitraffic-maritime/xreg/digitraffic_maritime.xreg.json
+++ b/digitraffic-maritime/xreg/digitraffic_maritime.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.marine.ais"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Maritime CloudEvents on the `digitraffic-maritime` topic keyed by `{mmsi}`."
     },
     "fi.digitraffic.marine.portcall.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.marine.portcall"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Maritime CloudEvents on the `digitraffic-maritime` topic keyed by `{port_call_id}`."
     },
     "fi.digitraffic.marine.portcall.vesseldetails.Kafka": {
       "usage": [
@@ -61,7 +63,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.marine.portcall.vesseldetails"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Maritime CloudEvents on the `digitraffic-maritime` topic keyed by `{vessel_id}`."
     },
     "fi.digitraffic.marine.portcall.portlocation.Kafka": {
       "usage": [
@@ -82,7 +85,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.marine.portcall.portlocation"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Maritime CloudEvents on the `digitraffic-maritime` topic keyed by `{locode}`."
     }
   },
   "messagegroups": {
@@ -104,7 +108,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.ais.jstruct/schemas/fi.digitraffic.marine.ais.VesselLocation"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.ais.jstruct/schemas/fi.digitraffic.marine.ais.VesselLocation",
+          "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "fi.digitraffic.marine.ais.VesselMetadata": {
           "name": "VesselMetadata",
@@ -122,9 +127,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.ais.jstruct/schemas/fi.digitraffic.marine.ais.VesselMetadata"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.ais.jstruct/schemas/fi.digitraffic.marine.ais.VesselMetadata",
+          "description": "A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
         }
-      }
+      },
+      "description": "Events from Digitraffic Maritime covering Finnish maritime fairways and vessels. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.marine.portcall": {
       "messages": {
@@ -144,9 +151,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.jstruct/schemas/fi.digitraffic.marine.portcall.PortCall"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.jstruct/schemas/fi.digitraffic.marine.portcall.PortCall",
+          "description": "A transport update from Fintraffic Digitraffic. It carries maritime traffic and fairway updates for Finnish maritime fairways and vessels."
         }
-      }
+      },
+      "description": "Events from Digitraffic Maritime covering Finnish maritime fairways and vessels. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.marine.portcall.vesseldetails": {
       "messages": {
@@ -166,9 +175,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.reference.jstruct/schemas/fi.digitraffic.marine.portcall.VesselDetails"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.reference.jstruct/schemas/fi.digitraffic.marine.portcall.VesselDetails",
+          "description": "A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
         }
-      }
+      },
+      "description": "Events from Digitraffic Maritime covering Finnish maritime fairways and vessels. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.marine.portcall.portlocation": {
       "messages": {
@@ -188,9 +199,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.reference.jstruct/schemas/fi.digitraffic.marine.portcall.PortLocation"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.marine.portcall.reference.jstruct/schemas/fi.digitraffic.marine.portcall.PortLocation",
+          "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         }
-      }
+      },
+      "description": "Events from Digitraffic Maritime covering Finnish maritime fairways and vessels. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -221,41 +234,52 @@
                 "name": "VesselLocation",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "time": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "sog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for sog in this record."
                   },
                   "cog": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for cog in this record."
                   },
                   "navStat": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for nav stat in this record."
                   },
                   "rot": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for rot in this record."
                   },
                   "posAcc": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for pos acc in this record."
                   },
                   "raim": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Provider field for raim in this record."
                   },
                   "heading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for heading in this record."
                   },
                   "lon": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for lon in this record."
                   },
                   "lat": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for lat in this record."
                   }
                 },
                 "$id": "https://example.com/schemas/fi/digitraffic/marine/ais/VesselLocation",
-                "description": "AIS vessel position report from Digitraffic MQTT stream. Represents a decoded AIS message type 1/2/3/18/19 position update."
+                "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           }
@@ -276,50 +300,64 @@
                 "name": "VesselMetadata",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "timestamp": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the resource."
                   },
                   "callSign": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for call sign in this record."
                   },
                   "imo": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for imo in this record."
                   },
                   "type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for type in this record."
                   },
                   "draught": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for draught in this record."
                   },
                   "eta": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for eta in this record."
                   },
                   "destination": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for destination in this record."
                   },
                   "posType": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for pos type in this record."
                   },
                   "refA": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ref a in this record."
                   },
                   "refB": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ref b in this record."
                   },
                   "refC": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ref c in this record."
                   },
                   "refD": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ref d in this record."
                   }
                 },
                 "$id": "https://example.com/schemas/fi/digitraffic/marine/ais/VesselMetadata",
-                "description": "AIS vessel static and voyage data from Digitraffic MQTT stream. Represents decoded AIS message type 5/24 data."
+                "description": "A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               }
             }
           }
@@ -340,7 +378,7 @@
                 "$id": "https://meri.digitraffic.fi/schemas/fi/digitraffic/marine/portcall/PortCall",
                 "type": "object",
                 "name": "PortCall",
-                "description": "Port call update from Digitraffic's Portnet-backed port-call API. Each event represents one vessel visit plan or update keyed by the Digitraffic port call identifier and carries the vessel identity, routing context, assigned agents, and berth-area timing details.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries maritime traffic and fairway updates for Finnish maritime fairways and vessels.",
                 "required": [
                   "port_call_id",
                   "updated_at",
@@ -363,7 +401,10 @@
                     "description": "Timestamp when this port call record was last updated in Digitraffic, from the portCallTimestamp field."
                   },
                   "customs_reference": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Customs reference string carried with the port call when available."
                   },
                   "port_to_visit": {
@@ -371,19 +412,31 @@
                     "description": "UN/LOCODE of the destination port that this call is scheduled to visit."
                   },
                   "previous_port": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "UN/LOCODE of the vessel's previous port when reported by Portnet."
                   },
                   "next_port": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "UN/LOCODE of the vessel's next announced port when reported by Portnet."
                   },
                   "mmsi": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Maritime Mobile Service Identity associated with the visiting vessel, when available."
                   },
                   "imo_lloyds": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "IMO or Lloyd's vessel number carried with the port call when available."
                   },
                   "vessel_name": {
@@ -391,19 +444,31 @@
                     "description": "Reported vessel name for the visit."
                   },
                   "vessel_name_prefix": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Reported vessel name prefix such as 'ms' or 'mt' when present."
                   },
                   "radio_call_sign": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Radio call sign for the visiting vessel when reported by Portnet."
                   },
                   "nationality": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Flag or nationality code reported for the vessel."
                   },
                   "vessel_type_code": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Digitraffic vessel type code for the visiting vessel."
                   },
                   "domestic_traffic_arrival": {
@@ -423,11 +488,17 @@
                     "description": "True when the vessel is reported as not loading cargo at the call."
                   },
                   "discharge": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Digitraffic discharge indicator value for the call when reported."
                   },
                   "current_security_level": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Current ISPS security level reported for the vessel at this call."
                   },
                   "agents": {
@@ -471,51 +542,87 @@
                       ],
                       "properties": {
                         "port_area_code": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Code of the destination port area when assigned."
                         },
                         "port_area_name": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Human-readable name of the destination port area when assigned."
                         },
                         "berth_code": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Berth code within the destination port area when assigned."
                         },
                         "berth_name": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Human-readable berth name when assigned."
                         },
                         "eta": {
-                          "type": ["datetime", "null"],
+                          "type": [
+                            "datetime",
+                            "null"
+                          ],
                           "description": "Estimated time of arrival for this port-area assignment."
                         },
                         "eta_source": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Source of the ETA value, for example an agent update."
                         },
                         "etd": {
-                          "type": ["datetime", "null"],
+                          "type": [
+                            "datetime",
+                            "null"
+                          ],
                           "description": "Estimated time of departure for this port-area assignment."
                         },
                         "etd_source": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Source of the ETD value, for example an agent update."
                         },
                         "ata": {
-                          "type": ["datetime", "null"],
+                          "type": [
+                            "datetime",
+                            "null"
+                          ],
                           "description": "Actual time of arrival for this port-area assignment when recorded."
                         },
                         "ata_source": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Source of the ATA value when recorded."
                         },
                         "atd": {
-                          "type": ["datetime", "null"],
+                          "type": [
+                            "datetime",
+                            "null"
+                          ],
                           "description": "Actual time of departure for this port-area assignment when recorded."
                         },
                         "atd_source": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Source of the ATD value when recorded."
                         },
                         "arrival_draught": {
@@ -554,7 +661,7 @@
                 "$id": "https://meri.digitraffic.fi/schemas/fi/digitraffic/marine/portcall/VesselDetails",
                 "type": "object",
                 "name": "VesselDetails",
-                "description": "Reference record from Digitraffic's Port Call vessel-details API. Each event represents the current known metadata for one vessel entity keyed by Digitraffic's stable vessel identifier and includes identity, construction, dimensions, registration, and contact details sourced from Portnet.",
+                "description": "A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed.",
                 "definitions": {
                   "VesselConstruction": {
                     "name": "VesselConstruction",
@@ -562,39 +669,66 @@
                     "description": "Construction and classification attributes for the vessel.",
                     "properties": {
                       "vessel_type_code": {
-                        "type": ["int32", "null"],
+                        "type": [
+                          "int32",
+                          "null"
+                        ],
                         "description": "Digitraffic vessel type code from vesselConstruction.vesselTypeCode when available."
                       },
                       "vessel_type_name": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Human-readable vessel type name from vesselConstruction.vesselTypeName when available."
                       },
                       "ice_class_code": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Ice class code reported for the vessel when available."
                       },
                       "ice_class_issue_date": {
-                        "type": ["datetime", "null"],
+                        "type": [
+                          "datetime",
+                          "null"
+                        ],
                         "description": "Date when the current ice-class endorsement was issued, when available."
                       },
                       "ice_class_issue_place": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Place where the ice-class endorsement was issued when available."
                       },
                       "ice_class_end_date": {
-                        "type": ["datetime", "null"],
+                        "type": [
+                          "datetime",
+                          "null"
+                        ],
                         "description": "Date when the current ice-class endorsement ends, when available."
                       },
                       "double_bottom": {
-                        "type": ["boolean", "null"],
+                        "type": [
+                          "boolean",
+                          "null"
+                        ],
                         "description": "True when the vessel is reported as having a double bottom."
                       },
                       "inert_gas_system": {
-                        "type": ["boolean", "null"],
+                        "type": [
+                          "boolean",
+                          "null"
+                        ],
                         "description": "True when the vessel is reported as having an inert gas system."
                       },
                       "ballast_tank": {
-                        "type": ["boolean", "null"],
+                        "type": [
+                          "boolean",
+                          "null"
+                        ],
                         "description": "True when the vessel is reported as having a ballast tank."
                       }
                     }
@@ -605,63 +739,99 @@
                     "description": "Tonnage and dimensional attributes for the vessel.",
                     "properties": {
                       "tonnage_certificate_issuer": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Issuer of the vessel tonnage certificate when available."
                       },
                       "date_of_issue": {
-                        "type": ["datetime", "null"],
+                        "type": [
+                          "datetime",
+                          "null"
+                        ],
                         "description": "Date when the tonnage certificate was issued when available."
                       },
                       "gross_tonnage": {
-                        "type": ["int32", "null"],
+                        "type": [
+                          "int32",
+                          "null"
+                        ],
                         "description": "Gross tonnage reported for the vessel when available."
                       },
                       "net_tonnage": {
-                        "type": ["int32", "null"],
+                        "type": [
+                          "int32",
+                          "null"
+                        ],
                         "description": "Net tonnage reported for the vessel when available."
                       },
                       "dead_weight": {
-                        "type": ["int32", "null"],
+                        "type": [
+                          "int32",
+                          "null"
+                        ],
                         "description": "Deadweight reported for the vessel from the deathWeight field when available."
                       },
                       "length": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported vessel length in meters when available.",
                         "unit": "m",
                         "symbol": "m"
                       },
                       "overall_length": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported vessel overall length in meters when available.",
                         "unit": "m",
                         "symbol": "m"
                       },
                       "height": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported vessel height in meters when available.",
                         "unit": "m",
                         "symbol": "m"
                       },
                       "breadth": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported vessel breadth in meters when available.",
                         "unit": "m",
                         "symbol": "m"
                       },
                       "draught": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported vessel draught in meters when available.",
                         "unit": "m",
                         "symbol": "m"
                       },
                       "max_speed": {
-                        "type": ["double", "null"],
+                        "type": [
+                          "double",
+                          "null"
+                        ],
                         "description": "Reported maximum vessel speed in knots when available.",
                         "unit": "kn",
                         "symbol": "kn"
                       },
                       "engine_power": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Engine power value as reported by Digitraffic when available."
                       }
                     }
@@ -672,11 +842,17 @@
                     "description": "Registry and nationality details for the vessel.",
                     "properties": {
                       "nationality": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Reported nationality or flag state for the vessel when available."
                       },
                       "port_of_registry": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Reported port of registry or home port for the vessel when available."
                       }
                     }
@@ -687,19 +863,31 @@
                     "description": "System and contact details carried with the vessel metadata.",
                     "properties": {
                       "ship_owner": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Reported ship owner name when available."
                       },
                       "ship_telephone_1": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Primary ship telephone number when available."
                       },
                       "ship_email": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Ship email address when available."
                       },
                       "ship_verifier": {
-                        "type": ["string", "null"],
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Verifier or registry authority code carried with the vessel system record when available."
                       }
                     }
@@ -719,47 +907,88 @@
                     "description": "Timestamp when Digitraffic last updated the vessel metadata record, from the updateTimestamp field."
                   },
                   "mmsi": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Maritime Mobile Service Identity associated with this vessel when available."
                   },
                   "name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Reported vessel name."
                   },
                   "name_prefix": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Reported vessel-name prefix such as ms when available."
                   },
                   "imo_lloyds": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "IMO or Lloyd's number associated with the vessel when available."
                   },
                   "radio_call_sign": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Radio call sign associated with the vessel when available."
                   },
                   "radio_call_sign_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Type of radio call sign reported by Digitraffic, for example REAL."
                   },
                   "data_source": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Upstream data source reported by Digitraffic for the vessel metadata, for example Portnet."
                   },
                   "vessel_construction": {
-                    "type": ["null", { "$ref": "#/definitions/VesselConstruction" }],
+                    "type": [
+                      "null",
+                      {
+                        "$ref": "#/definitions/VesselConstruction"
+                      }
+                    ],
                     "description": "Construction and classification attributes for the vessel."
                   },
                   "vessel_dimensions": {
-                    "type": ["null", { "$ref": "#/definitions/VesselDimensions" }],
+                    "type": [
+                      "null",
+                      {
+                        "$ref": "#/definitions/VesselDimensions"
+                      }
+                    ],
                     "description": "Tonnage and dimensional attributes for the vessel."
                   },
                   "vessel_registration": {
-                    "type": ["null", { "$ref": "#/definitions/VesselRegistration" }],
+                    "type": [
+                      "null",
+                      {
+                        "$ref": "#/definitions/VesselRegistration"
+                      }
+                    ],
                     "description": "Registry and nationality details for the vessel."
                   },
                   "vessel_system": {
-                    "type": ["null", { "$ref": "#/definitions/VesselSystem" }],
+                    "type": [
+                      "null",
+                      {
+                        "$ref": "#/definitions/VesselSystem"
+                      }
+                    ],
                     "description": "System and contact details carried with the vessel metadata."
                   }
                 }
@@ -779,7 +1008,7 @@
                 "$id": "https://meri.digitraffic.fi/schemas/fi/digitraffic/marine/portcall/PortLocation",
                 "type": "object",
                 "name": "PortLocation",
-                "description": "Reference record from Digitraffic's Port Call ports API. Each event represents one SafeSeaNet port location keyed by UN/LOCODE together with its point geometry, port-area definitions, and berth catalog from the same upstream snapshot.",
+                "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
                 "required": [
                   "locode",
                   "data_updated_time",
@@ -806,13 +1035,19 @@
                     "description": "Country name reported for the location in the ssnLocations feature properties."
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Longitude of the port location point in decimal degrees east when the upstream feature includes geometry.",
                     "unit": "deg",
                     "symbol": "deg"
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Latitude of the port location point in decimal degrees north when the upstream feature includes geometry.",
                     "unit": "deg",
                     "symbol": "deg"
@@ -837,18 +1072,25 @@
                           "description": "Human-readable name of the port area."
                         },
                         "longitude": {
-                          "type": ["double", "null"],
+                          "type": [
+                            "double",
+                            "null"
+                          ],
                           "description": "Longitude of the port-area point in decimal degrees east when the upstream feature includes geometry.",
                           "unit": "deg",
                           "symbol": "deg"
                         },
                         "latitude": {
-                          "type": ["double", "null"],
+                          "type": [
+                            "double",
+                            "null"
+                          ],
                           "description": "Latitude of the port-area point in decimal degrees north when the upstream feature includes geometry.",
                           "unit": "deg",
                           "symbol": "deg"
                         }
-                      }
+                      },
+                      "description": "A transport update from Fintraffic Digitraffic. It carries maritime traffic and fairway updates for Finnish maritime fairways and vessels."
                     }
                   },
                   "berths": {
@@ -875,7 +1117,8 @@
                           "type": "string",
                           "description": "Human-readable berth name."
                         }
-                      }
+                      },
+                      "description": "A transport update from Fintraffic Digitraffic. It carries maritime traffic and fairway updates for Finnish maritime fairways and vessels."
                     }
                   }
                 }
@@ -947,7 +1190,8 @@
                     "name": "lat",
                     "type": "double"
                   }
-                ]
+                ],
+                "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           }
@@ -1072,12 +1316,18 @@
                     ],
                     "default": null
                   }
-                ]
+                ],
+                "description": "A vehicle or vessel update from Fintraffic Digitraffic. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Digitraffic Maritime publishes maritime traffic and fairway updates from Fintraffic Digitraffic for Finnish maritime fairways and vessels. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Digitraffic Maritime, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/digitraffic-road/EVENTS.md
+++ b/digitraffic-road/EVENTS.md
@@ -1,6 +1,6 @@
 # Digitraffic Road — Finnish Road Traffic Data Events
 
-Real-time road traffic data from the Finnish national road network operated by Fintraffic. Telemetry is streamed via the Digitraffic MQTT service at `wss://tie.digitraffic.fi/mqtt` and includes TMS sensor readings, road weather sensor readings, traffic messages (incidents, road works, weight restrictions, exempted transports), and maintenance vehicle tracking. Station metadata and maintenance task type catalogs are fetched as reference data from the Digitraffic REST API at startup.
+Digitraffic Road publishes road traffic measurements and status updates from Fintraffic Digitraffic for Finnish road network sensors and traffic messages. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `fi.digitraffic.road.sensors.TmsSensorData`
 
 #### What it tells you
 
-Traffic Measurement System (TMS) sensor reading from the Finnish national road network operated by Fintraffic. Each message represents a single computational sensor measurement at a TMS station, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic tms-v2/{stationId}/{sensorId}. TMS stations measure vehicle counts (passings) and average speeds aggregated over rolling or fixed time windows.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -85,7 +85,7 @@ CloudEvents type: `fi.digitraffic.road.sensors.WeatherSensorData`
 
 #### What it tells you
 
-Road weather station sensor reading from the Finnish national road network operated by Fintraffic. Each message represents a single sensor measurement at a road weather station, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic weather-v2/{stationId}/{sensorId}. Over 350 road weather stations measure parameters including air temperature (ILMA), road surface temperature (TIE_1), ground temperature (MAA_1), dew point (KASTEPISTE), freezing point (JÄÄTYMISPISTE_1), wind speed (KESKITUULI, MAKSIMITUULI), humidity (ILMAN_KOSTEUS), and precipitation.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -128,7 +128,7 @@ CloudEvents type: `fi.digitraffic.road.messages.TrafficAnnouncement`
 
 #### What it tells you
 
-Traffic message from the Finnish national road network operated by Fintraffic, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic traffic-message-v3/simple/{situationType}. Traffic messages describe situations such as accidents, road works, weight restrictions, and exempted transports. Each message carries a stable situation identifier (GUID), a version counter, and one or more announcements with location, timing, and descriptive detail.
+A current transport measurement or status update from Fintraffic Digitraffic. It carries road traffic measurements and status updates when the upstream feed reports a new or refreshed value. A transport update from Fintraffic Digitraffic.
 
 #### Identity
 
@@ -197,7 +197,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Road Work
 
@@ -205,7 +205,7 @@ CloudEvents type: `fi.digitraffic.road.messages.RoadWork`
 
 #### What it tells you
 
-Traffic message from the Finnish national road network operated by Fintraffic, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic traffic-message-v3/simple/{situationType}. Traffic messages describe situations such as accidents, road works, weight restrictions, and exempted transports. Each message carries a stable situation identifier (GUID), a version counter, and one or more announcements with location, timing, and descriptive detail.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -282,7 +282,7 @@ CloudEvents type: `fi.digitraffic.road.messages.WeightRestriction`
 
 #### What it tells you
 
-Traffic message from the Finnish national road network operated by Fintraffic, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic traffic-message-v3/simple/{situationType}. Traffic messages describe situations such as accidents, road works, weight restrictions, and exempted transports. Each message carries a stable situation identifier (GUID), a version counter, and one or more announcements with location, timing, and descriptive detail.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -359,7 +359,7 @@ CloudEvents type: `fi.digitraffic.road.messages.ExemptedTransport`
 
 #### What it tells you
 
-Traffic message from the Finnish national road network operated by Fintraffic, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic traffic-message-v3/simple/{situationType}. Traffic messages describe situations such as accidents, road works, weight restrictions, and exempted transports. Each message carries a stable situation identifier (GUID), a version counter, and one or more announcements with location, timing, and descriptive detail.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -436,7 +436,7 @@ CloudEvents type: `fi.digitraffic.road.maintenance.MaintenanceTracking`
 
 #### What it tells you
 
-Road maintenance vehicle tracking update from the Finnish national road network operated by Fintraffic. Each message represents a position and task report from a maintenance vehicle, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic maintenance-v2/routes/{domain}. Data originates from the Finnish Transport Infrastructure Agency's Harja system for state roads and from municipal systems for other domains.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 
@@ -487,7 +487,7 @@ CloudEvents type: `fi.digitraffic.road.stations.TmsStation`
 
 #### What it tells you
 
-Traffic Measurement System (TMS) station metadata from the Finnish national road network operated by Fintraffic. Each TMS station is a fixed roadside installation that measures traffic volumes and speeds. Over 500 TMS stations are deployed across the Finnish road network.
+A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -580,7 +580,7 @@ CloudEvents type: `fi.digitraffic.road.stations.WeatherStation`
 
 #### What it tells you
 
-Road weather station metadata from the Finnish national road network operated by Fintraffic. Over 350 road weather stations measure atmospheric and road surface conditions. Station metadata includes geographic location, road address, municipality, sensor list, collection parameters, and administrative details.
+A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -673,7 +673,7 @@ CloudEvents type: `fi.digitraffic.road.maintenance.tasks.MaintenanceTaskType`
 
 #### What it tells you
 
-Maintenance task type reference from the Finnish road maintenance system operated by Fintraffic. Each task type classifies a specific road maintenance activity such as ploughing, salting, or brush clearing. Task type identifiers appear in the tasks array of MaintenanceTracking telemetry events.
+A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.
 
 #### Identity
 

--- a/digitraffic-road/xreg/digitraffic_road.xreg.json
+++ b/digitraffic-road/xreg/digitraffic_road.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.road.sensors"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Road CloudEvents on the `digitraffic-road-sensors` topic keyed by `{station_id}/{sensor_id}`."
     },
     "fi.digitraffic.road.messages.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.road.messages"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Road CloudEvents on the `digitraffic-road-messages` topic keyed by `{situation_id}`."
     },
     "fi.digitraffic.road.maintenance.Kafka": {
       "usage": [
@@ -61,7 +63,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.road.maintenance"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Road CloudEvents on the `digitraffic-road-maintenance` topic keyed by `{domain}`."
     },
     "fi.digitraffic.road.stations.Kafka": {
       "usage": [
@@ -82,7 +85,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.road.stations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Road CloudEvents on the `digitraffic-road-sensors` topic keyed by `{station_id}`."
     },
     "fi.digitraffic.road.maintenance.tasks.Kafka": {
       "usage": [
@@ -103,7 +107,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fi.digitraffic.road.maintenance.tasks"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Digitraffic Road CloudEvents on the `digitraffic-road-maintenance` topic keyed by `{task_id}`."
     }
   },
   "messagegroups": {
@@ -125,7 +130,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.sensors.jstruct/schemas/fi.digitraffic.road.sensors.TmsSensorData"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.sensors.jstruct/schemas/fi.digitraffic.road.sensors.TmsSensorData",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         },
         "fi.digitraffic.road.sensors.WeatherSensorData": {
           "name": "WeatherSensorData",
@@ -143,9 +149,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.sensors.jstruct/schemas/fi.digitraffic.road.sensors.WeatherSensorData"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.sensors.jstruct/schemas/fi.digitraffic.road.sensors.WeatherSensorData",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         }
-      }
+      },
+      "description": "Events from Digitraffic Road covering Finnish road network sensors and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.road.messages": {
       "messages": {
@@ -165,7 +173,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage",
+          "description": "A current transport measurement or status update from Fintraffic Digitraffic. It carries road traffic measurements and status updates when the upstream feed reports a new or refreshed value."
         },
         "fi.digitraffic.road.messages.RoadWork": {
           "name": "RoadWork",
@@ -183,7 +192,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         },
         "fi.digitraffic.road.messages.WeightRestriction": {
           "name": "WeightRestriction",
@@ -201,7 +211,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         },
         "fi.digitraffic.road.messages.ExemptedTransport": {
           "name": "ExemptedTransport",
@@ -219,9 +230,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.messages.jstruct/schemas/fi.digitraffic.road.messages.TrafficMessage",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         }
-      }
+      },
+      "description": "Events from Digitraffic Road covering Finnish road network sensors and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.road.maintenance": {
       "messages": {
@@ -241,9 +254,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.maintenance.jstruct/schemas/fi.digitraffic.road.maintenance.MaintenanceTracking"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.maintenance.jstruct/schemas/fi.digitraffic.road.maintenance.MaintenanceTracking",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         }
-      }
+      },
+      "description": "Events from Digitraffic Road covering Finnish road network sensors and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.road.stations": {
       "messages": {
@@ -263,7 +278,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.stations.jstruct/schemas/fi.digitraffic.road.stations.TmsStation"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.stations.jstruct/schemas/fi.digitraffic.road.stations.TmsStation",
+          "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "fi.digitraffic.road.stations.WeatherStation": {
           "name": "WeatherStation",
@@ -281,9 +297,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.stations.jstruct/schemas/fi.digitraffic.road.stations.WeatherStation"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.stations.jstruct/schemas/fi.digitraffic.road.stations.WeatherStation",
+          "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         }
-      }
+      },
+      "description": "Events from Digitraffic Road covering Finnish road network sensors and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fi.digitraffic.road.maintenance.tasks": {
       "messages": {
@@ -303,9 +321,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/fi.digitraffic.road.maintenance.tasks.jstruct/schemas/fi.digitraffic.road.maintenance.tasks.MaintenanceTaskType"
+          "dataschemauri": "#/schemagroups/fi.digitraffic.road.maintenance.tasks.jstruct/schemas/fi.digitraffic.road.maintenance.tasks.MaintenanceTaskType",
+          "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
         }
-      }
+      },
+      "description": "Events from Digitraffic Road covering Finnish road network sensors and traffic messages. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -323,7 +343,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/sensors/TmsSensorData",
                 "type": "object",
                 "name": "TmsSensorData",
-                "description": "Traffic Measurement System (TMS) sensor reading from the Finnish national road network operated by Fintraffic. Each message represents a single computational sensor measurement at a TMS station, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic tms-v2/{stationId}/{sensorId}. TMS stations measure vehicle counts (passings) and average speeds aggregated over rolling or fixed time windows. Over 500 stations across the Finnish road network report data every minute. See https://www.digitraffic.fi/en/road-traffic/ and the TMS documentation at https://www.digitraffic.fi/en/road-traffic/lam/ for full sensor descriptions.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.",
                 "required": [
                   "station_id",
                   "sensor_id",
@@ -378,7 +398,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/sensors/WeatherSensorData",
                 "type": "object",
                 "name": "WeatherSensorData",
-                "description": "Road weather station sensor reading from the Finnish national road network operated by Fintraffic. Each message represents a single sensor measurement at a road weather station, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic weather-v2/{stationId}/{sensorId}. Over 350 road weather stations measure parameters including air temperature (ILMA), road surface temperature (TIE_1), ground temperature (MAA_1), dew point (KASTEPISTE), freezing point (JÄÄTYMISPISTE_1), wind speed (KESKITUULI, MAKSIMITUULI), humidity (ILMAN_KOSTEUS), and precipitation. Data is updated every minute. See https://www.digitraffic.fi/en/road-traffic/ for full documentation.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.",
                 "required": [
                   "station_id",
                   "sensor_id",
@@ -423,7 +443,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/messages/TrafficMessage",
                 "type": "object",
                 "name": "TrafficMessage",
-                "description": "Traffic message from the Finnish national road network operated by Fintraffic, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic traffic-message-v3/simple/{situationType}. Traffic messages describe situations such as accidents, road works, weight restrictions, and exempted transports. Each message carries a stable situation identifier (GUID), a version counter, and one or more announcements with location, timing, and descriptive detail. The MQTT payload is gzip-compressed and base64-encoded Simple JSON derived from the GeoJSON-based Digitraffic traffic-message API. See https://www.digitraffic.fi/en/road-traffic/ for the full API documentation and situation type taxonomy.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.",
                 "required": [
                   "situation_id",
                   "situation_type",
@@ -585,7 +605,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/maintenance/MaintenanceTracking",
                 "type": "object",
                 "name": "MaintenanceTracking",
-                "description": "Road maintenance vehicle tracking update from the Finnish national road network operated by Fintraffic. Each message represents a position and task report from a maintenance vehicle, delivered in real time via the Digitraffic MQTT stream at wss://tie.digitraffic.fi/mqtt on topic maintenance-v2/routes/{domain}. Data originates from the Finnish Transport Infrastructure Agency's Harja system for state roads and from municipal systems for other domains. Updates arrive approximately every minute. A new tracking event is created when the vehicle's task changes, the gap between consecutive positions exceeds 5 minutes, or the calculated speed exceeds 140 km/h. See https://www.digitraffic.fi/en/road-traffic/ for the full API documentation and task type taxonomy at /api/maintenance/v1/tracking/tasks.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.",
                 "required": [
                   "domain",
                   "time",
@@ -612,7 +632,8 @@
                   "tasks": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
                     },
                     "description": "Array of maintenance task type identifiers being performed by the vehicle at this position. Task types follow the Fintraffic taxonomy, e.g. 'BRUSHING', 'SALTING', 'PLOUGHING_AND_SLUSH_REMOVAL', 'LEVELLING_GRAVEL_ROAD_SURFACE'. Full task type list with Finnish, English, and Swedish names is available at /api/maintenance/v1/tracking/tasks."
                   },
@@ -652,7 +673,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/stations/TmsStation",
                 "type": "object",
                 "name": "TmsStation",
-                "description": "Traffic Measurement System (TMS) station metadata from the Finnish national road network operated by Fintraffic. Each TMS station is a fixed roadside installation that measures traffic volumes and speeds. Over 500 TMS stations are deployed across the Finnish road network. Station metadata includes geographic location, road address, municipality, available sensor list, free-flow reference speeds, and collection status. This reference data contextualizes the real-time TmsSensorData telemetry events and is fetched from the Digitraffic REST API at https://tie.digitraffic.fi/api/tms/v1/stations. See https://www.digitraffic.fi/en/road-traffic/lam/ for full TMS station documentation.",
+                "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
                 "required": [
                   "station_id",
                   "name",
@@ -810,7 +831,8 @@
                   "sensors": {
                     "type": "array",
                     "items": {
-                      "type": "int32"
+                      "type": "int32",
+                      "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
                     },
                     "description": "Array of computational sensor identifiers available at this station. Each ID corresponds to a sensor that produces TmsSensorData telemetry events. Common sensor families: OHITUKSET (passings), KESKINOPEUS (average speed), LIUKUVA_NOPEUS (rolling speed). Sensor metadata is available at /api/tms/v1/sensors."
                   },
@@ -838,7 +860,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/stations/WeatherStation",
                 "type": "object",
                 "name": "WeatherStation",
-                "description": "Road weather station metadata from the Finnish national road network operated by Fintraffic. Over 350 road weather stations measure atmospheric and road surface conditions. Station metadata includes geographic location, road address, municipality, sensor list, collection parameters, and administrative details. This reference data contextualizes the real-time WeatherSensorData telemetry events and is fetched from the Digitraffic REST API at https://tie.digitraffic.fi/api/weather/v1/stations. See https://www.digitraffic.fi/en/road-traffic/ for full documentation.",
+                "description": "A reference record from Fintraffic Digitraffic for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
                 "required": [
                   "station_id",
                   "name",
@@ -992,7 +1014,8 @@
                   "sensors": {
                     "type": "array",
                     "items": {
-                      "type": "int32"
+                      "type": "int32",
+                      "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages."
                     },
                     "description": "Array of sensor identifiers available at this station. Each ID corresponds to a sensor producing WeatherSensorData telemetry. Common sensors: ILMA (1, air temp), TIE_1 (3, road surface temp), KASTEPISTE (9, dew point), KESKITUULI (16, avg wind), ILMAN_KOSTEUS (19, humidity). Full list at /api/weather/v1/sensors."
                   },
@@ -1024,7 +1047,7 @@
                 "$id": "https://fintraffic.fi/schemas/fi/digitraffic/road/maintenance/tasks/MaintenanceTaskType",
                 "type": "object",
                 "name": "MaintenanceTaskType",
-                "description": "Maintenance task type reference from the Finnish road maintenance system operated by Fintraffic. Each task type classifies a specific road maintenance activity such as ploughing, salting, or brush clearing. Task type identifiers appear in the tasks array of MaintenanceTracking telemetry events. This reference data provides multilingual human-readable names for each task identifier and is fetched from the Digitraffic REST API at https://tie.digitraffic.fi/api/maintenance/v1/tracking/tasks. Approximately 40 task types are defined. See https://www.digitraffic.fi/en/road-traffic/ for full documentation.",
+                "description": "A transport update from Fintraffic Digitraffic. It carries road traffic measurements and status updates for Finnish road network sensors and traffic messages.",
                 "required": [
                   "task_id",
                   "name_fi",
@@ -1062,5 +1085,10 @@
         }
       }
     }
+  },
+  "description": "Digitraffic Road publishes road traffic measurements and status updates from Fintraffic Digitraffic for Finnish road network sensors and traffic messages. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Digitraffic Road, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/entur-norway/EVENTS.md
+++ b/entur-norway/EVENTS.md
@@ -1,6 +1,6 @@
 # Entur Norway SIRI Bridge Events
 
-Message group for dated service journey reference data and real-time journey telemetry (ET and VM). All messages in this group share the journeys/{operating_day}/{service_journey_id} Kafka key.
+Entur Norway publishes transit realtime updates from Entur public transport feeds for Norwegian public-transport stops, lines, and journeys. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 

--- a/entur-norway/xreg/entur-norway.xreg.json
+++ b/entur-norway/xreg/entur-norway.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/no.entur.journeys"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Entur Norway CloudEvents on the `entur-norway` topic keyed by `journeys/{operating_day}/{service_journey_id}`."
     },
     "no.entur.situations.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/no.entur.situations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Entur Norway CloudEvents on the `entur-norway` topic keyed by `situations/{situation_number}`."
     },
     "no.entur.Mqtt": {
       "usage": [
@@ -59,14 +61,15 @@
       ],
       "messagegroups": [
         "#/messagegroups/no.entur.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Entur Norway CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
     "no.entur.journeys": {
       "id": "no.entur.journeys",
       "name": "Entur Journey Events",
-      "description": "Message group for dated service journey reference data and real-time journey telemetry (ET and VM). All messages in this group share the journeys/{operating_day}/{service_journey_id} Kafka key.",
+      "description": "Events from Entur Norway covering Norwegian public-transport stops, lines, and journeys. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update.",
       "messages": {
         "no.entur.DatedServiceJourney": {
           "id": "no.entur.DatedServiceJourney",
@@ -133,7 +136,7 @@
     "no.entur.situations": {
       "id": "no.entur.situations",
       "name": "Entur Situation Events",
-      "description": "Message group for SIRI-SX transit disruption and service alert events. All messages in this group share the situations/{situation_number} Kafka key.",
+      "description": "Events from Entur Norway covering Norwegian public-transport stops, lines, and journeys. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update.",
       "messages": {
         "no.entur.PtSituationElement": {
           "id": "no.entur.PtSituationElement",
@@ -158,7 +161,7 @@
       }
     },
     "no.entur.mqtt": {
-      "description": "MQTT/5.0 transport variant for Entur Norway SIRI real-time feeds. Non-retained QoS-1 streams route Estimated Timetable, Vehicle Monitoring, and Situation Exchange payloads by raw SIRI identifiers under transit/no/entur/entur-norway/... Missing routing fields are emitted as the literal unknown by the bridge.",
+      "description": "MQTT 5 variant of the Entur Norway events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "no.entur.mqtt.EstimatedVehicleJourney": {
           "name": "EstimatedVehicleJourney",
@@ -217,7 +220,7 @@
                       "DatedServiceJourney": {
                         "name": "DatedServiceJourney",
                         "type": "object",
-                        "description": "Reference data for a dated service journey in the Norwegian public transport network. A DatedServiceJourney is a specific vehicle journey operating on a particular operating day, identified by its NeTEx ServiceJourney reference (DatedVehicleJourneyRef) and operating day (DataFrameRef). This reference record is extracted from the SIRI-ET feed and published at startup and refresh intervals.",
+                        "description": "Reference data for a dated service journey in the Norwegian public transport network. A DatedServiceJourney is a specific vehicle journey operating on a particular operating day, identified by its NeTEx ServiceJourney reference and operating day. This reference event is emitted at bridge startup from the SIRI-ET feed and refreshed periodically to provide downstream consumers with the timetable context for subsequent telemetry events.",
                         "properties": {
                           "service_journey_id": {
                             "type": "string",
@@ -544,7 +547,7 @@
                       "EstimatedVehicleJourney": {
                         "name": "EstimatedVehicleJourney",
                         "type": "object",
-                        "description": "Real-time estimated timetable update for a vehicle journey from the Entur SIRI-ET feed. Contains per-stop arrival and departure predictions, journey-level cancellation and extra-journey flags, and monitoring status. Sourced from GET /realtime/v1/rest/et using incremental requestorId polling.",
+                        "description": "Real-time estimated timetable update for a vehicle journey from the Entur SIRI-ET feed (GET /realtime/v1/rest/et). Contains updated arrival and departure times for each stop along the journey, cancellation flags, and extra journey markers. Uses incremental requestorId polling to receive only changed journeys since the last poll.",
                         "properties": {
                           "service_journey_id": {
                             "type": "string",
@@ -746,7 +749,7 @@
                       "MonitoredVehicleJourney": {
                         "name": "MonitoredVehicleJourney",
                         "type": "object",
-                        "description": "Real-time vehicle monitoring update from the Entur SIRI-VM feed. Contains the current geographic position, bearing, delay, and occupancy of a vehicle operating a specific dated service journey. Sourced from GET /realtime/v1/rest/vm using incremental requestorId polling.",
+                        "description": "Real-time vehicle monitoring update from the Entur SIRI-VM feed (GET /realtime/v1/rest/vm). Contains the current geographic position of a vehicle, its bearing, delay, occupancy status, and the next monitored call. Uses incremental requestorId polling for efficient change delivery.",
                         "properties": {
                           "service_journey_id": {
                             "type": "string",
@@ -1008,7 +1011,7 @@
                       "PtSituationElement": {
                         "name": "PtSituationElement",
                         "type": "object",
-                        "description": "Real-time transit disruption or service alert from the Entur SIRI-SX feed. Describes a published situation element such as a service disruption, delay cause, planned engineering work, or passenger information notice. Includes affected network elements, severity, textual descriptions, and validity periods. Sourced from GET /realtime/v1/rest/sx.",
+                        "description": "Real-time transit disruption or service alert from the Entur SIRI-SX feed (GET /realtime/v1/rest/sx). Represents a published situation element describing a service disruption, delay cause, or passenger information notice. Includes affected lines, stops, severity level, and validity periods.",
                         "properties": {
                           "situation_number": {
                             "type": "string",
@@ -1273,7 +1276,8 @@
                     "default": null,
                     "doc": "Operator codespace originating this data record."
                   }
-                ]
+                ],
+                "description": "A transport update from Entur public transport feeds. It carries transit realtime updates for Norwegian public-transport stops, lines, and journeys."
               }
             }
           }
@@ -1547,7 +1551,8 @@
                     },
                     "doc": "Ordered list of estimated arrival and departure times for each stop."
                   }
-                ]
+                ],
+                "description": "A vehicle or vessel update from Entur public transport feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               }
             }
           }
@@ -1702,7 +1707,8 @@
                     "type": "boolean",
                     "doc": "True if this journey is actively monitored by an AVL system."
                   }
-                ]
+                ],
+                "description": "A vehicle or vessel update from Entur public transport feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               }
             }
           }
@@ -1842,12 +1848,18 @@
                     },
                     "doc": "StopPointRef values from AffectedStopPoint elements."
                   }
-                ]
+                ],
+                "description": "A traffic or service situation update from Entur public transport feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Entur Norway publishes transit realtime updates from Entur public transport feeds for Norwegian public-transport stops, lines, and journeys. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Entur Norway, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/french-road-traffic/EVENTS.md
+++ b/french-road-traffic/EVENTS.md
@@ -1,6 +1,6 @@
 # French Road Traffic Events
 
-Real-time traffic data from the French national non-conceded road network, published by [Bison Futé](https://www.bison-fute.gouv.fr/) via the [transport.data.gouv.fr](https://transport.data.gouv.fr/) open data portal.
+French Road Traffic publishes traffic measurements and road situations from French public road-traffic feeds for French road network sites and situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -37,7 +37,7 @@ CloudEvents type: `fr.gouv.transport.bison_fute.TrafficFlowMeasurement`
 
 #### What it tells you
 
-Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Published by Bison Futé (TIPI) as a MeasuredDataPublication snapshot every 6 minutes. Each record corresponds to one siteMeasurements element in the Bison Futé MeasuredDataPublication DATEX II feed, containing aggregated vehicle flow rate (vehicles per hour) and average vehicle speed (km/h) for the measurement interval.
+Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Published by Bison Futé (TIPI) as a MeasuredDataPublication snapshot every 6 minutes.
 
 #### Identity
 

--- a/french-road-traffic/xreg/french_road_traffic.xreg.json
+++ b/french-road-traffic/xreg/french_road_traffic.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fr.gouv.transport.bison_fute.traffic_flow"
-      ]
+      ],
+      "description": "Kafka producer endpoint for French Road Traffic CloudEvents on the `french-road-traffic-flow` topic keyed by `{site_id}`."
     },
     "fr.gouv.transport.bison_fute.road_event.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/fr.gouv.transport.bison_fute.road_event"
-      ]
+      ],
+      "description": "Kafka producer endpoint for French Road Traffic CloudEvents on the `french-road-traffic-events` topic keyed by `{situation_id}`."
     }
   },
   "messagegroups": {
@@ -66,7 +68,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/fr.gouv.transport.bison_fute.jstruct/schemas/fr.gouv.transport.bison_fute.TrafficFlowMeasurement"
         }
-      }
+      },
+      "description": "Events from French Road Traffic covering French road network sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "fr.gouv.transport.bison_fute.road_event": {
       "messages": {
@@ -90,7 +93,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/fr.gouv.transport.bison_fute.jstruct/schemas/fr.gouv.transport.bison_fute.RoadEvent"
         }
-      }
+      },
+      "description": "Events from French Road Traffic covering French road network sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -116,7 +120,7 @@
                           "TrafficFlowMeasurement": {
                             "name": "TrafficFlowMeasurement",
                             "type": "object",
-                            "description": "Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Each record corresponds to one siteMeasurements element in the Bison Futé MeasuredDataPublication DATEX II feed, containing aggregated vehicle flow rate (vehicles per hour) and average vehicle speed (km/h) for the measurement interval.",
+                            "description": "Real-time traffic flow and speed measurement from a DATEX II measurement site on the French national non-conceded road network. Published by Bison Futé (TIPI) as a MeasuredDataPublication snapshot every 6 minutes.",
                             "properties": {
                               "site_id": {
                                 "type": "string",
@@ -189,7 +193,7 @@
                           "RoadEvent": {
                             "name": "RoadEvent",
                             "type": "object",
-                            "description": "Real-time road situation record from the French national non-conceded road network DATEX II SituationPublication feed. Each record represents one situationRecord element within a situation, describing a traffic incident, construction works, lane management, environmental obstruction, or other event affecting road conditions. Location is provided as WGS84 coordinates and road identifiers.",
+                            "description": "Real-time road situation record from the French national non-conceded road network. Published by Bison Futé (TIPI) as a SituationPublication snapshot. Each record represents a traffic incident, construction works, lane management, obstruction, or other event affecting road conditions. Record types include Accident, ConstructionWorks, MaintenanceWorks, RoadOrCarriagewayOrLaneManagement, AbnormalTraffic, EnvironmentalObstruction, GeneralObstruction, VehicleObstruction, AnimalPresenceObstruction, InfrastructureDamageObstruction, GeneralNetworkManagement, ReroutingManagement, SpeedManagement, WeatherRelatedRoadConditions, OperatorAction, GeneralInstructionOrMessageToRoadUsers, and RoadsideServiceDisruption.",
                             "properties": {
                               "situation_id": {
                                 "type": "string",
@@ -388,7 +392,8 @@
                     "default": null,
                     "doc": "Number of vehicle observations used to compute the average speed."
                   }
-                ]
+                ],
+                "description": "A current transport measurement or status update from French public road-traffic feeds. It carries traffic measurements and road situations when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -555,12 +560,18 @@
                     "default": null,
                     "doc": "ISO 8601 timestamp of the most recent observation."
                   }
-                ]
+                ],
+                "description": "A transport update from French public road-traffic feeds. It carries traffic measurements and road situations for French road network sites and situations."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "French Road Traffic publishes traffic measurements and road situations from French public road-traffic feeds for French road network sites and situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for French Road Traffic, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/gtfs/EVENTS.md
+++ b/gtfs/EVENTS.md
@@ -1,6 +1,6 @@
 # GTFS and GTFS-RT API Bridge Usage Guide Events
 
-**GTFS and GTFS-RT API Bridge** is a tool that fetches GTFS (General Transit Feed Specification) Realtime and Static data from various transit agency sources, processes the data, and publishes it to Kafka topics using SASL PLAIN authentication. This tool can be integrated with systems like Microsoft Event Hubs or Microsoft Fabric Event Streams.
+GTFS Realtime publishes transit reference records and realtime vehicle, trip, and service-alert updates from public GTFS and GTFS Realtime feeds for transit agencies, routes, trips, stops, and vehicles. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -37,7 +37,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Vehicle.VehiclePosition`
 
 #### What it tells you
 
-Realtime positioning information for a given vehicle.
+A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed.
 
 #### Identity
 
@@ -155,7 +155,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Trip Update
 
@@ -163,7 +163,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Trip.TripUpdate`
 
 #### What it tells you
 
-Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -256,7 +256,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Alert.Alert`
 
 #### What it tells you
 
-An alert, indicating some sort of incident in the public transit network.
+A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network.
 
 #### Identity
 
@@ -363,7 +363,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Agency`
 
 #### What it tells you
 
-Information about the transit agencies.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -414,7 +414,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Areas`
 
 #### What it tells you
 
-Defines areas.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -457,7 +457,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Attributions`
 
 #### What it tells you
 
-Provides information about the attributions.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -514,7 +514,7 @@ CloudEvents type: `GeneralTransitFeed.BookingRules`
 
 #### What it tells you
 
-Defines booking rules.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -557,7 +557,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareAttributes`
 
 #### What it tells you
 
-Defines fare attributes.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -606,7 +606,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareLegRules`
 
 #### What it tells you
 
-Defines fare leg rules.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -653,7 +653,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareMedia`
 
 #### What it tells you
 
-Defines fare media.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -696,7 +696,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareProducts`
 
 #### What it tells you
 
-Defines fare products.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -739,7 +739,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareRules`
 
 #### What it tells you
 
-Defines fare rules.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -784,7 +784,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareTransferRules`
 
 #### What it tells you
 
-Defines fare transfer rules.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -833,7 +833,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FeedInfo`
 
 #### What it tells you
 
-Provides information about the GTFS feed itself.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -886,7 +886,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Frequencies`
 
 #### What it tells you
 
-Defines frequencies.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -931,7 +931,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Levels`
 
 #### What it tells you
 
-Defines levels.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -972,7 +972,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGeoJson`
 
 #### What it tells you
 
-Defines location GeoJSON data.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1013,7 +1013,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGroups`
 
 #### What it tells you
 
-Defines location groups.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1056,7 +1056,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGroupStores`
 
 #### What it tells you
 
-Defines location group stores.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1097,7 +1097,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Networks`
 
 #### What it tells you
 
-Defines networks.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1140,7 +1140,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Pathways`
 
 #### What it tells you
 
-Defines pathways.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1199,7 +1199,7 @@ CloudEvents type: `GeneralTransitFeedStatic.RouteNetworks`
 
 #### What it tells you
 
-Defines route networks.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1240,7 +1240,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Routes`
 
 #### What it tells you
 
-Identifies a route.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1329,7 +1329,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Shapes`
 
 #### What it tells you
 
-Defines shapes.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1374,7 +1374,7 @@ CloudEvents type: `GeneralTransitFeedStatic.StopAreas`
 
 #### What it tells you
 
-Defines stop areas.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1415,7 +1415,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Stops`
 
 #### What it tells you
 
-Identifies locations such as stop/platform, station, entrance/exit, generic node or boarding area.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1492,7 +1492,7 @@ CloudEvents type: `GeneralTransitFeedStatic.StopTimes`
 
 #### What it tells you
 
-Represents times that a vehicle arrives at and departs from individual stops for each trip.
+A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -1579,7 +1579,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Timeframes`
 
 #### What it tells you
 
-Used to describe fares that can vary based on the time of day, the day of the week, or a particular day in the year.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1622,7 +1622,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Transfers`
 
 #### What it tells you
 
-Defines transfers.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1665,7 +1665,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Translations`
 
 #### What it tells you
 
-Defines translations.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1708,7 +1708,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Trips`
 
 #### What it tells you
 
-Identifies a trip.
+A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
 
 #### Identity
 
@@ -1725,8 +1725,8 @@ Each event identifies the real-world resource with `{agencyid}`. `{agencyid}` is
 `Trips` payloads are JSON object. Required fields: `routeId`, `serviceDates`, `serviceExceptions`, `tripId`, `directionId`, `wheelchairAccessible`, `bikesAllowed`.
 
 - **`routeId`** (string, required): Identifies a route.
-- **`serviceDates`** (object, required): No description provided. See [Calendar](#payload-generaltransitfeedstatic-trips-calendar).
-- **`serviceExceptions`** (array of object, required): No description provided.
+- **`serviceDates`** (object, required): Calendar service pattern that identifies dates when this trip or route is scheduled to operate. See [Calendar](#payload-generaltransitfeedstatic-trips-calendar).
+- **`serviceExceptions`** (array of object, required): Calendar-date exceptions that add or remove service on specific dates.
 - **`tripId`** (string, required): Identifies a trip.
 - **`tripHeadsign`** (string, optional): Text that appears on signage identifying the trip's destination to riders.
 - **`tripShortName`** (string, optional): Public facing text used to identify the trip to riders.

--- a/gtfs/EVENTS.md
+++ b/gtfs/EVENTS.md
@@ -1,6 +1,6 @@
 # GTFS and GTFS-RT API Bridge Usage Guide Events
 
-GTFS Realtime publishes transit reference records and realtime vehicle, trip, and service-alert updates from public GTFS and GTFS Realtime feeds for transit agencies, routes, trips, stops, and vehicles. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
+**GTFS and GTFS-RT API Bridge** is a tool that fetches GTFS (General Transit Feed Specification) Realtime and Static data from various transit agency sources, processes the data, and publishes it to Kafka topics using SASL PLAIN authentication. This tool can be integrated with systems like Microsoft Event Hubs or Microsoft Fabric Event Streams.
 
 ## At a glance
 
@@ -37,7 +37,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Vehicle.VehiclePosition`
 
 #### What it tells you
 
-A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed.
+Realtime positioning information for a given vehicle.
 
 #### Identity
 
@@ -155,7 +155,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
+This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
 
 ### Trip Update
 
@@ -163,7 +163,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Trip.TripUpdate`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule.
 
 #### Identity
 
@@ -256,7 +256,7 @@ CloudEvents type: `GeneralTransitFeedRealTime.Alert.Alert`
 
 #### What it tells you
 
-A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network.
+An alert, indicating some sort of incident in the public transit network.
 
 #### Identity
 
@@ -363,7 +363,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Agency`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Information about the transit agencies.
 
 #### Identity
 
@@ -414,7 +414,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Areas`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines areas.
 
 #### Identity
 
@@ -457,7 +457,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Attributions`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Provides information about the attributions.
 
 #### Identity
 
@@ -514,7 +514,7 @@ CloudEvents type: `GeneralTransitFeed.BookingRules`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines booking rules.
 
 #### Identity
 
@@ -557,7 +557,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareAttributes`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare attributes.
 
 #### Identity
 
@@ -606,7 +606,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareLegRules`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare leg rules.
 
 #### Identity
 
@@ -653,7 +653,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareMedia`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare media.
 
 #### Identity
 
@@ -696,7 +696,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareProducts`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare products.
 
 #### Identity
 
@@ -739,7 +739,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareRules`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare rules.
 
 #### Identity
 
@@ -784,7 +784,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FareTransferRules`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines fare transfer rules.
 
 #### Identity
 
@@ -833,7 +833,7 @@ CloudEvents type: `GeneralTransitFeedStatic.FeedInfo`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Provides information about the GTFS feed itself.
 
 #### Identity
 
@@ -886,7 +886,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Frequencies`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines frequencies.
 
 #### Identity
 
@@ -931,7 +931,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Levels`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines levels.
 
 #### Identity
 
@@ -972,7 +972,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGeoJson`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Defines location GeoJSON data.
 
 #### Identity
 
@@ -1013,7 +1013,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGroups`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Defines location groups.
 
 #### Identity
 
@@ -1056,7 +1056,7 @@ CloudEvents type: `GeneralTransitFeedStatic.LocationGroupStores`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Defines location group stores.
 
 #### Identity
 
@@ -1097,7 +1097,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Networks`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines networks.
 
 #### Identity
 
@@ -1140,7 +1140,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Pathways`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines pathways.
 
 #### Identity
 
@@ -1199,7 +1199,7 @@ CloudEvents type: `GeneralTransitFeedStatic.RouteNetworks`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Defines route networks.
 
 #### Identity
 
@@ -1240,7 +1240,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Routes`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Identifies a route.
 
 #### Identity
 
@@ -1329,7 +1329,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Shapes`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines shapes.
 
 #### Identity
 
@@ -1374,7 +1374,7 @@ CloudEvents type: `GeneralTransitFeedStatic.StopAreas`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Defines stop areas.
 
 #### Identity
 
@@ -1415,7 +1415,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Stops`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Identifies locations such as stop/platform, station, entrance/exit, generic node or boarding area.
 
 #### Identity
 
@@ -1492,7 +1492,7 @@ CloudEvents type: `GeneralTransitFeedStatic.StopTimes`
 
 #### What it tells you
 
-A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
+Represents times that a vehicle arrives at and departs from individual stops for each trip.
 
 #### Identity
 
@@ -1579,7 +1579,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Timeframes`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Used to describe fares that can vary based on the time of day, the day of the week, or a particular day in the year.
 
 #### Identity
 
@@ -1622,7 +1622,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Transfers`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines transfers.
 
 #### Identity
 
@@ -1665,7 +1665,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Translations`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Defines translations.
 
 #### Identity
 
@@ -1708,7 +1708,7 @@ CloudEvents type: `GeneralTransitFeedStatic.Trips`
 
 #### What it tells you
 
-A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles.
+Identifies a trip.
 
 #### Identity
 
@@ -1725,8 +1725,8 @@ Each event identifies the real-world resource with `{agencyid}`. `{agencyid}` is
 `Trips` payloads are JSON object. Required fields: `routeId`, `serviceDates`, `serviceExceptions`, `tripId`, `directionId`, `wheelchairAccessible`, `bikesAllowed`.
 
 - **`routeId`** (string, required): Identifies a route.
-- **`serviceDates`** (object, required): Calendar service pattern that identifies dates when this trip or route is scheduled to operate. See [Calendar](#payload-generaltransitfeedstatic-trips-calendar).
-- **`serviceExceptions`** (array of object, required): Calendar-date exceptions that add or remove service on specific dates.
+- **`serviceDates`** (object, required): No description provided. See [Calendar](#payload-generaltransitfeedstatic-trips-calendar).
+- **`serviceExceptions`** (array of object, required): No description provided.
 - **`tripId`** (string, required): Identifies a trip.
 - **`tripHeadsign`** (string, optional): Text that appears on signage identifying the trip's destination to riders.
 - **`tripShortName`** (string, optional): Public facing text used to identify the trip to riders.

--- a/gtfs/xreg/gtfs.xreg.json
+++ b/gtfs/xreg/gtfs.xreg.json
@@ -20,7 +20,8 @@
       "messagegroups": [
         "#/messagegroups/GeneralTransitFeedRealTime",
         "#/messagegroups/GeneralTransitFeedStatic"
-      ]
+      ],
+      "description": "Kafka producer endpoint for GTFS Realtime CloudEvents on the `gtfs` topic keyed by `{agencyid}`."
     }
   },
   "messagegroups": {
@@ -65,7 +66,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
         },
         "GeneralTransitFeedRealTime.Trip.TripUpdate": {
           "messageid": "GeneralTransitFeedRealTime.Trip.TripUpdate",
@@ -105,7 +107,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedRealTime.Alert.Alert": {
           "messageid": "GeneralTransitFeedRealTime.Alert.Alert",
@@ -145,12 +148,14 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
         }
       },
       "createdat": "2024-10-18T13:47:59.334831",
       "epoch": 0,
-      "modifiedat": "2024-10-18T13:47:59.334831"
+      "modifiedat": "2024-10-18T13:47:59.334831",
+      "description": "Events from GTFS Realtime covering transit agencies, routes, trips, stops, and vehicles. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "GeneralTransitFeedStatic": {
       "messagegroupid": "GeneralTransitFeedStatic",
@@ -193,7 +198,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Areas": {
           "messageid": "GeneralTransitFeedStatic.Areas",
@@ -233,7 +239,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Attributions": {
           "messageid": "GeneralTransitFeedStatic.Attributions",
@@ -273,7 +280,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeed.BookingRules": {
           "messageid": "GeneralTransitFeed.BookingRules",
@@ -313,7 +321,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareAttributes": {
           "messageid": "GeneralTransitFeedStatic.FareAttributes",
@@ -353,7 +362,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareLegRules": {
           "messageid": "GeneralTransitFeedStatic.FareLegRules",
@@ -393,7 +403,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareMedia": {
           "messageid": "GeneralTransitFeedStatic.FareMedia",
@@ -433,7 +444,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareProducts": {
           "messageid": "GeneralTransitFeedStatic.FareProducts",
@@ -473,7 +485,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareRules": {
           "messageid": "GeneralTransitFeedStatic.FareRules",
@@ -513,7 +526,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FareTransferRules": {
           "messageid": "GeneralTransitFeedStatic.FareTransferRules",
@@ -553,7 +567,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.FeedInfo": {
           "messageid": "GeneralTransitFeedStatic.FeedInfo",
@@ -593,7 +608,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Frequencies": {
           "messageid": "GeneralTransitFeedStatic.Frequencies",
@@ -633,7 +649,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Levels": {
           "messageid": "GeneralTransitFeedStatic.Levels",
@@ -673,7 +690,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.LocationGeoJson": {
           "messageid": "GeneralTransitFeedStatic.LocationGeoJson",
@@ -713,7 +731,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.LocationGroups": {
           "messageid": "GeneralTransitFeedStatic.LocationGroups",
@@ -753,7 +772,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.LocationGroupStores": {
           "messageid": "GeneralTransitFeedStatic.LocationGroupStores",
@@ -793,7 +813,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Networks": {
           "messageid": "GeneralTransitFeedStatic.Networks",
@@ -833,7 +854,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Pathways": {
           "messageid": "GeneralTransitFeedStatic.Pathways",
@@ -873,7 +895,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.RouteNetworks": {
           "messageid": "GeneralTransitFeedStatic.RouteNetworks",
@@ -913,7 +936,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Routes": {
           "messageid": "GeneralTransitFeedStatic.Routes",
@@ -953,7 +977,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Shapes": {
           "messageid": "GeneralTransitFeedStatic.Shapes",
@@ -993,7 +1018,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.StopAreas": {
           "messageid": "GeneralTransitFeedStatic.StopAreas",
@@ -1033,7 +1059,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Stops": {
           "messageid": "GeneralTransitFeedStatic.Stops",
@@ -1073,7 +1100,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.StopTimes": {
           "messageid": "GeneralTransitFeedStatic.StopTimes",
@@ -1113,7 +1141,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "GeneralTransitFeedStatic.Timeframes": {
           "messageid": "GeneralTransitFeedStatic.Timeframes",
@@ -1153,7 +1182,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Transfers": {
           "messageid": "GeneralTransitFeedStatic.Transfers",
@@ -1193,7 +1223,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Translations": {
           "messageid": "GeneralTransitFeedStatic.Translations",
@@ -1233,7 +1264,8 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         },
         "GeneralTransitFeedStatic.Trips": {
           "messageid": "GeneralTransitFeedStatic.Trips",
@@ -1273,12 +1305,14 @@
               "description": "Provider name",
               "required": true
             }
-          }
+          },
+          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
         }
       },
       "createdat": "2024-10-18T13:48:10.557688",
       "epoch": 0,
-      "modifiedat": "2024-10-18T13:48:10.557688"
+      "modifiedat": "2024-10-18T13:48:10.557688",
+      "description": "Events from GTFS Realtime covering transit agencies, routes, trips, stops, and vehicles. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -1485,7 +1519,7 @@
                           }
                         },
                         "required": [],
-                        "description": "Realtime positioning information for a given vehicle."
+                        "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
                       }
                     }
                   }
@@ -1676,7 +1710,7 @@
                           "trip",
                           "stop_time_update"
                         ],
-                        "description": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful."
+                        "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                       }
                     }
                   }
@@ -1913,7 +1947,7 @@
                           "active_period",
                           "informed_entity"
                         ],
-                        "description": "An alert, indicating some sort of incident in the public transit network."
+                        "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
                       }
                     }
                   }
@@ -2209,7 +2243,8 @@
                     ]
                   }
                 ],
-                "doc": "Realtime positioning information for a given vehicle."
+                "doc": "Realtime positioning information for a given vehicle.",
+                "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
               },
               "createdat": "2024-10-18T13:47:58.386919",
               "epoch": 0,
@@ -2460,7 +2495,8 @@
                     "doc": "specified when the prediction is given relative to some existing schedule in GTFS. Delay (in seconds) can be positive (meaning that the vehicle is late) or negative (meaning that the vehicle is ahead of schedule). Delay of 0 means that the vehicle is exactly on time. Delay information in StopTimeUpdates take precedent of trip-level delay information, such that trip-level delay is only propagated until the next stop along the trip with a StopTimeUpdate delay value specified. Feed providers are strongly encouraged to provide a TripUpdate.timestamp value indicating when the delay value was last updated, in order to evaluate the freshness of the data. NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future."
                   }
                 ],
-                "doc": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful."
+                "doc": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful.",
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:02.088029",
               "epoch": 0,
@@ -2768,7 +2804,8 @@
                     "doc": "description should add to the information of the header."
                   }
                 ],
-                "doc": "An alert, indicating some sort of incident in the public transit network."
+                "doc": "An alert, indicating some sort of incident in the public transit network.",
+                "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
               },
               "createdat": "2024-10-18T13:48:05.926645",
               "epoch": 0,
@@ -2841,7 +2878,7 @@
                         "agencyUrl",
                         "agencyTimezone"
                       ],
-                      "description": "Information about the transit agencies."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -2890,7 +2927,7 @@
                         "areaId",
                         "areaName"
                       ],
-                      "description": "Defines areas."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -2974,7 +3011,7 @@
                       "required": [
                         "organizationName"
                       ],
-                      "description": "Provides information about the attributions."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3023,7 +3060,7 @@
                         "bookingRuleId",
                         "bookingRuleName"
                       ],
-                      "description": "Defines booking rules."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3087,7 +3124,7 @@
                         "currencyType",
                         "paymentMethod"
                       ],
-                      "description": "Defines fare attributes."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3146,7 +3183,7 @@
                         "fareLegRuleId",
                         "fareProductId"
                       ],
-                      "description": "Defines fare leg rules."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3195,7 +3232,7 @@
                         "fareMediaId",
                         "fareMediaName"
                       ],
-                      "description": "Defines fare media."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3244,7 +3281,7 @@
                         "fareProductId",
                         "fareProductName"
                       ],
-                      "description": "Defines fare products."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3298,7 +3335,7 @@
                       "required": [
                         "fareId"
                       ],
-                      "description": "Defines fare rules."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3362,7 +3399,7 @@
                         "fareTransferRuleId",
                         "fareProductId"
                       ],
-                      "description": "Defines fare transfer rules."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3436,7 +3473,7 @@
                         "feedPublisherUrl",
                         "feedLang"
                       ],
-                      "description": "Provides information about the GTFS feed itself."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3490,7 +3527,7 @@
                         "endTime",
                         "headwaySecs"
                       ],
-                      "description": "Defines frequencies."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3534,7 +3571,7 @@
                         "levelId",
                         "levelIndex"
                       ],
-                      "description": "Defines levels."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3578,7 +3615,7 @@
                         "locationGeoJsonType",
                         "locationGeoJsonData"
                       ],
-                      "description": "Defines location GeoJSON data."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -3627,7 +3664,7 @@
                         "locationGroupId",
                         "locationGroupName"
                       ],
-                      "description": "Defines location groups."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -3671,7 +3708,7 @@
                         "locationGroupId",
                         "storeId"
                       ],
-                      "description": "Defines location group stores."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -3720,7 +3757,7 @@
                         "networkId",
                         "networkName"
                       ],
-                      "description": "Defines networks."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3809,7 +3846,7 @@
                         "pathwayMode",
                         "isBidirectional"
                       ],
-                      "description": "Defines pathways."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -3853,7 +3890,7 @@
                         "routeId",
                         "networkId"
                       ],
-                      "description": "Defines route networks."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -3996,7 +4033,7 @@
                         "continuousPickup",
                         "continuousDropOff"
                       ],
-                      "description": "Identifies a route."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -4050,7 +4087,7 @@
                         "shapePtLon",
                         "shapePtSequence"
                       ],
-                      "description": "Defines shapes."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -4094,7 +4131,7 @@
                         "stopId",
                         "areaId"
                       ],
-                      "description": "Defines stop areas."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -4224,7 +4261,7 @@
                         "locationType",
                         "wheelchairBoarding"
                       ],
-                      "description": "Identifies locations such as stop/platform, station, entrance/exit, generic node or boarding area."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -4376,7 +4413,7 @@
                         "dropOffType",
                         "timepoint"
                       ],
-                      "description": "Represents times that a vehicle arrives at and departs from individual stops for each trip."
+                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
                     }
                   }
                 }
@@ -4548,7 +4585,7 @@
                         "timeframeGroupId",
                         "serviceDates"
                       ],
-                      "description": "Used to describe fares that can vary based on the time of day, the day of the week, or a particular day in the year."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -4597,7 +4634,7 @@
                         "toStopId",
                         "transferType"
                       ],
-                      "description": "Defines transfers."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -4646,7 +4683,7 @@
                         "language",
                         "translation"
                       ],
-                      "description": "Defines translations."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -4823,13 +4860,15 @@
                         "serviceDates": {
                           "type": {
                             "$ref": "#/definitions/GeneralTransitFeedStatic/Calendar"
-                          }
+                          },
+                          "description": "Calendar service pattern that identifies dates when this trip or route is scheduled to operate."
                         },
                         "serviceExceptions": {
                           "type": "array",
                           "items": {
                             "$ref": "#/definitions/GeneralTransitFeedStatic/CalendarDates"
-                          }
+                          },
+                          "description": "Calendar-date exceptions that add or remove service on specific dates."
                         },
                         "tripId": {
                           "type": "string",
@@ -4883,7 +4922,7 @@
                         "wheelchairAccessible",
                         "bikesAllowed"
                       ],
-                      "description": "Identifies a trip."
+                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
                     }
                   }
                 }
@@ -4965,7 +5004,8 @@
                     "default": null,
                     "doc": "Email address actively monitored by the agency’s customer service department."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:48:09.615958",
               "epoch": 0,
@@ -5015,7 +5055,8 @@
                     "default": null,
                     "doc": "URL of a web page about the area."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:13.396415",
               "epoch": 0,
@@ -5132,7 +5173,8 @@
                     "default": null,
                     "doc": "Phone number associated with the attribution."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:17.274791",
               "epoch": 0,
@@ -5182,7 +5224,8 @@
                     "default": null,
                     "doc": "URL of a web page about the booking rule."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:21.181899",
               "epoch": 0,
@@ -5251,7 +5294,8 @@
                     "default": null,
                     "doc": "Length of time in seconds before a transfer expires."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:24.820565",
               "epoch": 0,
@@ -5319,7 +5363,8 @@
                     "default": null,
                     "doc": "Identifies the destination area."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:28.496946",
               "epoch": 0,
@@ -5369,7 +5414,8 @@
                     "default": null,
                     "doc": "URL of a web page about the fare media."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:32.146791",
               "epoch": 0,
@@ -5419,7 +5465,8 @@
                     "default": null,
                     "doc": "URL of a web page about the fare product."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:36.101368",
               "epoch": 0,
@@ -5482,7 +5529,8 @@
                     "default": null,
                     "doc": "Identifies the fare zone that a rider will enter or leave."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:39.788513",
               "epoch": 0,
@@ -5559,7 +5607,8 @@
                     "default": null,
                     "doc": "Type of duration for the transfer."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:43.422035",
               "epoch": 0,
@@ -5650,7 +5699,8 @@
                     "default": null,
                     "doc": "URL for a web page that allows a feed consumer to contact the data publisher."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:47.038627",
               "epoch": 0,
@@ -5701,7 +5751,8 @@
                     "default": null,
                     "doc": "When 1, frequency-based trips should be exactly scheduled. When 0 (or empty), frequency-based trips are not exactly scheduled."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:50.701266",
               "epoch": 0,
@@ -5742,7 +5793,8 @@
                     "default": null,
                     "doc": "Name of the level."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:48:54.369996",
               "epoch": 0,
@@ -5779,7 +5831,8 @@
                     "type": "string",
                     "doc": "GeoJSON data."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:48:58.114853",
               "epoch": 0,
@@ -5829,7 +5882,8 @@
                     "default": null,
                     "doc": "URL of a web page about the location group."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:01.792371",
               "epoch": 0,
@@ -5866,7 +5920,8 @@
                     "type": "string",
                     "doc": "Identifies a store."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:05.485799",
               "epoch": 0,
@@ -5916,7 +5971,8 @@
                     "default": null,
                     "doc": "URL of a web page about the network."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:09.124828",
               "epoch": 0,
@@ -6026,7 +6082,8 @@
                     "default": null,
                     "doc": "Reversed signposting information for the pathway."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:12.77505",
               "epoch": 0,
@@ -6063,7 +6120,8 @@
                     "type": "string",
                     "doc": "Identifies a network."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:16.443796",
               "epoch": 0,
@@ -6229,7 +6287,8 @@
                     "default": null,
                     "doc": "Identifies a group of routes."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:20.138434",
               "epoch": 0,
@@ -6280,7 +6339,8 @@
                     "default": null,
                     "doc": "Actual distance traveled along the shape from the first shape point to the specified shape point."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:23.84702",
               "epoch": 0,
@@ -6317,7 +6377,8 @@
                     "type": "string",
                     "doc": "Identifies an area."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:27.526738",
               "epoch": 0,
@@ -6484,7 +6545,8 @@
                     "default": null,
                     "doc": "Platform identifier for a platform stop."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:31.180454",
               "epoch": 0,
@@ -6647,7 +6709,8 @@
                     },
                     "doc": "Indicates if arrival and departure times for a stop are strictly adhered to by the vehicle or if they are instead approximate and/or interpolated times."
                   }
-                ]
+                ],
+                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               },
               "createdat": "2024-10-18T13:49:34.844474",
               "epoch": 0,
@@ -6793,7 +6856,8 @@
                     ],
                     "doc": "Identifies a set of dates when service is available for one or more routes."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:38.592004",
               "epoch": 0,
@@ -6839,7 +6903,8 @@
                     "default": null,
                     "doc": "Amount of time, in seconds, needed to transfer from the specified (from_stop_id) to the specified (to_stop_id)."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:42.267607",
               "epoch": 0,
@@ -6881,7 +6946,8 @@
                     "type": "string",
                     "doc": "Translated value."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:45.952537",
               "epoch": 0,
@@ -7098,7 +7164,8 @@
                     },
                     "doc": "Indicates whether bikes are allowed."
                   }
-                ]
+                ],
+                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
               },
               "createdat": "2024-10-18T13:49:49.701913",
               "epoch": 0,
@@ -7108,5 +7175,10 @@
         }
       }
     }
+  },
+  "description": "GTFS Realtime publishes transit reference records and realtime vehicle, trip, and service-alert updates from public GTFS and GTFS Realtime feeds for transit agencies, routes, trips, stops, and vehicles. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for GTFS Realtime, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/gtfs/xreg/gtfs.xreg.json
+++ b/gtfs/xreg/gtfs.xreg.json
@@ -20,8 +20,7 @@
       "messagegroups": [
         "#/messagegroups/GeneralTransitFeedRealTime",
         "#/messagegroups/GeneralTransitFeedStatic"
-      ],
-      "description": "Kafka producer endpoint for GTFS Realtime CloudEvents on the `gtfs` topic keyed by `{agencyid}`."
+      ]
     }
   },
   "messagegroups": {
@@ -66,8 +65,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
+          }
         },
         "GeneralTransitFeedRealTime.Trip.TripUpdate": {
           "messageid": "GeneralTransitFeedRealTime.Trip.TripUpdate",
@@ -107,8 +105,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedRealTime.Alert.Alert": {
           "messageid": "GeneralTransitFeedRealTime.Alert.Alert",
@@ -148,14 +145,12 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
+          }
         }
       },
       "createdat": "2024-10-18T13:47:59.334831",
       "epoch": 0,
-      "modifiedat": "2024-10-18T13:47:59.334831",
-      "description": "Events from GTFS Realtime covering transit agencies, routes, trips, stops, and vehicles. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+      "modifiedat": "2024-10-18T13:47:59.334831"
     },
     "GeneralTransitFeedStatic": {
       "messagegroupid": "GeneralTransitFeedStatic",
@@ -198,8 +193,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Areas": {
           "messageid": "GeneralTransitFeedStatic.Areas",
@@ -239,8 +233,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Attributions": {
           "messageid": "GeneralTransitFeedStatic.Attributions",
@@ -280,8 +273,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeed.BookingRules": {
           "messageid": "GeneralTransitFeed.BookingRules",
@@ -321,8 +313,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareAttributes": {
           "messageid": "GeneralTransitFeedStatic.FareAttributes",
@@ -362,8 +353,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareLegRules": {
           "messageid": "GeneralTransitFeedStatic.FareLegRules",
@@ -403,8 +393,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareMedia": {
           "messageid": "GeneralTransitFeedStatic.FareMedia",
@@ -444,8 +433,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareProducts": {
           "messageid": "GeneralTransitFeedStatic.FareProducts",
@@ -485,8 +473,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareRules": {
           "messageid": "GeneralTransitFeedStatic.FareRules",
@@ -526,8 +513,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FareTransferRules": {
           "messageid": "GeneralTransitFeedStatic.FareTransferRules",
@@ -567,8 +553,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.FeedInfo": {
           "messageid": "GeneralTransitFeedStatic.FeedInfo",
@@ -608,8 +593,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Frequencies": {
           "messageid": "GeneralTransitFeedStatic.Frequencies",
@@ -649,8 +633,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Levels": {
           "messageid": "GeneralTransitFeedStatic.Levels",
@@ -690,8 +673,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.LocationGeoJson": {
           "messageid": "GeneralTransitFeedStatic.LocationGeoJson",
@@ -731,8 +713,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.LocationGroups": {
           "messageid": "GeneralTransitFeedStatic.LocationGroups",
@@ -772,8 +753,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.LocationGroupStores": {
           "messageid": "GeneralTransitFeedStatic.LocationGroupStores",
@@ -813,8 +793,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Networks": {
           "messageid": "GeneralTransitFeedStatic.Networks",
@@ -854,8 +833,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Pathways": {
           "messageid": "GeneralTransitFeedStatic.Pathways",
@@ -895,8 +873,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.RouteNetworks": {
           "messageid": "GeneralTransitFeedStatic.RouteNetworks",
@@ -936,8 +913,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Routes": {
           "messageid": "GeneralTransitFeedStatic.Routes",
@@ -977,8 +953,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Shapes": {
           "messageid": "GeneralTransitFeedStatic.Shapes",
@@ -1018,8 +993,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.StopAreas": {
           "messageid": "GeneralTransitFeedStatic.StopAreas",
@@ -1059,8 +1033,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Stops": {
           "messageid": "GeneralTransitFeedStatic.Stops",
@@ -1100,8 +1073,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.StopTimes": {
           "messageid": "GeneralTransitFeedStatic.StopTimes",
@@ -1141,8 +1113,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+          }
         },
         "GeneralTransitFeedStatic.Timeframes": {
           "messageid": "GeneralTransitFeedStatic.Timeframes",
@@ -1182,8 +1153,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Transfers": {
           "messageid": "GeneralTransitFeedStatic.Transfers",
@@ -1223,8 +1193,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Translations": {
           "messageid": "GeneralTransitFeedStatic.Translations",
@@ -1264,8 +1233,7 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         },
         "GeneralTransitFeedStatic.Trips": {
           "messageid": "GeneralTransitFeedStatic.Trips",
@@ -1305,14 +1273,12 @@
               "description": "Provider name",
               "required": true
             }
-          },
-          "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+          }
         }
       },
       "createdat": "2024-10-18T13:48:10.557688",
       "epoch": 0,
-      "modifiedat": "2024-10-18T13:48:10.557688",
-      "description": "Events from GTFS Realtime covering transit agencies, routes, trips, stops, and vehicles. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+      "modifiedat": "2024-10-18T13:48:10.557688"
     }
   },
   "schemagroups": {
@@ -1519,7 +1485,7 @@
                           }
                         },
                         "required": [],
-                        "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
+                        "description": "Realtime positioning information for a given vehicle."
                       }
                     }
                   }
@@ -1710,7 +1676,7 @@
                           "trip",
                           "stop_time_update"
                         ],
-                        "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                        "description": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful."
                       }
                     }
                   }
@@ -1947,7 +1913,7 @@
                           "active_period",
                           "informed_entity"
                         ],
-                        "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
+                        "description": "An alert, indicating some sort of incident in the public transit network."
                       }
                     }
                   }
@@ -2243,8 +2209,7 @@
                     ]
                   }
                 ],
-                "doc": "Realtime positioning information for a given vehicle.",
-                "description": "A vehicle or vessel update from public GTFS and GTFS Realtime feeds. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
+                "doc": "Realtime positioning information for a given vehicle."
               },
               "createdat": "2024-10-18T13:47:58.386919",
               "epoch": 0,
@@ -2495,8 +2460,7 @@
                     "doc": "specified when the prediction is given relative to some existing schedule in GTFS. Delay (in seconds) can be positive (meaning that the vehicle is late) or negative (meaning that the vehicle is ahead of schedule). Delay of 0 means that the vehicle is exactly on time. Delay information in StopTimeUpdates take precedent of trip-level delay information, such that trip-level delay is only propagated until the next stop along the trip with a StopTimeUpdate delay value specified. Feed providers are strongly encouraged to provide a TripUpdate.timestamp value indicating when the delay value was last updated, in order to evaluate the freshness of the data. NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future."
                   }
                 ],
-                "doc": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful.",
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                "doc": "Entities used in the feed. Realtime update of the progress of a vehicle along a trip. Depending on the value of ScheduleRelationship, a TripUpdate can specify: - A trip that proceeds along the schedule. - A trip that proceeds along a route but has no fixed schedule. - A trip that have been added or removed with regard to schedule. The updates can be for future, predicted arrival/departure events, or for past events that already occurred. Normally, updates should get more precise and more certain (see uncertainty below) as the events gets closer to current time. Even if that is not possible, the information for past events should be precise and certain. In particular, if an update points to time in the past but its update's uncertainty is not 0, the client should conclude that the update is a (wrong) prediction and that the trip has not completed yet. Note that the update can describe a trip that is already completed. To this end, it is enough to provide an update for the last stop of the trip. If the time of that is in the past, the client will conclude from that that the whole trip is in the past (it is possible, although inconsequential, to also provide updates for preceding stops). This option is most relevant for a trip that has completed ahead of schedule, but according to the schedule, the trip is still proceeding at the current time. Removing the updates for this trip could make the client assume that the trip is still proceeding. Note that the feed provider is allowed, but not required, to purge past updates - this is one case where this would be practically useful."
               },
               "createdat": "2024-10-18T13:48:02.088029",
               "epoch": 0,
@@ -2804,8 +2768,7 @@
                     "doc": "description should add to the information of the header."
                   }
                 ],
-                "doc": "An alert, indicating some sort of incident in the public transit network.",
-                "description": "A traffic or service situation update from public GTFS and GTFS Realtime feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
+                "doc": "An alert, indicating some sort of incident in the public transit network."
               },
               "createdat": "2024-10-18T13:48:05.926645",
               "epoch": 0,
@@ -2878,7 +2841,7 @@
                         "agencyUrl",
                         "agencyTimezone"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Information about the transit agencies."
                     }
                   }
                 }
@@ -2927,7 +2890,7 @@
                         "areaId",
                         "areaName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines areas."
                     }
                   }
                 }
@@ -3011,7 +2974,7 @@
                       "required": [
                         "organizationName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Provides information about the attributions."
                     }
                   }
                 }
@@ -3060,7 +3023,7 @@
                         "bookingRuleId",
                         "bookingRuleName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines booking rules."
                     }
                   }
                 }
@@ -3124,7 +3087,7 @@
                         "currencyType",
                         "paymentMethod"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare attributes."
                     }
                   }
                 }
@@ -3183,7 +3146,7 @@
                         "fareLegRuleId",
                         "fareProductId"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare leg rules."
                     }
                   }
                 }
@@ -3232,7 +3195,7 @@
                         "fareMediaId",
                         "fareMediaName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare media."
                     }
                   }
                 }
@@ -3281,7 +3244,7 @@
                         "fareProductId",
                         "fareProductName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare products."
                     }
                   }
                 }
@@ -3335,7 +3298,7 @@
                       "required": [
                         "fareId"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare rules."
                     }
                   }
                 }
@@ -3399,7 +3362,7 @@
                         "fareTransferRuleId",
                         "fareProductId"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines fare transfer rules."
                     }
                   }
                 }
@@ -3473,7 +3436,7 @@
                         "feedPublisherUrl",
                         "feedLang"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Provides information about the GTFS feed itself."
                     }
                   }
                 }
@@ -3527,7 +3490,7 @@
                         "endTime",
                         "headwaySecs"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines frequencies."
                     }
                   }
                 }
@@ -3571,7 +3534,7 @@
                         "levelId",
                         "levelIndex"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines levels."
                     }
                   }
                 }
@@ -3615,7 +3578,7 @@
                         "locationGeoJsonType",
                         "locationGeoJsonData"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Defines location GeoJSON data."
                     }
                   }
                 }
@@ -3664,7 +3627,7 @@
                         "locationGroupId",
                         "locationGroupName"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Defines location groups."
                     }
                   }
                 }
@@ -3708,7 +3671,7 @@
                         "locationGroupId",
                         "storeId"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Defines location group stores."
                     }
                   }
                 }
@@ -3757,7 +3720,7 @@
                         "networkId",
                         "networkName"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines networks."
                     }
                   }
                 }
@@ -3846,7 +3809,7 @@
                         "pathwayMode",
                         "isBidirectional"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines pathways."
                     }
                   }
                 }
@@ -3890,7 +3853,7 @@
                         "routeId",
                         "networkId"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Defines route networks."
                     }
                   }
                 }
@@ -4033,7 +3996,7 @@
                         "continuousPickup",
                         "continuousDropOff"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Identifies a route."
                     }
                   }
                 }
@@ -4087,7 +4050,7 @@
                         "shapePtLon",
                         "shapePtSequence"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines shapes."
                     }
                   }
                 }
@@ -4131,7 +4094,7 @@
                         "stopId",
                         "areaId"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Defines stop areas."
                     }
                   }
                 }
@@ -4261,7 +4224,7 @@
                         "locationType",
                         "wheelchairBoarding"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Identifies locations such as stop/platform, station, entrance/exit, generic node or boarding area."
                     }
                   }
                 }
@@ -4413,7 +4376,7 @@
                         "dropOffType",
                         "timepoint"
                       ],
-                      "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                      "description": "Represents times that a vehicle arrives at and departs from individual stops for each trip."
                     }
                   }
                 }
@@ -4585,7 +4548,7 @@
                         "timeframeGroupId",
                         "serviceDates"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Used to describe fares that can vary based on the time of day, the day of the week, or a particular day in the year."
                     }
                   }
                 }
@@ -4634,7 +4597,7 @@
                         "toStopId",
                         "transferType"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines transfers."
                     }
                   }
                 }
@@ -4683,7 +4646,7 @@
                         "language",
                         "translation"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Defines translations."
                     }
                   }
                 }
@@ -4860,15 +4823,13 @@
                         "serviceDates": {
                           "type": {
                             "$ref": "#/definitions/GeneralTransitFeedStatic/Calendar"
-                          },
-                          "description": "Calendar service pattern that identifies dates when this trip or route is scheduled to operate."
+                          }
                         },
                         "serviceExceptions": {
                           "type": "array",
                           "items": {
                             "$ref": "#/definitions/GeneralTransitFeedStatic/CalendarDates"
-                          },
-                          "description": "Calendar-date exceptions that add or remove service on specific dates."
+                          }
                         },
                         "tripId": {
                           "type": "string",
@@ -4922,7 +4883,7 @@
                         "wheelchairAccessible",
                         "bikesAllowed"
                       ],
-                      "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                      "description": "Identifies a trip."
                     }
                   }
                 }
@@ -5004,8 +4965,7 @@
                     "default": null,
                     "doc": "Email address actively monitored by the agency’s customer service department."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:48:09.615958",
               "epoch": 0,
@@ -5055,8 +5015,7 @@
                     "default": null,
                     "doc": "URL of a web page about the area."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:13.396415",
               "epoch": 0,
@@ -5173,8 +5132,7 @@
                     "default": null,
                     "doc": "Phone number associated with the attribution."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:17.274791",
               "epoch": 0,
@@ -5224,8 +5182,7 @@
                     "default": null,
                     "doc": "URL of a web page about the booking rule."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:21.181899",
               "epoch": 0,
@@ -5294,8 +5251,7 @@
                     "default": null,
                     "doc": "Length of time in seconds before a transfer expires."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:24.820565",
               "epoch": 0,
@@ -5363,8 +5319,7 @@
                     "default": null,
                     "doc": "Identifies the destination area."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:28.496946",
               "epoch": 0,
@@ -5414,8 +5369,7 @@
                     "default": null,
                     "doc": "URL of a web page about the fare media."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:32.146791",
               "epoch": 0,
@@ -5465,8 +5419,7 @@
                     "default": null,
                     "doc": "URL of a web page about the fare product."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:36.101368",
               "epoch": 0,
@@ -5529,8 +5482,7 @@
                     "default": null,
                     "doc": "Identifies the fare zone that a rider will enter or leave."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:39.788513",
               "epoch": 0,
@@ -5607,8 +5559,7 @@
                     "default": null,
                     "doc": "Type of duration for the transfer."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:43.422035",
               "epoch": 0,
@@ -5699,8 +5650,7 @@
                     "default": null,
                     "doc": "URL for a web page that allows a feed consumer to contact the data publisher."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:47.038627",
               "epoch": 0,
@@ -5751,8 +5701,7 @@
                     "default": null,
                     "doc": "When 1, frequency-based trips should be exactly scheduled. When 0 (or empty), frequency-based trips are not exactly scheduled."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:50.701266",
               "epoch": 0,
@@ -5793,8 +5742,7 @@
                     "default": null,
                     "doc": "Name of the level."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:48:54.369996",
               "epoch": 0,
@@ -5831,8 +5779,7 @@
                     "type": "string",
                     "doc": "GeoJSON data."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:48:58.114853",
               "epoch": 0,
@@ -5882,8 +5829,7 @@
                     "default": null,
                     "doc": "URL of a web page about the location group."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:01.792371",
               "epoch": 0,
@@ -5920,8 +5866,7 @@
                     "type": "string",
                     "doc": "Identifies a store."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:05.485799",
               "epoch": 0,
@@ -5971,8 +5916,7 @@
                     "default": null,
                     "doc": "URL of a web page about the network."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:09.124828",
               "epoch": 0,
@@ -6082,8 +6026,7 @@
                     "default": null,
                     "doc": "Reversed signposting information for the pathway."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:12.77505",
               "epoch": 0,
@@ -6120,8 +6063,7 @@
                     "type": "string",
                     "doc": "Identifies a network."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:16.443796",
               "epoch": 0,
@@ -6287,8 +6229,7 @@
                     "default": null,
                     "doc": "Identifies a group of routes."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:20.138434",
               "epoch": 0,
@@ -6339,8 +6280,7 @@
                     "default": null,
                     "doc": "Actual distance traveled along the shape from the first shape point to the specified shape point."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:23.84702",
               "epoch": 0,
@@ -6377,8 +6317,7 @@
                     "type": "string",
                     "doc": "Identifies an area."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:27.526738",
               "epoch": 0,
@@ -6545,8 +6484,7 @@
                     "default": null,
                     "doc": "Platform identifier for a platform stop."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:31.180454",
               "epoch": 0,
@@ -6709,8 +6647,7 @@
                     },
                     "doc": "Indicates if arrival and departure times for a stop are strictly adhered to by the vehicle or if they are instead approximate and/or interpolated times."
                   }
-                ],
-                "description": "A reference record from public GTFS and GTFS Realtime feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+                ]
               },
               "createdat": "2024-10-18T13:49:34.844474",
               "epoch": 0,
@@ -6856,8 +6793,7 @@
                     ],
                     "doc": "Identifies a set of dates when service is available for one or more routes."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:38.592004",
               "epoch": 0,
@@ -6903,8 +6839,7 @@
                     "default": null,
                     "doc": "Amount of time, in seconds, needed to transfer from the specified (from_stop_id) to the specified (to_stop_id)."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:42.267607",
               "epoch": 0,
@@ -6946,8 +6881,7 @@
                     "type": "string",
                     "doc": "Translated value."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:45.952537",
               "epoch": 0,
@@ -7164,8 +7098,7 @@
                     },
                     "doc": "Indicates whether bikes are allowed."
                   }
-                ],
-                "description": "A transport update from public GTFS and GTFS Realtime feeds. It carries transit reference records and realtime vehicle, trip, and service-alert updates for transit agencies, routes, trips, stops, and vehicles."
+                ]
               },
               "createdat": "2024-10-18T13:49:49.701913",
               "epoch": 0,
@@ -7175,10 +7108,5 @@
         }
       }
     }
-  },
-  "description": "GTFS Realtime publishes transit reference records and realtime vehicle, trip, and service-alert updates from public GTFS and GTFS Realtime feeds for transit agencies, routes, trips, stops, and vehicles. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
-  "documentation": {
-    "description": "Source documentation for GTFS Realtime, including upstream feed context and bridge deployment notes.",
-    "url": "README.md"
   }
 }

--- a/irail/EVENTS.md
+++ b/irail/EVENTS.md
@@ -1,6 +1,6 @@
 # iRail Belgian Railway Bridge Events
 
-MQTT/5.0 transport variants for iRail Belgian railway station metadata and live board snapshots. Topics are retained QoS-1 state leaves under transit/be/irail/irail/{station_id}/{event}. The station_id topic axis preserves the existing Kafka/CloudEvents subject. Use transit/be/irail/irail/{station_id}/# for one station, transit/be/irail/irail/+/station-board for all departure boards, and transit/be/irail/irail/+/arrival-board for all arrival boards. Board snapshots use message expiry so stale liveboards age out if polling stops.
+iRail publishes train departure, arrival, and connection updates from the Belgian iRail train data API for Belgian railway stations, vehicles, and connections. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 

--- a/irail/xreg/irail.xreg.json
+++ b/irail/xreg/irail.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.irail"
-      ]
+      ],
+      "description": "Kafka producer endpoint for iRail CloudEvents on the `irail` topic keyed by `{station_id}`."
     },
     "be.irail.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/be.irail.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for iRail CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -103,10 +105,11 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/be.irail.jstruct/schemas/be.irail.ArrivalBoard"
         }
-      }
+      },
+      "description": "Events from iRail covering Belgian railway stations, vehicles, and connections. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "be.irail.mqtt": {
-      "description": "MQTT/5.0 transport variants for iRail Belgian railway station metadata and live board snapshots. Topics are retained QoS-1 state leaves under transit/be/irail/irail/{station_id}/{event}. The station_id topic axis preserves the existing Kafka/CloudEvents subject. Use transit/be/irail/irail/{station_id}/# for one station, transit/be/irail/irail/+/station-board for all departure boards, and transit/be/irail/irail/+/arrival-board for all arrival boards. Board snapshots use message expiry so stale liveboards age out if polling stops.",
+      "description": "MQTT 5 variant of the iRail events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "be.irail.mqtt.Station": {
           "name": "Station",
@@ -164,7 +167,7 @@
                       "Station": {
                         "name": "Station",
                         "type": "object",
-                        "description": "Metadata for a Belgian railway station in the NMBS/SNCB (Nationale Maatschappij der Belgische Spoorwegen / Soci\u00e9t\u00e9 Nationale des Chemins de fer Belges) network. Station identifiers follow the UIC (Union Internationale des Chemins de fer) numbering scheme with a Belgian country prefix of 0088. The iRail API provides these as nine-digit codes prefixed with 'BE.NMBS.'.",
+                        "description": "Metadata for a Belgian railway station in the NMBS/SNCB network as provided by the iRail API. The Belgian rail network comprises approximately 600 passenger stations. Each station has a unique UIC-derived numeric identifier assigned by the NMBS, geographic coordinates, and multilingual names.",
                         "properties": {
                           "station_id": {
                             "type": "string",
@@ -188,7 +191,7 @@
                             "type": "double",
                             "description": "Longitude of the station in WGS84 decimal degrees. Sourced from the iRail locationX field.",
                             "unit": "deg",
-                            "symbol": "\u00b0",
+                            "symbol": "°",
                             "altnames": {
                               "json": "locationX"
                             }
@@ -197,7 +200,7 @@
                             "type": "double",
                             "description": "Latitude of the station in WGS84 decimal degrees. Sourced from the iRail locationY field.",
                             "unit": "deg",
-                            "symbol": "\u00b0",
+                            "symbol": "°",
                             "altnames": {
                               "json": "locationY"
                             }
@@ -337,7 +340,7 @@
                       "StationBoard": {
                         "name": "StationBoard",
                         "type": "object",
-                        "description": "Real-time departure board for a Belgian railway station. Contains all currently visible departures from the station as returned by the iRail liveboard API. The board reflects the current state of the departure display at the station, including delays, cancellations, and platform assignments. Typically shows the next 30-50 departures within a rolling time window.",
+                        "description": "A real-time departure board snapshot for a Belgian railway station from the iRail liveboard API. Contains all currently scheduled departures from the station with real-time delay information, platform assignments, cancellation status, and crowd-sourced occupancy levels. The board is polled periodically and each event replaces the previous board state for the same station.",
                         "properties": {
                           "station_id": {
                             "type": "string",
@@ -491,7 +494,7 @@
                       "ArrivalBoard": {
                         "name": "ArrivalBoard",
                         "type": "object",
-                        "description": "Real-time arrival board for a Belgian railway station. Contains all currently visible arrivals at the station as returned by the iRail liveboard API with arrdep=arrival. The board reflects the current state of the arrival display at the station, including delays, cancellations, and platform assignments.",
+                        "description": "A real-time arrival board snapshot for a Belgian railway station from the iRail liveboard API. Contains all currently scheduled arrivals at the station with real-time delay information, platform assignments, cancellation status, and crowd-sourced occupancy levels. The board is polled periodically and each event replaces the previous arrival-board state for the same station.",
                         "properties": {
                           "station_id": {
                             "type": "string",
@@ -578,7 +581,8 @@
                     "type": "string",
                     "doc": "Stable linked-data URI identifying this station."
                   }
-                ]
+                ],
+                "description": "A reference record from the Belgian iRail train data API for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           },
@@ -707,7 +711,8 @@
                     },
                     "doc": "Array of departure entries on the station board."
                   }
-                ]
+                ],
+                "description": "A reference record from the Belgian iRail train data API for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
               }
             }
           },
@@ -836,7 +841,8 @@
                     },
                     "doc": "Array of arrival entries on the station board."
                   }
-                ]
+                ],
+                "description": "A transport update from the Belgian iRail train data API. It carries train departure, arrival, and connection updates for Belgian railway stations, vehicles, and connections."
               }
             }
           },
@@ -844,5 +850,10 @@
         }
       }
     }
+  },
+  "description": "iRail publishes train departure, arrival, and connection updates from the Belgian iRail train data API for Belgian railway stations, vehicles, and connections. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for iRail, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/king-county-marine/EVENTS.md
+++ b/king-county-marine/EVENTS.md
@@ -1,6 +1,6 @@
 # King County Marine Bridge Events
 
-MQTT/5.0 transport variants for King County marine station reference data and water-quality readings. The station-only UNS topic tree is maritime/us/wa/king-county/king-county-marine/{station_id}/{event}. Station info and latest water-quality readings are retained with QoS 1 so late subscribers can discover stations and their latest values.
+King County Marine publishes marine transit schedule and status updates from King County Metro marine feeds for King County water-taxi routes and sailings. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `US.WA.KingCounty.Marine.Station`
 
 #### What it tells you
 
-Reference metadata for one active King County buoy or mooring raw-data dataset.
+A reference record from King County Metro marine feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -104,7 +104,7 @@ CloudEvents type: `US.WA.KingCounty.Marine.WaterQualityReading`
 
 #### What it tells you
 
-Normalized King County buoy or mooring reading carrying the documented water-quality and weather measurements published by the current raw-data datasets.
+A transport update from King County Metro marine feeds. It carries marine transit schedule and status updates for King County water-taxi routes and sailings.
 
 #### Identity
 

--- a/king-county-marine/xreg/king_county_marine.xreg.json
+++ b/king-county-marine/xreg/king_county_marine.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/US.WA.KingCounty.Marine"
-      ]
+      ],
+      "description": "Kafka producer endpoint for King County Marine CloudEvents on the `king-county-marine` topic keyed by `{station_id}`."
     },
     "US.WA.KingCounty.Marine.Mqtt": {
       "usage": [
@@ -41,7 +42,7 @@
       "messagegroups": [
         "#/messagegroups/US.WA.KingCounty.Marine.mqtt"
       ],
-      "description": "MQTT/5.0 binary-mode CloudEvents producer for the King County Marine UNS topic tree."
+      "description": "MQTT 5 producer endpoint for King County Marine CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -63,7 +64,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/US.WA.KingCounty.Marine.jstruct/schemas/US.WA.KingCounty.Marine.Station"
+          "dataschemauri": "#/schemagroups/US.WA.KingCounty.Marine.jstruct/schemas/US.WA.KingCounty.Marine.Station",
+          "description": "A reference record from King County Metro marine feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
         },
         "US.WA.KingCounty.Marine.WaterQualityReading": {
           "name": "WaterQualityReading",
@@ -81,12 +83,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/US.WA.KingCounty.Marine.jstruct/schemas/US.WA.KingCounty.Marine.WaterQualityReading"
+          "dataschemauri": "#/schemagroups/US.WA.KingCounty.Marine.jstruct/schemas/US.WA.KingCounty.Marine.WaterQualityReading",
+          "description": "A transport update from King County Metro marine feeds. It carries marine transit schedule and status updates for King County water-taxi routes and sailings."
         }
-      }
+      },
+      "description": "Events from King County Marine covering King County water-taxi routes and sailings. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "US.WA.KingCounty.Marine.mqtt": {
-      "description": "MQTT/5.0 transport variants for King County marine station reference data and water-quality readings. The station-only UNS topic tree is maritime/us/wa/king-county/king-county-marine/{station_id}/{event}. Station info and latest water-quality readings are retained with QoS 1 so late subscribers can discover stations and their latest values.",
+      "description": "MQTT 5 variant of the King County Marine events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "US.WA.KingCounty.Marine.mqtt.Station": {
           "name": "Station",
@@ -135,7 +139,7 @@
                   "sensor_level"
                 ],
                 "name": "Station",
-                "description": "Reference metadata for one active King County buoy or mooring raw-data dataset.",
+                "description": "A reference record from King County Metro marine feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
                 "properties": {
                   "station_id": {
                     "type": "string",
@@ -197,7 +201,7 @@
                   "observation_time"
                 ],
                 "name": "WaterQualityReading",
-                "description": "Normalized King County buoy or mooring reading carrying the documented water-quality and weather measurements published by the current raw-data datasets.",
+                "description": "A transport update from King County Metro marine feeds. It carries marine transit schedule and status updates for King County water-taxi routes and sailings.",
                 "properties": {
                   "station_id": {
                     "type": "string",
@@ -414,5 +418,10 @@
         }
       }
     }
+  },
+  "description": "King County Marine publishes marine transit schedule and status updates from King County Metro marine feeds for King County water-taxi routes and sailings. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for King County Marine, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/kystverket-ais/EVENTS.md
+++ b/kystverket-ais/EVENTS.md
@@ -1,6 +1,6 @@
 # Kystverket AIS Bridge Usage Guide Events
 
-MQTT/5.0 non-retained UNS variants of the Kystverket AIS CloudEvents. Each event family (position-report, static, aid-to-navigation) gets a dedicated topic with the kebab family literal baked as the trailing segment. QoS 0, retain=false — there is no LKV slot for a firehose.
+Kystverket AIS publishes vessel position and voyage updates from the Norwegian Coastal Administration for AIS-equipped vessels in Norwegian waters. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -51,11 +51,11 @@ CloudEvents type: `NO.Kystverket.AIS.PositionReportClassA`
 
 #### What it tells you
 
-This event carries position report class a data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -67,18 +67,18 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Position Report Class A` payloads are JSON object. Required fields: `mmsi`, `longitude`, `latitude`, `timestamp`.
 
-- **`mmsi`** (int32, required): No description provided.
-- **`navigation_status`** (int32, optional): No description provided.
-- **`rate_of_turn`** (double, optional): No description provided.
-- **`speed_over_ground`** (double, optional): No description provided.
-- **`position_accuracy`** (int32, optional): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`course_over_ground`** (double, optional): No description provided.
-- **`true_heading`** (int32, optional): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`station_id`** (string, optional): No description provided.
-- **`msg_type`** (int32, optional): No description provided.
+- **`mmsi`** (int32, required): Provider field for mmsi in this record.
+- **`navigation_status`** (int32, optional): Provider field for navigation status in this record.
+- **`rate_of_turn`** (double, optional): Provider field for rate of turn in this record.
+- **`speed_over_ground`** (double, optional): Provider field for speed over ground in this record.
+- **`position_accuracy`** (int32, optional): Provider field for position accuracy in this record.
+- **`longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`course_over_ground`** (double, optional): Provider field for course over ground in this record.
+- **`true_heading`** (int32, optional): Provider field for true heading in this record.
+- **`timestamp`** (string, required): Time when the provider recorded or published the update.
+- **`station_id`** (string, optional): Stable identifier assigned by the upstream provider for the station or stop.
+- **`msg_type`** (int32, optional): Provider field for msg type in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -110,11 +110,11 @@ CloudEvents type: `NO.Kystverket.AIS.StaticVoyageData`
 
 #### What it tells you
 
-This event carries static voyage data data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -126,23 +126,23 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Static Voyage Data` payloads are JSON object. Required fields: `mmsi`, `timestamp`.
 
-- **`mmsi`** (int32, required): No description provided.
-- **`imo_number`** (int32, optional): No description provided.
-- **`callsign`** (string, optional): No description provided.
-- **`ship_name`** (string, optional): No description provided.
-- **`ship_type`** (int32, optional): No description provided.
-- **`dimension_to_bow`** (int32, optional): No description provided.
-- **`dimension_to_stern`** (int32, optional): No description provided.
-- **`dimension_to_port`** (int32, optional): No description provided.
-- **`dimension_to_starboard`** (int32, optional): No description provided.
-- **`draught`** (double, optional): No description provided.
-- **`destination`** (string, optional): No description provided.
-- **`eta_month`** (int32, optional): No description provided.
-- **`eta_day`** (int32, optional): No description provided.
-- **`eta_hour`** (int32, optional): No description provided.
-- **`eta_minute`** (int32, optional): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`station_id`** (string, optional): No description provided.
+- **`mmsi`** (int32, required): Provider field for mmsi in this record.
+- **`imo_number`** (int32, optional): Provider field for imo number in this record.
+- **`callsign`** (string, optional): Provider field for callsign in this record.
+- **`ship_name`** (string, optional): Human-readable name of the ship.
+- **`ship_type`** (int32, optional): Provider field for ship type in this record.
+- **`dimension_to_bow`** (int32, optional): Provider field for dimension to bow in this record.
+- **`dimension_to_stern`** (int32, optional): Provider field for dimension to stern in this record.
+- **`dimension_to_port`** (int32, optional): Provider field for dimension to port in this record.
+- **`dimension_to_starboard`** (int32, optional): Provider field for dimension to starboard in this record.
+- **`draught`** (double, optional): Provider field for draught in this record.
+- **`destination`** (string, optional): Provider field for destination in this record.
+- **`eta_month`** (int32, optional): Provider field for eta month in this record.
+- **`eta_day`** (int32, optional): Provider field for eta day in this record.
+- **`eta_hour`** (int32, optional): Provider field for eta hour in this record.
+- **`eta_minute`** (int32, optional): Provider field for eta minute in this record.
+- **`timestamp`** (string, required): Time when the provider recorded or published the update.
+- **`station_id`** (string, optional): Stable identifier assigned by the upstream provider for the station or stop.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -179,11 +179,11 @@ CloudEvents type: `NO.Kystverket.AIS.PositionReportClassB`
 
 #### What it tells you
 
-This event carries position report class b data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -195,16 +195,16 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Position Report Class B` payloads are JSON object. Required fields: `mmsi`, `longitude`, `latitude`, `timestamp`.
 
-- **`mmsi`** (int32, required): No description provided.
-- **`speed_over_ground`** (double, optional): No description provided.
-- **`position_accuracy`** (int32, optional): No description provided.
-- **`longitude`** (double, required): No description provided.
-- **`latitude`** (double, required): No description provided.
-- **`course_over_ground`** (double, optional): No description provided.
-- **`true_heading`** (int32, optional): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`station_id`** (string, optional): No description provided.
-- **`msg_type`** (int32, optional): No description provided.
+- **`mmsi`** (int32, required): Provider field for mmsi in this record.
+- **`speed_over_ground`** (double, optional): Provider field for speed over ground in this record.
+- **`position_accuracy`** (int32, optional): Provider field for position accuracy in this record.
+- **`longitude`** (double, required): Longitude of the resource in WGS 84 coordinates.
+- **`latitude`** (double, required): Latitude of the resource in WGS 84 coordinates.
+- **`course_over_ground`** (double, optional): Provider field for course over ground in this record.
+- **`true_heading`** (int32, optional): Provider field for true heading in this record.
+- **`timestamp`** (string, required): Time when the provider recorded or published the update.
+- **`station_id`** (string, optional): Stable identifier assigned by the upstream provider for the station or stop.
+- **`msg_type`** (int32, optional): Provider field for msg type in this record.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -234,11 +234,11 @@ CloudEvents type: `NO.Kystverket.AIS.StaticDataClassB`
 
 #### What it tells you
 
-This event carries static data class b data for this source. The payload fields below are the authoritative reference for the fields currently documented in the xRegistry manifest.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
-Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a payload field with the same name. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
+Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is provider field for mmsi in this record. That value is the CloudEvents `subject` and is mirrored into transport routing fields where the protocol has them.
 
 #### Where to find it
 
@@ -250,17 +250,17 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is a paylo
 
 `Static Data Class B` payloads are JSON object. Required fields: `mmsi`, `timestamp`.
 
-- **`mmsi`** (int32, required): No description provided.
-- **`part_number`** (int32, optional): No description provided.
-- **`ship_name`** (string, optional): No description provided.
-- **`ship_type`** (int32, optional): No description provided.
-- **`callsign`** (string, optional): No description provided.
-- **`dimension_to_bow`** (int32, optional): No description provided.
-- **`dimension_to_stern`** (int32, optional): No description provided.
-- **`dimension_to_port`** (int32, optional): No description provided.
-- **`dimension_to_starboard`** (int32, optional): No description provided.
-- **`timestamp`** (string, required): No description provided.
-- **`station_id`** (string, optional): No description provided.
+- **`mmsi`** (int32, required): Provider field for mmsi in this record.
+- **`part_number`** (int32, optional): Provider field for part number in this record.
+- **`ship_name`** (string, optional): Human-readable name of the ship.
+- **`ship_type`** (int32, optional): Provider field for ship type in this record.
+- **`callsign`** (string, optional): Provider field for callsign in this record.
+- **`dimension_to_bow`** (int32, optional): Provider field for dimension to bow in this record.
+- **`dimension_to_stern`** (int32, optional): Provider field for dimension to stern in this record.
+- **`dimension_to_port`** (int32, optional): Provider field for dimension to port in this record.
+- **`dimension_to_starboard`** (int32, optional): Provider field for dimension to starboard in this record.
+- **`timestamp`** (string, required): Time when the provider recorded or published the update.
+- **`station_id`** (string, optional): Stable identifier assigned by the upstream provider for the station or stop.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -291,7 +291,7 @@ CloudEvents type: `NO.Kystverket.AIS.AidToNavigation`
 
 #### What it tells you
 
-Aid-to-Navigation report (Type 21) projected onto the UNS axes.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
@@ -323,9 +323,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`ais_msg_type`** (int32, required): Original ITU-R M.1371 message ID (21).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -358,7 +358,7 @@ CloudEvents type: `NO.Kystverket.AIS.PositionReport`
 
 #### What it tells you
 
-AIS position report (Type 1/2/3/18/19) projected onto the UNS axes.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
@@ -393,9 +393,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`ais_msg_type`** (int32, required): Original ITU-R M.1371 message ID (1, 2, 3, 18, or 19).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -431,7 +431,7 @@ CloudEvents type: `NO.Kystverket.AIS.ShipStatic`
 
 #### What it tells you
 
-AIS static and voyage-related data (Type 5 / Type 24) projected onto the UNS axes.
+A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.
 
 #### Identity
 
@@ -469,9 +469,9 @@ Each event identifies the real-world resource with `{mmsi}`. `{mmsi}` is source 
 - **`ais_msg_type`** (int32, required): Original ITU-R M.1371 message ID (5 or 24).
 ##### `msg_type` values
 
-- `position-report`
-- `static`
-- `aid-to-navigation`
+- `position-report`: Provider coded value `position-report` for this field.
+- `static`: Provider coded value `static` for this field.
+- `aid-to-navigation`: Provider coded value `aid-to-navigation` for this field.
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.

--- a/kystverket-ais/xreg/ais.xreg.json
+++ b/kystverket-ais/xreg/ais.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NO.Kystverket.AIS"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Kystverket AIS CloudEvents on the `ais` topic keyed by `{mmsi}`."
     },
     "NO.Kystverket.AIS.Mqtt": {
       "usage": [
@@ -35,7 +36,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NO.Kystverket.AIS.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Kystverket AIS CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -57,7 +59,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReportClassA"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReportClassA",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.StaticVoyageData": {
           "name": "StaticVoyageData",
@@ -75,7 +78,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.StaticVoyageData"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.StaticVoyageData",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.PositionReportClassB": {
           "name": "PositionReportClassB",
@@ -93,7 +97,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReportClassB"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReportClassB",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.StaticDataClassB": {
           "name": "StaticDataClassB",
@@ -111,7 +116,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.StaticDataClassB"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.StaticDataClassB",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.AidToNavigation": {
           "name": "AidToNavigation",
@@ -129,7 +135,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.AidToNavigation"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.AidToNavigation",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.PositionReport": {
           "name": "PositionReport",
@@ -147,7 +154,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReport"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.PositionReport",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         },
         "NO.Kystverket.AIS.ShipStatic": {
           "name": "ShipStatic",
@@ -165,12 +173,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.ShipStatic"
+          "dataschemauri": "#/schemagroups/NO.Kystverket.AIS.jstruct/schemas/NO.Kystverket.AIS.ShipStatic",
+          "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
         }
-      }
+      },
+      "description": "Events from Kystverket AIS covering AIS-equipped vessels in Norwegian waters. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "NO.Kystverket.AIS.mqtt": {
-      "description": "MQTT/5.0 non-retained UNS variants of the Kystverket AIS CloudEvents. Each event family (position-report, static, aid-to-navigation) gets a dedicated topic with the kebab family literal baked as the trailing segment. QoS 0, retain=false — there is no LKV slot for a firehose.",
+      "description": "MQTT 5 variant of the Kystverket AIS events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "NO.Kystverket.AIS.mqtt.PositionReport": {
           "name": "PositionReport",
@@ -227,43 +237,56 @@
                 "name": "PositionReportClassA",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "navigation_status": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for navigation status in this record."
                   },
                   "rate_of_turn": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for rate of turn in this record."
                   },
                   "speed_over_ground": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for speed over ground in this record."
                   },
                   "position_accuracy": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "course_over_ground": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for course over ground in this record."
                   },
                   "true_heading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for true heading in this record."
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the station or stop."
                   },
                   "msg_type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for msg type in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/NO/Kystverket/AIS/PositionReportClassA"
+                "$id": "https://example.com/schemas/NO/Kystverket/AIS/PositionReportClassA",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
               }
             }
           }
@@ -285,58 +308,76 @@
                 "name": "StaticVoyageData",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "imo_number": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for imo number in this record."
                   },
                   "callsign": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for callsign in this record."
                   },
                   "ship_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the ship."
                   },
                   "ship_type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ship type in this record."
                   },
                   "dimension_to_bow": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to bow in this record."
                   },
                   "dimension_to_stern": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to stern in this record."
                   },
                   "dimension_to_port": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to port in this record."
                   },
                   "dimension_to_starboard": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to starboard in this record."
                   },
                   "draught": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for draught in this record."
                   },
                   "destination": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for destination in this record."
                   },
                   "eta_month": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for eta month in this record."
                   },
                   "eta_day": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for eta day in this record."
                   },
                   "eta_hour": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for eta hour in this record."
                   },
                   "eta_minute": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for eta minute in this record."
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the station or stop."
                   }
                 },
-                "$id": "https://example.com/schemas/NO/Kystverket/AIS/StaticVoyageData"
+                "$id": "https://example.com/schemas/NO/Kystverket/AIS/StaticVoyageData",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
               }
             }
           }
@@ -360,37 +401,48 @@
                 "name": "PositionReportClassB",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "speed_over_ground": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for speed over ground in this record."
                   },
                   "position_accuracy": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for position accuracy in this record."
                   },
                   "longitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Longitude of the resource in WGS 84 coordinates."
                   },
                   "latitude": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Latitude of the resource in WGS 84 coordinates."
                   },
                   "course_over_ground": {
-                    "type": "double"
+                    "type": "double",
+                    "description": "Provider field for course over ground in this record."
                   },
                   "true_heading": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for true heading in this record."
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the station or stop."
                   },
                   "msg_type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for msg type in this record."
                   }
                 },
-                "$id": "https://example.com/schemas/NO/Kystverket/AIS/PositionReportClassB"
+                "$id": "https://example.com/schemas/NO/Kystverket/AIS/PositionReportClassB",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
               }
             }
           }
@@ -412,40 +464,52 @@
                 "name": "StaticDataClassB",
                 "properties": {
                   "mmsi": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for mmsi in this record."
                   },
                   "part_number": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for part number in this record."
                   },
                   "ship_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human-readable name of the ship."
                   },
                   "ship_type": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for ship type in this record."
                   },
                   "callsign": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Provider field for callsign in this record."
                   },
                   "dimension_to_bow": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to bow in this record."
                   },
                   "dimension_to_stern": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to stern in this record."
                   },
                   "dimension_to_port": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to port in this record."
                   },
                   "dimension_to_starboard": {
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Provider field for dimension to starboard in this record."
                   },
                   "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Time when the provider recorded or published the update."
                   },
                   "station_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Stable identifier assigned by the upstream provider for the station or stop."
                   }
                 },
-                "$id": "https://example.com/schemas/NO/Kystverket/AIS/StaticDataClassB"
+                "$id": "https://example.com/schemas/NO/Kystverket/AIS/StaticDataClassB",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters."
               }
             }
           }
@@ -461,7 +525,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "AidToNavigation",
-                "description": "Aid-to-Navigation report (Type 21) projected onto the UNS axes.",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -500,7 +564,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "name": {
                     "type": "string",
@@ -551,7 +620,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "PositionReport",
-                "description": "AIS position report (Type 1/2/3/18/19) projected onto the UNS axes.",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -589,7 +658,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "latitude": {
                     "type": "double",
@@ -652,7 +726,7 @@
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "type": "object",
                 "name": "ShipStatic",
-                "description": "AIS static and voyage-related data (Type 5 / Type 24) projected onto the UNS axes.",
+                "description": "A transport update from the Norwegian Coastal Administration. It carries vessel position and voyage updates for AIS-equipped vessels in Norwegian waters.",
                 "required": [
                   "mmsi",
                   "flag",
@@ -689,7 +763,12 @@
                       "static",
                       "aid-to-navigation"
                     ],
-                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template."
+                    "description": "Kebab-case event family used as the trailing UNS topic segment. Always equals the segment baked into the message's MQTT topic template.",
+                    "descriptions": {
+                      "position-report": "Provider coded value `position-report` for this field.",
+                      "static": "Provider coded value `static` for this field.",
+                      "aid-to-navigation": "Provider coded value `aid-to-navigation` for this field."
+                    }
                   },
                   "ship_name": {
                     "type": "string",
@@ -755,5 +834,10 @@
         }
       }
     }
+  },
+  "description": "Kystverket AIS publishes vessel position and voyage updates from the Norwegian Coastal Administration for AIS-equipped vessels in Norwegian waters. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Kystverket AIS, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/madrid-traffic/EVENTS.md
+++ b/madrid-traffic/EVENTS.md
@@ -1,6 +1,6 @@
 # Madrid Real-Time Traffic (Informo) Events
 
-This bridge polls the Madrid Informo traffic sensor API and sends traffic data to Apache Kafka as CloudEvents.
+Madrid Traffic publishes traffic intensity and occupancy measurements from Madrid open traffic sensor feeds for Madrid traffic sensors. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `es.madrid.informo.MeasurementPoint`
 
 #### What it tells you
 
-Reference data for a traffic measurement point (sensor) in Madrid's Informo road traffic monitoring system. Each measurement point is installed on a specific road segment and reports traffic intensity, occupancy, and service level readings. This data is relatively static and describes the sensor installation, not the real-time traffic conditions.
+A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -87,7 +87,7 @@ CloudEvents type: `es.madrid.informo.TrafficReading`
 
 #### What it tells you
 
-Real-time traffic reading from a measurement point in Madrid's Informo road traffic monitoring system. Updated approximately every 5 minutes. Each reading provides the current traffic intensity, road occupancy, load, and service level for a specific sensor on Madrid's road network, including the M-30 ring motorway and urban streets.
+A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value.
 
 #### Identity
 

--- a/madrid-traffic/xreg/madrid_traffic.xreg.json
+++ b/madrid-traffic/xreg/madrid_traffic.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/es.madrid.informo"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Madrid Traffic CloudEvents on the `madrid-traffic` topic keyed by `{sensor_id}`."
     }
   },
   "messagegroups": {
@@ -41,7 +42,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/es.madrid.informo.jstruct/schemas/es.madrid.informo.MeasurementPoint"
+          "dataschemauri": "#/schemagroups/es.madrid.informo.jstruct/schemas/es.madrid.informo.MeasurementPoint",
+          "description": "A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value."
         },
         "es.madrid.informo.TrafficReading": {
           "name": "TrafficReading",
@@ -59,9 +61,11 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/es.madrid.informo.jstruct/schemas/es.madrid.informo.TrafficReading"
+          "dataschemauri": "#/schemagroups/es.madrid.informo.jstruct/schemas/es.madrid.informo.TrafficReading",
+          "description": "A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Madrid Traffic covering Madrid traffic sensors. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -98,30 +102,45 @@
                     }
                   },
                   "element_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Classification of the measurement point within Madrid's traffic network. Derived from the 'accesoAsociado' field prefix in the upstream XML. Common values include 'URB' for urban streets and 'M30' for the M-30 ring motorway.",
                     "altnames": {
                       "lang:es": "tipo_elem"
                     }
                   },
                   "subarea": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Traffic management zone code for this sensor. Corresponds to 'subarea' in the upstream XML. Used by Madrid's traffic management center for geographic grouping of sensors."
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Longitude of the sensor in decimal degrees (WGS84, EPSG:4326). Converted from the UTM easting in 'st_x' in the upstream XML, which uses European comma decimal separators.",
                     "unit": "deg",
                     "symbol": "°"
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Latitude of the sensor in decimal degrees (WGS84, EPSG:4326). Converted from the UTM northing in 'st_y' in the upstream XML, which uses European comma decimal separators.",
                     "unit": "deg",
                     "symbol": "°"
                   },
                   "saturation_intensity": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Maximum traffic intensity that the road segment can handle, expressed in vehicles per hour. Corresponds to 'intensidadSat' in the upstream XML. Used as the denominator for computing load and saturation ratios.",
                     "unit": "1/h",
                     "symbol": "veh/h",
@@ -131,7 +150,7 @@
                   }
                 },
                 "$id": "https://informo.madrid.es/schemas/es/madrid/informo/MeasurementPoint",
-                "description": "Reference data for a traffic measurement point (sensor) in Madrid's Informo road traffic monitoring system. Each measurement point is installed on a specific road segment and reports traffic intensity, occupancy, and service level readings. This data is relatively static and describes the sensor installation, not the real-time traffic conditions."
+                "description": "A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -160,7 +179,10 @@
                     }
                   },
                   "intensity": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Current traffic intensity measured by the sensor, expressed in vehicles per hour. Corresponds to 'intensidad' in the upstream XML. A value of 0 may indicate no traffic or a sensor in standby mode.",
                     "unit": "1/h",
                     "symbol": "veh/h",
@@ -169,7 +191,10 @@
                     }
                   },
                   "occupancy": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Percentage of time the sensor detects a vehicle presence. Corresponds to 'ocupacion' in the upstream XML. Range is 0 to 100.",
                     "unit": "%",
                     "symbol": "%",
@@ -178,7 +203,10 @@
                     }
                   },
                   "load": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Load percentage representing the ratio of current intensity to saturation intensity. Corresponds to 'carga' in the upstream XML. Range is typically 0 to 100.",
                     "unit": "%",
                     "symbol": "%",
@@ -187,14 +215,20 @@
                     }
                   },
                   "service_level": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "description": "Traffic service level reported by the sensor. Corresponds to 'nivelServicio' in the upstream XML. Values: 0 = fluid/free flow, 1 = moderate/dense, 2 = congested, 3 = severely congested.",
                     "altnames": {
                       "lang:es": "nivelServicio"
                     }
                   },
                   "error_flag": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Error status flag for this reading. Corresponds to 'error' in the upstream XML. 'N' indicates a normal reading, 'S' or 'Y' indicates the sensor is reporting an error and the data may be unreliable."
                   },
                   "timestamp": {
@@ -203,12 +237,17 @@
                   }
                 },
                 "$id": "https://informo.madrid.es/schemas/es/madrid/informo/TrafficReading",
-                "description": "Real-time traffic reading from a measurement point in Madrid's Informo road traffic monitoring system. Updated approximately every 5 minutes. Each reading provides the current traffic intensity, road occupancy, load, and service level for a specific sensor on Madrid's road network, including the M-30 ring motorway and urban streets."
+                "description": "A current transport measurement or status update from Madrid open traffic sensor feeds. It carries traffic intensity and occupancy measurements when the upstream feed reports a new or refreshed value."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "Madrid Traffic publishes traffic intensity and occupancy measurements from Madrid open traffic sensor feeds for Madrid traffic sensors. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Madrid Traffic, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/ndl-netherlands/EVENTS.md
+++ b/ndl-netherlands/EVENTS.md
@@ -1,6 +1,6 @@
 # NDW Netherlands Road Traffic Bridge Events
 
-This bridge downloads DATEX II XML data published by the Dutch NDW (Nationaal Dataportaal Wegverkeer) at `https://opendata.ndw.nu` and forwards traffic speed, travel time, and situation data to Apache Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams as CloudEvents.
+NDL Netherlands publishes road traffic measurements and situation updates from Dutch road-traffic open data feeds for Dutch road network sites and traffic situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `NL.NDW.Traffic.TrafficSpeed`
 
 #### What it tells you
 
-Aggregated traffic speed and flow measurement per road segment from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes. Aggregated traffic speed and flow measurement per road segment from the NDW DATEX II trafficspeed feed.
+Aggregated traffic speed and flow measurement per road segment from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes.
 
 #### Identity
 
@@ -83,7 +83,7 @@ CloudEvents type: `NL.NDW.Traffic.TravelTime`
 
 #### What it tells you
 
-Travel time measurement for a road segment from the Dutch NDW DATEX II traveltime feed. Each record contains the actual measured travel time and the static free-flow reference time for a measurement site. Travel time measurement for a road segment from the NDW DATEX II traveltime feed.
+Travel time measurement for a road segment from the Dutch NDW DATEX II traveltime feed. Each record contains the actual measured travel time and the static free-flow reference time for a measurement site.
 
 #### Identity
 
@@ -132,7 +132,7 @@ CloudEvents type: `NL.NDW.Traffic.TrafficSituation`
 
 #### What it tells you
 
-Current traffic situation record from the Dutch NDW DATEX II actueel_beeld (current situation overview) feed. Includes road works, closures, lane management, and other traffic-affecting events on the Dutch road network. Current traffic situation from the NDW DATEX II v3 actueel_beeld feed.
+Current traffic situation record from the Dutch NDW DATEX II actueel_beeld (current situation overview) feed. Includes road works, closures, lane management, and other traffic-affecting events on the Dutch road network.
 
 #### Identity
 

--- a/ndl-netherlands/xreg/ndl_netherlands.xreg.json
+++ b/ndl-netherlands/xreg/ndl_netherlands.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.Traffic.Measurements"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDL Netherlands CloudEvents on the `ndl-traffic` topic keyed by `{site_id}`."
     },
     "NL.NDW.Traffic.Situations.Kafka": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.Traffic.Situations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDL Netherlands CloudEvents on the `ndl-traffic-situations` topic keyed by `{situation_id}`."
     }
   },
   "messagegroups": {
@@ -84,7 +86,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.Traffic.jstruct/schemas/NL.NDW.Traffic.TravelTime"
         }
-      }
+      },
+      "description": "Events from NDL Netherlands covering Dutch road network sites and traffic situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "NL.NDW.Traffic.Situations": {
       "messages": {
@@ -107,7 +110,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.Traffic.jstruct/schemas/NL.NDW.Traffic.TrafficSituation"
         }
-      }
+      },
+      "description": "Events from NDL Netherlands covering Dutch road network sites and traffic situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -132,7 +136,7 @@
                         "TrafficSpeed": {
                           "name": "TrafficSpeed",
                           "type": "object",
-                          "description": "Aggregated traffic speed and flow measurement per road segment from the NDW DATEX II trafficspeed feed. Speed is averaged and flow is summed across all reporting lanes at the measurement site.",
+                          "description": "Aggregated traffic speed and flow measurement per road segment from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes.",
                           "properties": {
                             "site_id": {
                               "type": "string",
@@ -143,12 +147,18 @@
                               "description": "Timestamp of the measurement in ISO 8601 format (UTC), from the DATEX II measurementTimeDefault element."
                             },
                             "average_speed": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Average vehicle speed in km/h across all lanes with valid data at this site. Null when no lane reported a valid speed (all lanes had speed <= 0).",
                               "unit": "km/h"
                             },
                             "vehicle_flow_rate": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Total vehicle flow rate in vehicles per hour, summed across all lanes at this measurement site. Null when no valid flow data was reported.",
                               "unit": "vehicles/h"
                             },
@@ -190,7 +200,7 @@
                         "TravelTime": {
                           "name": "TravelTime",
                           "type": "object",
-                          "description": "Travel time measurement for a road segment from the NDW DATEX II traveltime feed. Contains actual measured travel time and the static free-flow reference time.",
+                          "description": "Travel time measurement for a road segment from the Dutch NDW DATEX II traveltime feed. Each record contains the actual measured travel time and the static free-flow reference time for a measurement site.",
                           "properties": {
                             "site_id": {
                               "type": "string",
@@ -201,25 +211,40 @@
                               "description": "Timestamp of the measurement in ISO 8601 format (UTC), from the DATEX II measurementTimeDefault element."
                             },
                             "duration": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Actual measured travel time in seconds for this road segment. Null when the measurement has a data error (duration is -1 in the upstream).",
                               "unit": "s"
                             },
                             "reference_duration": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Static reference (free-flow) travel time in seconds for this road segment. Null when unavailable or when the measurement has a data error.",
                               "unit": "s"
                             },
                             "accuracy": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Accuracy of the travel time measurement as a percentage (0-100), indicating the quality of the sensor coverage."
                             },
                             "data_quality": {
-                              "type": ["double", "null"],
+                              "type": [
+                                "double",
+                                "null"
+                              ],
                               "description": "Supplier-calculated data quality score as a percentage (0-100). Higher values indicate more reliable measurements."
                             },
                             "number_of_input_values": {
-                              "type": ["int32", "null"],
+                              "type": [
+                                "int32",
+                                "null"
+                              ],
                               "description": "Number of individual vehicle travel times used to compute this aggregate travel time measurement."
                             }
                           },
@@ -255,7 +280,7 @@
                         "TrafficSituation": {
                           "name": "TrafficSituation",
                           "type": "object",
-                          "description": "Current traffic situation from the NDW DATEX II v3 actueel_beeld feed. Covers road works, lane closures, diversions, and other traffic-affecting events on the Dutch road network.",
+                          "description": "Current traffic situation record from the Dutch NDW DATEX II actueel_beeld (current situation overview) feed. Includes road works, closures, lane management, and other traffic-affecting events on the Dutch road network.",
                           "properties": {
                             "situation_id": {
                               "type": "string",
@@ -266,23 +291,38 @@
                               "description": "Timestamp of the latest version of this situation in ISO 8601 format (UTC), from the DATEX II situationVersionTime element."
                             },
                             "severity": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Overall severity of the situation. Values include: low, medium, high, highest, unknown. Null if not specified."
                             },
                             "record_type": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "DATEX II situation record type indicating the nature of the event. Common values: RoadOrCarriagewayOrLaneManagement, MaintenanceWorks, ConstructionWorks, ReroutingManagement. Null when not available."
                             },
                             "cause_type": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Cause of the traffic situation. Common values: roadMaintenance, accident, congestion, roadClosed. Null when no cause is specified."
                             },
                             "start_time": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "Start time of the situation validity period in ISO 8601 format (UTC). Null when no validity time specification is provided."
                             },
                             "end_time": {
-                              "type": ["string", "null"],
+                              "type": [
+                                "string",
+                                "null"
+                              ],
                               "description": "End time of the situation validity period in ISO 8601 format (UTC). Null when the end time is open-ended or not specified."
                             },
                             "information_status": {
@@ -331,13 +371,19 @@
                   },
                   {
                     "name": "average_speed",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Average vehicle speed in km/h across all lanes with valid data. Null when no valid speed data.",
                     "default": null
                   },
                   {
                     "name": "vehicle_flow_rate",
-                    "type": ["null", "int"],
+                    "type": [
+                      "null",
+                      "int"
+                    ],
                     "doc": "Total vehicle flow rate in vehicles per hour summed across all lanes. Null when no valid flow data.",
                     "default": null
                   },
@@ -346,7 +392,8 @@
                     "type": "int",
                     "doc": "Number of lanes that reported valid measurement data."
                   }
-                ]
+                ],
+                "description": "A current transport measurement or status update from Dutch road-traffic open data feeds. It carries road traffic measurements and situation updates when the upstream feed reports a new or refreshed value."
               }
             }
           }
@@ -374,35 +421,51 @@
                   },
                   {
                     "name": "duration",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Actual measured travel time in seconds. Null when data error.",
                     "default": null
                   },
                   {
                     "name": "reference_duration",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Static reference (free-flow) travel time in seconds. Null when unavailable.",
                     "default": null
                   },
                   {
                     "name": "accuracy",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Accuracy percentage (0-100).",
                     "default": null
                   },
                   {
                     "name": "data_quality",
-                    "type": ["null", "double"],
+                    "type": [
+                      "null",
+                      "double"
+                    ],
                     "doc": "Supplier-calculated data quality percentage (0-100).",
                     "default": null
                   },
                   {
                     "name": "number_of_input_values",
-                    "type": ["null", "int"],
+                    "type": [
+                      "null",
+                      "int"
+                    ],
                     "doc": "Number of individual vehicle travel times used in the calculation.",
                     "default": null
                   }
-                ]
+                ],
+                "description": "A transport update from Dutch road-traffic open data feeds. It carries road traffic measurements and situation updates for Dutch road network sites and traffic situations."
               }
             }
           }
@@ -430,31 +493,46 @@
                   },
                   {
                     "name": "severity",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "doc": "Overall severity: low, medium, high, highest, unknown.",
                     "default": null
                   },
                   {
                     "name": "record_type",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "doc": "DATEX II situation record type.",
                     "default": null
                   },
                   {
                     "name": "cause_type",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "doc": "Cause of the traffic situation.",
                     "default": null
                   },
                   {
                     "name": "start_time",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "doc": "Start time of the situation validity period in ISO 8601 format.",
                     "default": null
                   },
                   {
                     "name": "end_time",
-                    "type": ["null", "string"],
+                    "type": [
+                      "null",
+                      "string"
+                    ],
                     "doc": "End time of the situation validity period in ISO 8601 format.",
                     "default": null
                   },
@@ -463,12 +541,18 @@
                     "type": "string",
                     "doc": "Status of the information: real, test, or exercise."
                   }
-                ]
+                ],
+                "description": "A traffic or service situation update from Dutch road-traffic open data feeds. It describes a disruption, incident, closure, roadwork, or service alert affecting the covered network."
               }
             }
           }
         }
       }
     }
+  },
+  "description": "NDL Netherlands publishes road traffic measurements and situation updates from Dutch road-traffic open data feeds for Dutch road network sites and traffic situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for NDL Netherlands, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/ndw-road-traffic/EVENTS.md
+++ b/ndw-road-traffic/EVENTS.md
@@ -1,6 +1,6 @@
 # NDW Road Traffic Events
 
-Real-time road traffic data from the Dutch [Nationaal Dataportaal Wegverkeer (NDW)](https://www.ndw.nu/), the Netherlands national road traffic data platform. Provides live traffic speed, travel time, Dynamic Route Information Panel (DRIP) signs, Matrix Signal Installation (MSI) lane signals, and situation events (road works, bridge openings, temporary closures, speed limits, safety messages) for the Dutch national road network (rijkswegen and provinciale wegen).
+NDW Road Traffic publishes traffic flow, signs, travel-time, and situation updates from the Dutch National Data Warehouse for Traffic Information (NDW) for Dutch road network measurement sites and situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `NL.NDW.AVG.PointMeasurementSite`
 
 #### What it tells you
 
-Reference record for a point measurement site from the Dutch NDW DATEX II measurement_current feed. Contains location, sensor technology type, and lane configuration for a fixed inductive-loop or microwave sensor. Reference data for a point measurement site from the NDW DATEX II measurement_current feed.
+Reference record for a point measurement site from the Dutch NDW DATEX II measurement_current feed. Contains location, sensor technology type, and lane configuration for a fixed inductive-loop or microwave sensor.
 
 #### Identity
 
@@ -91,7 +91,7 @@ CloudEvents type: `NL.NDW.AVG.RouteMeasurementSite`
 
 #### What it tells you
 
-Reference record for a route (section) measurement site from the Dutch NDW DATEX II measurement_current feed. Covers a road segment between two coordinates used for travel time computation. Reference data for a route (section) measurement site from the NDW DATEX II measurement_current feed.
+Reference record for a route (section) measurement site from the Dutch NDW DATEX II measurement_current feed. Covers a road segment between two coordinates used for travel time computation.
 
 #### Identity
 
@@ -146,7 +146,7 @@ CloudEvents type: `NL.NDW.AVG.TrafficObservation`
 
 #### What it tells you
 
-Aggregated traffic speed and flow observation from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes. Aggregated traffic speed and flow observation per road segment from the NDW DATEX II trafficspeed feed.
+Aggregated traffic speed and flow observation from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes.
 
 #### Identity
 
@@ -191,7 +191,7 @@ CloudEvents type: `NL.NDW.AVG.TravelTimeObservation`
 
 #### What it tells you
 
-Travel time observation for a road segment from the Dutch NDW DATEX II traveltime feed. Contains the actual measured travel time and the static free-flow reference time for a route measurement site. Travel time observation for a road segment from the NDW DATEX II traveltime feed.
+Travel time observation for a road segment from the Dutch NDW DATEX II traveltime feed. Contains the actual measured travel time and the static free-flow reference time for a route measurement site.
 
 #### Identity
 
@@ -240,7 +240,7 @@ CloudEvents type: `NL.NDW.DRIP.DripSign`
 
 #### What it tells you
 
-Reference record for a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Describes the physical installation, location, and type of an individual VMS sign unit. Reference data for a Dynamic Route Information Panel (DRIP) sign from the NDW DATEX II dynamische_route_informatie_paneel feed.
+Reference record for a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Describes the physical installation, location, and type of an individual VMS sign unit.
 
 #### Identity
 
@@ -289,7 +289,7 @@ CloudEvents type: `NL.NDW.DRIP.DripDisplayState`
 
 #### What it tells you
 
-Current display state of a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Captures the active text, pictogram codes, and operational state of the sign. Current display state of a Dynamic Route Information Panel (DRIP) sign from the NDW DATEX II dynamische_route_informatie_paneel feed.
+Current display state of a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Captures the active text, pictogram codes, and operational state of the sign.
 
 #### Identity
 
@@ -338,7 +338,7 @@ CloudEvents type: `NL.NDW.MSI.MsiSign`
 
 #### What it tells you
 
-Reference record for a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Describes the physical location, lane assignment, and type of a matrix signal sign above a motorway lane. Reference data for a Matrix Signal Installation (MSI) sign from the NDW DATEX II Matrixsignaalinformatie feed.
+Reference record for a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Describes the physical location, lane assignment, and type of a matrix signal sign above a motorway lane.
 
 #### Identity
 
@@ -387,7 +387,7 @@ CloudEvents type: `NL.NDW.MSI.MsiDisplayState`
 
 #### What it tells you
 
-Current display state of a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Captures the displayed image code, operational state, and any speed limit shown. Current display state of a Matrix Signal Installation (MSI) sign from the NDW DATEX II Matrixsignaalinformatie feed.
+Current display state of a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Captures the displayed image code, operational state, and any speed limit shown.
 
 #### Identity
 
@@ -432,7 +432,7 @@ CloudEvents type: `NL.NDW.Situations.Roadwork`
 
 #### What it tells you
 
-Road construction or maintenance work event from the Dutch NDW DATEX II planningsfeed_wegwerkzaamheden_en_evenementen feed. Represents a planned or active roadwork situation on the Dutch national road network. Road construction or maintenance work event from the NDW DATEX II planningsfeed_wegwerkzaamheden_en_evenementen feed.
+Road construction or maintenance work event from the Dutch NDW DATEX II planningsfeed_wegwerkzaamheden_en_evenementen feed. Represents a planned or active roadwork situation on the Dutch national road network.
 
 #### Identity
 
@@ -489,7 +489,7 @@ CloudEvents type: `NL.NDW.Situations.BridgeOpening`
 
 #### What it tells you
 
-Bridge opening event from the Dutch NDW DATEX II planningsfeed_brugopeningen feed. Represents a scheduled or active bridge opening that causes temporary road closure. Bridge opening event from the NDW DATEX II planningsfeed_brugopeningen feed.
+Bridge opening event from the Dutch NDW DATEX II planningsfeed_brugopeningen feed. Represents a scheduled or active bridge opening that causes temporary road closure.
 
 #### Identity
 
@@ -540,7 +540,7 @@ CloudEvents type: `NL.NDW.Situations.TemporaryClosure`
 
 #### What it tells you
 
-Temporary road closure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_afsluitingen feed. Represents a temporary closure of a road section or lane on the Dutch national road network. Temporary road closure from the NDW DATEX II tijdelijke_verkeersmaatregelen_afsluitingen feed.
+Temporary road closure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_afsluitingen feed. Represents a temporary closure of a road section or lane on the Dutch national road network.
 
 #### Identity
 
@@ -593,7 +593,7 @@ CloudEvents type: `NL.NDW.Situations.TemporarySpeedLimit`
 
 #### What it tells you
 
-Temporary speed limit measure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_maximum_snelheden feed. Represents a temporary reduction in maximum speed on a section of the national road network. Temporary speed limit measure from the NDW DATEX II tijdelijke_verkeersmaatregelen_maximum_snelheden feed.
+Temporary speed limit measure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_maximum_snelheden feed. Represents a temporary reduction in maximum speed on a section of the national road network.
 
 #### Identity
 
@@ -646,7 +646,7 @@ CloudEvents type: `NL.NDW.Situations.SafetyRelatedMessage`
 
 #### What it tells you
 
-Safety-related traffic information message from the Dutch NDW DATEX II veiligheidsgerelateerde_berichten_srti feed. Contains urgent safety alerts and hazard notifications on the national road network. Safety-related traffic information message from the NDW DATEX II veiligheidsgerelateerde_berichten_srti feed.
+Safety-related traffic information message from the Dutch NDW DATEX II veiligheidsgerelateerde_berichten_srti feed. Contains urgent safety alerts and hazard notifications on the national road network.
 
 #### Identity
 

--- a/ndw-road-traffic/xreg/ndw-road-traffic.xreg.json
+++ b/ndw-road-traffic/xreg/ndw-road-traffic.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "NL.NDW.AVG.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -17,10 +19,13 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.AVG"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDW Road Traffic CloudEvents on the `ndw-road-traffic` topic keyed by `measurement-sites/{measurement_site_id}`."
     },
     "NL.NDW.DRIP.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -36,10 +41,13 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.DRIP"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDW Road Traffic CloudEvents on the `ndw-road-traffic` topic keyed by `drips/{vms_controller_id}/{vms_index}`."
     },
     "NL.NDW.MSI.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -55,10 +63,13 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.MSI"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDW Road Traffic CloudEvents on the `ndw-road-traffic` topic keyed by `msi-signs/{sign_id}`."
     },
     "NL.NDW.Situations.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -74,7 +85,8 @@
       },
       "messagegroups": [
         "#/messagegroups/NL.NDW.Situations"
-      ]
+      ],
+      "description": "Kafka producer endpoint for NDW Road Traffic CloudEvents on the `ndw-road-traffic` topic keyed by `situations/{situation_record_id}`."
     }
   },
   "messagegroups": {
@@ -156,7 +168,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.jstruct/schemas/NL.NDW.AVG.TravelTimeObservation"
         }
-      }
+      },
+      "description": "Events from NDW Road Traffic covering Dutch road network measurement sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "NL.NDW.DRIP": {
       "messages": {
@@ -198,7 +211,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.jstruct/schemas/NL.NDW.DRIP.DripDisplayState"
         }
-      }
+      },
+      "description": "Events from NDW Road Traffic covering Dutch road network measurement sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "NL.NDW.MSI": {
       "messages": {
@@ -240,7 +254,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.jstruct/schemas/NL.NDW.MSI.MsiDisplayState"
         }
-      }
+      },
+      "description": "Events from NDW Road Traffic covering Dutch road network measurement sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "NL.NDW.Situations": {
       "messages": {
@@ -339,7 +354,8 @@
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/NL.NDW.jstruct/schemas/NL.NDW.Situations.SafetyRelatedMessage"
         }
-      }
+      },
+      "description": "Events from NDW Road Traffic covering Dutch road network measurement sites and situations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -357,49 +373,75 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/AVG/PointMeasurementSite",
                 "type": "object",
                 "name": "PointMeasurementSite",
-                "description": "Reference data for a point measurement site from the NDW DATEX II measurement_current feed. A point site uses a fixed sensor (inductive loop or microwave) to measure speed and flow at a single cross-section of road.",
+                "description": "Reference record for a point measurement site from the Dutch NDW DATEX II measurement_current feed. Contains location, sensor technology type, and lane configuration for a fixed inductive-loop or microwave sensor.",
                 "properties": {
                   "measurement_site_id": {
                     "type": "string",
                     "description": "Unique identifier of the NDW measurement site, from the DATEX II measurementSiteRecord id attribute. Example: RWS01_MST_0001-01."
                   },
                   "name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable name of the measurement site from the DATEX II measurementSiteName element."
                   },
                   "measurement_site_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Sensor technology type used at this measurement site, from the DATEX II measurementEquipmentTypeUsed element. Example values: inductionLoop, microwave."
                   },
                   "period": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Measurement aggregation period in seconds, from the DATEX II measurementSpecificCharacteristics period element.",
                     "unit": "s"
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the measurement point in decimal degrees, from the DATEX II pointByCoordinates/pointCoordinates/latitude element.",
                     "unit": "deg"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the measurement point in decimal degrees, from the DATEX II pointByCoordinates/pointCoordinates/longitude element.",
                     "unit": "deg"
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier on which the sensor is located, from the DATEX II roadInformation/roadName element. Example values: A1, N205."
                   },
                   "lane_count": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Number of lanes monitored at this measurement site, derived from the number of measurementSpecificCharacteristics elements."
                   },
                   "carriageway_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Carriageway type from the DATEX II carriagewayType element. Example values: mainCarriageway, slipRoad, connectingCarriageway."
                   }
                 },
-                "required": ["measurement_site_id"]
+                "required": [
+                  "measurement_site_id"
+                ]
               }
             }
           }
@@ -416,56 +458,85 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/AVG/RouteMeasurementSite",
                 "type": "object",
                 "name": "RouteMeasurementSite",
-                "description": "Reference data for a route (section) measurement site from the NDW DATEX II measurement_current feed. A route site covers a road segment between two geographic endpoints used for travel time computation.",
+                "description": "Reference record for a route (section) measurement site from the Dutch NDW DATEX II measurement_current feed. Covers a road segment between two coordinates used for travel time computation.",
                 "properties": {
                   "measurement_site_id": {
                     "type": "string",
                     "description": "Unique identifier of the NDW route measurement site, from the DATEX II measurementSiteRecord id attribute."
                   },
                   "name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable name of the route measurement site from the DATEX II measurementSiteName element."
                   },
                   "measurement_site_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Measurement method type, from the DATEX II measurementEquipmentTypeUsed element. Example values: detectLoop, floatingCar."
                   },
                   "period": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Measurement aggregation period in seconds, from the DATEX II measurementSpecificCharacteristics period element.",
                     "unit": "s"
                   },
                   "start_latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the route start point in decimal degrees.",
                     "unit": "deg"
                   },
                   "start_longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the route start point in decimal degrees.",
                     "unit": "deg"
                   },
                   "end_latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the route end point in decimal degrees.",
                     "unit": "deg"
                   },
                   "end_longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the route end point in decimal degrees.",
                     "unit": "deg"
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier for the route section. Example values: A1, A10, N44."
                   },
                   "length_metres": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Length of the route section in metres, from the DATEX II length element.",
                     "unit": "m"
                   }
                 },
-                "required": ["measurement_site_id"]
+                "required": [
+                  "measurement_site_id"
+                ]
               }
             }
           }
@@ -482,7 +553,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/AVG/TrafficObservation",
                 "type": "object",
                 "name": "TrafficObservation",
-                "description": "Aggregated traffic speed and flow observation per road segment from the NDW DATEX II trafficspeed feed. Speed is averaged and flow summed across all reporting lanes at the measurement site.",
+                "description": "Aggregated traffic speed and flow observation from the Dutch NDW DATEX II trafficspeed feed. Each record represents one measurement site with speed averaged and flow summed across all reporting lanes.",
                 "properties": {
                   "measurement_site_id": {
                     "type": "string",
@@ -493,12 +564,18 @@
                     "description": "Timestamp of the measurement in ISO 8601 UTC format, from the DATEX II measurementTimeDefault element."
                   },
                   "average_speed": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Average vehicle speed in km/h across all lanes with valid data at this site. Null when no lane reported a valid speed.",
                     "unit": "km/h"
                   },
                   "vehicle_flow_rate": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Total vehicle flow rate in vehicles per hour, summed across all lanes at this measurement site. Null when no valid flow data was reported.",
                     "unit": "vehicles/h"
                   },
@@ -507,7 +584,11 @@
                     "description": "Number of lanes that reported valid measurement data at this measurement site."
                   }
                 },
-                "required": ["measurement_site_id", "measurement_time", "number_of_lanes_with_data"]
+                "required": [
+                  "measurement_site_id",
+                  "measurement_time",
+                  "number_of_lanes_with_data"
+                ]
               }
             }
           }
@@ -524,7 +605,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/AVG/TravelTimeObservation",
                 "type": "object",
                 "name": "TravelTimeObservation",
-                "description": "Travel time observation for a road segment from the NDW DATEX II traveltime feed. Contains the actual measured travel time and the static free-flow reference time for a route measurement site.",
+                "description": "Travel time observation for a road segment from the Dutch NDW DATEX II traveltime feed. Contains the actual measured travel time and the static free-flow reference time for a route measurement site.",
                 "properties": {
                   "measurement_site_id": {
                     "type": "string",
@@ -535,31 +616,49 @@
                     "description": "Timestamp of the measurement in ISO 8601 UTC format, from the DATEX II measurementTimeDefault element."
                   },
                   "duration": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Measured travel time in seconds for the route section, from the DATEX II travelTime/duration element. Null if the upstream value was negative (invalid).",
                     "unit": "s"
                   },
                   "reference_duration": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Free-flow reference travel time in seconds for the route section, from the DATEX II basicDataReferenceValue/travelTimeData/travelTime/duration extension element. Null if not provided.",
                     "unit": "s"
                   },
                   "accuracy": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Accuracy percentage of the travel time measurement as a value between 0 and 100, from the DATEX II travelTime accuracy attribute.",
                     "unit": "%"
                   },
                   "data_quality": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Supplier-calculated data quality score as a value between 0 and 100, from the DATEX II supplierCalculatedDataQuality attribute.",
                     "unit": "%"
                   },
                   "number_of_input_values": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Number of input observations used to compute the travel time, from the DATEX II numberOfInputValuesUsed attribute."
                   }
                 },
-                "required": ["measurement_site_id", "measurement_time"]
+                "required": [
+                  "measurement_site_id",
+                  "measurement_time"
+                ]
               }
             }
           }
@@ -576,7 +675,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/DRIP/DripSign",
                 "type": "object",
                 "name": "DripSign",
-                "description": "Reference data for a Dynamic Route Information Panel (DRIP) sign from the NDW DATEX II dynamische_route_informatie_paneel feed. Describes the physical installation, location, and type of an individual VMS sign within a VMS controller.",
+                "description": "Reference record for a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Describes the physical installation, location, and type of an individual VMS sign unit.",
                 "properties": {
                   "vms_controller_id": {
                     "type": "string",
@@ -587,29 +686,47 @@
                     "description": "Index of the individual VMS sign within the controller unit, from the DATEX II vmsRecord index attribute, converted to string."
                   },
                   "vms_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "DRIP sign type, from the DATEX II vmsType element. Example values: presignalling, matrixBoardTwoByTwo, matrixBoardOneByTwo."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the DRIP sign location in decimal degrees.",
                     "unit": "deg"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the DRIP sign location in decimal degrees.",
                     "unit": "deg"
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier where the DRIP sign is located. Example values: A1, A10."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the DRIP sign from the DATEX II description element."
                   }
                 },
-                "required": ["vms_controller_id", "vms_index"]
+                "required": [
+                  "vms_controller_id",
+                  "vms_index"
+                ]
               }
             }
           }
@@ -626,7 +743,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/DRIP/DripDisplayState",
                 "type": "object",
                 "name": "DripDisplayState",
-                "description": "Current display state of a Dynamic Route Information Panel (DRIP) sign from the NDW DATEX II dynamische_route_informatie_paneel feed. Captures the active text, pictogram codes, and operational state.",
+                "description": "Current display state of a Dynamic Route Information Panel (DRIP) sign from the Dutch NDW DATEX II dynamische_route_informatie_paneel feed. Captures the active text, pictogram codes, and operational state of the sign.",
                 "properties": {
                   "vms_controller_id": {
                     "type": "string",
@@ -641,23 +758,39 @@
                     "description": "ISO 8601 UTC timestamp when this display state was published, from the DATEX II publicationTime element."
                   },
                   "active": {
-                    "type": ["boolean", "null"],
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
                     "description": "Whether the DRIP sign is currently displaying content. Derived from the DATEX II vmsWorking or displayActive element."
                   },
                   "vms_text": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Concatenated text from all display panels of the sign, from the DATEX II displayedText/vmsText/vmsTextLine elements."
                   },
                   "pictogram_code": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Pictogram code displayed on the sign, from the DATEX II pictogramDisplayAreaSettings/vmsPicktogramDisplayCharacteristics/vmsPicktogramDescription element."
                   },
                   "state": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Operational state of the DRIP sign, from the DATEX II vmsUnitFault or operationalState element. Example values: working, fault, maintenance."
                   }
                 },
-                "required": ["vms_controller_id", "vms_index", "publication_time"]
+                "required": [
+                  "vms_controller_id",
+                  "vms_index",
+                  "publication_time"
+                ]
               }
             }
           }
@@ -674,40 +807,60 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/MSI/MsiSign",
                 "type": "object",
                 "name": "MsiSign",
-                "description": "Reference data for a Matrix Signal Installation (MSI) sign from the NDW DATEX II Matrixsignaalinformatie feed. Describes the physical location, lane assignment, and type of a matrix signal sign above a motorway lane.",
+                "description": "Reference record for a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Describes the physical location, lane assignment, and type of a matrix signal sign above a motorway lane.",
                 "properties": {
                   "sign_id": {
                     "type": "string",
                     "description": "Unique identifier of the MSI sign, from the DATEX II vmsUnitRecord id attribute."
                   },
                   "sign_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "MSI sign type, from the DATEX II vmsType element. Example values: matrixBoardOneByOne, matrixBoardTwoByOne."
                   },
                   "latitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 latitude of the MSI sign location in decimal degrees.",
                     "unit": "deg"
                   },
                   "longitude": {
-                    "type": ["double", "null"],
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "WGS84 longitude of the MSI sign location in decimal degrees.",
                     "unit": "deg"
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier where the MSI sign is located. Example values: A1, A2."
                   },
                   "lane": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Lane designation above which the MSI sign is installed, from the DATEX II laneNumber element."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the MSI sign installation from the DATEX II description element."
                   }
                 },
-                "required": ["sign_id"]
+                "required": [
+                  "sign_id"
+                ]
               }
             }
           }
@@ -724,7 +877,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/MSI/MsiDisplayState",
                 "type": "object",
                 "name": "MsiDisplayState",
-                "description": "Current display state of a Matrix Signal Installation (MSI) sign from the NDW DATEX II Matrixsignaalinformatie feed. Captures the displayed image code, operational state, and any speed limit shown.",
+                "description": "Current display state of a Matrix Signal Installation (MSI) sign from the Dutch NDW DATEX II Matrixsignaalinformatie feed. Captures the displayed image code, operational state, and any speed limit shown.",
                 "properties": {
                   "sign_id": {
                     "type": "string",
@@ -735,20 +888,32 @@
                     "description": "ISO 8601 UTC timestamp when this display state was published, from the DATEX II publicationTime element."
                   },
                   "image_code": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Code of the image currently displayed on the MSI sign, from the DATEX II imageCode or displayedText element. Example values: blank, closed, 70, 80, 100, arrow_left."
                   },
                   "state": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Operational state derived from the displayed image. Example values: open, closed, speed_limit."
                   },
                   "speed_limit": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Speed limit in km/h displayed on the sign when showing a speed limit image. Null when the sign is blank or shows a non-numeric image.",
                     "unit": "km/h"
                   }
                 },
-                "required": ["sign_id", "publication_time"]
+                "required": [
+                  "sign_id",
+                  "publication_time"
+                ]
               }
             }
           }
@@ -765,7 +930,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/Situations/Roadwork",
                 "type": "object",
                 "name": "Roadwork",
-                "description": "Road construction or maintenance work event from the NDW DATEX II planningsfeed_wegwerkzaamheden_en_evenementen feed. Represents a planned or active roadwork situation on the Dutch national road network.",
+                "description": "Road construction or maintenance work event from the Dutch NDW DATEX II planningsfeed_wegwerkzaamheden_en_evenementen feed. Represents a planned or active roadwork situation on the Dutch national road network.",
                 "properties": {
                   "situation_record_id": {
                     "type": "string",
@@ -776,43 +941,73 @@
                     "description": "ISO 8601 UTC timestamp when this situation record version was created, from the DATEX II situationVersionTime element."
                   },
                   "validity_status": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Validity status of the situation record, from the DATEX II validityStatus element. Example values: active, suspended, definedByValidityTimeSpec."
                   },
                   "start_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the roadwork validity period starts, from the DATEX II overallStartTime element."
                   },
                   "end_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the roadwork validity period ends, from the DATEX II overallEndTime element. Null for open-ended situations."
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road name or identifier where the roadwork is located."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the roadwork situation from the DATEX II comment or description element."
                   },
                   "location_description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the roadwork location from the DATEX II locationDescriptor element."
                   },
                   "probability": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Probability of occurrence for the roadwork, from the DATEX II probabilityOfOccurrence element. Example values: certain, probable, risk."
                   },
                   "severity": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Overall severity of the roadwork impact, from the DATEX II severity element. Example values: highest, high, medium, low, lowest."
                   },
                   "management_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Type of road management applied, from the DATEX II roadMaintenanceType or managementType element. Example values: laneClosures, carriagewayClosure."
                   }
                 },
-                "required": ["situation_record_id", "version_time"]
+                "required": [
+                  "situation_record_id",
+                  "version_time"
+                ]
               }
             }
           }
@@ -829,7 +1024,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/Situations/BridgeOpening",
                 "type": "object",
                 "name": "BridgeOpening",
-                "description": "Bridge opening event from the NDW DATEX II planningsfeed_brugopeningen feed. Represents a scheduled or active bridge opening that causes a temporary road closure on the Dutch road network.",
+                "description": "Bridge opening event from the Dutch NDW DATEX II planningsfeed_brugopeningen feed. Represents a scheduled or active bridge opening that causes temporary road closure.",
                 "properties": {
                   "situation_record_id": {
                     "type": "string",
@@ -840,31 +1035,52 @@
                     "description": "ISO 8601 UTC timestamp when this situation record version was created, from the DATEX II situationVersionTime element."
                   },
                   "validity_status": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Validity status of the bridge opening record from the DATEX II validityStatus element."
                   },
                   "start_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the bridge opening starts."
                   },
                   "end_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the bridge opening ends and the road reopens."
                   },
                   "bridge_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Name of the bridge being opened, from the DATEX II bridgeName or locationName element."
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier that is affected by the bridge opening."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the bridge opening event from the DATEX II comment or description element."
                   }
                 },
-                "required": ["situation_record_id", "version_time"]
+                "required": [
+                  "situation_record_id",
+                  "version_time"
+                ]
               }
             }
           }
@@ -881,7 +1097,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/Situations/TemporaryClosure",
                 "type": "object",
                 "name": "TemporaryClosure",
-                "description": "Temporary road closure from the NDW DATEX II tijdelijke_verkeersmaatregelen_afsluitingen feed. Represents a temporary closure of a road section or individual lanes on the Dutch national road network.",
+                "description": "Temporary road closure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_afsluitingen feed. Represents a temporary closure of a road section or lane on the Dutch national road network.",
                 "properties": {
                   "situation_record_id": {
                     "type": "string",
@@ -892,35 +1108,59 @@
                     "description": "ISO 8601 UTC timestamp when this situation record version was created, from the DATEX II situationVersionTime element."
                   },
                   "validity_status": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Validity status of the temporary closure record from the DATEX II validityStatus element."
                   },
                   "start_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the temporary closure starts."
                   },
                   "end_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the temporary closure ends."
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier where the temporary closure applies."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the temporary closure from the DATEX II comment or description element."
                   },
                   "location_description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the closure location from the DATEX II locationDescriptor element."
                   },
                   "severity": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Overall severity of the closure impact, from the DATEX II severity element."
                   }
                 },
-                "required": ["situation_record_id", "version_time"]
+                "required": [
+                  "situation_record_id",
+                  "version_time"
+                ]
               }
             }
           }
@@ -937,7 +1177,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/Situations/TemporarySpeedLimit",
                 "type": "object",
                 "name": "TemporarySpeedLimit",
-                "description": "Temporary speed limit measure from the NDW DATEX II tijdelijke_verkeersmaatregelen_maximum_snelheden feed. Represents a temporary reduction in the maximum allowed speed on a section of the national road network.",
+                "description": "Temporary speed limit measure from the Dutch NDW DATEX II tijdelijke_verkeersmaatregelen_maximum_snelheden feed. Represents a temporary reduction in maximum speed on a section of the national road network.",
                 "properties": {
                   "situation_record_id": {
                     "type": "string",
@@ -948,36 +1188,60 @@
                     "description": "ISO 8601 UTC timestamp when this situation record version was created, from the DATEX II situationVersionTime element."
                   },
                   "validity_status": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Validity status of the temporary speed limit record from the DATEX II validityStatus element."
                   },
                   "start_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the temporary speed limit starts."
                   },
                   "end_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the temporary speed limit ends."
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier where the temporary speed limit applies."
                   },
                   "speed_limit_kmh": {
-                    "type": ["int32", "null"],
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
                     "description": "Temporary maximum speed limit in km/h, from the DATEX II speedLimit/maximumSpeedLimit element.",
                     "unit": "km/h"
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the temporary speed limit from the DATEX II comment or description element."
                   },
                   "location_description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the speed limit section location from the DATEX II locationDescriptor element."
                   }
                 },
-                "required": ["situation_record_id", "version_time"]
+                "required": [
+                  "situation_record_id",
+                  "version_time"
+                ]
               }
             }
           }
@@ -994,7 +1258,7 @@
                 "$id": "https://opendata.ndw.nu/schemas/NL/NDW/Situations/SafetyRelatedMessage",
                 "type": "object",
                 "name": "SafetyRelatedMessage",
-                "description": "Safety-related traffic information message from the NDW DATEX II veiligheidsgerelateerde_berichten_srti feed. Contains urgent safety alerts and hazard notifications on the national road network.",
+                "description": "Safety-related traffic information message from the Dutch NDW DATEX II veiligheidsgerelateerde_berichten_srti feed. Contains urgent safety alerts and hazard notifications on the national road network.",
                 "properties": {
                   "situation_record_id": {
                     "type": "string",
@@ -1005,40 +1269,69 @@
                     "description": "ISO 8601 UTC timestamp when this situation record version was created, from the DATEX II situationVersionTime element."
                   },
                   "validity_status": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Validity status of the safety message record from the DATEX II validityStatus element."
                   },
                   "start_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the safety-related situation starts."
                   },
                   "end_time": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "ISO 8601 UTC timestamp when the safety-related situation ends."
                   },
                   "road_name": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Road identifier where the safety-related event is located."
                   },
                   "message_type": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Type of safety-related message, from the DATEX II xsi:type attribute on the situationRecord. Example values: RoadOrCarriagewayOrLaneManagement, VehicleObstruction, PoorRoadInfrastructure."
                   },
                   "description": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Human-readable description of the safety-related message from the DATEX II comment or description element."
                   },
                   "urgency": {
-                    "type": ["string", "null"],
+                    "type": [
+                      "string",
+                      "null"
+                    ],
                     "description": "Urgency level of the safety message, from the DATEX II urgency element. Example values: extremelyUrgent, urgent, normalUrgency."
                   }
                 },
-                "required": ["situation_record_id", "version_time"]
+                "required": [
+                  "situation_record_id",
+                  "version_time"
+                ]
               }
             }
           }
         }
       }
     }
+  },
+  "description": "NDW Road Traffic publishes traffic flow, signs, travel-time, and situation updates from the Dutch National Data Warehouse for Traffic Information (NDW) for Dutch road network measurement sites and situations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for NDW Road Traffic, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/paris-bicycle-counters/EVENTS.md
+++ b/paris-bicycle-counters/EVENTS.md
@@ -1,6 +1,6 @@
 # Paris Bicycle Counters Poller Events
 
-MQTT/5.0 transport variants for Paris bicycle counters. Topics route by stable MQTT-safe counter_id (upstream id_compteur; values containing /, +, #, or NUL are dropped) under traffic/fr/paris/paris-bicycle-counters/{counter_id}/... . Counter reference records are retained QoS 1; hourly bicycle counts are non-retained QoS 1 events.
+Paris Bicycle Counters publishes bicycle count observations from Paris open-data bicycle counter feeds for Paris bicycle-counting stations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `FR.Paris.OpenData.Velo.Counter`
 
 #### What it tells you
 
-Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.
+A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -94,7 +94,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ### Bicycle Count
 
@@ -102,7 +102,7 @@ CloudEvents type: `FR.Paris.OpenData.Velo.BicycleCount`
 
 #### What it tells you
 
-Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.
+A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value.
 
 #### Identity
 
@@ -144,7 +144,7 @@ Synthetic example values are generated deterministically from the schema: consta
 
 #### Reference vs telemetry
 
-This is telemetry/event data. Treat each event as a current observation or state change rather than a complete catalog.
+This is telemetry/event data. Treat each event as a current observation or state change. If an MQTT binding is retained, the retained copy is only the latest value for that exact topic, not a history.
 
 ## Conventions
 

--- a/paris-bicycle-counters/xreg/paris_bicycle_counters.xreg.json
+++ b/paris-bicycle-counters/xreg/paris_bicycle_counters.xreg.json
@@ -19,7 +19,8 @@
       },
       "messagegroups": [
         "#/messagegroups/FR.Paris.OpenData.Velo"
-      ]
+      ],
+      "description": "Kafka producer endpoint for Paris Bicycle Counters CloudEvents on the `paris-bicycle-counters` topic keyed by `{counter_id}`."
     },
     "FR.Paris.OpenData.Velo.Mqtt": {
       "usage": [
@@ -40,7 +41,8 @@
       },
       "messagegroups": [
         "#/messagegroups/FR.Paris.OpenData.Velo.mqtt"
-      ]
+      ],
+      "description": "MQTT 5 producer endpoint for Paris Bicycle Counters CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
   },
   "messagegroups": {
@@ -66,7 +68,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FR.Paris.OpenData.Velo.jstruct/schemas/FR.Paris.OpenData.Velo.Counter"
+          "dataschemauri": "#/schemagroups/FR.Paris.OpenData.Velo.jstruct/schemas/FR.Paris.OpenData.Velo.Counter",
+          "description": "A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value."
         },
         "FR.Paris.OpenData.Velo.BicycleCount": {
           "name": "BicycleCount",
@@ -92,12 +95,14 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/FR.Paris.OpenData.Velo.jstruct/schemas/FR.Paris.OpenData.Velo.BicycleCount"
+          "dataschemauri": "#/schemagroups/FR.Paris.OpenData.Velo.jstruct/schemas/FR.Paris.OpenData.Velo.BicycleCount",
+          "description": "A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value."
         }
-      }
+      },
+      "description": "Events from Paris Bicycle Counters covering Paris bicycle-counting stations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "FR.Paris.OpenData.Velo.mqtt": {
-      "description": "MQTT/5.0 transport variants for Paris bicycle counters. Topics route by stable MQTT-safe counter_id (upstream id_compteur; values containing /, +, #, or NUL are dropped) under traffic/fr/paris/paris-bicycle-counters/{counter_id}/... . Counter reference records are retained QoS 1; hourly bicycle counts are non-retained QoS 1 events.",
+      "description": "MQTT 5 variant of the Paris Bicycle Counters events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
       "messages": {
         "FR.Paris.OpenData.Velo.mqtt.Counter": {
           "name": "Counter",
@@ -142,7 +147,7 @@
                   "counter_name"
                 ],
                 "name": "Counter",
-                "description": "Reference record describing a permanent bicycle counting station in Paris, including its identifier, display name, directional channel, installation date, and geographic coordinates.",
+                "description": "A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value.",
                 "properties": {
                   "counter_id": {
                     "type": "string",
@@ -225,7 +230,7 @@
                   "date"
                 ],
                 "name": "BicycleCount",
-                "description": "Hourly bicycle count observation from a permanent counting station in Paris, reporting the number of bicycles detected during a one-hour window.",
+                "description": "A current transport measurement or status update from Paris open-data bicycle counter feeds. It carries bicycle count observations when the upstream feed reports a new or refreshed value.",
                 "properties": {
                   "counter_id": {
                     "type": "string",
@@ -295,5 +300,10 @@
         }
       }
     }
+  },
+  "description": "Paris Bicycle Counters publishes bicycle count observations from Paris open-data bicycle counter feeds for Paris bicycle-counting stations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Paris Bicycle Counters, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }

--- a/tfl-road-traffic/EVENTS.md
+++ b/tfl-road-traffic/EVENTS.md
@@ -1,6 +1,6 @@
 # TfL Road Traffic Events
 
-MQTT/5.0 binary CloudEvents for the TfL Road Traffic Unified Namespace. Roads are retained last-known-value topics; disruption severities are literal topic partitions.
+TfL Road Traffic publishes road disruption and traffic status updates from Transport for London for London roads and disruption areas. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -52,7 +52,7 @@ CloudEvents type: `uk.gov.tfl.road.RoadCorridor`
 
 #### What it tells you
 
-Reference record for a TfL managed road corridor fetched from GET /Road. Reference record for a Transport for London (TfL) managed road corridor. Fetched from the GET /Road endpoint at bridge startup and refreshed periodically.
+Reference record for a TfL managed road corridor fetched from GET /Road.
 
 #### Identity
 
@@ -106,7 +106,7 @@ CloudEvents type: `uk.gov.tfl.road.RoadStatus`
 
 #### What it tells you
 
-Real-time status snapshot for a TfL managed road corridor fetched from GET /Road/all/Status. Real-time status snapshot for a Transport for London (TfL) managed road corridor. Fetched from the GET /Road/all/Status endpoint on each polling cycle.
+Real-time status snapshot for a TfL managed road corridor fetched from GET /Road/all/Status.
 
 #### Identity
 
@@ -160,7 +160,7 @@ CloudEvents type: `uk.gov.tfl.road.RoadDisruption`
 
 #### What it tells you
 
-Real-time road disruption event on the TfL road network fetched from GET /Road/all/Disruption. Real-time road disruption event on the Transport for London (TfL) road network. Fetched from the GET /Road/all/Disruption endpoint.
+Real-time road disruption event on the TfL road network fetched from GET /Road/all/Disruption.
 
 #### Identity
 

--- a/tfl-road-traffic/xreg/tfl_road_traffic.xreg.json
+++ b/tfl-road-traffic/xreg/tfl_road_traffic.xreg.json
@@ -1,712 +1,724 @@
 {
-    "endpoints": {
-        "uk.gov.tfl.road.corridors.Kafka": {
-            "usage": [
-                "producer"
-            ],
-            "protocol": "KAFKA",
-            "envelope": "CloudEvents/1.0",
-            "envelopeoptions": {
-                "mode": "structured",
-                "format": "application/cloudevents+json"
-            },
-            "protocoloptions": {
-                "deployed": false,
-                "options": {
-                    "topic": "tfl-road-traffic",
-                    "key": "roads/{road_id}"
-                }
-            },
-            "messagegroups": [
-                "#/messagegroups/uk.gov.tfl.road.corridors"
-            ]
-        },
-        "uk.gov.tfl.road.disruptions.Kafka": {
-            "usage": [
-                "producer"
-            ],
-            "protocol": "KAFKA",
-            "envelope": "CloudEvents/1.0",
-            "envelopeoptions": {
-                "mode": "structured",
-                "format": "application/cloudevents+json"
-            },
-            "protocoloptions": {
-                "deployed": false,
-                "options": {
-                    "topic": "tfl-road-traffic",
-                    "key": "disruptions/{road_id}/{severity}/{disruption_id}"
-                }
-            },
-            "messagegroups": [
-                "#/messagegroups/uk.gov.tfl.road.disruptions"
-            ]
-        },
-        "uk.gov.tfl.road.Mqtt": {
-            "usage": [
-                "producer"
-            ],
-            "protocol": "MQTT/5.0",
-            "envelope": "CloudEvents/1.0",
-            "envelopeoptions": {
-                "mode": "binary"
-            },
-            "protocoloptions": {
-                "deployed": false,
-                "endpoints": [
-                    {
-                        "uri": "mqtt://localhost:1883"
-                    }
-                ]
-            },
-            "messagegroups": [
-                "#/messagegroups/uk.gov.tfl.road.mqtt"
-            ]
+  "endpoints": {
+    "uk.gov.tfl.road.corridors.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "tfl-road-traffic",
+          "key": "roads/{road_id}"
         }
+      },
+      "messagegroups": [
+        "#/messagegroups/uk.gov.tfl.road.corridors"
+      ],
+      "description": "Kafka producer endpoint for TfL Road Traffic CloudEvents on the `tfl-road-traffic` topic keyed by `roads/{road_id}`."
     },
-    "messagegroups": {
-        "uk.gov.tfl.road.corridors": {
-            "messages": {
-                "uk.gov.tfl.road.RoadCorridor": {
-                    "name": "RoadCorridor",
-                    "envelope": "CloudEvents/1.0",
-                    "description": "Reference record for a TfL managed road corridor fetched from GET /Road.",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "uk.gov.tfl.road.RoadCorridor"
-                        },
-                        "source": {
-                            "value": "https://api.tfl.gov.uk/Road"
-                        },
-                        "subject": {
-                            "value": "roads/{road_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadCorridor"
-                },
-                "uk.gov.tfl.road.RoadStatus": {
-                    "name": "RoadStatus",
-                    "envelope": "CloudEvents/1.0",
-                    "description": "Real-time status snapshot for a TfL managed road corridor fetched from GET /Road/all/Status.",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "uk.gov.tfl.road.RoadStatus"
-                        },
-                        "source": {
-                            "value": "https://api.tfl.gov.uk/Road/all/Status"
-                        },
-                        "subject": {
-                            "value": "roads/{road_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadStatus"
-                }
-            }
-        },
-        "uk.gov.tfl.road.disruptions": {
-            "messages": {
-                "uk.gov.tfl.road.RoadDisruption": {
-                    "name": "RoadDisruption",
-                    "envelope": "CloudEvents/1.0",
-                    "description": "Real-time road disruption event on the TfL road network fetched from GET /Road/all/Disruption.",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "uk.gov.tfl.road.RoadDisruption"
-                        },
-                        "source": {
-                            "value": "https://api.tfl.gov.uk/Road/all/Disruption"
-                        },
-                        "subject": {
-                            "value": "disruptions/{road_id}/{severity}/{disruption_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadDisruption"
-                }
-            }
-        },
-        "uk.gov.tfl.road.mqtt": {
-            "description": "MQTT/5.0 binary CloudEvents for the TfL Road Traffic Unified Namespace. Roads are retained last-known-value topics; disruption severities are literal topic partitions.",
-            "messages": {
-                "uk.gov.tfl.road.mqtt.RoadCorridor": {
-                    "name": "RoadCorridor",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.corridors/messages/uk.gov.tfl.road.RoadCorridor",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/roads/{road_id}/corridor",
-                        "qos": 1,
-                        "retain": true
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadStatus": {
-                    "name": "RoadStatus",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.corridors/messages/uk.gov.tfl.road.RoadStatus",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/roads/{road_id}/status",
-                        "qos": 1,
-                        "retain": true
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionSerious": {
-                    "name": "RoadDisruptionSerious",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/serious/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionSevere": {
-                    "name": "RoadDisruptionSevere",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/severe/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionModerate": {
-                    "name": "RoadDisruptionModerate",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/moderate/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionMinor": {
-                    "name": "RoadDisruptionMinor",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/minor/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionInformation": {
-                    "name": "RoadDisruptionInformation",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/information/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                },
-                "uk.gov.tfl.road.mqtt.RoadDisruptionClosure": {
-                    "name": "RoadDisruptionClosure",
-                    "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
-                    "protocol": "MQTT/5.0",
-                    "protocoloptions": {
-                        "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/closure/{disruption_id}",
-                        "qos": 1,
-                        "retain": false
-                    }
-                }
-            }
+    "uk.gov.tfl.road.disruptions.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "tfl-road-traffic",
+          "key": "disruptions/{road_id}/{severity}/{disruption_id}"
         }
+      },
+      "messagegroups": [
+        "#/messagegroups/uk.gov.tfl.road.disruptions"
+      ],
+      "description": "Kafka producer endpoint for TfL Road Traffic CloudEvents on the `tfl-road-traffic` topic keyed by `disruptions/{road_id}/{severity}/{disruption_id}`."
     },
-    "schemagroups": {
-        "uk.gov.tfl.road.jstruct": {
-            "schemas": {
-                "uk.gov.tfl.road.RoadCorridor": {
-                    "name": "RoadCorridor",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadCorridor",
-                                "type": "object",
-                                "name": "RoadCorridor",
-                                "description": "Reference record for a Transport for London (TfL) managed road corridor. Fetched from the GET /Road endpoint at bridge startup and refreshed periodically. Each corridor is a named road segment under TfL operational control, such as the A2, A12, or M25, with its current aggregate traffic status.",
-                                "required": [
-                                    "road_id",
-                                    "display_name"
-                                ],
-                                "properties": {
-                                    "road_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier for the road corridor as used by the TfL Unified API. Corresponds to 'id' in the upstream response. Examples: 'a2', 'a12', 'm25'. Used as the stable domain key.",
-                                        "altnames": {
-                                            "upstream": "id"
-                                        }
-                                    },
-                                    "display_name": {
-                                        "type": "string",
-                                        "description": "Human-readable display name for the road corridor as reported by TfL. Corresponds to 'displayName' in the upstream response. Examples: 'A2', 'A12', 'M25'.",
-                                        "altnames": {
-                                            "upstream": "displayName"
-                                        }
-                                    },
-                                    "status_severity": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Current aggregate status severity for this corridor as assessed by TfL. Corresponds to 'statusSeverity' in the upstream response. Common values: 'Good', 'Moderate', 'Serious', 'Severe', 'NoDisruptions'.",
-                                        "altnames": {
-                                            "upstream": "statusSeverity"
-                                        }
-                                    },
-                                    "status_severity_description": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Human-readable description of the current status severity. Corresponds to 'statusSeverityDescription' in the upstream response. Example: 'Serious Delays'.",
-                                        "altnames": {
-                                            "upstream": "statusSeverityDescription"
-                                        }
-                                    },
-                                    "bounds": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Bounding box for the road corridor as a JSON array string. Corresponds to 'bounds' in the upstream response. Format: '[[lon_sw,lat_sw],[lon_ne,lat_ne]]' in WGS84 decimal degrees."
-                                    },
-                                    "envelope": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "GeoJSON envelope polygon for the road corridor geometry. Corresponds to 'envelope' in the upstream response."
-                                    },
-                                    "url": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "URL to the TfL Unified API detail page for this corridor. Corresponds to 'url' in the upstream response."
-                                    },
-                                    "status_aggregation_start_date": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Start date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationStartDate' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "statusAggregationStartDate"
-                                        }
-                                    },
-                                    "status_aggregation_end_date": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "End date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationEndDate' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "statusAggregationEndDate"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "uk.gov.tfl.road.RoadStatus": {
-                    "name": "RoadStatus",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadStatus",
-                                "type": "object",
-                                "name": "RoadStatus",
-                                "description": "Real-time status snapshot for a Transport for London (TfL) managed road corridor. Fetched from the GET /Road/all/Status endpoint on each polling cycle. Each event represents the current aggregate traffic status for one corridor as computed by TfL from active disruptions.",
-                                "required": [
-                                    "road_id",
-                                    "display_name"
-                                ],
-                                "properties": {
-                                    "road_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier for the road corridor as used by the TfL Unified API. Corresponds to 'id' in the upstream response. Examples: 'a2', 'a12', 'm25'. Used as the stable domain key.",
-                                        "altnames": {
-                                            "upstream": "id"
-                                        }
-                                    },
-                                    "display_name": {
-                                        "type": "string",
-                                        "description": "Human-readable display name for the road corridor as reported by TfL. Corresponds to 'displayName' in the upstream response. Examples: 'A2', 'A12', 'M25'.",
-                                        "altnames": {
-                                            "upstream": "displayName"
-                                        }
-                                    },
-                                    "status_severity": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Current aggregate status severity for this corridor as assessed by TfL. Corresponds to 'statusSeverity' in the upstream response. Common values: 'Good', 'Moderate', 'Serious', 'Severe', 'NoDisruptions'.",
-                                        "altnames": {
-                                            "upstream": "statusSeverity"
-                                        }
-                                    },
-                                    "status_severity_description": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Human-readable description of the current status severity. Corresponds to 'statusSeverityDescription' in the upstream response. Example: 'Serious Delays'.",
-                                        "altnames": {
-                                            "upstream": "statusSeverityDescription"
-                                        }
-                                    },
-                                    "bounds": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Bounding box for the road corridor as a JSON array string. Corresponds to 'bounds' in the upstream response. Format: '[[lon_sw,lat_sw],[lon_ne,lat_ne]]' in WGS84 decimal degrees."
-                                    },
-                                    "envelope": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "GeoJSON envelope polygon for the road corridor geometry. Corresponds to 'envelope' in the upstream response."
-                                    },
-                                    "url": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "URL to the TfL Unified API detail page for this corridor. Corresponds to 'url' in the upstream response."
-                                    },
-                                    "status_aggregation_start_date": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Start date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationStartDate' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "statusAggregationStartDate"
-                                        }
-                                    },
-                                    "status_aggregation_end_date": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "End date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationEndDate' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "statusAggregationEndDate"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "uk.gov.tfl.road.RoadDisruption": {
-                    "name": "RoadDisruption",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadDisruption",
-                                "type": "object",
-                                "name": "RoadDisruption",
-                                "description": "Real-time road disruption event on the Transport for London (TfL) road network. Fetched from the GET /Road/all/Disruption endpoint. Each disruption represents an active incident, planned works, or road closure affecting one or more roads in London. Disruption records are deduped by ID and lastModifiedTime so only changed records are re-emitted.",
-                                "required": [
-                                    "disruption_id",
-                                    "road_id",
-                                    "severity"
-                                ],
-                                "definitions": {
-                                    "Street": {
-                                        "name": "Street",
-                                        "type": "object",
-                                        "description": "An individual street segment affected by a road disruption in London. Part of the 'streets' array in a RoadDisruption event.",
-                                        "properties": {
-                                            "name": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Street name as reported by TfL. Corresponds to 'name' in the upstream streets array entry."
-                                            },
-                                            "closure": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Type of closure applied to this street. Corresponds to 'closure' in the upstream streets entry. Values: 'Full', 'Partial'."
-                                            },
-                                            "directions": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Affected directions of travel on this street. Corresponds to 'directions' in the upstream streets entry. Examples: 'Both Directions', 'Northbound', 'Southbound'."
-                                            },
-                                            "source_system_id": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Source system identifier for this street record. Corresponds to 'sourceSystemId' in the upstream streets entry.",
-                                                "altnames": {
-                                                    "upstream": "sourceSystemId"
-                                                }
-                                            },
-                                            "source_system_key": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Source system key for this street record. Corresponds to 'sourceSystemKey' in the upstream streets entry.",
-                                                "altnames": {
-                                                    "upstream": "sourceSystemKey"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "CorridorIdArray": {
-                                        "name": "CorridorIdArray",
-                                        "type": "array",
-                                        "description": "Array of road corridor identifiers affected by this disruption.",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "StreetArray": {
-                                        "name": "StreetArray",
-                                        "type": "array",
-                                        "description": "Array of street segments affected by this disruption.",
-                                        "items": {
-                                            "type": {
-                                                "$ref": "#/definitions/Street"
-                                            }
-                                        }
-                                    }
-                                },
-                                "properties": {
-                                    "road_id": {
-                                        "type": "string",
-                                        "description": "Primary affected TfL road corridor identifier used by MQTT/UNS topics. Derived from the first upstream corridorIds entry when present, otherwise 'unknown'."
-                                    },
-                                    "disruption_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier for the disruption assigned by the TfL Traffic Information Management System (TIMS). Corresponds to 'id' in the upstream response. Format: 'TIMS-NNNNN' or similar TIMS prefix.",
-                                        "altnames": {
-                                            "upstream": "id"
-                                        }
-                                    },
-                                    "category": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Top-level category of the disruption. Corresponds to 'category' in the upstream response. Common values: 'RealTime' for live incidents, 'PlannedWork' for scheduled roadworks."
-                                    },
-                                    "sub_category": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "More detailed sub-category of the disruption. Corresponds to 'subCategory' in the upstream response. Examples: 'TfL planned works', 'Utility works', 'Incident', 'Traffic signal failure'.",
-                                        "altnames": {
-                                            "upstream": "subCategory"
-                                        }
-                                    },
-                                    "severity": {
-                                        "type": "string",
-                                        "description": "Normalized TfL-native severity for MQTT partitioning. Values: serious, severe, moderate, minor, information, closure. Upstream values are normalized to lowercase-kebab."
-                                    },
-                                    "ordinal": {
-                                        "type": [
-                                            "int32",
-                                            "null"
-                                        ],
-                                        "description": "Ordinal rank of this disruption used for ordering within a severity level. Corresponds to 'ordinal' in the upstream response."
-                                    },
-                                    "url": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "URL to the TfL Unified API detail page for this disruption. Corresponds to 'url' in the upstream response."
-                                    },
-                                    "point": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Representative point location of the disruption as a WKT or coordinate string. Corresponds to 'point' in the upstream response."
-                                    },
-                                    "comments": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Free-text comments describing the disruption context. Corresponds to 'comments' in the upstream response. May include street names, junction descriptions, or operational notes."
-                                    },
-                                    "current_update": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Latest operational update text for this disruption. Corresponds to 'currentUpdate' in the upstream response. Updated by TfL operators as the situation evolves.",
-                                        "altnames": {
-                                            "upstream": "currentUpdate"
-                                        }
-                                    },
-                                    "current_update_datetime": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Timestamp when the current update text was last modified. Corresponds to 'currentUpdateDateTime' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "currentUpdateDateTime"
-                                        }
-                                    },
-                                    "corridor_ids": {
-                                        "type": [
-                                            {
-                                                "$ref": "#/definitions/CorridorIdArray"
-                                            },
-                                            "null"
-                                        ],
-                                        "description": "Array of road corridor identifiers affected by this disruption. Corresponds to 'corridorIds' in the upstream response. Examples: ['a2', 'a12']. May be empty or null for disruptions not associated with a specific named corridor.",
-                                        "altnames": {
-                                            "upstream": "corridorIds"
-                                        }
-                                    },
-                                    "start_datetime": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Scheduled or actual start date and time of the disruption. Corresponds to 'startDateTime' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "startDateTime"
-                                        }
-                                    },
-                                    "end_datetime": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Scheduled or actual end date and time of the disruption. Corresponds to 'endDateTime' in the upstream response. May be null for open-ended incidents.",
-                                        "altnames": {
-                                            "upstream": "endDateTime"
-                                        }
-                                    },
-                                    "last_modified_time": {
-                                        "type": [
-                                            "datetime",
-                                            "null"
-                                        ],
-                                        "description": "Timestamp when this disruption record was last modified in the TfL system. Corresponds to 'lastModifiedTime' in the upstream response. Used for deduplication: disruptions are re-emitted only when this value changes.",
-                                        "altnames": {
-                                            "upstream": "lastModifiedTime"
-                                        }
-                                    },
-                                    "level_of_interest": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "TfL classification of the level of public interest for this disruption. Corresponds to 'levelOfInterest' in the upstream response. Examples: 'Low', 'Medium', 'High'.",
-                                        "altnames": {
-                                            "upstream": "levelOfInterest"
-                                        }
-                                    },
-                                    "location": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Free-text textual description of the disruption location. Corresponds to 'location' in the upstream response."
-                                    },
-                                    "is_provisional": {
-                                        "type": [
-                                            "boolean",
-                                            "null"
-                                        ],
-                                        "description": "Whether the disruption timing or details are provisional and subject to change. Corresponds to 'isProvisional' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "isProvisional"
-                                        }
-                                    },
-                                    "has_closures": {
-                                        "type": [
-                                            "boolean",
-                                            "null"
-                                        ],
-                                        "description": "Whether this disruption includes full or partial road closures. Corresponds to 'hasClosures' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "hasClosures"
-                                        }
-                                    },
-                                    "streets": {
-                                        "type": [
-                                            {
-                                                "$ref": "#/definitions/StreetArray"
-                                            },
-                                            "null"
-                                        ],
-                                        "description": "Array of street segments affected by this disruption. Corresponds to 'streets' in the upstream response. Each entry describes an individual street with its closure type, affected directions, and geometry."
-                                    },
-                                    "geography": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "GeoJSON geometry of the disruption area as a JSON string. Corresponds to 'geography' in the upstream response. May be a Point, LineString, or Polygon representing the spatial extent of the disruption."
-                                    },
-                                    "geometry": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Secondary geometry field from the TfL database as a JSON string. Corresponds to 'geometry' in the upstream response. May contain database geometry in an alternate representation."
-                                    },
-                                    "status": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Current lifecycle status of the disruption. Corresponds to 'status' in the upstream response."
-                                    },
-                                    "is_active": {
-                                        "type": [
-                                            "boolean",
-                                            "null"
-                                        ],
-                                        "description": "Whether this disruption is currently active. Corresponds to 'isActive' in the upstream response.",
-                                        "altnames": {
-                                            "upstream": "isActive"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    "uk.gov.tfl.road.Mqtt": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "MQTT/5.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "mqtt://localhost:1883"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/uk.gov.tfl.road.mqtt"
+      ],
+      "description": "MQTT 5 producer endpoint for TfL Road Traffic CloudEvents using the topic hierarchy and retain settings declared in this manifest."
     }
+  },
+  "messagegroups": {
+    "uk.gov.tfl.road.corridors": {
+      "messages": {
+        "uk.gov.tfl.road.RoadCorridor": {
+          "name": "RoadCorridor",
+          "envelope": "CloudEvents/1.0",
+          "description": "Reference record for a TfL managed road corridor fetched from GET /Road.",
+          "envelopemetadata": {
+            "type": {
+              "value": "uk.gov.tfl.road.RoadCorridor"
+            },
+            "source": {
+              "value": "https://api.tfl.gov.uk/Road"
+            },
+            "subject": {
+              "value": "roads/{road_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadCorridor"
+        },
+        "uk.gov.tfl.road.RoadStatus": {
+          "name": "RoadStatus",
+          "envelope": "CloudEvents/1.0",
+          "description": "Real-time status snapshot for a TfL managed road corridor fetched from GET /Road/all/Status.",
+          "envelopemetadata": {
+            "type": {
+              "value": "uk.gov.tfl.road.RoadStatus"
+            },
+            "source": {
+              "value": "https://api.tfl.gov.uk/Road/all/Status"
+            },
+            "subject": {
+              "value": "roads/{road_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadStatus"
+        }
+      },
+      "description": "Events from TfL Road Traffic covering London roads and disruption areas. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+    },
+    "uk.gov.tfl.road.disruptions": {
+      "messages": {
+        "uk.gov.tfl.road.RoadDisruption": {
+          "name": "RoadDisruption",
+          "envelope": "CloudEvents/1.0",
+          "description": "Real-time road disruption event on the TfL road network fetched from GET /Road/all/Disruption.",
+          "envelopemetadata": {
+            "type": {
+              "value": "uk.gov.tfl.road.RoadDisruption"
+            },
+            "source": {
+              "value": "https://api.tfl.gov.uk/Road/all/Disruption"
+            },
+            "subject": {
+              "value": "disruptions/{road_id}/{severity}/{disruption_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/uk.gov.tfl.road.jstruct/schemas/uk.gov.tfl.road.RoadDisruption"
+        }
+      },
+      "description": "Events from TfL Road Traffic covering London roads and disruption areas. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+    },
+    "uk.gov.tfl.road.mqtt": {
+      "description": "MQTT 5 variant of the TfL Road Traffic events. It carries the same transport semantics as the base events with MQTT topic routing and retain behavior declared per message.",
+      "messages": {
+        "uk.gov.tfl.road.mqtt.RoadCorridor": {
+          "name": "RoadCorridor",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.corridors/messages/uk.gov.tfl.road.RoadCorridor",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/roads/{road_id}/corridor",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadStatus": {
+          "name": "RoadStatus",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.corridors/messages/uk.gov.tfl.road.RoadStatus",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/roads/{road_id}/status",
+            "qos": 1,
+            "retain": true
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionSerious": {
+          "name": "RoadDisruptionSerious",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/serious/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionSevere": {
+          "name": "RoadDisruptionSevere",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/severe/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionModerate": {
+          "name": "RoadDisruptionModerate",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/moderate/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionMinor": {
+          "name": "RoadDisruptionMinor",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/minor/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionInformation": {
+          "name": "RoadDisruptionInformation",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/information/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        },
+        "uk.gov.tfl.road.mqtt.RoadDisruptionClosure": {
+          "name": "RoadDisruptionClosure",
+          "basemessageurl": "/messagegroups/uk.gov.tfl.road.disruptions/messages/uk.gov.tfl.road.RoadDisruption",
+          "protocol": "MQTT/5.0",
+          "protocoloptions": {
+            "topic_name": "traffic/gb/tfl/tfl-road-traffic/disruptions/{road_id}/closure/{disruption_id}",
+            "qos": 1,
+            "retain": false
+          }
+        }
+      }
+    }
+  },
+  "schemagroups": {
+    "uk.gov.tfl.road.jstruct": {
+      "schemas": {
+        "uk.gov.tfl.road.RoadCorridor": {
+          "name": "RoadCorridor",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadCorridor",
+                "type": "object",
+                "name": "RoadCorridor",
+                "description": "Reference record for a TfL managed road corridor fetched from GET /Road.",
+                "required": [
+                  "road_id",
+                  "display_name"
+                ],
+                "properties": {
+                  "road_id": {
+                    "type": "string",
+                    "description": "Unique identifier for the road corridor as used by the TfL Unified API. Corresponds to 'id' in the upstream response. Examples: 'a2', 'a12', 'm25'. Used as the stable domain key.",
+                    "altnames": {
+                      "upstream": "id"
+                    }
+                  },
+                  "display_name": {
+                    "type": "string",
+                    "description": "Human-readable display name for the road corridor as reported by TfL. Corresponds to 'displayName' in the upstream response. Examples: 'A2', 'A12', 'M25'.",
+                    "altnames": {
+                      "upstream": "displayName"
+                    }
+                  },
+                  "status_severity": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Current aggregate status severity for this corridor as assessed by TfL. Corresponds to 'statusSeverity' in the upstream response. Common values: 'Good', 'Moderate', 'Serious', 'Severe', 'NoDisruptions'.",
+                    "altnames": {
+                      "upstream": "statusSeverity"
+                    }
+                  },
+                  "status_severity_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable description of the current status severity. Corresponds to 'statusSeverityDescription' in the upstream response. Example: 'Serious Delays'.",
+                    "altnames": {
+                      "upstream": "statusSeverityDescription"
+                    }
+                  },
+                  "bounds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Bounding box for the road corridor as a JSON array string. Corresponds to 'bounds' in the upstream response. Format: '[[lon_sw,lat_sw],[lon_ne,lat_ne]]' in WGS84 decimal degrees."
+                  },
+                  "envelope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "GeoJSON envelope polygon for the road corridor geometry. Corresponds to 'envelope' in the upstream response."
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "URL to the TfL Unified API detail page for this corridor. Corresponds to 'url' in the upstream response."
+                  },
+                  "status_aggregation_start_date": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Start date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationStartDate' in the upstream response.",
+                    "altnames": {
+                      "upstream": "statusAggregationStartDate"
+                    }
+                  },
+                  "status_aggregation_end_date": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "End date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationEndDate' in the upstream response.",
+                    "altnames": {
+                      "upstream": "statusAggregationEndDate"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uk.gov.tfl.road.RoadStatus": {
+          "name": "RoadStatus",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadStatus",
+                "type": "object",
+                "name": "RoadStatus",
+                "description": "Real-time status snapshot for a TfL managed road corridor fetched from GET /Road/all/Status.",
+                "required": [
+                  "road_id",
+                  "display_name"
+                ],
+                "properties": {
+                  "road_id": {
+                    "type": "string",
+                    "description": "Unique identifier for the road corridor as used by the TfL Unified API. Corresponds to 'id' in the upstream response. Examples: 'a2', 'a12', 'm25'. Used as the stable domain key.",
+                    "altnames": {
+                      "upstream": "id"
+                    }
+                  },
+                  "display_name": {
+                    "type": "string",
+                    "description": "Human-readable display name for the road corridor as reported by TfL. Corresponds to 'displayName' in the upstream response. Examples: 'A2', 'A12', 'M25'.",
+                    "altnames": {
+                      "upstream": "displayName"
+                    }
+                  },
+                  "status_severity": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Current aggregate status severity for this corridor as assessed by TfL. Corresponds to 'statusSeverity' in the upstream response. Common values: 'Good', 'Moderate', 'Serious', 'Severe', 'NoDisruptions'.",
+                    "altnames": {
+                      "upstream": "statusSeverity"
+                    }
+                  },
+                  "status_severity_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable description of the current status severity. Corresponds to 'statusSeverityDescription' in the upstream response. Example: 'Serious Delays'.",
+                    "altnames": {
+                      "upstream": "statusSeverityDescription"
+                    }
+                  },
+                  "bounds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Bounding box for the road corridor as a JSON array string. Corresponds to 'bounds' in the upstream response. Format: '[[lon_sw,lat_sw],[lon_ne,lat_ne]]' in WGS84 decimal degrees."
+                  },
+                  "envelope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "GeoJSON envelope polygon for the road corridor geometry. Corresponds to 'envelope' in the upstream response."
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "URL to the TfL Unified API detail page for this corridor. Corresponds to 'url' in the upstream response."
+                  },
+                  "status_aggregation_start_date": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Start date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationStartDate' in the upstream response.",
+                    "altnames": {
+                      "upstream": "statusAggregationStartDate"
+                    }
+                  },
+                  "status_aggregation_end_date": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "End date of the current status aggregation period reported by TfL. Corresponds to 'statusAggregationEndDate' in the upstream response.",
+                    "altnames": {
+                      "upstream": "statusAggregationEndDate"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uk.gov.tfl.road.RoadDisruption": {
+          "name": "RoadDisruption",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://api.tfl.gov.uk/schemas/uk/gov/tfl/road/RoadDisruption",
+                "type": "object",
+                "name": "RoadDisruption",
+                "description": "Real-time road disruption event on the TfL road network fetched from GET /Road/all/Disruption.",
+                "required": [
+                  "disruption_id",
+                  "road_id",
+                  "severity"
+                ],
+                "definitions": {
+                  "Street": {
+                    "name": "Street",
+                    "type": "object",
+                    "description": "An individual street segment affected by a road disruption in London. Part of the 'streets' array in a RoadDisruption event.",
+                    "properties": {
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Street name as reported by TfL. Corresponds to 'name' in the upstream streets array entry."
+                      },
+                      "closure": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Type of closure applied to this street. Corresponds to 'closure' in the upstream streets entry. Values: 'Full', 'Partial'."
+                      },
+                      "directions": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Affected directions of travel on this street. Corresponds to 'directions' in the upstream streets entry. Examples: 'Both Directions', 'Northbound', 'Southbound'."
+                      },
+                      "source_system_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Source system identifier for this street record. Corresponds to 'sourceSystemId' in the upstream streets entry.",
+                        "altnames": {
+                          "upstream": "sourceSystemId"
+                        }
+                      },
+                      "source_system_key": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Source system key for this street record. Corresponds to 'sourceSystemKey' in the upstream streets entry.",
+                        "altnames": {
+                          "upstream": "sourceSystemKey"
+                        }
+                      }
+                    }
+                  },
+                  "CorridorIdArray": {
+                    "name": "CorridorIdArray",
+                    "type": "array",
+                    "description": "Array of road corridor identifiers affected by this disruption.",
+                    "items": {
+                      "type": "string",
+                      "description": "A transport update from Transport for London. It carries road disruption and traffic status updates for London roads and disruption areas."
+                    }
+                  },
+                  "StreetArray": {
+                    "name": "StreetArray",
+                    "type": "array",
+                    "description": "Array of street segments affected by this disruption.",
+                    "items": {
+                      "type": {
+                        "$ref": "#/definitions/Street"
+                      },
+                      "description": "A transport update from Transport for London. It carries road disruption and traffic status updates for London roads and disruption areas."
+                    }
+                  }
+                },
+                "properties": {
+                  "road_id": {
+                    "type": "string",
+                    "description": "Primary affected TfL road corridor identifier used by MQTT/UNS topics. Derived from the first upstream corridorIds entry when present, otherwise 'unknown'."
+                  },
+                  "disruption_id": {
+                    "type": "string",
+                    "description": "Unique identifier for the disruption assigned by the TfL Traffic Information Management System (TIMS). Corresponds to 'id' in the upstream response. Format: 'TIMS-NNNNN' or similar TIMS prefix.",
+                    "altnames": {
+                      "upstream": "id"
+                    }
+                  },
+                  "category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Top-level category of the disruption. Corresponds to 'category' in the upstream response. Common values: 'RealTime' for live incidents, 'PlannedWork' for scheduled roadworks."
+                  },
+                  "sub_category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "More detailed sub-category of the disruption. Corresponds to 'subCategory' in the upstream response. Examples: 'TfL planned works', 'Utility works', 'Incident', 'Traffic signal failure'.",
+                    "altnames": {
+                      "upstream": "subCategory"
+                    }
+                  },
+                  "severity": {
+                    "type": "string",
+                    "description": "Normalized TfL-native severity for MQTT partitioning. Values: serious, severe, moderate, minor, information, closure. Upstream values are normalized to lowercase-kebab."
+                  },
+                  "ordinal": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Ordinal rank of this disruption used for ordering within a severity level. Corresponds to 'ordinal' in the upstream response."
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "URL to the TfL Unified API detail page for this disruption. Corresponds to 'url' in the upstream response."
+                  },
+                  "point": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Representative point location of the disruption as a WKT or coordinate string. Corresponds to 'point' in the upstream response."
+                  },
+                  "comments": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Free-text comments describing the disruption context. Corresponds to 'comments' in the upstream response. May include street names, junction descriptions, or operational notes."
+                  },
+                  "current_update": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Latest operational update text for this disruption. Corresponds to 'currentUpdate' in the upstream response. Updated by TfL operators as the situation evolves.",
+                    "altnames": {
+                      "upstream": "currentUpdate"
+                    }
+                  },
+                  "current_update_datetime": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Timestamp when the current update text was last modified. Corresponds to 'currentUpdateDateTime' in the upstream response.",
+                    "altnames": {
+                      "upstream": "currentUpdateDateTime"
+                    }
+                  },
+                  "corridor_ids": {
+                    "type": [
+                      {
+                        "$ref": "#/definitions/CorridorIdArray"
+                      },
+                      "null"
+                    ],
+                    "description": "Array of road corridor identifiers affected by this disruption. Corresponds to 'corridorIds' in the upstream response. Examples: ['a2', 'a12']. May be empty or null for disruptions not associated with a specific named corridor.",
+                    "altnames": {
+                      "upstream": "corridorIds"
+                    }
+                  },
+                  "start_datetime": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Scheduled or actual start date and time of the disruption. Corresponds to 'startDateTime' in the upstream response.",
+                    "altnames": {
+                      "upstream": "startDateTime"
+                    }
+                  },
+                  "end_datetime": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Scheduled or actual end date and time of the disruption. Corresponds to 'endDateTime' in the upstream response. May be null for open-ended incidents.",
+                    "altnames": {
+                      "upstream": "endDateTime"
+                    }
+                  },
+                  "last_modified_time": {
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
+                    "description": "Timestamp when this disruption record was last modified in the TfL system. Corresponds to 'lastModifiedTime' in the upstream response. Used for deduplication: disruptions are re-emitted only when this value changes.",
+                    "altnames": {
+                      "upstream": "lastModifiedTime"
+                    }
+                  },
+                  "level_of_interest": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "TfL classification of the level of public interest for this disruption. Corresponds to 'levelOfInterest' in the upstream response. Examples: 'Low', 'Medium', 'High'.",
+                    "altnames": {
+                      "upstream": "levelOfInterest"
+                    }
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Free-text textual description of the disruption location. Corresponds to 'location' in the upstream response."
+                  },
+                  "is_provisional": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether the disruption timing or details are provisional and subject to change. Corresponds to 'isProvisional' in the upstream response.",
+                    "altnames": {
+                      "upstream": "isProvisional"
+                    }
+                  },
+                  "has_closures": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether this disruption includes full or partial road closures. Corresponds to 'hasClosures' in the upstream response.",
+                    "altnames": {
+                      "upstream": "hasClosures"
+                    }
+                  },
+                  "streets": {
+                    "type": [
+                      {
+                        "$ref": "#/definitions/StreetArray"
+                      },
+                      "null"
+                    ],
+                    "description": "Array of street segments affected by this disruption. Corresponds to 'streets' in the upstream response. Each entry describes an individual street with its closure type, affected directions, and geometry."
+                  },
+                  "geography": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "GeoJSON geometry of the disruption area as a JSON string. Corresponds to 'geography' in the upstream response. May be a Point, LineString, or Polygon representing the spatial extent of the disruption."
+                  },
+                  "geometry": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Secondary geometry field from the TfL database as a JSON string. Corresponds to 'geometry' in the upstream response. May contain database geometry in an alternate representation."
+                  },
+                  "status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Current lifecycle status of the disruption. Corresponds to 'status' in the upstream response."
+                  },
+                  "is_active": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether this disruption is currently active. Corresponds to 'isActive' in the upstream response.",
+                    "altnames": {
+                      "upstream": "isActive"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "description": "TfL Road Traffic publishes road disruption and traffic status updates from Transport for London for London roads and disruption areas. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for TfL Road Traffic, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
+  }
 }

--- a/tokyo-docomo-bikeshare/EVENTS.md
+++ b/tokyo-docomo-bikeshare/EVENTS.md
@@ -1,6 +1,6 @@
 # Tokyo Docomo Bikeshare Events
 
-Real-time bikeshare data for **Tokyo Docomo Bikeshare** (ドコモ・バイクシェア), Japan's largest bikeshare network with 1,794 dock-based stations across the central wards of Tokyo (Chiyoda, Minato, Shibuya, Shinjuku, and others).
+Tokyo Docomo Bikeshare publishes station status and availability updates from Docomo Bike Share open feeds for Tokyo bike-share stations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `JP.ODPT.DocomoBikeshare.BikeshareSystem`
 
 #### What it tells you
 
-Metadata describing the Tokyo Docomo Bikeshare system, sourced from the GBFS 2.3 system_information.json feed published by the Open Data Platform for Transportation (ODPT).
+A transport update from Docomo Bike Share open feeds. It carries station status and availability updates for Tokyo bike-share stations.
 
 #### Identity
 
@@ -99,7 +99,7 @@ CloudEvents type: `JP.ODPT.DocomoBikeshare.BikeshareStation`
 
 #### What it tells you
 
-Physical location and static attributes of a single Tokyo Docomo Bikeshare docking station, sourced from the GBFS 2.3 station_information.json feed published by the Open Data Platform for Transportation (ODPT).
+A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 
@@ -158,7 +158,7 @@ CloudEvents type: `JP.ODPT.DocomoBikeshare.BikeshareStationStatus`
 
 #### What it tells you
 
-Real-time availability and operational status of a single Tokyo Docomo Bikeshare docking station, sourced from the GBFS 2.3 station_status.json feed published by the Open Data Platform for Transportation (ODPT). Updates on a 60-second TTL.
+A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.
 
 #### Identity
 

--- a/tokyo-docomo-bikeshare/xreg/tokyo-docomo-bikeshare.xreg.json
+++ b/tokyo-docomo-bikeshare/xreg/tokyo-docomo-bikeshare.xreg.json
@@ -1,338 +1,410 @@
 {
-    "endpoints": {
-        "JP.ODPT.DocomoBikeshare.System.Kafka": {
-            "usage": [
-                "producer"
-            ],
-            "protocol": "KAFKA",
-            "envelope": "CloudEvents/1.0",
-            "envelopeoptions": {
-                "mode": "structured",
-                "format": "application/cloudevents+json"
-            },
-            "protocoloptions": {
-                "deployed": false,
-                "options": {
-                    "topic": "tokyo-docomo-bikeshare",
-                    "key": "{system_id}"
-                }
-            },
-            "messagegroups": [
-                "#/messagegroups/JP.ODPT.DocomoBikeshare.System"
-            ]
-        },
-        "JP.ODPT.DocomoBikeshare.Stations.Kafka": {
-            "usage": [
-                "producer"
-            ],
-            "protocol": "KAFKA",
-            "envelope": "CloudEvents/1.0",
-            "envelopeoptions": {
-                "mode": "structured",
-                "format": "application/cloudevents+json"
-            },
-            "protocoloptions": {
-                "deployed": false,
-                "options": {
-                    "topic": "tokyo-docomo-bikeshare",
-                    "key": "{system_id}/{station_id}"
-                }
-            },
-            "messagegroups": [
-                "#/messagegroups/JP.ODPT.DocomoBikeshare.Stations"
-            ]
+  "endpoints": {
+    "JP.ODPT.DocomoBikeshare.System.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "tokyo-docomo-bikeshare",
+          "key": "{system_id}"
         }
+      },
+      "messagegroups": [
+        "#/messagegroups/JP.ODPT.DocomoBikeshare.System"
+      ],
+      "description": "Kafka producer endpoint for Tokyo Docomo Bikeshare CloudEvents on the `tokyo-docomo-bikeshare` topic keyed by `{system_id}`."
     },
-    "messagegroups": {
-        "JP.ODPT.DocomoBikeshare.System": {
-            "messages": {
-                "JP.ODPT.DocomoBikeshare.BikeshareSystem": {
-                    "name": "BikeshareSystem",
-                    "envelope": "CloudEvents/1.0",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "JP.ODPT.DocomoBikeshare.BikeshareSystem"
-                        },
-                        "source": {
-                            "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
-                        },
-                        "subject": {
-                            "value": "{system_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareSystem"
-                }
-            }
-        },
-        "JP.ODPT.DocomoBikeshare.Stations": {
-            "messages": {
-                "JP.ODPT.DocomoBikeshare.BikeshareStation": {
-                    "name": "BikeshareStation",
-                    "envelope": "CloudEvents/1.0",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "JP.ODPT.DocomoBikeshare.BikeshareStation"
-                        },
-                        "source": {
-                            "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
-                        },
-                        "subject": {
-                            "value": "{system_id}/{station_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareStation"
-                },
-                "JP.ODPT.DocomoBikeshare.BikeshareStationStatus": {
-                    "name": "BikeshareStationStatus",
-                    "envelope": "CloudEvents/1.0",
-                    "envelopemetadata": {
-                        "type": {
-                            "value": "JP.ODPT.DocomoBikeshare.BikeshareStationStatus"
-                        },
-                        "source": {
-                            "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
-                        },
-                        "subject": {
-                            "value": "{system_id}/{station_id}",
-                            "type": "uritemplate"
-                        }
-                    },
-                    "dataschemaformat": "JsonStructure/draft-02",
-                    "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareStationStatus"
-                }
-            }
+    "JP.ODPT.DocomoBikeshare.Stations.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "tokyo-docomo-bikeshare",
+          "key": "{system_id}/{station_id}"
         }
-    },
-    "schemagroups": {
-        "JP.ODPT.DocomoBikeshare.jstruct": {
-            "schemas": {
-                "JP.ODPT.DocomoBikeshare.BikeshareSystem": {
-                    "name": "BikeshareSystem",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareSystem",
-                                "type": "object",
-                                "name": "BikeshareSystem",
-                                "description": "Metadata describing the Tokyo Docomo Bikeshare system, sourced from the GBFS 2.3 system_information.json feed published by the Open Data Platform for Transportation (ODPT).",
-                                "required": [
-                                    "system_id",
-                                    "language",
-                                    "name",
-                                    "timezone"
-                                ],
-                                "properties": {
-                                    "system_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier for this bikeshare system. A short, URL-friendly identifier that does not contain spaces, for example 'docomo-cycle-tokyo'. This value is stable and matches the GBFS feed directory name on the ODPT platform."
-                                    },
-                                    "language": {
-                                        "type": "string",
-                                        "description": "A single IETF BCP 47 language identifier representing the primary language used in this feed, for example 'ja' for Japanese or 'en' for English."
-                                    },
-                                    "name": {
-                                        "type": "string",
-                                        "description": "Full name of the bikeshare system as displayed to customers, for example 'ドコモ・バイクシェア' or 'Docomo Bikeshare'."
-                                    },
-                                    "short_name": {
-                                        "type": ["string", "null"],
-                                        "description": "Optional abbreviation or short form of the system name, for example 'DocomoBike'."
-                                    },
-                                    "operator": {
-                                        "type": ["string", "null"],
-                                        "description": "Name of the company or organization that operates the bikeshare system, for example 'NTT Docomo, Inc.'."
-                                    },
-                                    "url": {
-                                        "type": ["string", "null"],
-                                        "description": "URL of the bikeshare system or operator website for end users, for example 'https://docomo-cycle.jp/'."
-                                    },
-                                    "purchase_url": {
-                                        "type": ["string", "null"],
-                                        "description": "URL where a customer can purchase a membership or learn about purchasing memberships for this bikeshare system."
-                                    },
-                                    "start_date": {
-                                        "type": ["string", "null"],
-                                        "description": "Date that the bikeshare system began operations, formatted as YYYY-MM-DD in accordance with ISO 8601."
-                                    },
-                                    "phone_number": {
-                                        "type": ["string", "null"],
-                                        "description": "A single voice telephone number for the customer service department of this bikeshare system, including country and area code."
-                                    },
-                                    "email": {
-                                        "type": ["string", "null"],
-                                        "description": "A single contact email address actively monitored by the operator's customer service department."
-                                    },
-                                    "feed_contact_email": {
-                                        "type": ["string", "null"],
-                                        "description": "A single contact email address for the purpose of reporting issues with the GBFS feed for this system."
-                                    },
-                                    "timezone": {
-                                        "type": "string",
-                                        "description": "The IANA time zone database name for the time zone where the system is located, for example 'Asia/Tokyo'."
-                                    },
-                                    "license_url": {
-                                        "type": ["string", "null"],
-                                        "description": "A fully qualified URL of a page that defines the license terms for the GBFS data published by this system."
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "JP.ODPT.DocomoBikeshare.BikeshareStation": {
-                    "name": "BikeshareStation",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareStation",
-                                "type": "object",
-                                "name": "BikeshareStation",
-                                "description": "Physical location and static attributes of a single Tokyo Docomo Bikeshare docking station, sourced from the GBFS 2.3 station_information.json feed published by the Open Data Platform for Transportation (ODPT).",
-                                "required": [
-                                    "system_id",
-                                    "station_id",
-                                    "name",
-                                    "lat",
-                                    "lon"
-                                ],
-                                "properties": {
-                                    "system_id": {
-                                        "type": "string",
-                                        "description": "Identifier of the bikeshare system this station belongs to, for example 'docomo-cycle-tokyo'. Included in the payload so that the composite Kafka key {system_id}/{station_id} can be resolved from the event data."
-                                    },
-                                    "station_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier of the station within the GBFS feed, for example '00010137'. Stable across feed updates; used as the second component of the Kafka key."
-                                    },
-                                    "name": {
-                                        "type": "string",
-                                        "description": "Public name of the station as displayed to customers. Tokyo Docomo Bikeshare publishes bilingual names in the format 'Japanese / English', for example 'A4-01.東京駅八重洲口 / Tokyo Station Yaesu'."
-                                    },
-                                    "short_name": {
-                                        "type": ["string", "null"],
-                                        "description": "Short name or other operator-assigned identifier for the station, if provided."
-                                    },
-                                    "lat": {
-                                        "type": "double",
-                                        "description": "WGS 84 latitude of the station in decimal degrees. Positive values indicate north of the equator.",
-                                        "unit": "deg",
-                                        "symbol": "°"
-                                    },
-                                    "lon": {
-                                        "type": "double",
-                                        "description": "WGS 84 longitude of the station in decimal degrees. Positive values indicate east of the prime meridian.",
-                                        "unit": "deg",
-                                        "symbol": "°"
-                                    },
-                                    "address": {
-                                        "type": ["string", "null"],
-                                        "description": "Street address of the station, if provided by the operator."
-                                    },
-                                    "cross_street": {
-                                        "type": ["string", "null"],
-                                        "description": "Cross street or nearby landmark of the station location, if provided."
-                                    },
-                                    "region_id": {
-                                        "type": ["string", "null"],
-                                        "description": "Identifier of the district or region where the station is located, as defined in the GBFS system_regions.json feed."
-                                    },
-                                    "post_code": {
-                                        "type": ["string", "null"],
-                                        "description": "Postal code of the station location, if provided."
-                                    },
-                                    "capacity": {
-                                        "type": ["int32", "null"],
-                                        "description": "Total number of docking points installed at the station, including those that are temporarily disabled. Reflects the physical capacity of the station."
-                                    },
-                                    "is_virtual_station": {
-                                        "type": ["boolean", "null"],
-                                        "description": "If true, the station is a virtual station (i.e., a parking zone without physical docks) rather than a docked station. If absent or false, the station has physical docking points."
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "JP.ODPT.DocomoBikeshare.BikeshareStationStatus": {
-                    "name": "BikeshareStationStatus",
-                    "format": "JsonStructure/draft-02",
-                    "defaultversionid": "1",
-                    "versions": {
-                        "1": {
-                            "format": "JsonStructure/draft-02",
-                            "schema": {
-                                "$schema": "https://json-structure.org/meta/extended/v0/#",
-                                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareStationStatus",
-                                "type": "object",
-                                "name": "BikeshareStationStatus",
-                                "description": "Real-time availability and operational status of a single Tokyo Docomo Bikeshare docking station, sourced from the GBFS 2.3 station_status.json feed published by the Open Data Platform for Transportation (ODPT). Updates on a 60-second TTL.",
-                                "required": [
-                                    "system_id",
-                                    "station_id",
-                                    "num_bikes_available",
-                                    "is_installed",
-                                    "is_renting",
-                                    "is_returning"
-                                ],
-                                "properties": {
-                                    "system_id": {
-                                        "type": "string",
-                                        "description": "Identifier of the bikeshare system this station belongs to, for example 'docomo-cycle-tokyo'. Included in the payload so that the composite Kafka key {system_id}/{station_id} can be resolved from the event data."
-                                    },
-                                    "station_id": {
-                                        "type": "string",
-                                        "description": "Unique identifier of the station within the GBFS feed, for example '00010137'. Matches the station_id in the corresponding BikeshareStation event."
-                                    },
-                                    "num_bikes_available": {
-                                        "type": "int32",
-                                        "description": "Number of functional vehicles (bicycles) physically available for rental at this station at the time of the last update."
-                                    },
-                                    "num_bikes_disabled": {
-                                        "type": ["int32", "null"],
-                                        "description": "Number of disabled or broken vehicles at the station that are not available for rental. Absent if the operator does not publish this value."
-                                    },
-                                    "num_docks_available": {
-                                        "type": ["int32", "null"],
-                                        "description": "Number of empty and functional docking points at the station where a customer can return a vehicle. Absent if the operator does not publish this value."
-                                    },
-                                    "num_docks_disabled": {
-                                        "type": ["int32", "null"],
-                                        "description": "Number of broken or disabled docking points at the station that cannot accept vehicle returns. Absent if the operator does not publish this value."
-                                    },
-                                    "is_installed": {
-                                        "type": "boolean",
-                                        "description": "Indicates whether the station infrastructure is installed on-street and operational. A value of false means the station is temporarily or permanently removed from service."
-                                    },
-                                    "is_renting": {
-                                        "type": "boolean",
-                                        "description": "Indicates whether the station is currently allowing vehicle rentals. May be false even when bikes are present, for example during a system outage."
-                                    },
-                                    "is_returning": {
-                                        "type": "boolean",
-                                        "description": "Indicates whether the station is currently accepting vehicle returns. May be false even when docks are empty, for example during a system outage."
-                                    },
-                                    "last_reported": {
-                                        "type": ["int32", "null"],
-                                        "description": "Unix timestamp in seconds (UTC) indicating the last time this station's status was updated by the operator's system. Absent if the operator does not publish this value."
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+      },
+      "messagegroups": [
+        "#/messagegroups/JP.ODPT.DocomoBikeshare.Stations"
+      ],
+      "description": "Kafka producer endpoint for Tokyo Docomo Bikeshare CloudEvents on the `tokyo-docomo-bikeshare` topic keyed by `{system_id}/{station_id}`."
     }
+  },
+  "messagegroups": {
+    "JP.ODPT.DocomoBikeshare.System": {
+      "messages": {
+        "JP.ODPT.DocomoBikeshare.BikeshareSystem": {
+          "name": "BikeshareSystem",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "JP.ODPT.DocomoBikeshare.BikeshareSystem"
+            },
+            "source": {
+              "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
+            },
+            "subject": {
+              "value": "{system_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareSystem",
+          "description": "A transport update from Docomo Bike Share open feeds. It carries station status and availability updates for Tokyo bike-share stations."
+        }
+      },
+      "description": "Events from Tokyo Docomo Bikeshare covering Tokyo bike-share stations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+    },
+    "JP.ODPT.DocomoBikeshare.Stations": {
+      "messages": {
+        "JP.ODPT.DocomoBikeshare.BikeshareStation": {
+          "name": "BikeshareStation",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "JP.ODPT.DocomoBikeshare.BikeshareStation"
+            },
+            "source": {
+              "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
+            },
+            "subject": {
+              "value": "{system_id}/{station_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareStation",
+          "description": "A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+        },
+        "JP.ODPT.DocomoBikeshare.BikeshareStationStatus": {
+          "name": "BikeshareStationStatus",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "JP.ODPT.DocomoBikeshare.BikeshareStationStatus"
+            },
+            "source": {
+              "value": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo"
+            },
+            "subject": {
+              "value": "{system_id}/{station_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JsonStructure/draft-02",
+          "dataschemauri": "#/schemagroups/JP.ODPT.DocomoBikeshare.jstruct/schemas/JP.ODPT.DocomoBikeshare.BikeshareStationStatus",
+          "description": "A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+        }
+      },
+      "description": "Events from Tokyo Docomo Bikeshare covering Tokyo bike-share stations. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
+    }
+  },
+  "schemagroups": {
+    "JP.ODPT.DocomoBikeshare.jstruct": {
+      "schemas": {
+        "JP.ODPT.DocomoBikeshare.BikeshareSystem": {
+          "name": "BikeshareSystem",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareSystem",
+                "type": "object",
+                "name": "BikeshareSystem",
+                "description": "A transport update from Docomo Bike Share open feeds. It carries station status and availability updates for Tokyo bike-share stations.",
+                "required": [
+                  "system_id",
+                  "language",
+                  "name",
+                  "timezone"
+                ],
+                "properties": {
+                  "system_id": {
+                    "type": "string",
+                    "description": "Unique identifier for this bikeshare system. A short, URL-friendly identifier that does not contain spaces, for example 'docomo-cycle-tokyo'. This value is stable and matches the GBFS feed directory name on the ODPT platform."
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "A single IETF BCP 47 language identifier representing the primary language used in this feed, for example 'ja' for Japanese or 'en' for English."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Full name of the bikeshare system as displayed to customers, for example 'ドコモ・バイクシェア' or 'Docomo Bikeshare'."
+                  },
+                  "short_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Optional abbreviation or short form of the system name, for example 'DocomoBike'."
+                  },
+                  "operator": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the company or organization that operates the bikeshare system, for example 'NTT Docomo, Inc.'."
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "URL of the bikeshare system or operator website for end users, for example 'https://docomo-cycle.jp/'."
+                  },
+                  "purchase_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "URL where a customer can purchase a membership or learn about purchasing memberships for this bikeshare system."
+                  },
+                  "start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Date that the bikeshare system began operations, formatted as YYYY-MM-DD in accordance with ISO 8601."
+                  },
+                  "phone_number": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "A single voice telephone number for the customer service department of this bikeshare system, including country and area code."
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "A single contact email address actively monitored by the operator's customer service department."
+                  },
+                  "feed_contact_email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "A single contact email address for the purpose of reporting issues with the GBFS feed for this system."
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "description": "The IANA time zone database name for the time zone where the system is located, for example 'Asia/Tokyo'."
+                  },
+                  "license_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "A fully qualified URL of a page that defines the license terms for the GBFS data published by this system."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "JP.ODPT.DocomoBikeshare.BikeshareStation": {
+          "name": "BikeshareStation",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareStation",
+                "type": "object",
+                "name": "BikeshareStation",
+                "description": "A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
+                "required": [
+                  "system_id",
+                  "station_id",
+                  "name",
+                  "lat",
+                  "lon"
+                ],
+                "properties": {
+                  "system_id": {
+                    "type": "string",
+                    "description": "Identifier of the bikeshare system this station belongs to, for example 'docomo-cycle-tokyo'. Included in the payload so that the composite Kafka key {system_id}/{station_id} can be resolved from the event data."
+                  },
+                  "station_id": {
+                    "type": "string",
+                    "description": "Unique identifier of the station within the GBFS feed, for example '00010137'. Stable across feed updates; used as the second component of the Kafka key."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Public name of the station as displayed to customers. Tokyo Docomo Bikeshare publishes bilingual names in the format 'Japanese / English', for example 'A4-01.東京駅八重洲口 / Tokyo Station Yaesu'."
+                  },
+                  "short_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Short name or other operator-assigned identifier for the station, if provided."
+                  },
+                  "lat": {
+                    "type": "double",
+                    "description": "WGS 84 latitude of the station in decimal degrees. Positive values indicate north of the equator.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "lon": {
+                    "type": "double",
+                    "description": "WGS 84 longitude of the station in decimal degrees. Positive values indicate east of the prime meridian.",
+                    "unit": "deg",
+                    "symbol": "°"
+                  },
+                  "address": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Street address of the station, if provided by the operator."
+                  },
+                  "cross_street": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Cross street or nearby landmark of the station location, if provided."
+                  },
+                  "region_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Identifier of the district or region where the station is located, as defined in the GBFS system_regions.json feed."
+                  },
+                  "post_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Postal code of the station location, if provided."
+                  },
+                  "capacity": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Total number of docking points installed at the station, including those that are temporarily disabled. Reflects the physical capacity of the station."
+                  },
+                  "is_virtual_station": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "If true, the station is a virtual station (i.e., a parking zone without physical docks) rather than a docked station. If absent or false, the station has physical docking points."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "JP.ODPT.DocomoBikeshare.BikeshareStationStatus": {
+          "name": "BikeshareStationStatus",
+          "format": "JsonStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JsonStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://real-time-sources.2030.io/schemas/jp/odpt/docomobikeshare/BikeshareStationStatus",
+                "type": "object",
+                "name": "BikeshareStationStatus",
+                "description": "A reference record from Docomo Bike Share open feeds for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates.",
+                "required": [
+                  "system_id",
+                  "station_id",
+                  "num_bikes_available",
+                  "is_installed",
+                  "is_renting",
+                  "is_returning"
+                ],
+                "properties": {
+                  "system_id": {
+                    "type": "string",
+                    "description": "Identifier of the bikeshare system this station belongs to, for example 'docomo-cycle-tokyo'. Included in the payload so that the composite Kafka key {system_id}/{station_id} can be resolved from the event data."
+                  },
+                  "station_id": {
+                    "type": "string",
+                    "description": "Unique identifier of the station within the GBFS feed, for example '00010137'. Matches the station_id in the corresponding BikeshareStation event."
+                  },
+                  "num_bikes_available": {
+                    "type": "int32",
+                    "description": "Number of functional vehicles (bicycles) physically available for rental at this station at the time of the last update."
+                  },
+                  "num_bikes_disabled": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Number of disabled or broken vehicles at the station that are not available for rental. Absent if the operator does not publish this value."
+                  },
+                  "num_docks_available": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Number of empty and functional docking points at the station where a customer can return a vehicle. Absent if the operator does not publish this value."
+                  },
+                  "num_docks_disabled": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Number of broken or disabled docking points at the station that cannot accept vehicle returns. Absent if the operator does not publish this value."
+                  },
+                  "is_installed": {
+                    "type": "boolean",
+                    "description": "Indicates whether the station infrastructure is installed on-street and operational. A value of false means the station is temporarily or permanently removed from service."
+                  },
+                  "is_renting": {
+                    "type": "boolean",
+                    "description": "Indicates whether the station is currently allowing vehicle rentals. May be false even when bikes are present, for example during a system outage."
+                  },
+                  "is_returning": {
+                    "type": "boolean",
+                    "description": "Indicates whether the station is currently accepting vehicle returns. May be false even when docks are empty, for example during a system outage."
+                  },
+                  "last_reported": {
+                    "type": [
+                      "int32",
+                      "null"
+                    ],
+                    "description": "Unix timestamp in seconds (UTC) indicating the last time this station's status was updated by the operator's system. Absent if the operator does not publish this value."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "description": "Tokyo Docomo Bikeshare publishes station status and availability updates from Docomo Bike Share open feeds for Tokyo bike-share stations. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for Tokyo Docomo Bikeshare, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
+  }
 }

--- a/wsdot/EVENTS.md
+++ b/wsdot/EVENTS.md
@@ -1,6 +1,6 @@
 # WSDOT Traveler Information Events
 
-This source bridges the Washington State Department of Transportation (WSDOT) Traveler Information API and Washington State Ferries API to Apache Kafka, producing real-time data across eight event families: traffic flow, travel times, mountain pass conditions, road weather, toll rates, commercial vehicle restrictions, US-Canada border crossing wait times, and ferry vessel locations.
+WSDOT publishes traffic, travel, bridge, toll, pass, ferry, and border-wait updates from Washington State Department of Transportation for Washington road, bridge, pass, ferry, and border resources. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.
 
 ## At a glance
 
@@ -38,7 +38,7 @@ CloudEvents type: `us.wa.wsdot.traffic.TrafficFlowStation`
 
 #### What it tells you
 
-Metadata for a traffic flow sensor station in the Washington State DOT network. WSDOT deploys approximately 1,400 inductive loop sensors embedded in highway pavement across four geographic regions. Metadata for a traffic flow sensor station in the WSDOT network.
+Metadata for a traffic flow sensor station in the Washington State DOT network. WSDOT deploys approximately 1,400 inductive loop sensors embedded in highway pavement across four geographic regions.
 
 #### Identity
 
@@ -156,7 +156,7 @@ CloudEvents type: `us.wa.wsdot.traveltimes.TravelTimeRoute`
 
 #### What it tells you
 
-A named travel time route monitored by WSDOT. Each route has fixed start and end points on Washington State highways with historical average and current real-time travel times. A named travel time route monitored by WSDOT with historical average and current real-time travel times in minutes.
+A named travel time route monitored by WSDOT. Each route has fixed start and end points on Washington State highways with historical average and current real-time travel times.
 
 #### Identity
 
@@ -229,7 +229,7 @@ CloudEvents type: `us.wa.wsdot.mountainpass.MountainPassCondition`
 
 #### What it tells you
 
-Current conditions at a Washington State mountain pass including temperature, weather, road conditions, travel advisories, and directional restrictions. Current conditions at a Washington State mountain pass. WSDOT monitors 16 mountain passes reporting temperature, weather, road conditions, travel advisories, and directional restrictions.
+Current conditions at a Washington State mountain pass including temperature, weather, road conditions, travel advisories, and directional restrictions.
 
 #### Identity
 
@@ -292,7 +292,7 @@ CloudEvents type: `us.wa.wsdot.weather.WeatherStation`
 
 #### What it tells you
 
-Metadata for a WSDOT road weather information system (RWIS) station. WSDOT operates approximately 134 stations across Washington State highways. Metadata for a WSDOT RWIS station.
+Metadata for a WSDOT road weather information system (RWIS) station. WSDOT operates approximately 134 stations across Washington State highways.
 
 #### Identity
 
@@ -335,7 +335,7 @@ CloudEvents type: `us.wa.wsdot.weather.WeatherReading`
 
 #### What it tells you
 
-A current weather reading from a WSDOT road weather station including temperature, wind, precipitation, pressure, humidity, visibility, and sky coverage. A current weather reading from a WSDOT RWIS station.
+A current weather reading from a WSDOT road weather station including temperature, wind, precipitation, pressure, humidity, visibility, and sky coverage.
 
 #### Identity
 
@@ -400,7 +400,7 @@ CloudEvents type: `us.wa.wsdot.tolls.TollRate`
 
 #### What it tells you
 
-Current toll rate for a WSDOT tolled route segment. WSDOT operates dynamic tolling on SR 99, I-405, and SR 167. Current toll rate for a WSDOT tolled route segment with dynamic pricing.
+Current toll rate for a WSDOT tolled route segment. WSDOT operates dynamic tolling on SR 99, I-405, and SR 167.
 
 #### Identity
 
@@ -544,7 +544,7 @@ CloudEvents type: `us.wa.wsdot.border.BorderCrossing`
 
 #### What it tells you
 
-Current wait time at a US-Canada border crossing lane in Washington State. Wait times are in minutes, updated approximately every 5 minutes. US-Canada border crossing wait time in Washington State.
+Current wait time at a US-Canada border crossing lane in Washington State. Wait times are in minutes, updated approximately every 5 minutes.
 
 #### Identity
 

--- a/wsdot/xreg/wsdot.xreg.json
+++ b/wsdot/xreg/wsdot.xreg.json
@@ -1,7 +1,9 @@
 {
   "endpoints": {
     "us.wa.wsdot.traffic.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -15,10 +17,15 @@
           "key": "{flow_data_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.traffic"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.traffic"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{flow_data_id}`."
     },
     "us.wa.wsdot.traveltimes.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -32,10 +39,15 @@
           "key": "{travel_time_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.traveltimes"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.traveltimes"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{travel_time_id}`."
     },
     "us.wa.wsdot.mountainpass.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -49,10 +61,15 @@
           "key": "{mountain_pass_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.mountainpass"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.mountainpass"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{mountain_pass_id}`."
     },
     "us.wa.wsdot.weather.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -66,10 +83,15 @@
           "key": "{station_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.weather"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.weather"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{station_id}`."
     },
     "us.wa.wsdot.tolls.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -83,10 +105,15 @@
           "key": "{trip_name}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.tolls"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.tolls"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{trip_name}`."
     },
     "us.wa.wsdot.cvrestrictions.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -100,10 +127,15 @@
           "key": "{state_route_id}/{bridge_number}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.cvrestrictions"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.cvrestrictions"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{state_route_id}/{bridge_number}`."
     },
     "us.wa.wsdot.border.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -117,10 +149,15 @@
           "key": "{crossing_name}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.border"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.border"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{crossing_name}`."
     },
     "us.wa.wsdot.ferries.Kafka": {
-      "usage": ["producer"],
+      "usage": [
+        "producer"
+      ],
       "protocol": "KAFKA",
       "envelope": "CloudEvents/1.0",
       "envelopeoptions": {
@@ -134,7 +171,10 @@
           "key": "{vessel_id}"
         }
       },
-      "messagegroups": ["#/messagegroups/us.wa.wsdot.ferries"]
+      "messagegroups": [
+        "#/messagegroups/us.wa.wsdot.ferries"
+      ],
+      "description": "Kafka producer endpoint for WSDOT CloudEvents on the `wsdot` topic keyed by `{vessel_id}`."
     }
   },
   "messagegroups": {
@@ -145,9 +185,17 @@
           "envelope": "CloudEvents/1.0",
           "description": "Metadata for a traffic flow sensor station in the Washington State DOT network. WSDOT deploys approximately 1,400 inductive loop sensors embedded in highway pavement across four geographic regions.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.traffic.TrafficFlowStation" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{flow_data_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.traffic.TrafficFlowStation"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{flow_data_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.traffic.jstruct/schemas/us.wa.wsdot.traffic.TrafficFlowStation"
@@ -157,14 +205,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "A traffic flow reading from a WSDOT sensor station. Updated approximately every 90 seconds, each reading reports the current Level of Service.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.traffic.TrafficFlowReading" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{flow_data_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.traffic.TrafficFlowReading"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{flow_data_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.traffic.jstruct/schemas/us.wa.wsdot.traffic.TrafficFlowReading"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.traveltimes": {
       "messages": {
@@ -173,14 +230,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "A named travel time route monitored by WSDOT. Each route has fixed start and end points on Washington State highways with historical average and current real-time travel times.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.traveltimes.TravelTimeRoute" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{travel_time_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.traveltimes.TravelTimeRoute"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{travel_time_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.traveltimes.jstruct/schemas/us.wa.wsdot.traveltimes.TravelTimeRoute"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.mountainpass": {
       "messages": {
@@ -189,14 +255,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "Current conditions at a Washington State mountain pass including temperature, weather, road conditions, travel advisories, and directional restrictions.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.mountainpass.MountainPassCondition" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{mountain_pass_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.mountainpass.MountainPassCondition"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{mountain_pass_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.mountainpass.jstruct/schemas/us.wa.wsdot.mountainpass.MountainPassCondition"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.weather": {
       "messages": {
@@ -205,9 +280,17 @@
           "envelope": "CloudEvents/1.0",
           "description": "Metadata for a WSDOT road weather information system (RWIS) station. WSDOT operates approximately 134 stations across Washington State highways.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.weather.WeatherStation" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{station_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.weather.WeatherStation"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.weather.jstruct/schemas/us.wa.wsdot.weather.WeatherStation"
@@ -217,14 +300,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "A current weather reading from a WSDOT road weather station including temperature, wind, precipitation, pressure, humidity, visibility, and sky coverage.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.weather.WeatherReading" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{station_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.weather.WeatherReading"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.weather.jstruct/schemas/us.wa.wsdot.weather.WeatherReading"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.tolls": {
       "messages": {
@@ -233,14 +325,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "Current toll rate for a WSDOT tolled route segment. WSDOT operates dynamic tolling on SR 99, I-405, and SR 167.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.tolls.TollRate" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{trip_name}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.tolls.TollRate"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{trip_name}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.tolls.jstruct/schemas/us.wa.wsdot.tolls.TollRate"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.cvrestrictions": {
       "messages": {
@@ -249,14 +350,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "A commercial vehicle restriction on a Washington State highway bridge or road segment. Restrictions limit vehicle weight, height, length, or width.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{state_route_id}/{bridge_number}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{state_route_id}/{bridge_number}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.cvrestrictions.jstruct/schemas/us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.border": {
       "messages": {
@@ -265,14 +375,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "Current wait time at a US-Canada border crossing lane in Washington State. Wait times are in minutes, updated approximately every 5 minutes.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.border.BorderCrossing" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{crossing_name}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.border.BorderCrossing"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{crossing_name}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.border.jstruct/schemas/us.wa.wsdot.border.BorderCrossing"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     },
     "us.wa.wsdot.ferries": {
       "messages": {
@@ -281,14 +400,23 @@
           "envelope": "CloudEvents/1.0",
           "description": "Real-time location and status of a Washington State Ferries vessel. WSF operates approximately 21 vessels across Puget Sound routes.",
           "envelopemetadata": {
-            "type": { "value": "us.wa.wsdot.ferries.VesselLocation" },
-            "source": { "value": "{feedurl}", "type": "uritemplate" },
-            "subject": { "value": "{vessel_id}", "type": "uritemplate" }
+            "type": {
+              "value": "us.wa.wsdot.ferries.VesselLocation"
+            },
+            "source": {
+              "value": "{feedurl}",
+              "type": "uritemplate"
+            },
+            "subject": {
+              "value": "{vessel_id}",
+              "type": "uritemplate"
+            }
           },
           "dataschemaformat": "JsonStructure/draft-02",
           "dataschemauri": "#/schemagroups/us.wa.wsdot.ferries.jstruct/schemas/us.wa.wsdot.ferries.VesselLocation"
         }
-      }
+      },
+      "description": "Events from WSDOT covering Washington road, bridge, pass, ferry, and border resources. Reference records identify transport resources; realtime records carry the current source status, measurement, or movement update."
     }
   },
   "schemagroups": {
@@ -307,25 +435,114 @@
                 "name": "TrafficFlowStation",
                 "$root": "#/definitions/us/wa/wsdot/traffic/TrafficFlowStation",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "traffic": {
-                    "TrafficFlowStation": {
-                      "name": "TrafficFlowStation",
-                      "type": "object",
-                      "description": "Metadata for a traffic flow sensor station in the WSDOT network. Each sensor is identified by a unique FlowDataID integer.",
-                      "properties": {
-                        "flow_data_id": { "type": "string", "description": "Unique numeric identifier for this traffic flow sensor station, stringified from upstream FlowDataID.", "altnames": { "json": "FlowDataID" } },
-                        "station_name": { "type": "string", "description": "Descriptive name of the flow sensor station.", "altnames": { "json": "StationName" } },
-                        "region": { "type": "string", "description": "WSDOT geographic coverage region.", "altnames": { "json": "Region" }, "enum": ["Eastern", "Northwest", "Olympic", "Southwest"] },
-                        "description": { "type": ["string", "null"], "description": "Location description. Null if not provided.", "altnames": { "json": "Description" } },
-                        "road_name": { "type": "string", "description": "Road designation where the sensor is installed.", "altnames": { "json": "RoadName" } },
-                        "direction": { "type": ["string", "null"], "description": "Direction of travel monitored. Examples: NB, SB, EB, WB.", "altnames": { "json": "Direction" } },
-                        "milepost": { "type": ["double", "null"], "description": "Milepost marker along the roadway.", "altnames": { "json": "MilePost" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84 decimal degrees.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84 decimal degrees.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } }
-                      },
-                      "required": ["flow_data_id", "station_name", "region", "description", "road_name", "direction", "milepost", "latitude", "longitude"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "traffic": {
+                          "TrafficFlowStation": {
+                            "name": "TrafficFlowStation",
+                            "type": "object",
+                            "description": "Metadata for a traffic flow sensor station in the Washington State DOT network. WSDOT deploys approximately 1,400 inductive loop sensors embedded in highway pavement across four geographic regions.",
+                            "properties": {
+                              "flow_data_id": {
+                                "type": "string",
+                                "description": "Unique numeric identifier for this traffic flow sensor station, stringified from upstream FlowDataID.",
+                                "altnames": {
+                                  "json": "FlowDataID"
+                                }
+                              },
+                              "station_name": {
+                                "type": "string",
+                                "description": "Descriptive name of the flow sensor station.",
+                                "altnames": {
+                                  "json": "StationName"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "WSDOT geographic coverage region.",
+                                "altnames": {
+                                  "json": "Region"
+                                },
+                                "enum": [
+                                  "Eastern",
+                                  "Northwest",
+                                  "Olympic",
+                                  "Southwest"
+                                ]
+                              },
+                              "description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Location description. Null if not provided.",
+                                "altnames": {
+                                  "json": "Description"
+                                }
+                              },
+                              "road_name": {
+                                "type": "string",
+                                "description": "Road designation where the sensor is installed.",
+                                "altnames": {
+                                  "json": "RoadName"
+                                }
+                              },
+                              "direction": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Direction of travel monitored. Examples: NB, SB, EB, WB.",
+                                "altnames": {
+                                  "json": "Direction"
+                                }
+                              },
+                              "milepost": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Milepost marker along the roadway.",
+                                "altnames": {
+                                  "json": "MilePost"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84 decimal degrees.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84 decimal degrees.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              }
+                            },
+                            "required": [
+                              "flow_data_id",
+                              "station_name",
+                              "region",
+                              "description",
+                              "road_name",
+                              "direction",
+                              "milepost",
+                              "latitude",
+                              "longitude"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -344,21 +561,84 @@
                 "name": "TrafficFlowReading",
                 "$root": "#/definitions/us/wa/wsdot/traffic/TrafficFlowReading",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "traffic": {
-                    "TrafficFlowReading": {
-                      "name": "TrafficFlowReading",
-                      "type": "object",
-                      "description": "A traffic flow reading from a WSDOT sensor station.",
-                      "properties": {
-                        "flow_data_id": { "type": "string", "description": "Sensor station identifier, stringified from upstream FlowDataID.", "altnames": { "json": "FlowDataID" } },
-                        "station_name": { "type": "string", "description": "Station name.", "altnames": { "json": "StationName" } },
-                        "region": { "type": "string", "description": "WSDOT region.", "altnames": { "json": "Region" }, "enum": ["Eastern", "Northwest", "Olympic", "Southwest"] },
-                        "flow_reading": { "type": "string", "description": "Current traffic Level of Service. Converted from upstream FlowReadingValue byte.", "enum": ["Unknown", "WideOpen", "Moderate", "Heavy", "StopAndGo", "NoData"], "altenums": { "upstream_byte": { "Unknown": "0", "WideOpen": "1", "Moderate": "2", "Heavy": "3", "StopAndGo": "4", "NoData": "5" } } },
-                        "reading_time": { "type": "string", "description": "ISO 8601 UTC timestamp of the reading.", "altnames": { "json": "Time" } }
-                      },
-                      "required": ["flow_data_id", "station_name", "region", "flow_reading", "reading_time"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "traffic": {
+                          "TrafficFlowReading": {
+                            "name": "TrafficFlowReading",
+                            "type": "object",
+                            "description": "A traffic flow reading from a WSDOT sensor station. Updated approximately every 90 seconds, each reading reports the current Level of Service.",
+                            "properties": {
+                              "flow_data_id": {
+                                "type": "string",
+                                "description": "Sensor station identifier, stringified from upstream FlowDataID.",
+                                "altnames": {
+                                  "json": "FlowDataID"
+                                }
+                              },
+                              "station_name": {
+                                "type": "string",
+                                "description": "Station name.",
+                                "altnames": {
+                                  "json": "StationName"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "WSDOT region.",
+                                "altnames": {
+                                  "json": "Region"
+                                },
+                                "enum": [
+                                  "Eastern",
+                                  "Northwest",
+                                  "Olympic",
+                                  "Southwest"
+                                ]
+                              },
+                              "flow_reading": {
+                                "type": "string",
+                                "description": "Current traffic Level of Service. Converted from upstream FlowReadingValue byte.",
+                                "enum": [
+                                  "Unknown",
+                                  "WideOpen",
+                                  "Moderate",
+                                  "Heavy",
+                                  "StopAndGo",
+                                  "NoData"
+                                ],
+                                "altenums": {
+                                  "upstream_byte": {
+                                    "Unknown": "0",
+                                    "WideOpen": "1",
+                                    "Moderate": "2",
+                                    "Heavy": "3",
+                                    "StopAndGo": "4",
+                                    "NoData": "5"
+                                  }
+                                }
+                              },
+                              "reading_time": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC timestamp of the reading.",
+                                "altnames": {
+                                  "json": "Time"
+                                }
+                              }
+                            },
+                            "required": [
+                              "flow_data_id",
+                              "station_name",
+                              "region",
+                              "flow_reading",
+                              "reading_time"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -381,35 +661,177 @@
                 "name": "TravelTimeRoute",
                 "$root": "#/definitions/us/wa/wsdot/traveltimes/TravelTimeRoute",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "traveltimes": {
-                    "TravelTimeRoute": {
-                      "name": "TravelTimeRoute",
-                      "type": "object",
-                      "description": "A named travel time route monitored by WSDOT with historical average and current real-time travel times in minutes.",
-                      "properties": {
-                        "travel_time_id": { "type": "string", "description": "Unique route identifier, stringified from upstream TravelTimeID.", "altnames": { "json": "TravelTimeID" } },
-                        "name": { "type": "string", "description": "Short route segment name.", "altnames": { "json": "Name" } },
-                        "description": { "type": "string", "description": "Longer description including lane type.", "altnames": { "json": "Description" } },
-                        "distance": { "type": "double", "description": "Route distance in miles.", "unit": "mi", "symbol": "mi", "altnames": { "json": "Distance" } },
-                        "average_time": { "type": "int32", "description": "Historical average travel time in minutes.", "unit": "min", "symbol": "min", "altnames": { "json": "AverageTime" } },
-                        "current_time": { "type": "int32", "description": "Current real-time travel time in minutes.", "unit": "min", "symbol": "min", "altnames": { "json": "CurrentTime" } },
-                        "time_updated": { "type": "string", "description": "ISO 8601 UTC timestamp of last update.", "altnames": { "json": "TimeUpdated" } },
-                        "start_description": { "type": ["string", "null"], "description": "Start point description." },
-                        "start_road_name": { "type": ["string", "null"], "description": "Road at start point." },
-                        "start_direction": { "type": ["string", "null"], "description": "Direction at start point." },
-                        "start_milepost": { "type": ["double", "null"], "description": "Milepost at start." },
-                        "start_latitude": { "type": "double", "description": "Start latitude in WGS84.", "unit": "deg", "symbol": "\u00b0" },
-                        "start_longitude": { "type": "double", "description": "Start longitude in WGS84.", "unit": "deg", "symbol": "\u00b0" },
-                        "end_description": { "type": ["string", "null"], "description": "End point description." },
-                        "end_road_name": { "type": ["string", "null"], "description": "Road at end point." },
-                        "end_direction": { "type": ["string", "null"], "description": "Direction at end point." },
-                        "end_milepost": { "type": ["double", "null"], "description": "Milepost at end." },
-                        "end_latitude": { "type": "double", "description": "End latitude in WGS84.", "unit": "deg", "symbol": "\u00b0" },
-                        "end_longitude": { "type": "double", "description": "End longitude in WGS84.", "unit": "deg", "symbol": "\u00b0" }
-                      },
-                      "required": ["travel_time_id", "name", "description", "distance", "average_time", "current_time", "time_updated", "start_description", "start_road_name", "start_direction", "start_milepost", "start_latitude", "start_longitude", "end_description", "end_road_name", "end_direction", "end_milepost", "end_latitude", "end_longitude"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "traveltimes": {
+                          "TravelTimeRoute": {
+                            "name": "TravelTimeRoute",
+                            "type": "object",
+                            "description": "A named travel time route monitored by WSDOT. Each route has fixed start and end points on Washington State highways with historical average and current real-time travel times.",
+                            "properties": {
+                              "travel_time_id": {
+                                "type": "string",
+                                "description": "Unique route identifier, stringified from upstream TravelTimeID.",
+                                "altnames": {
+                                  "json": "TravelTimeID"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Short route segment name.",
+                                "altnames": {
+                                  "json": "Name"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Longer description including lane type.",
+                                "altnames": {
+                                  "json": "Description"
+                                }
+                              },
+                              "distance": {
+                                "type": "double",
+                                "description": "Route distance in miles.",
+                                "unit": "mi",
+                                "symbol": "mi",
+                                "altnames": {
+                                  "json": "Distance"
+                                }
+                              },
+                              "average_time": {
+                                "type": "int32",
+                                "description": "Historical average travel time in minutes.",
+                                "unit": "min",
+                                "symbol": "min",
+                                "altnames": {
+                                  "json": "AverageTime"
+                                }
+                              },
+                              "current_time": {
+                                "type": "int32",
+                                "description": "Current real-time travel time in minutes.",
+                                "unit": "min",
+                                "symbol": "min",
+                                "altnames": {
+                                  "json": "CurrentTime"
+                                }
+                              },
+                              "time_updated": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC timestamp of last update.",
+                                "altnames": {
+                                  "json": "TimeUpdated"
+                                }
+                              },
+                              "start_description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Start point description."
+                              },
+                              "start_road_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Road at start point."
+                              },
+                              "start_direction": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Direction at start point."
+                              },
+                              "start_milepost": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Milepost at start."
+                              },
+                              "start_latitude": {
+                                "type": "double",
+                                "description": "Start latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              },
+                              "start_longitude": {
+                                "type": "double",
+                                "description": "Start longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              },
+                              "end_description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "End point description."
+                              },
+                              "end_road_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Road at end point."
+                              },
+                              "end_direction": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Direction at end point."
+                              },
+                              "end_milepost": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Milepost at end."
+                              },
+                              "end_latitude": {
+                                "type": "double",
+                                "description": "End latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              },
+                              "end_longitude": {
+                                "type": "double",
+                                "description": "End longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              }
+                            },
+                            "required": [
+                              "travel_time_id",
+                              "name",
+                              "description",
+                              "distance",
+                              "average_time",
+                              "current_time",
+                              "time_updated",
+                              "start_description",
+                              "start_road_name",
+                              "start_direction",
+                              "start_milepost",
+                              "start_latitude",
+                              "start_longitude",
+                              "end_description",
+                              "end_road_name",
+                              "end_direction",
+                              "end_milepost",
+                              "end_latitude",
+                              "end_longitude"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -432,30 +854,146 @@
                 "name": "MountainPassCondition",
                 "$root": "#/definitions/us/wa/wsdot/mountainpass/MountainPassCondition",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "mountainpass": {
-                    "MountainPassCondition": {
-                      "name": "MountainPassCondition",
-                      "type": "object",
-                      "description": "Current conditions at a Washington State mountain pass. WSDOT monitors 16 mountain passes reporting temperature, weather, road conditions, travel advisories, and directional restrictions.",
-                      "properties": {
-                        "mountain_pass_id": { "type": "string", "description": "Unique pass identifier, stringified from upstream MountainPassId.", "altnames": { "json": "MountainPassId" } },
-                        "mountain_pass_name": { "type": "string", "description": "Pass name with highway designation.", "altnames": { "json": "MountainPassName" } },
-                        "elevation_in_feet": { "type": "int32", "description": "Summit elevation in feet above sea level.", "unit": "ft", "symbol": "ft", "altnames": { "json": "ElevationInFeet" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } },
-                        "temperature_in_fahrenheit": { "type": ["int32", "null"], "description": "Temperature at the summit in Fahrenheit. Null if not reporting.", "unit": "degF", "symbol": "\u00b0F", "altnames": { "json": "TemperatureInFahrenheit" } },
-                        "weather_condition": { "type": "string", "description": "Current weather condition text. Examples: Clear, Rain, Snow, Fog.", "altnames": { "json": "WeatherCondition" } },
-                        "road_condition": { "type": "string", "description": "Road surface condition text. Examples: Dry, Wet, Compact Snow, Ice.", "altnames": { "json": "RoadCondition" } },
-                        "travel_advisory_active": { "type": "boolean", "description": "True if a travel advisory is in effect.", "altnames": { "json": "TravelAdvisoryActive" } },
-                        "restriction_one_direction": { "type": ["string", "null"], "description": "Direction for first restriction." },
-                        "restriction_one_text": { "type": ["string", "null"], "description": "First restriction text." },
-                        "restriction_two_direction": { "type": ["string", "null"], "description": "Direction for second restriction." },
-                        "restriction_two_text": { "type": ["string", "null"], "description": "Second restriction text." },
-                        "date_updated": { "type": "string", "description": "ISO 8601 UTC timestamp of last update.", "altnames": { "json": "DateUpdated" } }
-                      },
-                      "required": ["mountain_pass_id", "mountain_pass_name", "elevation_in_feet", "latitude", "longitude", "temperature_in_fahrenheit", "weather_condition", "road_condition", "travel_advisory_active", "restriction_one_direction", "restriction_one_text", "restriction_two_direction", "restriction_two_text", "date_updated"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "mountainpass": {
+                          "MountainPassCondition": {
+                            "name": "MountainPassCondition",
+                            "type": "object",
+                            "description": "Current conditions at a Washington State mountain pass including temperature, weather, road conditions, travel advisories, and directional restrictions.",
+                            "properties": {
+                              "mountain_pass_id": {
+                                "type": "string",
+                                "description": "Unique pass identifier, stringified from upstream MountainPassId.",
+                                "altnames": {
+                                  "json": "MountainPassId"
+                                }
+                              },
+                              "mountain_pass_name": {
+                                "type": "string",
+                                "description": "Pass name with highway designation.",
+                                "altnames": {
+                                  "json": "MountainPassName"
+                                }
+                              },
+                              "elevation_in_feet": {
+                                "type": "int32",
+                                "description": "Summit elevation in feet above sea level.",
+                                "unit": "ft",
+                                "symbol": "ft",
+                                "altnames": {
+                                  "json": "ElevationInFeet"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              },
+                              "temperature_in_fahrenheit": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Temperature at the summit in Fahrenheit. Null if not reporting.",
+                                "unit": "degF",
+                                "symbol": "°F",
+                                "altnames": {
+                                  "json": "TemperatureInFahrenheit"
+                                }
+                              },
+                              "weather_condition": {
+                                "type": "string",
+                                "description": "Current weather condition text. Examples: Clear, Rain, Snow, Fog.",
+                                "altnames": {
+                                  "json": "WeatherCondition"
+                                }
+                              },
+                              "road_condition": {
+                                "type": "string",
+                                "description": "Road surface condition text. Examples: Dry, Wet, Compact Snow, Ice.",
+                                "altnames": {
+                                  "json": "RoadCondition"
+                                }
+                              },
+                              "travel_advisory_active": {
+                                "type": "boolean",
+                                "description": "True if a travel advisory is in effect.",
+                                "altnames": {
+                                  "json": "TravelAdvisoryActive"
+                                }
+                              },
+                              "restriction_one_direction": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Direction for first restriction."
+                              },
+                              "restriction_one_text": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "First restriction text."
+                              },
+                              "restriction_two_direction": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Direction for second restriction."
+                              },
+                              "restriction_two_text": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Second restriction text."
+                              },
+                              "date_updated": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC timestamp of last update.",
+                                "altnames": {
+                                  "json": "DateUpdated"
+                                }
+                              }
+                            },
+                            "required": [
+                              "mountain_pass_id",
+                              "mountain_pass_name",
+                              "elevation_in_feet",
+                              "latitude",
+                              "longitude",
+                              "temperature_in_fahrenheit",
+                              "weather_condition",
+                              "road_condition",
+                              "travel_advisory_active",
+                              "restriction_one_direction",
+                              "restriction_one_text",
+                              "restriction_two_direction",
+                              "restriction_two_text",
+                              "date_updated"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -478,20 +1016,59 @@
                 "name": "WeatherStation",
                 "$root": "#/definitions/us/wa/wsdot/weather/WeatherStation",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "weather": {
-                    "WeatherStation": {
-                      "name": "WeatherStation",
-                      "type": "object",
-                      "description": "Metadata for a WSDOT RWIS station.",
-                      "properties": {
-                        "station_id": { "type": "string", "description": "Station identifier from upstream StationCode.", "altnames": { "json": "StationCode" } },
-                        "station_name": { "type": "string", "description": "Station name with highway and milepost.", "altnames": { "json": "StationName" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } }
-                      },
-                      "required": ["station_id", "station_name", "latitude", "longitude"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "weather": {
+                          "WeatherStation": {
+                            "name": "WeatherStation",
+                            "type": "object",
+                            "description": "Metadata for a WSDOT road weather information system (RWIS) station. WSDOT operates approximately 134 stations across Washington State highways.",
+                            "properties": {
+                              "station_id": {
+                                "type": "string",
+                                "description": "Station identifier from upstream StationCode.",
+                                "altnames": {
+                                  "json": "StationCode"
+                                }
+                              },
+                              "station_name": {
+                                "type": "string",
+                                "description": "Station name with highway and milepost.",
+                                "altnames": {
+                                  "json": "StationName"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              }
+                            },
+                            "required": [
+                              "station_id",
+                              "station_name",
+                              "latitude",
+                              "longitude"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -510,31 +1087,191 @@
                 "name": "WeatherReading",
                 "$root": "#/definitions/us/wa/wsdot/weather/WeatherReading",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "weather": {
-                    "WeatherReading": {
-                      "name": "WeatherReading",
-                      "type": "object",
-                      "description": "A current weather reading from a WSDOT RWIS station.",
-                      "properties": {
-                        "station_id": { "type": "string", "description": "Station identifier from upstream StationID.", "altnames": { "json": "StationID" } },
-                        "station_name": { "type": "string", "description": "Station name.", "altnames": { "json": "StationName" } },
-                        "reading_time": { "type": "string", "description": "ISO 8601 UTC timestamp.", "altnames": { "json": "ReadingTime" } },
-                        "temperature_in_fahrenheit": { "type": ["double", "null"], "description": "Air temperature in Fahrenheit.", "unit": "degF", "symbol": "\u00b0F", "altnames": { "json": "TemperatureInFahrenheit" } },
-                        "precipitation_in_inches": { "type": ["double", "null"], "description": "Precipitation in inches.", "unit": "in", "symbol": "in", "altnames": { "json": "PrecipitationInInches" } },
-                        "wind_speed_in_mph": { "type": ["double", "null"], "description": "Wind speed in mph.", "unit": "mi/h", "symbol": "mph", "altnames": { "json": "WindSpeedInMPH" } },
-                        "wind_gust_speed_in_mph": { "type": ["double", "null"], "description": "Wind gust speed in mph.", "unit": "mi/h", "symbol": "mph", "altnames": { "json": "WindGustSpeedInMPH" } },
-                        "wind_direction": { "type": ["int32", "null"], "description": "Wind direction in degrees from true north.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "WindDirection" } },
-                        "wind_direction_cardinal": { "type": ["string", "null"], "description": "Wind direction as cardinal abbreviation.", "altnames": { "json": "WindDirectionCardinal" } },
-                        "barometric_pressure": { "type": ["double", "null"], "description": "Barometric pressure in hPa.", "unit": "hPa", "symbol": "hPa", "altnames": { "json": "BarometricPressure" } },
-                        "relative_humidity": { "type": ["int32", "null"], "description": "Relative humidity percentage.", "unit": "%", "symbol": "%", "altnames": { "json": "RelativeHumidity" } },
-                        "visibility": { "type": ["double", "null"], "description": "Visibility distance.", "altnames": { "json": "Visibility" } },
-                        "sky_coverage": { "type": ["string", "null"], "description": "Sky coverage description.", "altnames": { "json": "SkyCoverage" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } }
-                      },
-                      "required": ["station_id", "station_name", "reading_time", "temperature_in_fahrenheit", "precipitation_in_inches", "wind_speed_in_mph", "wind_gust_speed_in_mph", "wind_direction", "wind_direction_cardinal", "barometric_pressure", "relative_humidity", "visibility", "sky_coverage", "latitude", "longitude"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "weather": {
+                          "WeatherReading": {
+                            "name": "WeatherReading",
+                            "type": "object",
+                            "description": "A current weather reading from a WSDOT road weather station including temperature, wind, precipitation, pressure, humidity, visibility, and sky coverage.",
+                            "properties": {
+                              "station_id": {
+                                "type": "string",
+                                "description": "Station identifier from upstream StationID.",
+                                "altnames": {
+                                  "json": "StationID"
+                                }
+                              },
+                              "station_name": {
+                                "type": "string",
+                                "description": "Station name.",
+                                "altnames": {
+                                  "json": "StationName"
+                                }
+                              },
+                              "reading_time": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC timestamp.",
+                                "altnames": {
+                                  "json": "ReadingTime"
+                                }
+                              },
+                              "temperature_in_fahrenheit": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Air temperature in Fahrenheit.",
+                                "unit": "degF",
+                                "symbol": "°F",
+                                "altnames": {
+                                  "json": "TemperatureInFahrenheit"
+                                }
+                              },
+                              "precipitation_in_inches": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Precipitation in inches.",
+                                "unit": "in",
+                                "symbol": "in",
+                                "altnames": {
+                                  "json": "PrecipitationInInches"
+                                }
+                              },
+                              "wind_speed_in_mph": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Wind speed in mph.",
+                                "unit": "mi/h",
+                                "symbol": "mph",
+                                "altnames": {
+                                  "json": "WindSpeedInMPH"
+                                }
+                              },
+                              "wind_gust_speed_in_mph": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Wind gust speed in mph.",
+                                "unit": "mi/h",
+                                "symbol": "mph",
+                                "altnames": {
+                                  "json": "WindGustSpeedInMPH"
+                                }
+                              },
+                              "wind_direction": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Wind direction in degrees from true north.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "WindDirection"
+                                }
+                              },
+                              "wind_direction_cardinal": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Wind direction as cardinal abbreviation.",
+                                "altnames": {
+                                  "json": "WindDirectionCardinal"
+                                }
+                              },
+                              "barometric_pressure": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Barometric pressure in hPa.",
+                                "unit": "hPa",
+                                "symbol": "hPa",
+                                "altnames": {
+                                  "json": "BarometricPressure"
+                                }
+                              },
+                              "relative_humidity": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Relative humidity percentage.",
+                                "unit": "%",
+                                "symbol": "%",
+                                "altnames": {
+                                  "json": "RelativeHumidity"
+                                }
+                              },
+                              "visibility": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Visibility distance.",
+                                "altnames": {
+                                  "json": "Visibility"
+                                }
+                              },
+                              "sky_coverage": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Sky coverage description.",
+                                "altnames": {
+                                  "json": "SkyCoverage"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              }
+                            },
+                            "required": [
+                              "station_id",
+                              "station_name",
+                              "reading_time",
+                              "temperature_in_fahrenheit",
+                              "precipitation_in_inches",
+                              "wind_speed_in_mph",
+                              "wind_gust_speed_in_mph",
+                              "wind_direction",
+                              "wind_direction_cardinal",
+                              "barometric_pressure",
+                              "relative_humidity",
+                              "visibility",
+                              "sky_coverage",
+                              "latitude",
+                              "longitude"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -557,30 +1294,146 @@
                 "name": "TollRate",
                 "$root": "#/definitions/us/wa/wsdot/tolls/TollRate",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "tolls": {
-                    "TollRate": {
-                      "name": "TollRate",
-                      "type": "object",
-                      "description": "Current toll rate for a WSDOT tolled route segment with dynamic pricing.",
-                      "properties": {
-                        "trip_name": { "type": "string", "description": "Tolled route segment identifier.", "altnames": { "json": "TripName" } },
-                        "state_route": { "type": "string", "description": "State route number.", "altnames": { "json": "StateRoute" } },
-                        "travel_direction": { "type": "string", "description": "Travel direction: N, S, E, W.", "altnames": { "json": "TravelDirection" } },
-                        "current_toll": { "type": "int32", "description": "Current toll in cents.", "altnames": { "json": "CurrentToll" } },
-                        "current_message": { "type": ["string", "null"], "description": "Optional status message.", "altnames": { "json": "CurrentMessage" } },
-                        "time_updated": { "type": "string", "description": "ISO 8601 UTC timestamp.", "altnames": { "json": "TimeUpdated" } },
-                        "start_location_name": { "type": "string", "description": "Start location name.", "altnames": { "json": "StartLocationName" } },
-                        "start_latitude": { "type": "double", "description": "Start latitude.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "StartLatitude" } },
-                        "start_longitude": { "type": "double", "description": "Start longitude.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "StartLongitude" } },
-                        "start_milepost": { "type": "double", "description": "Start milepost.", "altnames": { "json": "StartMilepost" } },
-                        "end_location_name": { "type": "string", "description": "End location name.", "altnames": { "json": "EndLocationName" } },
-                        "end_latitude": { "type": "double", "description": "End latitude.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "EndLatitude" } },
-                        "end_longitude": { "type": "double", "description": "End longitude.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "EndLongitude" } },
-                        "end_milepost": { "type": "double", "description": "End milepost.", "altnames": { "json": "EndMilepost" } }
-                      },
-                      "required": ["trip_name", "state_route", "travel_direction", "current_toll", "current_message", "time_updated", "start_location_name", "start_latitude", "start_longitude", "start_milepost", "end_location_name", "end_latitude", "end_longitude", "end_milepost"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "tolls": {
+                          "TollRate": {
+                            "name": "TollRate",
+                            "type": "object",
+                            "description": "Current toll rate for a WSDOT tolled route segment. WSDOT operates dynamic tolling on SR 99, I-405, and SR 167.",
+                            "properties": {
+                              "trip_name": {
+                                "type": "string",
+                                "description": "Tolled route segment identifier.",
+                                "altnames": {
+                                  "json": "TripName"
+                                }
+                              },
+                              "state_route": {
+                                "type": "string",
+                                "description": "State route number.",
+                                "altnames": {
+                                  "json": "StateRoute"
+                                }
+                              },
+                              "travel_direction": {
+                                "type": "string",
+                                "description": "Travel direction: N, S, E, W.",
+                                "altnames": {
+                                  "json": "TravelDirection"
+                                }
+                              },
+                              "current_toll": {
+                                "type": "int32",
+                                "description": "Current toll in cents.",
+                                "altnames": {
+                                  "json": "CurrentToll"
+                                }
+                              },
+                              "current_message": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Optional status message.",
+                                "altnames": {
+                                  "json": "CurrentMessage"
+                                }
+                              },
+                              "time_updated": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC timestamp.",
+                                "altnames": {
+                                  "json": "TimeUpdated"
+                                }
+                              },
+                              "start_location_name": {
+                                "type": "string",
+                                "description": "Start location name.",
+                                "altnames": {
+                                  "json": "StartLocationName"
+                                }
+                              },
+                              "start_latitude": {
+                                "type": "double",
+                                "description": "Start latitude.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "StartLatitude"
+                                }
+                              },
+                              "start_longitude": {
+                                "type": "double",
+                                "description": "Start longitude.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "StartLongitude"
+                                }
+                              },
+                              "start_milepost": {
+                                "type": "double",
+                                "description": "Start milepost.",
+                                "altnames": {
+                                  "json": "StartMilepost"
+                                }
+                              },
+                              "end_location_name": {
+                                "type": "string",
+                                "description": "End location name.",
+                                "altnames": {
+                                  "json": "EndLocationName"
+                                }
+                              },
+                              "end_latitude": {
+                                "type": "double",
+                                "description": "End latitude.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "EndLatitude"
+                                }
+                              },
+                              "end_longitude": {
+                                "type": "double",
+                                "description": "End longitude.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "EndLongitude"
+                                }
+                              },
+                              "end_milepost": {
+                                "type": "double",
+                                "description": "End milepost.",
+                                "altnames": {
+                                  "json": "EndMilepost"
+                                }
+                              }
+                            },
+                            "required": [
+                              "trip_name",
+                              "state_route",
+                              "travel_direction",
+                              "current_toll",
+                              "current_message",
+                              "time_updated",
+                              "start_location_name",
+                              "start_latitude",
+                              "start_longitude",
+                              "start_milepost",
+                              "end_location_name",
+                              "end_latitude",
+                              "end_longitude",
+                              "end_milepost"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -603,39 +1456,266 @@
                 "name": "CommercialVehicleRestriction",
                 "$root": "#/definitions/us/wa/wsdot/cvrestrictions/CommercialVehicleRestriction",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "cvrestrictions": {
-                    "CommercialVehicleRestriction": {
-                      "name": "CommercialVehicleRestriction",
-                      "type": "object",
-                      "description": "A commercial vehicle restriction on a Washington State highway bridge or road segment.",
-                      "properties": {
-                        "state_route_id": { "type": "string", "description": "State route identifier, first part of composite key.", "altnames": { "json": "StateRouteID" } },
-                        "bridge_number": { "type": "string", "description": "Bridge or structure number, second part of composite key.", "altnames": { "json": "BridgeNumber" } },
-                        "bridge_name": { "type": ["string", "null"], "description": "Bridge or structure name.", "altnames": { "json": "BridgeName" } },
-                        "location_name": { "type": ["string", "null"], "description": "Location relative to landmarks.", "altnames": { "json": "LocationName" } },
-                        "location_description": { "type": ["string", "null"], "description": "Detailed location description.", "altnames": { "json": "LocationDescription" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } },
-                        "state": { "type": ["string", "null"], "description": "State abbreviation, typically WA.", "altnames": { "json": "State" } },
-                        "restriction_type": { "type": ["string", "null"], "description": "Type: BridgeRestriction, RoadRestriction.", "altnames": { "json": "RestrictionType" } },
-                        "vehicle_type": { "type": ["string", "null"], "description": "Affected vehicle type.", "altnames": { "json": "VehicleType" } },
-                        "restriction_weight_in_pounds": { "type": ["int32", "null"], "description": "Axle weight limit in pounds.", "unit": "lb", "symbol": "lbs", "altnames": { "json": "RestrictionWeightInPounds" } },
-                        "maximum_gross_vehicle_weight_in_pounds": { "type": ["int32", "null"], "description": "GVW limit in pounds.", "unit": "lb", "symbol": "lbs", "altnames": { "json": "MaximumGrossVehicleWeightInPounds" } },
-                        "restriction_height_in_inches": { "type": ["int32", "null"], "description": "Height limit in inches.", "unit": "in", "symbol": "in", "altnames": { "json": "RestrictionHeightInInches" } },
-                        "restriction_width_in_inches": { "type": ["int32", "null"], "description": "Width limit in inches.", "unit": "in", "symbol": "in", "altnames": { "json": "RestrictionWidthInInches" } },
-                        "restriction_length_in_inches": { "type": ["int32", "null"], "description": "Length limit in inches.", "unit": "in", "symbol": "in", "altnames": { "json": "RestrictionLengthInInches" } },
-                        "is_permanent_restriction": { "type": "boolean", "description": "True if permanent.", "altnames": { "json": "IsPermanentRestriction" } },
-                        "is_warning": { "type": "boolean", "description": "True if warning only.", "altnames": { "json": "IsWarning" } },
-                        "is_detour_available": { "type": "boolean", "description": "True if detour exists.", "altnames": { "json": "IsDetourAvailable" } },
-                        "is_exceptions_allowed": { "type": "boolean", "description": "True if permits available.", "altnames": { "json": "IsExceptionsAllowed" } },
-                        "restriction_comment": { "type": ["string", "null"], "description": "Additional details.", "altnames": { "json": "RestrictionComment" } },
-                        "date_posted": { "type": ["string", "null"], "description": "ISO 8601 UTC date posted.", "altnames": { "json": "DatePosted" } },
-                        "date_effective": { "type": ["string", "null"], "description": "ISO 8601 UTC date effective.", "altnames": { "json": "DateEffective" } },
-                        "date_expires": { "type": ["string", "null"], "description": "ISO 8601 UTC date expires.", "altnames": { "json": "DateExpires" } }
-                      },
-                      "required": ["state_route_id", "bridge_number", "bridge_name", "location_name", "location_description", "latitude", "longitude", "state", "restriction_type", "vehicle_type", "restriction_weight_in_pounds", "maximum_gross_vehicle_weight_in_pounds", "restriction_height_in_inches", "restriction_width_in_inches", "restriction_length_in_inches", "is_permanent_restriction", "is_warning", "is_detour_available", "is_exceptions_allowed", "restriction_comment", "date_posted", "date_effective", "date_expires"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "cvrestrictions": {
+                          "CommercialVehicleRestriction": {
+                            "name": "CommercialVehicleRestriction",
+                            "type": "object",
+                            "description": "A commercial vehicle restriction on a Washington State highway bridge or road segment. Restrictions limit vehicle weight, height, length, or width.",
+                            "properties": {
+                              "state_route_id": {
+                                "type": "string",
+                                "description": "State route identifier, first part of composite key.",
+                                "altnames": {
+                                  "json": "StateRouteID"
+                                }
+                              },
+                              "bridge_number": {
+                                "type": "string",
+                                "description": "Bridge or structure number, second part of composite key.",
+                                "altnames": {
+                                  "json": "BridgeNumber"
+                                }
+                              },
+                              "bridge_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Bridge or structure name.",
+                                "altnames": {
+                                  "json": "BridgeName"
+                                }
+                              },
+                              "location_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Location relative to landmarks.",
+                                "altnames": {
+                                  "json": "LocationName"
+                                }
+                              },
+                              "location_description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Detailed location description.",
+                                "altnames": {
+                                  "json": "LocationDescription"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              },
+                              "state": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "State abbreviation, typically WA.",
+                                "altnames": {
+                                  "json": "State"
+                                }
+                              },
+                              "restriction_type": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Type: BridgeRestriction, RoadRestriction.",
+                                "altnames": {
+                                  "json": "RestrictionType"
+                                }
+                              },
+                              "vehicle_type": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Affected vehicle type.",
+                                "altnames": {
+                                  "json": "VehicleType"
+                                }
+                              },
+                              "restriction_weight_in_pounds": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Axle weight limit in pounds.",
+                                "unit": "lb",
+                                "symbol": "lbs",
+                                "altnames": {
+                                  "json": "RestrictionWeightInPounds"
+                                }
+                              },
+                              "maximum_gross_vehicle_weight_in_pounds": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "GVW limit in pounds.",
+                                "unit": "lb",
+                                "symbol": "lbs",
+                                "altnames": {
+                                  "json": "MaximumGrossVehicleWeightInPounds"
+                                }
+                              },
+                              "restriction_height_in_inches": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Height limit in inches.",
+                                "unit": "in",
+                                "symbol": "in",
+                                "altnames": {
+                                  "json": "RestrictionHeightInInches"
+                                }
+                              },
+                              "restriction_width_in_inches": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Width limit in inches.",
+                                "unit": "in",
+                                "symbol": "in",
+                                "altnames": {
+                                  "json": "RestrictionWidthInInches"
+                                }
+                              },
+                              "restriction_length_in_inches": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Length limit in inches.",
+                                "unit": "in",
+                                "symbol": "in",
+                                "altnames": {
+                                  "json": "RestrictionLengthInInches"
+                                }
+                              },
+                              "is_permanent_restriction": {
+                                "type": "boolean",
+                                "description": "True if permanent.",
+                                "altnames": {
+                                  "json": "IsPermanentRestriction"
+                                }
+                              },
+                              "is_warning": {
+                                "type": "boolean",
+                                "description": "True if warning only.",
+                                "altnames": {
+                                  "json": "IsWarning"
+                                }
+                              },
+                              "is_detour_available": {
+                                "type": "boolean",
+                                "description": "True if detour exists.",
+                                "altnames": {
+                                  "json": "IsDetourAvailable"
+                                }
+                              },
+                              "is_exceptions_allowed": {
+                                "type": "boolean",
+                                "description": "True if permits available.",
+                                "altnames": {
+                                  "json": "IsExceptionsAllowed"
+                                }
+                              },
+                              "restriction_comment": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Additional details.",
+                                "altnames": {
+                                  "json": "RestrictionComment"
+                                }
+                              },
+                              "date_posted": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC date posted.",
+                                "altnames": {
+                                  "json": "DatePosted"
+                                }
+                              },
+                              "date_effective": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC date effective.",
+                                "altnames": {
+                                  "json": "DateEffective"
+                                }
+                              },
+                              "date_expires": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC date expires.",
+                                "altnames": {
+                                  "json": "DateExpires"
+                                }
+                              }
+                            },
+                            "required": [
+                              "state_route_id",
+                              "bridge_number",
+                              "bridge_name",
+                              "location_name",
+                              "location_description",
+                              "latitude",
+                              "longitude",
+                              "state",
+                              "restriction_type",
+                              "vehicle_type",
+                              "restriction_weight_in_pounds",
+                              "maximum_gross_vehicle_weight_in_pounds",
+                              "restriction_height_in_inches",
+                              "restriction_width_in_inches",
+                              "restriction_length_in_inches",
+                              "is_permanent_restriction",
+                              "is_warning",
+                              "is_detour_available",
+                              "is_exceptions_allowed",
+                              "restriction_comment",
+                              "date_posted",
+                              "date_effective",
+                              "date_expires"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -658,23 +1738,82 @@
                 "name": "BorderCrossing",
                 "$root": "#/definitions/us/wa/wsdot/border/BorderCrossing",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "border": {
-                    "BorderCrossing": {
-                      "name": "BorderCrossing",
-                      "type": "object",
-                      "description": "US-Canada border crossing wait time in Washington State.",
-                      "properties": {
-                        "crossing_name": { "type": "string", "description": "Crossing lane identifier.", "altnames": { "json": "CrossingName" } },
-                        "wait_time": { "type": ["int32", "null"], "description": "Wait time in minutes.", "unit": "min", "symbol": "min", "altnames": { "json": "WaitTime" } },
-                        "time": { "type": "string", "description": "ISO 8601 UTC measurement timestamp.", "altnames": { "json": "Time" } },
-                        "description": { "type": ["string", "null"], "description": "Lane description." },
-                        "road_name": { "type": ["string", "null"], "description": "Road designation." },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0" },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0" }
-                      },
-                      "required": ["crossing_name", "wait_time", "time", "description", "road_name", "latitude", "longitude"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "border": {
+                          "BorderCrossing": {
+                            "name": "BorderCrossing",
+                            "type": "object",
+                            "description": "Current wait time at a US-Canada border crossing lane in Washington State. Wait times are in minutes, updated approximately every 5 minutes.",
+                            "properties": {
+                              "crossing_name": {
+                                "type": "string",
+                                "description": "Crossing lane identifier.",
+                                "altnames": {
+                                  "json": "CrossingName"
+                                }
+                              },
+                              "wait_time": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Wait time in minutes.",
+                                "unit": "min",
+                                "symbol": "min",
+                                "altnames": {
+                                  "json": "WaitTime"
+                                }
+                              },
+                              "time": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC measurement timestamp.",
+                                "altnames": {
+                                  "json": "Time"
+                                }
+                              },
+                              "description": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Lane description."
+                              },
+                              "road_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Road designation."
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°"
+                              }
+                            },
+                            "required": [
+                              "crossing_name",
+                              "wait_time",
+                              "time",
+                              "description",
+                              "road_name",
+                              "latitude",
+                              "longitude"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -697,37 +1836,238 @@
                 "name": "VesselLocation",
                 "$root": "#/definitions/us/wa/wsdot/ferries/VesselLocation",
                 "definitions": {
-                  "us": { "wa": { "wsdot": { "ferries": {
-                    "VesselLocation": {
-                      "name": "VesselLocation",
-                      "type": "object",
-                      "description": "Real-time location and status of a Washington State Ferries vessel.",
-                      "properties": {
-                        "vessel_id": { "type": "string", "description": "Vessel identifier, stringified from upstream VesselID.", "altnames": { "json": "VesselID" } },
-                        "vessel_name": { "type": "string", "description": "Ferry vessel name.", "altnames": { "json": "VesselName" } },
-                        "mmsi": { "type": ["int32", "null"], "description": "Maritime Mobile Service Identity for AIS.", "altnames": { "json": "Mmsi" } },
-                        "in_service": { "type": "boolean", "description": "True if in active service.", "altnames": { "json": "InService" } },
-                        "at_dock": { "type": "boolean", "description": "True if docked.", "altnames": { "json": "AtDock" } },
-                        "latitude": { "type": "double", "description": "Latitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Latitude" } },
-                        "longitude": { "type": "double", "description": "Longitude in WGS84.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Longitude" } },
-                        "speed": { "type": ["double", "null"], "description": "Speed in knots.", "unit": "kn", "symbol": "kn", "altnames": { "json": "Speed" } },
-                        "heading": { "type": ["int32", "null"], "description": "Heading in degrees.", "unit": "deg", "symbol": "\u00b0", "altnames": { "json": "Heading" } },
-                        "departing_terminal_id": { "type": ["int32", "null"], "description": "Departure terminal ID.", "altnames": { "json": "DepartingTerminalID" } },
-                        "departing_terminal_name": { "type": ["string", "null"], "description": "Departure terminal name.", "altnames": { "json": "DepartingTerminalName" } },
-                        "departing_terminal_abbrev": { "type": ["string", "null"], "description": "Departure terminal abbreviation.", "altnames": { "json": "DepartingTerminalAbbrev" } },
-                        "arriving_terminal_id": { "type": ["int32", "null"], "description": "Arrival terminal ID.", "altnames": { "json": "ArrivingTerminalID" } },
-                        "arriving_terminal_name": { "type": ["string", "null"], "description": "Arrival terminal name.", "altnames": { "json": "ArrivingTerminalName" } },
-                        "arriving_terminal_abbrev": { "type": ["string", "null"], "description": "Arrival terminal abbreviation.", "altnames": { "json": "ArrivingTerminalAbbrev" } },
-                        "scheduled_departure": { "type": ["string", "null"], "description": "ISO 8601 UTC scheduled departure.", "altnames": { "json": "ScheduledDeparture" } },
-                        "left_dock": { "type": ["string", "null"], "description": "ISO 8601 UTC actual departure.", "altnames": { "json": "LeftDock" } },
-                        "eta": { "type": ["string", "null"], "description": "ISO 8601 UTC estimated arrival.", "altnames": { "json": "Eta" } },
-                        "eta_basis": { "type": ["string", "null"], "description": "ETA calculation description.", "altnames": { "json": "EtaBasis" } },
-                        "route_abbreviation": { "type": ["string", "null"], "description": "Current route abbreviation." },
-                        "timestamp": { "type": "string", "description": "ISO 8601 UTC position timestamp.", "altnames": { "json": "TimeStamp" } }
-                      },
-                      "required": ["vessel_id", "vessel_name", "mmsi", "in_service", "at_dock", "latitude", "longitude", "speed", "heading", "departing_terminal_id", "departing_terminal_name", "departing_terminal_abbrev", "arriving_terminal_id", "arriving_terminal_name", "arriving_terminal_abbrev", "scheduled_departure", "left_dock", "eta", "eta_basis", "route_abbreviation", "timestamp"]
+                  "us": {
+                    "wa": {
+                      "wsdot": {
+                        "ferries": {
+                          "VesselLocation": {
+                            "name": "VesselLocation",
+                            "type": "object",
+                            "description": "Real-time location and status of a Washington State Ferries vessel. WSF operates approximately 21 vessels across Puget Sound routes.",
+                            "properties": {
+                              "vessel_id": {
+                                "type": "string",
+                                "description": "Vessel identifier, stringified from upstream VesselID.",
+                                "altnames": {
+                                  "json": "VesselID"
+                                }
+                              },
+                              "vessel_name": {
+                                "type": "string",
+                                "description": "Ferry vessel name.",
+                                "altnames": {
+                                  "json": "VesselName"
+                                }
+                              },
+                              "mmsi": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Maritime Mobile Service Identity for AIS.",
+                                "altnames": {
+                                  "json": "Mmsi"
+                                }
+                              },
+                              "in_service": {
+                                "type": "boolean",
+                                "description": "True if in active service.",
+                                "altnames": {
+                                  "json": "InService"
+                                }
+                              },
+                              "at_dock": {
+                                "type": "boolean",
+                                "description": "True if docked.",
+                                "altnames": {
+                                  "json": "AtDock"
+                                }
+                              },
+                              "latitude": {
+                                "type": "double",
+                                "description": "Latitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Latitude"
+                                }
+                              },
+                              "longitude": {
+                                "type": "double",
+                                "description": "Longitude in WGS84.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Longitude"
+                                }
+                              },
+                              "speed": {
+                                "type": [
+                                  "double",
+                                  "null"
+                                ],
+                                "description": "Speed in knots.",
+                                "unit": "kn",
+                                "symbol": "kn",
+                                "altnames": {
+                                  "json": "Speed"
+                                }
+                              },
+                              "heading": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Heading in degrees.",
+                                "unit": "deg",
+                                "symbol": "°",
+                                "altnames": {
+                                  "json": "Heading"
+                                }
+                              },
+                              "departing_terminal_id": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Departure terminal ID.",
+                                "altnames": {
+                                  "json": "DepartingTerminalID"
+                                }
+                              },
+                              "departing_terminal_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Departure terminal name.",
+                                "altnames": {
+                                  "json": "DepartingTerminalName"
+                                }
+                              },
+                              "departing_terminal_abbrev": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Departure terminal abbreviation.",
+                                "altnames": {
+                                  "json": "DepartingTerminalAbbrev"
+                                }
+                              },
+                              "arriving_terminal_id": {
+                                "type": [
+                                  "int32",
+                                  "null"
+                                ],
+                                "description": "Arrival terminal ID.",
+                                "altnames": {
+                                  "json": "ArrivingTerminalID"
+                                }
+                              },
+                              "arriving_terminal_name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Arrival terminal name.",
+                                "altnames": {
+                                  "json": "ArrivingTerminalName"
+                                }
+                              },
+                              "arriving_terminal_abbrev": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Arrival terminal abbreviation.",
+                                "altnames": {
+                                  "json": "ArrivingTerminalAbbrev"
+                                }
+                              },
+                              "scheduled_departure": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC scheduled departure.",
+                                "altnames": {
+                                  "json": "ScheduledDeparture"
+                                }
+                              },
+                              "left_dock": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC actual departure.",
+                                "altnames": {
+                                  "json": "LeftDock"
+                                }
+                              },
+                              "eta": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ISO 8601 UTC estimated arrival.",
+                                "altnames": {
+                                  "json": "Eta"
+                                }
+                              },
+                              "eta_basis": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "ETA calculation description.",
+                                "altnames": {
+                                  "json": "EtaBasis"
+                                }
+                              },
+                              "route_abbreviation": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "Current route abbreviation."
+                              },
+                              "timestamp": {
+                                "type": "string",
+                                "description": "ISO 8601 UTC position timestamp.",
+                                "altnames": {
+                                  "json": "TimeStamp"
+                                }
+                              }
+                            },
+                            "required": [
+                              "vessel_id",
+                              "vessel_name",
+                              "mmsi",
+                              "in_service",
+                              "at_dock",
+                              "latitude",
+                              "longitude",
+                              "speed",
+                              "heading",
+                              "departing_terminal_id",
+                              "departing_terminal_name",
+                              "departing_terminal_abbrev",
+                              "arriving_terminal_id",
+                              "arriving_terminal_name",
+                              "arriving_terminal_abbrev",
+                              "scheduled_departure",
+                              "left_dock",
+                              "eta",
+                              "eta_basis",
+                              "route_abbreviation",
+                              "timestamp"
+                            ]
+                          }
+                        }
+                      }
                     }
-                  }}}}
+                  }
                 }
               }
             }
@@ -739,11 +2079,105 @@
       "schemas": {
         "us.wa.wsdot.traffic.TrafficFlowStation": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "TrafficFlowStation", "namespace": "us.wa.wsdot.traffic", "doc": "Traffic flow sensor station metadata.", "fields": [{"name": "flow_data_id", "type": "string"}, {"name": "station_name", "type": "string"}, {"name": "region", "type": "string"}, {"name": "description", "type": ["null", "string"], "default": null}, {"name": "road_name", "type": "string"}, {"name": "direction", "type": ["null", "string"], "default": null}, {"name": "milepost", "type": ["null", "double"], "default": null}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "TrafficFlowStation",
+                "namespace": "us.wa.wsdot.traffic",
+                "doc": "Traffic flow sensor station metadata.",
+                "fields": [
+                  {
+                    "name": "flow_data_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "station_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "region",
+                    "type": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "road_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "direction",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "milepost",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  }
+                ],
+                "description": "A reference record from Washington State Department of Transportation for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+              }
+            }
+          }
         },
         "us.wa.wsdot.traffic.TrafficFlowReading": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "TrafficFlowReading", "namespace": "us.wa.wsdot.traffic", "doc": "Traffic flow reading.", "fields": [{"name": "flow_data_id", "type": "string"}, {"name": "station_name", "type": "string"}, {"name": "region", "type": "string"}, {"name": "flow_reading", "type": "string"}, {"name": "reading_time", "type": "string"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "TrafficFlowReading",
+                "namespace": "us.wa.wsdot.traffic",
+                "doc": "Traffic flow reading.",
+                "fields": [
+                  {
+                    "name": "flow_data_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "station_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "region",
+                    "type": "string"
+                  },
+                  {
+                    "name": "flow_reading",
+                    "type": "string"
+                  },
+                  {
+                    "name": "reading_time",
+                    "type": "string"
+                  }
+                ],
+                "description": "A current transport measurement or status update from Washington State Department of Transportation. It carries traffic, travel, bridge, toll, pass, ferry, and border-wait updates when the upstream feed reports a new or refreshed value."
+              }
+            }
+          }
         }
       }
     },
@@ -751,7 +2185,128 @@
       "schemas": {
         "us.wa.wsdot.traveltimes.TravelTimeRoute": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "TravelTimeRoute", "namespace": "us.wa.wsdot.traveltimes", "doc": "Travel time route.", "fields": [{"name": "travel_time_id", "type": "string"}, {"name": "name", "type": "string"}, {"name": "description", "type": "string"}, {"name": "distance", "type": "double"}, {"name": "average_time", "type": "int"}, {"name": "current_time", "type": "int"}, {"name": "time_updated", "type": "string"}, {"name": "start_description", "type": ["null", "string"], "default": null}, {"name": "start_road_name", "type": ["null", "string"], "default": null}, {"name": "start_direction", "type": ["null", "string"], "default": null}, {"name": "start_milepost", "type": ["null", "double"], "default": null}, {"name": "start_latitude", "type": "double"}, {"name": "start_longitude", "type": "double"}, {"name": "end_description", "type": ["null", "string"], "default": null}, {"name": "end_road_name", "type": ["null", "string"], "default": null}, {"name": "end_direction", "type": ["null", "string"], "default": null}, {"name": "end_milepost", "type": ["null", "double"], "default": null}, {"name": "end_latitude", "type": "double"}, {"name": "end_longitude", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "TravelTimeRoute",
+                "namespace": "us.wa.wsdot.traveltimes",
+                "doc": "Travel time route.",
+                "fields": [
+                  {
+                    "name": "travel_time_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": "string"
+                  },
+                  {
+                    "name": "distance",
+                    "type": "double"
+                  },
+                  {
+                    "name": "average_time",
+                    "type": "int"
+                  },
+                  {
+                    "name": "current_time",
+                    "type": "int"
+                  },
+                  {
+                    "name": "time_updated",
+                    "type": "string"
+                  },
+                  {
+                    "name": "start_description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "start_road_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "start_direction",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "start_milepost",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "start_latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "start_longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "end_description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "end_road_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "end_direction",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "end_milepost",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "end_latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "end_longitude",
+                    "type": "double"
+                  }
+                ],
+                "description": "A reference record from Washington State Department of Transportation for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+              }
+            }
+          }
         }
       }
     },
@@ -759,7 +2314,96 @@
       "schemas": {
         "us.wa.wsdot.mountainpass.MountainPassCondition": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "MountainPassCondition", "namespace": "us.wa.wsdot.mountainpass", "doc": "Mountain pass conditions.", "fields": [{"name": "mountain_pass_id", "type": "string"}, {"name": "mountain_pass_name", "type": "string"}, {"name": "elevation_in_feet", "type": "int"}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}, {"name": "temperature_in_fahrenheit", "type": ["null", "int"], "default": null}, {"name": "weather_condition", "type": "string"}, {"name": "road_condition", "type": "string"}, {"name": "travel_advisory_active", "type": "boolean"}, {"name": "restriction_one_direction", "type": ["null", "string"], "default": null}, {"name": "restriction_one_text", "type": ["null", "string"], "default": null}, {"name": "restriction_two_direction", "type": ["null", "string"], "default": null}, {"name": "restriction_two_text", "type": ["null", "string"], "default": null}, {"name": "date_updated", "type": "string"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "MountainPassCondition",
+                "namespace": "us.wa.wsdot.mountainpass",
+                "doc": "Mountain pass conditions.",
+                "fields": [
+                  {
+                    "name": "mountain_pass_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "mountain_pass_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "elevation_in_feet",
+                    "type": "int"
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "temperature_in_fahrenheit",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "weather_condition",
+                    "type": "string"
+                  },
+                  {
+                    "name": "road_condition",
+                    "type": "string"
+                  },
+                  {
+                    "name": "travel_advisory_active",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "restriction_one_direction",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_one_text",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_two_direction",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_two_text",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "date_updated",
+                    "type": "string"
+                  }
+                ],
+                "description": "A transport update from Washington State Department of Transportation. It carries traffic, travel, bridge, toll, pass, ferry, and border-wait updates for Washington road, bridge, pass, ferry, and border resources."
+              }
+            }
+          }
         }
       }
     },
@@ -767,11 +2411,153 @@
       "schemas": {
         "us.wa.wsdot.weather.WeatherStation": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "WeatherStation", "namespace": "us.wa.wsdot.weather", "doc": "WSDOT weather station metadata.", "fields": [{"name": "station_id", "type": "string"}, {"name": "station_name", "type": "string"}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "WeatherStation",
+                "namespace": "us.wa.wsdot.weather",
+                "doc": "WSDOT weather station metadata.",
+                "fields": [
+                  {
+                    "name": "station_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "station_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  }
+                ],
+                "description": "A reference record from Washington State Department of Transportation for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+              }
+            }
+          }
         },
         "us.wa.wsdot.weather.WeatherReading": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "WeatherReading", "namespace": "us.wa.wsdot.weather", "doc": "Weather reading.", "fields": [{"name": "station_id", "type": "string"}, {"name": "station_name", "type": "string"}, {"name": "reading_time", "type": "string"}, {"name": "temperature_in_fahrenheit", "type": ["null", "double"], "default": null}, {"name": "precipitation_in_inches", "type": ["null", "double"], "default": null}, {"name": "wind_speed_in_mph", "type": ["null", "double"], "default": null}, {"name": "wind_gust_speed_in_mph", "type": ["null", "double"], "default": null}, {"name": "wind_direction", "type": ["null", "int"], "default": null}, {"name": "wind_direction_cardinal", "type": ["null", "string"], "default": null}, {"name": "barometric_pressure", "type": ["null", "double"], "default": null}, {"name": "relative_humidity", "type": ["null", "int"], "default": null}, {"name": "visibility", "type": ["null", "double"], "default": null}, {"name": "sky_coverage", "type": ["null", "string"], "default": null}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "WeatherReading",
+                "namespace": "us.wa.wsdot.weather",
+                "doc": "Weather reading.",
+                "fields": [
+                  {
+                    "name": "station_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "station_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "reading_time",
+                    "type": "string"
+                  },
+                  {
+                    "name": "temperature_in_fahrenheit",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "precipitation_in_inches",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "wind_speed_in_mph",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "wind_gust_speed_in_mph",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "wind_direction",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "wind_direction_cardinal",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "barometric_pressure",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "relative_humidity",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "visibility",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "sky_coverage",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  }
+                ],
+                "description": "A transport update from Washington State Department of Transportation. It carries traffic, travel, bridge, toll, pass, ferry, and border-wait updates for Washington road, bridge, pass, ferry, and border resources."
+              }
+            }
+          }
         }
       }
     },
@@ -779,7 +2565,80 @@
       "schemas": {
         "us.wa.wsdot.tolls.TollRate": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "TollRate", "namespace": "us.wa.wsdot.tolls", "doc": "Toll rate.", "fields": [{"name": "trip_name", "type": "string"}, {"name": "state_route", "type": "string"}, {"name": "travel_direction", "type": "string"}, {"name": "current_toll", "type": "int"}, {"name": "current_message", "type": ["null", "string"], "default": null}, {"name": "time_updated", "type": "string"}, {"name": "start_location_name", "type": "string"}, {"name": "start_latitude", "type": "double"}, {"name": "start_longitude", "type": "double"}, {"name": "start_milepost", "type": "double"}, {"name": "end_location_name", "type": "string"}, {"name": "end_latitude", "type": "double"}, {"name": "end_longitude", "type": "double"}, {"name": "end_milepost", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "TollRate",
+                "namespace": "us.wa.wsdot.tolls",
+                "doc": "Toll rate.",
+                "fields": [
+                  {
+                    "name": "trip_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "state_route",
+                    "type": "string"
+                  },
+                  {
+                    "name": "travel_direction",
+                    "type": "string"
+                  },
+                  {
+                    "name": "current_toll",
+                    "type": "int"
+                  },
+                  {
+                    "name": "current_message",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "time_updated",
+                    "type": "string"
+                  },
+                  {
+                    "name": "start_location_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "start_latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "start_longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "start_milepost",
+                    "type": "double"
+                  },
+                  {
+                    "name": "end_location_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "end_latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "end_longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "end_milepost",
+                    "type": "double"
+                  }
+                ],
+                "description": "A transport update from Washington State Department of Transportation. It carries traffic, travel, bridge, toll, pass, ferry, and border-wait updates for Washington road, bridge, pass, ferry, and border resources."
+              }
+            }
+          }
         }
       }
     },
@@ -787,7 +2646,172 @@
       "schemas": {
         "us.wa.wsdot.cvrestrictions.CommercialVehicleRestriction": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "CommercialVehicleRestriction", "namespace": "us.wa.wsdot.cvrestrictions", "doc": "Commercial vehicle restriction.", "fields": [{"name": "state_route_id", "type": "string"}, {"name": "bridge_number", "type": "string"}, {"name": "bridge_name", "type": ["null", "string"], "default": null}, {"name": "location_name", "type": ["null", "string"], "default": null}, {"name": "location_description", "type": ["null", "string"], "default": null}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}, {"name": "state", "type": ["null", "string"], "default": null}, {"name": "restriction_type", "type": ["null", "string"], "default": null}, {"name": "vehicle_type", "type": ["null", "string"], "default": null}, {"name": "restriction_weight_in_pounds", "type": ["null", "int"], "default": null}, {"name": "maximum_gross_vehicle_weight_in_pounds", "type": ["null", "int"], "default": null}, {"name": "restriction_height_in_inches", "type": ["null", "int"], "default": null}, {"name": "restriction_width_in_inches", "type": ["null", "int"], "default": null}, {"name": "restriction_length_in_inches", "type": ["null", "int"], "default": null}, {"name": "is_permanent_restriction", "type": "boolean"}, {"name": "is_warning", "type": "boolean"}, {"name": "is_detour_available", "type": "boolean"}, {"name": "is_exceptions_allowed", "type": "boolean"}, {"name": "restriction_comment", "type": ["null", "string"], "default": null}, {"name": "date_posted", "type": ["null", "string"], "default": null}, {"name": "date_effective", "type": ["null", "string"], "default": null}, {"name": "date_expires", "type": ["null", "string"], "default": null}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "CommercialVehicleRestriction",
+                "namespace": "us.wa.wsdot.cvrestrictions",
+                "doc": "Commercial vehicle restriction.",
+                "fields": [
+                  {
+                    "name": "state_route_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "bridge_number",
+                    "type": "string"
+                  },
+                  {
+                    "name": "bridge_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "location_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "location_description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "state",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_type",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "vehicle_type",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_weight_in_pounds",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "maximum_gross_vehicle_weight_in_pounds",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_height_in_inches",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_width_in_inches",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "restriction_length_in_inches",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "is_permanent_restriction",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "is_warning",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "is_detour_available",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "is_exceptions_allowed",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "restriction_comment",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "date_posted",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "date_effective",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "date_expires",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  }
+                ],
+                "description": "A vehicle or vessel update from Washington State Department of Transportation. It reports the latest position, movement, identity, or voyage information available from the upstream feed."
+              }
+            }
+          }
         }
       }
     },
@@ -795,7 +2819,60 @@
       "schemas": {
         "us.wa.wsdot.border.BorderCrossing": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "BorderCrossing", "namespace": "us.wa.wsdot.border", "doc": "Border crossing wait time.", "fields": [{"name": "crossing_name", "type": "string"}, {"name": "wait_time", "type": ["null", "int"], "default": null}, {"name": "time", "type": "string"}, {"name": "description", "type": ["null", "string"], "default": null}, {"name": "road_name", "type": ["null", "string"], "default": null}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "BorderCrossing",
+                "namespace": "us.wa.wsdot.border",
+                "doc": "Border crossing wait time.",
+                "fields": [
+                  {
+                    "name": "crossing_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "wait_time",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "time",
+                    "type": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "road_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  }
+                ],
+                "description": "A transport update from Washington State Department of Transportation. It carries traffic, travel, bridge, toll, pass, ferry, and border-wait updates for Washington road, bridge, pass, ferry, and border resources."
+              }
+            }
+          }
         }
       }
     },
@@ -803,9 +2880,167 @@
       "schemas": {
         "us.wa.wsdot.ferries.VesselLocation": {
           "format": "Avro/1.11.3",
-          "versions": { "1": { "format": "Avro/1.11.3", "schema": { "type": "record", "name": "VesselLocation", "namespace": "us.wa.wsdot.ferries", "doc": "WSF vessel location.", "fields": [{"name": "vessel_id", "type": "string"}, {"name": "vessel_name", "type": "string"}, {"name": "mmsi", "type": ["null", "int"], "default": null}, {"name": "in_service", "type": "boolean"}, {"name": "at_dock", "type": "boolean"}, {"name": "latitude", "type": "double"}, {"name": "longitude", "type": "double"}, {"name": "speed", "type": ["null", "double"], "default": null}, {"name": "heading", "type": ["null", "int"], "default": null}, {"name": "departing_terminal_id", "type": ["null", "int"], "default": null}, {"name": "departing_terminal_name", "type": ["null", "string"], "default": null}, {"name": "departing_terminal_abbrev", "type": ["null", "string"], "default": null}, {"name": "arriving_terminal_id", "type": ["null", "int"], "default": null}, {"name": "arriving_terminal_name", "type": ["null", "string"], "default": null}, {"name": "arriving_terminal_abbrev", "type": ["null", "string"], "default": null}, {"name": "scheduled_departure", "type": ["null", "string"], "default": null}, {"name": "left_dock", "type": ["null", "string"], "default": null}, {"name": "eta", "type": ["null", "string"], "default": null}, {"name": "eta_basis", "type": ["null", "string"], "default": null}, {"name": "route_abbreviation", "type": ["null", "string"], "default": null}, {"name": "timestamp", "type": "string"}]}}}
+          "versions": {
+            "1": {
+              "format": "Avro/1.11.3",
+              "schema": {
+                "type": "record",
+                "name": "VesselLocation",
+                "namespace": "us.wa.wsdot.ferries",
+                "doc": "WSF vessel location.",
+                "fields": [
+                  {
+                    "name": "vessel_id",
+                    "type": "string"
+                  },
+                  {
+                    "name": "vessel_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "mmsi",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "in_service",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "at_dock",
+                    "type": "boolean"
+                  },
+                  {
+                    "name": "latitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "longitude",
+                    "type": "double"
+                  },
+                  {
+                    "name": "speed",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "heading",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "departing_terminal_id",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "departing_terminal_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "departing_terminal_abbrev",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "arriving_terminal_id",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "arriving_terminal_name",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "arriving_terminal_abbrev",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "scheduled_departure",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "left_dock",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "eta",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "eta_basis",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "route_abbreviation",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "timestamp",
+                    "type": "string"
+                  }
+                ],
+                "description": "A reference record from Washington State Department of Transportation for a station, stop, route, site, or other transport resource. It gives consumers stable identifiers and labels needed to interpret realtime updates."
+              }
+            }
+          }
         }
       }
     }
+  },
+  "description": "WSDOT publishes traffic, travel, bridge, toll, pass, ferry, and border-wait updates from Washington State Department of Transportation for Washington road, bridge, pass, ferry, and border resources. These events help consumers monitor mobility operations, passenger information, and traffic conditions without polling the upstream source directly.",
+  "documentation": {
+    "description": "Source documentation for WSDOT, including upstream feed context and bridge deployment notes.",
+    "url": "README.md"
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites xRegistry descriptions for Batch D transport, traffic, maritime, and mobility sources.
- Updates only description fields plus regenerated EVENTS.md files.
- Keeps source schemas, identifiers, topics, and CloudEvents metadata unchanged.

## Validation
- Regenerated each Batch D source with `pwsh .\tools\generate-events-md.ps1 -Source <source>`.

## Sources
autobahn, tfl-road-traffic, french-road-traffic, ndw-road-traffic, ndl-netherlands, wsdot, irail, gtfs, digitraffic-road, digitraffic-maritime, kystverket-ais, aisstream, paris-bicycle-counters, tokyo-docomo-bikeshare, madrid-traffic, entur-norway, king-county-marine.