### PR TITLE
feat(weather-aq): AMQP companion feeders for 3 weather/AQ sources

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -413,7 +413,9 @@
     "key": false,
     "desc": "Hong Kong — 18 AQHI stations, hourly health index",
     "kql": true,
-    "notebook": true
+    "notebook": true,
+    "mqtt": true,
+    "amqp": true
   },
   {
     "id": "irceline-belgium",

--- a/catalog.json
+++ b/catalog.json
@@ -304,7 +304,8 @@
     "key": false,
     "desc": "Europe — 37 countries, severe weather warnings",
     "kql": true,
-    "mqtt": true
+    "mqtt": true,
+    "amqp": true
   },
   {
     "id": "noaa-goes",

--- a/catalog.json
+++ b/catalog.json
@@ -385,7 +385,8 @@
     "desc": "United States — city-scoped hourly and daily UV forecasts",
     "kql": true,
     "notebook": true,
-    "mqtt": true
+    "mqtt": true,
+    "amqp": true
   },
   {
     "id": "fmi-finland",

--- a/epa-uv/CONTAINER.md
+++ b/epa-uv/CONTAINER.md
@@ -1,6 +1,6 @@
-# EPA UV Bridge to Apache Kafka, Azure Event Hubs, and Fabric Event Streams
+# EPA UV Bridge to Kafka, MQTT, and AMQP 1.0
 
-This container polls the official US EPA Envirofacts UV Index web services and emits hourly and daily UV forecast events to Kafka-compatible endpoints as CloudEvents JSON.
+This container polls the official US EPA Envirofacts UV Index web services and emits hourly and daily UV forecast events to Kafka-compatible endpoints, MQTT 5.0, or AMQP 1.0 as CloudEvents.
 
 ## Upstream
 
@@ -116,3 +116,68 @@ Deploy the MQTT container against an existing MQTT 5 broker:
 Deploy the MQTT container with a new Azure Event Grid namespace MQTT broker:
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fepa-uv%2Fazure-template-with-eventgrid-mqtt.json)
+
+## AMQP 1.0 container variant
+
+Image: `ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest`
+
+The AMQP companion publishes EPA UV Index CloudEvents to generic AMQP 1.0 brokers with SASL PLAIN, Azure Service Bus with Entra ID CBS, or Service Bus-compatible SAS CBS. It uses the same event schemas as the Kafka and MQTT variants.
+
+### Generic AMQP broker
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=epa-uv \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest
+```
+
+### Azure Service Bus with Entra ID
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=<namespace>.servicebus.windows.net \
+  -e AMQP_PORT=5671 \
+  -e AMQP_TLS=true \
+  -e AMQP_ADDRESS=epa-uv \
+  -e AMQP_AUTH_MODE=entra \
+  -e AMQP_ENTRA_AUDIENCE=https://servicebus.azure.net/.default \
+  -e AMQP_ENTRA_CLIENT_ID=<managed-identity-client-id> \
+  ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest
+```
+
+### Service Bus emulator / SAS CBS
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=servicebus-emulator \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=epa-uv \
+  -e AMQP_AUTH_MODE=sas \
+  -e AMQP_SAS_KEY_NAME=RootManageSharedAccessKey \
+  -e AMQP_SAS_KEY=<key> \
+  ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest
+```
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `AMQP_BROKER_URL` | Optional `amqp://` or `amqps://` URL; path overrides `AMQP_ADDRESS`. | empty |
+| `AMQP_HOST` / `AMQP_PORT` | AMQP broker host and port when no broker URL is supplied. | `localhost` / `5672` (`5671` with TLS) |
+| `AMQP_ADDRESS` | Queue, topic, or link target address. | `epa-uv` |
+| `AMQP_AUTH_MODE` | `password`, `entra`, or `sas`. | `password` |
+| `AMQP_USERNAME` / `AMQP_PASSWORD` | SASL PLAIN credentials for generic brokers. | empty |
+| `AMQP_TLS` | Enable TLS; automatically true for Entra auth. | `false` |
+| `AMQP_ENTRA_AUDIENCE` | Token scope for CBS put-token. | `https://servicebus.azure.net/.default` |
+| `AMQP_ENTRA_CLIENT_ID` | Optional user-assigned managed identity client id. | empty |
+| `AMQP_SAS_KEY_NAME` / `AMQP_SAS_KEY` | SAS CBS credentials for Service Bus-compatible brokers. | empty |
+| `AMQP_CONTENT_MODE` | CloudEvents AMQP content mode. | `binary` |
+| `POLLING_INTERVAL` | Poll interval in seconds. | source-specific |
+| `EPA_UV_STATE_FILE` | Persistent dedupe state file path. | source-specific |
+| `EPA_UV_MOCK` | Emit built-in sample events for Docker E2E and offline validation. | `false` |
+
+Use `azure-template-with-servicebus.json` or `infra/azure-template-amqp.json` for one-click Azure Service Bus deployment. The templates create a queue, Azure Files state share, ACI, user-assigned managed identity, and `Azure Service Bus Data Sender` role assignment scoped to the queue.
+

--- a/epa-uv/Dockerfile.amqp
+++ b/epa-uv/Dockerfile.amqp
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/epa-uv"
+LABEL org.opencontainers.image.title="EPA UV Index → AMQP 1.0 bridge"
+LABEL org.opencontainers.image.description="Polls EPA Envirofacts UV Index hourly and daily forecasts and publishes CloudEvents over AMQP 1.0 for generic brokers and Azure Service Bus. Supports SASL PLAIN, Service Bus Entra ID CBS, and Service Bus SAS CBS authentication."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/epa-uv/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="amqp"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+RUN apt-get update  && apt-get install -y --no-install-recommends         build-essential cmake pkg-config swig         libssl-dev libsasl2-dev python3-dev         libsasl2-2 libsasl2-modules  && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_data  && pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./epa_uv_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+
+ENV AMQP_BROKER_URL=""
+ENV AMQP_ADDRESS="epa-uv"
+
+CMD ["python", "-m", "epa_uv_amqp", "feed"]

--- a/epa-uv/EVENTS.md
+++ b/epa-uv/EVENTS.md
@@ -4,8 +4,8 @@ MQTT/5.0 transport variants for EPA UV Index forecasts. Topics are retained QoS-
 
 ## At a glance
 
-- **Event types:** 2 documented event types (4 transport bindings in the manifest).
-- **Transports:** KAFKA, MQTT/5.0
+- **Event types:** 2 documented event types (6 transport bindings in the manifest).
+- **Transports:** KAFKA, MQTT/5.0, AMQP/1.0
 - **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{location_id}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
@@ -43,6 +43,20 @@ c.loop_forever()
 ```
 
 Subscribe at QoS 1 with a stable client id, `CleanStart=false`, and a finite non-zero session expiry when you need at-least-once delivery across reconnects. Retained messages are delivered subject to MQTT 5 Retain Handling, and publishing an empty retained payload clears the retained value. MQTT 5 user properties carry CloudEvents metadata; MQTT 3.1.1 clients need structured CloudEvents because they do not have user properties.
+### AMQP 1.0
+
+Attach a link with `role=receiver` whose **source** is `epa-uv`. The source terminus is the broker-side node you consume from; source filters such as selectors, Event Hubs offsets, or subscription filters further select which messages flow. The target is your client-side terminus. Generic brokers use their advertised SASL mechanisms (often PLAIN over TLS, EXTERNAL with mTLS, or ANONYMOUS on trusted links). Azure Service Bus and Event Hubs can use SASL PLAIN for SAS credentials on short-lived connections; CBS `put-token` on `$cbs` installs and refreshes Entra ID JWTs or SAS tokens for long-lived AMQP connections.
+
+```python
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+class H(MessagingHandler):
+    def on_start(self,e): e.container.create_receiver('amqps://user:pass@localhost:5671/epa-uv')
+    def on_message(self,e): print(e.message.subject, e.message.properties, e.message.body)
+Container(H()).run()
+```
+
+The examples use AMQP binary content mode: the JSON payload is the message body, `datacontenttype` maps to the AMQP `content-type`, and CloudEvents attributes map to application properties named `cloudEvents:<attribute>`.
 
 ## Event catalog
 
@@ -52,7 +66,7 @@ CloudEvents type: `US.EPA.UVIndex.HourlyForecast`
 
 #### What it tells you
 
-Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.
+An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast valid hour, normalized location identity, and UV index value for operational exposure planning. Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.
 
 #### Identity
 
@@ -64,6 +78,7 @@ Each event identifies the real-world resource with `{location_id}`. `{location_i
 | --- | --- |
 | `KAFKA` | topic `epa-uv`, key `{location_id}` |
 | `MQTT/5.0` | topic `uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/hourly/{forecast_hour}`, retain `true`, QoS `1` |
+| `AMQP/1.0` | source address `amqps://localhost:5671/epa-uv`, message subject `{location_id}`; application properties state `{state}`, city_slug `{city_slug}`, forecast_hour `{forecast_hour}` |
 
 #### Payload
 
@@ -102,7 +117,7 @@ CloudEvents type: `US.EPA.UVIndex.DailyForecast`
 
 #### What it tells you
 
-Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.
+A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning. Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.
 
 #### Identity
 
@@ -114,6 +129,7 @@ Each event identifies the real-world resource with `{location_id}`. `{location_i
 | --- | --- |
 | `KAFKA` | topic `epa-uv`, key `{location_id}` |
 | `MQTT/5.0` | topic `uv/us/epa/epa-uv/{state}/{city_slug}/{location_id}/daily/{forecast_date}`, retain `true`, QoS `1` |
+| `AMQP/1.0` | source address `amqps://localhost:5671/epa-uv`, message subject `{location_id}`; application properties state `{state}`, city_slug `{city_slug}`, forecast_date `{forecast_date}` |
 
 #### Payload
 

--- a/epa-uv/README.md
+++ b/epa-uv/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**EPA UV Bridge** polls the official US EPA Envirofacts UV Index web services and emits hourly and daily UV forecast events to Kafka as CloudEvents.
+**EPA UV Bridge** polls the official US EPA Envirofacts UV Index web services and emits hourly and daily UV forecast events to Kafka, MQTT 5.0, and AMQP 1.0 as CloudEvents.
 
 The upstream exposes four parameterized endpoints: hourly-by-city/state, hourly-by-ZIP, daily-by-city/state, and daily-by-ZIP. This bridge models the city/state family because the ZIP endpoints are duplicate parameterizations of the same products rather than distinct event families.
 
@@ -97,3 +97,23 @@ Four Azure Container Instance deployment shapes are documented for this source:
 | MQTT, create an Azure Event Grid namespace MQTT broker | `azure-template-with-eventgrid-mqtt.json` |
 
 See [CONTAINER.md](CONTAINER.md) for runtime environment variables and deployment badges, and [EVENTS.md](EVENTS.md) for the full CloudEvents and MQTT topic contract.
+
+## AMQP 1.0 companion feeder
+
+This source now ships Kafka, MQTT, and AMQP 1.0 transport variants. The AMQP container (`ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest`) publishes the same CloudEvents payloads as the Kafka and MQTT feeders to a single broker address named `epa-uv` by default, using binary-mode AMQP 1.0 for generic brokers or Azure Service Bus.
+
+Run locally against an AMQP 1.0 broker:
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=epa-uv \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest
+```
+
+Deploy to Azure Service Bus with `azure-template-with-servicebus.json` (also mirrored at `infra/azure-template-amqp.json`). The template provisions a Service Bus queue, storage-backed state share, a user-assigned managed identity, and an Azure Container Instance configured for AMQP CBS / Entra ID authentication.
+

--- a/epa-uv/azure-template-with-servicebus.json
+++ b/epa-uv/azure-template-with-servicebus.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the EPA UV Index AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'epa-uv'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "epa-uv",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for EPA UV Index feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "epa-uv",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all EPA UV Index CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "21600"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/epa_uv_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/epa-uv/epa_uv_amqp/epa_uv_amqp/__main__.py
+++ b/epa-uv/epa_uv_amqp/epa_uv_amqp/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/epa-uv/epa_uv_amqp/epa_uv_amqp/app.py
+++ b/epa-uv/epa_uv_amqp/epa_uv_amqp/app.py
@@ -1,0 +1,155 @@
+"""AMQP 1.0 feeder application for EPA UV Index."""
+
+from __future__ import annotations
+
+
+import argparse
+import logging
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+DEFAULT_ENTRA_AUDIENCE_SERVICEBUS = "https://servicebus.azure.net/.default"
+
+
+def _parse_amqp_broker_url(url: str) -> tuple[str, int, bool, Optional[str], Optional[str], Optional[str]]:
+    parsed = urlparse(url if "://" in url else f"amqp://{url}")
+    scheme = (parsed.scheme or "amqp").lower()
+    tls = scheme in ("amqps", "ssl", "tls")
+    port = parsed.port or (5671 if tls else 5672)
+    return parsed.hostname or "localhost", port, tls, parsed.username or None, parsed.password or None, (parsed.path or "").lstrip("/") or None
+
+
+def _build_amqp_producer(producer_cls, *, host: str, port: int, address: str, use_tls: bool, content_mode: str, auth_mode: str, username: Optional[str], password: Optional[str], entra_audience: str, entra_client_id: Optional[str], sas_key_name: Optional[str], sas_key: Optional[str]):
+    if auth_mode == "entra":
+        from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+        credential = ManagedIdentityCredential(client_id=entra_client_id) if entra_client_id else DefaultAzureCredential()
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, credential=credential, entra_audience=entra_audience, use_tls=use_tls)
+    if auth_mode == "sas":
+        if not sas_key_name or not sas_key:
+            raise RuntimeError("AMQP auth-mode=sas requires AMQP_SAS_KEY_NAME and AMQP_SAS_KEY")
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, sas_key_name=sas_key_name, sas_key=sas_key, use_tls=use_tls)
+    return producer_cls(host=host, address=address, port=port, username=username, password=password, content_mode=content_mode, use_tls=use_tls)
+
+
+def add_amqp_arguments(parser: argparse.ArgumentParser, default_address: str) -> None:
+    parser.add_argument("--broker-url", default=os.getenv("AMQP_BROKER_URL"))
+    parser.add_argument("--host", default=os.getenv("AMQP_HOST"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("AMQP_PORT", "0")) or None)
+    parser.add_argument("--address", default=os.getenv("AMQP_ADDRESS", default_address))
+    parser.add_argument("--username", default=os.getenv("AMQP_USERNAME"))
+    parser.add_argument("--password", default=os.getenv("AMQP_PASSWORD"))
+    parser.add_argument("--tls", action="store_true", default=os.getenv("AMQP_TLS", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("AMQP_CONTENT_MODE", "binary"))
+    parser.add_argument("--auth-mode", choices=("password", "entra", "sas"), default=os.getenv("AMQP_AUTH_MODE", "password"))
+    parser.add_argument("--entra-audience", default=os.getenv("AMQP_ENTRA_AUDIENCE", DEFAULT_ENTRA_AUDIENCE_SERVICEBUS))
+    parser.add_argument("--entra-client-id", default=os.getenv("AMQP_ENTRA_CLIENT_ID"))
+    parser.add_argument("--sas-key-name", default=os.getenv("AMQP_SAS_KEY_NAME"))
+    parser.add_argument("--sas-key", default=os.getenv("AMQP_SAS_KEY"))
+
+
+def create_amqp_producer(args: argparse.Namespace, producer_cls):
+    address = args.address
+    if args.broker_url:
+        host, port, tls, user, pwd, path = _parse_amqp_broker_url(args.broker_url)
+        username = args.username or user
+        password = args.password or pwd
+        if args.port:
+            port = args.port
+        if args.tls:
+            tls = True
+        if path:
+            address = path
+    else:
+        host = args.host or "localhost"
+        tls = bool(args.tls) or args.auth_mode == "entra"
+        port = args.port or (5671 if tls else 5672)
+        username = args.username
+        password = args.password
+    if not address:
+        raise RuntimeError("AMQP address is required")
+    logging.info("Connecting AMQP producer to %s:%s/%s auth=%s tls=%s", host, port, address, args.auth_mode, tls)
+    return _build_amqp_producer(producer_cls, host=host, port=port, address=address, use_tls=tls, content_mode=args.content_mode, auth_mode=args.auth_mode, username=username, password=password, entra_audience=args.entra_audience, entra_client_id=args.entra_client_id, sas_key_name=args.sas_key_name, sas_key=args.sas_key)
+
+
+import argparse
+import logging
+import os
+import time
+
+from epa_uv.epa_uv import DEFAULT_POLL_INTERVAL_SECONDS, EPAUVBridge, parse_locations
+from epa_uv_amqp_producer_data import DailyForecast, HourlyForecast
+from epa_uv_amqp_producer_amqp_producer.producer import USEPAUVIndexAmqpProducer
+
+logger = logging.getLogger(__name__)
+
+
+def _sample_events() -> tuple[list[HourlyForecast], list[DailyForecast]]:
+    hourly = HourlyForecast(location_id="seattle-wa", city="Seattle", state="wa", city_slug="seattle", forecast_datetime="2026-01-01T12:00:00", forecast_hour="20260101T12", uv_index=2)
+    daily = DailyForecast(location_id="seattle-wa", city="Seattle", state="wa", city_slug="seattle", forecast_date="2026-01-01", uv_index=2, uv_alert="Low")
+    return [hourly], [daily]
+
+
+def _publish(producer: USEPAUVIndexAmqpProducer, hourly_events, daily_events) -> tuple[int, int]:
+    hourly_count = 0
+    for hourly in hourly_events:
+        producer.send_hourly_forecast(data=hourly, _location_id=hourly.location_id, _state=hourly.state, _city_slug=hourly.city_slug, _forecast_hour=hourly.forecast_hour)
+        hourly_count += 1
+    daily_count = 0
+    for daily in daily_events:
+        producer.send_daily_forecast(data=daily, _location_id=daily.location_id, _state=daily.state, _city_slug=daily.city_slug, _forecast_date=daily.forecast_date)
+        daily_count += 1
+    return hourly_count, daily_count
+
+
+def feed(args: argparse.Namespace) -> None:
+    producer = create_amqp_producer(args, USEPAUVIndexAmqpProducer)
+    bridge = EPAUVBridge(parse_locations(args.locations), state_file=args.state_file)
+    try:
+        while True:
+            if args.mock_mode:
+                hourly_events, daily_events = _sample_events()
+            else:
+                hourly_events = []
+                daily_events = []
+                for city, state in bridge.locations:
+                    for hourly in bridge.fetch_hourly(city, state):
+                        event_id = f"{hourly.location_id}|{hourly.forecast_datetime}"
+                        if event_id in bridge.seen_hourly_ids:
+                            continue
+                        hourly_events.append(hourly)
+                        bridge._remember(bridge.hourly_order, bridge.seen_hourly_ids, event_id)
+                    for daily in bridge.fetch_daily(city, state):
+                        event_id = f"{daily.location_id}|{daily.forecast_date}"
+                        if event_id in bridge.seen_daily_ids:
+                            continue
+                        daily_events.append(daily)
+                        bridge._remember(bridge.daily_order, bridge.seen_daily_ids, event_id)
+                bridge.save_state()
+            hourly_count, daily_count = _publish(producer, hourly_events, daily_events)
+            logger.info("Published %d hourly and %d daily EPA UV forecasts to AMQP", hourly_count, daily_count)
+            if args.once:
+                break
+            time.sleep(args.polling_interval)
+    finally:
+        producer.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper(), format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="EPA UV Index AMQP 1.0 bridge")
+    parser.add_argument("feed_command", nargs="?", default="feed")
+    add_amqp_arguments(parser, "epa-uv")
+    parser.add_argument("--locations", default=os.getenv("EPA_UV_LOCATIONS", "Seattle,WA"))
+    parser.add_argument("--state-file", default=os.getenv("EPA_UV_STATE_FILE", "/var/lib/epa-uv/state.json"))
+    parser.add_argument("--polling-interval", type=int, default=int(os.getenv("POLLING_INTERVAL", str(DEFAULT_POLL_INTERVAL_SECONDS))))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--mock-mode", action="store_true", default=os.getenv("EPA_UV_MOCK", "").lower() in ("1", "true", "yes"))
+    args = parser.parse_args()
+    if args.feed_command != "feed":
+        parser.error("only the 'feed' command is supported")
+    feed(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/epa-uv/epa_uv_amqp/pyproject.toml
+++ b/epa-uv/epa_uv_amqp/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "epa-uv-amqp"
+version = "0.1.0"
+description = "AMQP 1.0 feeder for EPA UV Index"
+requires-python = ">=3.10"
+dependencies = [
+    "python-qpid-proton>=0.40.0",
+    "cloudevents>=1.11.0,<2.0.0",
+    "dataclasses_json>=0.6.7",
+    "avro>=1.11.3",
+    "azure-identity>=1.17.0",
+    "azure-core>=1.30.0",
+    "requests>=2.32.0"
+]
+
+[project.scripts]
+epa-uv-amqp = "epa_uv_amqp.app:main"
+
+[tool.setuptools.packages.find]
+include = ["epa_uv_amqp*"]

--- a/epa-uv/epa_uv_amqp_producer/Makefile
+++ b/epa-uv/epa_uv_amqp_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install test
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./epa_uv_amqp_producer_data ./epa_uv_amqp_producer_amqp_producer
+
+install: build
+	cd epa_uv_amqp_producer_data && poetry install
+	cd epa_uv_amqp_producer_amqp_producer && poetry install
+	pip install ./epa_uv_amqp_producer_data ./epa_uv_amqp_producer_amqp_producer
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./epa_uv_amqp_producer_amqp_producer/tests ./epa_uv_amqp_producer_data/tests

--- a/epa-uv/epa_uv_amqp_producer/README.md
+++ b/epa-uv/epa_uv_amqp_producer/README.md
@@ -1,0 +1,487 @@
+
+# Epa_uv_amqp_producer - AMQP 1.0 Producer
+
+Auto-generated Python producer for sending messages via AMQP 1.0 protocol.
+
+## Overview
+
+This module provides a type-safe AMQP 1.0 producer for sending events with optional CloudEvents envelope format. Built
+on the `python-qpid-proton` library for Python.
+
+## What is AMQP 1.0?
+
+**AMQP (Advanced Message Queuing Protocol) 1.0** is an open standard for business messaging that supports:
+- **Protocol-level interoperability** between different platforms and vendors
+- **Reliable message delivery** with settlement modes and flow control
+- **Multiple messaging patterns** including queues, topics, and request-reply
+- **Built-in security** with SASL authentication and TLS encryption
+
+Use cases: Enterprise integration, IoT messaging, financial services, cloud-native applications.
+
+**Supported AMQP 1.0 Brokers:**
+- Apache ActiveMQ Artemis (native AMQP 1.0)
+- Apache Qpid (native AMQP 1.0)
+- Azure Service Bus (native AMQP 1.0)
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-
+cli/blob/main/docs/rabbitmq_amqp_setup.md))
+
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup
+Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+
+
+## Azure Entra ID (CBS) Authentication — enabled
+
+This producer was generated with `--template-args azure_cbs_target=servicebus`,
+which wires in AMQP CBS (Claims-Based Security) put-token flow for **Azure Event Hubs** and
+**Azure Service Bus** using `azure-identity` token credentials.
+
+```python
+from azure.identity import DefaultAzureCredential
+producer = <Group>Producer(
+    host="my-namespace.servicebus.windows.net",   # EH or SB FQDN
+    address="my-hub-or-queue",                    # entity path
+    credential=DefaultAzureCredential(),
+)
+producer.send_my_event(...)
+producer.close()
+```
+
+CBS audience: `https://servicebus.azure.net/.default`
+(override with `--template-args azure_cbs_audience=<scope>` at code-gen time)
+
+Required RBAC role on the entity or namespace, e.g.:
+- Event Hubs: **Azure Event Hubs Data Sender**
+- Service Bus: **Azure Service Bus Data Sender**
+
+Debug logging:
+
+```python
+import logging
+logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
+```
+
+**Known limitations of the v1 CBS implementation:**
+- Token is acquired once at `__init__` time; there is no background refresh. Recreate the
+  producer (or open a fresh one) before token expiry (~60 min for Entra ID).
+- On Windows, the official `python-qpid-proton` PyPI wheel (verified on 0.40.0,
+  the latest release at the time of writing) is linked against SChannel via the
+  legacy `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service
+  Bus namespaces with `minimumTlsVersion=1.3` will return
+  `amqp:unauthorized-access "Invalid TLS version"` at AMQP open. Tracked
+  upstream as [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933).
+
+  Until the upstream wheel is fixed, install the OpenSSL-backed Windows
+  wheel published from `xregistry/codegen`:
+
+  ```
+  pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton
+  ```
+
+  pip will pick the `0.40.0+xrcgN` build automatically on Windows; Linux and
+  macOS continue to install the stock `0.40.0` from PyPI.
+- A reactor-based handler is used on the CBS path; the non-CBS path keeps the
+  `BlockingConnection` implementation unchanged.
+
+
+## Installation
+
+```bash
+pip install python-qpid-proton cloudevents azure-identity azure-core
+```
+
+### Windows: TLS 1.3 — extra index URL required
+
+The official `python-qpid-proton` Windows wheel does not support TLS 1.3
+(it links against SChannel via a deprecated API). If your AMQP broker
+requires TLS 1.3 — most notably Azure Service Bus namespaces with
+`minimumTlsVersion=1.3` — install with our OpenSSL-backed patched wheel:
+
+```bash
+pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton cloudevents azure-
+identity azure-core
+```
+
+pip selects the patched wheel only on Windows (it has a strictly higher
+PEP 440 local version `0.40.0+xrcgN`); Linux and macOS continue to install
+the stock release from PyPI. The patched wheel will be retired as soon as
+upstream proton ships a Windows wheel with TLS 1.3 support.
+
+## Generated Producers
+
+
+
+### USEPAUVIndexAmqpProducer
+
+`USEPAUVIndexAmqpProducer` sends messages for the US.EPA.UVIndex.amqp message group.
+
+#### Quick Start
+
+```python
+from epa_uv_amqp_producer import USEPAUVIndexAmqpProducer
+
+# Create producer
+producer = USEPAUVIndexAmqpProducer(
+    host="localhost",
+    address="my-queue",
+    port=5672,
+    username="guest",
+    password="guest"
+)
+
+# Send a message
+
+producer.send_hourly_forecast(
+    data=HourlyForecast(...),
+    content_type="application/json"
+)
+
+producer.send_daily_forecast(
+    data=DailyForecast(...),
+    content_type="application/json"
+)
+
+
+# Close producer
+producer.close()
+```
+
+#### Configuration Options
+
+The producer constructor accepts:
+
+- `host` (str): AMQP broker hostname
+- `address` (str): AMQP address (queue or topic name)
+- `port` (int): AMQP broker port (default: 5672, for TLS typically 5671)
+- `username` (Optional[str]): Username for SASL authentication
+- `password` (Optional[str]): Password for SASL authentication
+- `content_mode` (Literal['structured', 'binary']): CloudEvents encoding mode (default: 'structured')
+  - **structured**: Entire CloudEvent as JSON in message body
+  - **binary**: Event data in body, CloudEvents attributes in AMQP application properties
+- `format_type` (str): Content type for structured mode (default: 'application/json')
+
+#### Available Methods
+
+
+
+##### `send_hourly_forecast()`
+An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries
+the forecast valid hour, normalized location identity, and UV index value for operational exposure planning.
+
+**Parameters:**
+- `data` (HourlyForecast): The message data object
+- `_location_id` (str): Value for placeholder location_id in attribute subject
+- `content_type` (str): Content type of the message data (default: 'application/json')
+
+##### `send_hourly_forecast_batch()`
+
+Send multiple HourlyForecast messages in sequence.
+
+**Parameters:**
+- `data_array` (List[HourlyForecast]): Array of message data objects
+- `_location_id` (str): Value for placeholder location_id in attribute subject
+- `content_type` (str): Content type of the message data
+
+
+
+##### `send_daily_forecast()`
+A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the
+forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning.
+
+**Parameters:**
+- `data` (DailyForecast): The message data object
+- `_location_id` (str): Value for placeholder location_id in attribute subject
+- `content_type` (str): Content type of the message data (default: 'application/json')
+
+##### `send_daily_forecast_batch()`
+
+Send multiple DailyForecast messages in sequence.
+
+**Parameters:**
+- `data_array` (List[DailyForecast]): Array of message data objects
+- `_location_id` (str): Value for placeholder location_id in attribute subject
+- `content_type` (str): Content type of the message data
+
+
+
+
+## AMQP Broker Compatibility
+
+This library has been tested with:
+- **Azure Service Bus** (AMQP 1.0 over TLS on port 5671)
+- **Apache ActiveMQ Artemis** (AMQP 1.0 on port 5672)
+- **Apache Qpid Broker-J** (AMQP 1.0 on port 5672)
+
+## Security Considerations
+
+- Always use TLS/SSL encryption in production (port 5671)
+- Store credentials securely (environment variables, key vaults)
+- Use SASL authentication mechanisms appropriate for your broker
+- Consider using token-based authentication (OAuth, JWT) where supported
+
+## Advanced Usage
+
+### Batch Sending with Concurrency Control
+
+Send multiple messages efficiently with rate limiting:
+
+```python
+import asyncio
+from typing import List
+
+
+class BatchProducer:
+    def __init__(self, producer: USEPAUVIndexAmqpProducer, max_concurrency: int = 10):
+        self.producer = producer
+        self.semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def send_batch_async(self, data_array: List[HourlyForecast]):
+        """Send multiple messages with concurrency control."""
+        async def send_one(data):
+            async with self.semaphore:
+                await asyncio.to_thread(
+                    self.producer.send_hourly_forecast,
+                    data
+                )
+
+        tasks = [send_one(data) for data in data_array]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+# Usage
+producer = USEPAUVIndexAmqpProducer(host="localhost", address="my-queue")
+batch_producer = BatchProducer(producer, max_concurrency=20)
+
+data_list = [HourlyForecast(...) for _ in range(100)]
+asyncio.run(batch_producer.send_batch_async(data_list))
+```
+
+
+### Connection Pooling
+
+Reuse producer connections across your application:
+
+```python
+from threading import Lock
+
+
+class ProducerPool:
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance.producer = USEPAUVIndexAmqpProducer(
+                        host="localhost",
+                        address="my-queue",
+                        username="guest",
+                        password="guest"
+                    )
+        return cls._instance
+
+    def get_producer(self) -> USEPAUVIndexAmqpProducer:
+        return self.producer
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+# Use from anywhere
+pool = ProducerPool()
+producer = pool.get_producer()
+
+```
+
+### Connection Resilience
+
+Automatically reconnect on connection failures:
+
+```python
+import time
+from typing import Optional
+
+
+class ResilientProducer:
+    def __init__(self, host: str, address: str, **kwargs):
+        self.host = host
+        self.address = address
+        self.kwargs = kwargs
+        self.producer: Optional[USEPAUVIndexAmqpProducer] = None
+        self._connect()
+
+    def _connect(self):
+        """Establish connection to AMQP broker."""
+        if self.producer:
+            try:
+                self.producer.close()
+            except:
+                pass
+
+        self.producer = USEPAUVIndexAmqpProducer(
+            host=self.host,
+            address=self.address,
+            **self.kwargs
+        )
+
+    def send_with_retry(self, data: HourlyForecast, max_retries: int = 3):
+        """Send message with automatic retry on connection failure."""
+        for attempt in range(max_retries):
+            try:
+                self.producer.send_hourly_forecast(data)
+                return
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    time.sleep(2 ** attempt)  # Exponential backoff
+                    self._connect()  # Reconnect
+                else:
+                    raise Exception(f"Failed after {max_retries} attempts") from e
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+```
+
+### Custom CloudEvents Attributes
+
+Add extension attributes to CloudEvents:
+
+```python
+
+
+producer = USEPAUVIndexAmqpProducer(host="localhost", address="my-queue")
+
+# CloudEvents extension attributes can be added via metadata
+producer.send_hourly_forecast(
+    data=data,
+    _tenant="contoso",           # Custom extension attribute
+    _deviceid="device-001",      # Custom extension attribute
+    _region="us-west-2",         # Custom extension attribute
+    _priority="high",            # Custom extension attribute
+    content_type="application/json"
+)
+
+```
+
+## Error Handling
+
+### Basic Error Handling
+
+```python
+from uamqp import errors
+
+try:
+    producer.send_message(data)
+except errors.AMQPConnectionError as e:
+    print(f"Connection error: {e}")
+except errors.MessageException as e:
+    print(f"Message error: {e}")
+finally:
+    producer.close()
+```
+
+### Retry with Exponential Backoff
+
+```python
+import time
+from typing import Any
+
+
+def send_with_retry(
+    producer: USEPAUVIndexAmqpProducer,
+    data: HourlyForecast,
+    max_retries: int = 5,
+    initial_delay: float = 1.0,
+    max_delay: float = 60.0
+) -> None:
+    """
+    Send message with exponential backoff retry.
+
+    Args:
+        producer: The producer instance
+        data: Message data to send
+        max_retries: Maximum number of retry attempts
+        initial_delay: Initial delay in seconds
+        max_delay: Maximum delay between retries
+
+    Raises:
+        Exception: If all retries are exhausted
+    """
+    for attempt in range(max_retries):
+        try:
+            producer.send_hourly_forecast(data)
+            return  # Success
+        except errors.AMQPConnectionError as e:
+            if attempt < max_retries - 1:
+                delay = min(initial_delay * (2 ** attempt), max_delay)
+                print(f"Attempt {attempt + 1}/{max_retries} failed. Retrying in {delay}s...")
+                time.sleep(delay)
+            else:
+                raise Exception(f"Failed after {max_retries} attempts") from e
+
+```
+
+### Circuit Breaker Pattern
+
+```python
+from datetime import datetime, timedelta
+
+
+class CircuitBreakerProducer:
+    """Producer with circuit breaker to prevent cascading failures."""
+
+    def __init__(self, producer: USEPAUVIndexAmqpProducer, threshold: int = 5, timeout: int = 60):
+        self.producer = producer
+        self.threshold = threshold
+        self.timeout = timedelta(seconds=timeout)
+        self.failure_count = 0
+        self.last_failure_time = None
+        self.is_open = False
+
+    def send(self, data: HourlyForecast):
+        """Send message with circuit breaker protection."""
+        # Check if circuit breaker is open
+        if self.is_open:
+            if datetime.now() - self.last_failure_time < self.timeout:
+                raise Exception("Circuit breaker is open. Too many consecutive failures.")
+            else:
+                # Try to close the circuit
+                self.is_open = False
+                self.failure_count = 0
+
+        try:
+            self.producer.send_hourly_forecast(data)
+            self.failure_count = 0  # Reset on success
+        except Exception as e:
+            self.failure_count += 1
+            self.last_failure_time = datetime.now()
+
+            if self.failure_count >= self.threshold:
+                self.is_open = True
+            raise
+
+```
+
+## Building and Testing
+
+```bash
+# Install dependencies
+poetry install
+
+# Run tests
+poetry run pytest
+
+# Build package
+poetry build
+```
+
+## Dependencies
+
+- `uamqp>=1.6.10` - AMQP 1.0 client library
+- `cloudevents>=1.10.1` - CloudEvents SDK
+- Python 3.10+
+
+## License
+
+This generated code is provided as-is for use in your projects.

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/pyproject.toml
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/pyproject.toml
@@ -1,0 +1,33 @@
+
+[tool.poetry]
+name = "epa-uv-amqp-producer-amqp-producer"
+description = "epa_uv_amqp_producer_amqp_producer AMQP 1.0 producer library (Azure servicebus CBS/Entra ID enabled)"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "epa_uv_amqp_producer_amqp_producer", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+epa-uv-amqp-producer-data = {path = "../epa_uv_amqp_producer_data", develop = true}  
+python-qpid-proton = ">=0.39.0"
+cloudevents = ">=1.10.1,<2.0.0"
+azure-identity = ">=1.15.0"
+azure-core = ">=1.30.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+filterwarnings = [
+    "ignore::DeprecationWarning:testcontainers.core.waiting_utils"
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/src/epa_uv_amqp_producer_amqp_producer/__init__.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/src/epa_uv_amqp_producer_amqp_producer/__init__.py
@@ -1,0 +1,9 @@
+"""
+epa_uv_amqp_producer_amqp_producer - AMQP 1.0 Producer
+"""
+
+from .producer import *
+
+__all__ = [
+    "USEPAUVIndexAmqpProducer",
+]

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/src/epa_uv_amqp_producer_amqp_producer/producer.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/src/epa_uv_amqp_producer_amqp_producer/producer.py
@@ -1,0 +1,833 @@
+
+
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+
+"""
+Producer module for sending messages via AMQP 1.0 protocol.
+
+Generated with Azure CBS support (target: servicebus).
+Supports Entra ID (Azure AD) authentication via Claims-Based Security (CBS)
+put-token, in addition to SASL PLAIN and SAS connection-string auth.
+"""
+
+import sys
+import typing
+import uuid
+import json
+import threading
+import queue
+import concurrent.futures
+from urllib.parse import quote_plus
+from proton import Message
+from proton.utils import BlockingConnection
+from cloudevents.http import CloudEvent
+from cloudevents.conversion import to_binary, to_structured
+
+# --- Azure CBS support (azure_cbs_target=servicebus) ---
+# Two CBS auth modes are supported:
+#   1. Entra ID (Azure AD) JWT bearer via an azure-identity TokenCredential
+#      (``type=jwt``) -- works against live Azure Service Bus / Event Hubs.
+#   2. SAS token (``type=servicebus.windows.net:sastoken``) -- works against
+#      both live Azure namespaces configured for SAS and the local Service Bus
+#      emulator, which validates the ``type`` field strictly and refuses JWT.
+import base64
+import hashlib
+import hmac
+import logging
+import time as _cbs_time
+from urllib.parse import quote
+from proton import Endpoint, symbol
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, AtLeastOnce
+
+try:  # azure-identity is optional when only SAS auth is used
+    from azure.core.credentials import TokenCredential  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    TokenCredential = typing.Any  # type: ignore
+
+_cbs_logger = logging.getLogger("amqp.cbs")
+
+
+class _CbsTokenProvider:
+    """Abstract provider that mints a CBS put-token body + metadata."""
+
+    token_type: str = ""
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        """Return (token_body, absolute_expiry_unix_seconds)."""
+        raise NotImplementedError
+
+
+class _JwtTokenProvider(_CbsTokenProvider):
+    """Entra ID JWT acquired from an azure-identity ``TokenCredential``."""
+
+    token_type = "jwt"
+
+    def __init__(self, credential, audience: str):
+        self._credential = credential
+        self._audience = audience
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        token = self._credential.get_token(self._audience)
+        return token.token, int(token.expires_on)
+
+
+class _SasTokenProvider(_CbsTokenProvider):
+    """SAS token minted from a shared-access key + key name.
+
+    Produces a token of the form::
+
+        SharedAccessSignature sr=<url-quoted resource_uri>
+                              &sig=<url-quoted base64 HMAC-SHA256>
+                              &se=<expiry-unix-seconds>
+                              &skn=<key name>
+    """
+
+    token_type = "servicebus.windows.net:sastoken"
+
+    def __init__(self, key_name: str, key: str, resource_uri: str,
+                 ttl_seconds: int = 3600):
+        if not key_name or not key:
+            raise ValueError("SAS auth requires both key_name and key")
+        self._key_name = key_name
+        self._key = key
+        self._resource_uri = resource_uri
+        self._ttl = int(ttl_seconds)
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        expiry = int(_cbs_time.time()) + self._ttl
+        encoded_uri = quote(self._resource_uri, safe="")
+        string_to_sign = (encoded_uri + "\n" + str(expiry)).encode("utf-8")
+        try:
+            signing_key = self._key.encode("utf-8")
+        except AttributeError:
+            signing_key = bytes(self._key)
+        signature = base64.b64encode(
+            hmac.new(signing_key, string_to_sign, hashlib.sha256).digest()
+        )
+        encoded_sig = quote(signature, safe="")
+        token = (
+            "SharedAccessSignature "
+            f"sr={encoded_uri}&sig={encoded_sig}&se={expiry}"
+            f"&skn={quote(self._key_name, safe='')}"
+        )
+        return token, expiry
+
+
+class _CbsAzureHandler(MessagingHandler):
+    """Reactor handler that establishes an Azure CBS-authenticated AMQP connection.
+
+    State machine:
+      1. ``on_start``                -> open SASL ANONYMOUS amqps:// connection.
+      2. ``on_connection_opened``    -> attach ``$cbs`` sender + receiver pair
+                                       (receiver source AND target pinned to ``$cbs``).
+      3. both CBS links opened       -> send put-token request (with correlation id).
+      4. CBS reply (status 200/202)  -> attach main sender to ``self._address``
+                                       (with AtLeastOnce so we get accepted/rejected).
+      5. main sender opened          -> signal ``_init_future`` ready.
+      6. ``on_sendable`` / injected  -> drain outbound queue, track each delivery.
+      7. ``on_accepted/rejected``    -> resolve the per-send ``Future``.
+      8. ``on_disconnected``         -> fail everything (v1: no reconnect).
+    """
+
+    def __init__(self, host, port, address, token_provider, use_tls,
+                 init_future, send_queue, close_event):
+        super().__init__(auto_settle=False, auto_accept=False)
+        self._host = host
+        self._port = port
+        self._address = address
+        self._token_provider = token_provider
+        self._use_tls = use_tls
+        self._init_future = init_future
+        self._send_queue = send_queue
+        self._close_event = close_event
+        self._close_requested = False
+
+        self._container = None
+        self._conn = None
+        self._cbs_sender = None
+        self._cbs_receiver = None
+        self._main_sender = None
+        self._cbs_sender_opened = False
+        self._cbs_receiver_opened = False
+        self._cbs_request_id = None
+        self._pending: typing.Dict[bytes, concurrent.futures.Future] = {}
+        self._failed = False
+
+    # ---- lifecycle ----
+
+    def on_start(self, event):
+        self._container = event.container
+        scheme = "amqps" if self._use_tls else "amqp"
+        url = f"{scheme}://{self._host}:{self._port}"
+        # SASL ANONYMOUS: Azure broker accepts the connection without creds;
+        # authn is established by the subsequent CBS put-token exchange.
+        self._conn = self._container.connect(
+            url,
+            sasl_enabled=True,
+            allowed_mechs="ANONYMOUS",
+            reconnect=False,
+        )
+        # Cross-thread wakeup: poll the send-queue + close-flag periodically.
+        # EventInjector is not portable on Windows (needs a real socketpair),
+        # so a 25ms recurring timer is used instead. Latency overhead is
+        # negligible for non-bulk workloads.
+        self._container.schedule(0.025, self)
+
+    def on_timer_task(self, event):
+        if self._close_requested:
+            self._begin_close()
+            return
+        if self._main_sender is not None and self._main_sender.credit > 0:
+            self._pump()
+        self._container.schedule(0.025, self)
+
+    def on_connection_opened(self, event):
+        _cbs_logger.debug("[cbs] on_connection_opened")
+        # Attach the CBS sender + receiver. Both terminus addresses pinned to "$cbs".
+        self._cbs_sender = self._container.create_sender(self._conn, "$cbs", name="cbs-sender")
+        self._cbs_receiver = self._container.create_receiver(
+            self._conn, "$cbs", name="cbs-receiver"
+        )
+        # Pin the receiver target explicitly (Azure rejects dynamic terminus).
+        self._cbs_receiver.target.address = "$cbs"
+        self._cbs_receiver.target.dynamic = False
+
+    def on_link_opened(self, event):
+        _cbs_logger.debug(f"[cbs] on_link_opened {event.link.name}")
+        try:
+            link_name = event.link.name
+            if link_name == "cbs-sender":
+                self._cbs_sender_opened = True
+            elif link_name == "cbs-receiver":
+                self._cbs_receiver_opened = True
+            elif link_name == "main-sender":
+                if not self._init_future.done():
+                    self._init_future.set_result(True)
+                return
+            if self._cbs_sender_opened and self._cbs_receiver_opened and self._cbs_request_id is None:
+                self._send_put_token()
+        except Exception as exc:
+            self._fail_init(exc)
+
+    def _send_put_token(self):
+        _cbs_logger.debug(
+            "[cbs] _send_put_token: acquiring token (type=%s)",
+            self._token_provider.token_type,
+        )
+        try:
+            token_body, expires_on = self._token_provider.acquire()
+        except Exception as exc:
+            self._fail_init(exc)
+            return
+        _cbs_logger.debug(f"[cbs] _send_put_token: token len={len(token_body)} exp={expires_on}")
+        resource_uri = f"sb://{self._host}/{self._address}"
+        self._cbs_request_id = str(uuid.uuid4())
+        msg = Message(body=token_body)
+        msg.address = "$cbs"
+        msg.reply_to = "$cbs"
+        msg.id = self._cbs_request_id
+        msg.properties = {
+            "operation": "put-token",
+            "type": self._token_provider.token_type,
+            "name": resource_uri,
+            "expiration": int(expires_on),
+        }
+        try:
+            self._cbs_sender.send(msg)
+            _cbs_logger.debug("[cbs] _send_put_token: sent")
+        except Exception as exc:
+            _cbs_logger.debug(f"[cbs] _send_put_token: send raised {exc!r}")
+            self._fail_init(RuntimeError(f"CBS put-token send failed: {exc}"))
+
+    def on_message(self, event):
+        _cbs_logger.debug(f"[cbs] on_message link={event.link.name}")
+        # Only CBS replies are expected on this handler's receiver.
+        if event.link.name != "cbs-receiver":
+            return
+        reply = event.message
+        _cbs_logger.debug(f"[cbs] on_message correlation_id={reply.correlation_id!r} expected={self._cbs_request_id!r} props={dict(reply.properties or {})}")
+        try:
+            event.delivery.update(event.delivery.ACCEPTED)
+            event.delivery.settle()
+        except Exception:
+            pass
+        # Correlate: only accept the reply matching our put-token request id.
+        # Compare as strings to tolerate UUID/bytes/str shapes.
+        if str(reply.correlation_id) != str(self._cbs_request_id):
+            _cbs_logger.debug("[cbs] on_message: correlation mismatch, ignoring")
+            return
+        props = reply.properties or {}
+        status_code = props.get("status-code") or props.get(symbol("status-code")) or 0
+        status_desc = props.get("status-description") or props.get(symbol("status-description")) or ""
+        _cbs_logger.debug(f"[cbs] on_message: status_code={status_code} desc={status_desc!r}")
+        if status_code in (200, 202):
+            try:
+                self._main_sender = self._container.create_sender(
+                    self._conn, self._address, name="main-sender", options=AtLeastOnce()
+                )
+                _cbs_logger.debug("[cbs] on_message: main-sender create requested")
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] on_message: create_sender raised {exc!r}")
+                self._fail_init(exc)
+        else:
+            self._fail_init(RuntimeError(
+                f"CBS put-token rejected: status_code={status_code} {status_desc!r}"
+            ))
+
+    # ---- outbound sends ----
+
+    def on_sendable(self, event):
+        if event.link is self._main_sender:
+            self._pump()
+
+    def _pump(self):
+        if self._main_sender is None or self._failed:
+            return
+        while self._main_sender.credit > 0:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                return
+            if req is None:  # close sentinel
+                self._begin_close()
+                return
+            msg, fut = req
+            tag = str(uuid.uuid4()).encode()
+            try:
+                delivery = self._main_sender.send(msg, tag=tag)
+            except Exception as exc:
+                if not fut.done():
+                    fut.set_exception(exc)
+                continue
+            self._pending[tag] = fut
+            # delivery.tag is what comes back on disposition events
+            self._pending[delivery.tag] = fut
+
+    def on_accepted(self, event):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_result(True)
+
+    def on_rejected(self, event):
+        self._fail_delivery(event, "rejected")
+
+    def on_released(self, event):
+        self._fail_delivery(event, "released")
+
+    def on_modified(self, event):
+        self._fail_delivery(event, "modified")
+
+    def _fail_delivery(self, event, reason):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_exception(RuntimeError(f"Send failed: {reason}"))
+
+    # ---- error / close ----
+
+    def on_inject_close(self, event):
+        self._begin_close()
+
+    def request_close(self):
+        """Called from the producer thread; reactor picks it up on next timer tick."""
+        self._close_requested = True
+
+    def _begin_close(self):
+        try:
+            if self._main_sender:
+                self._main_sender.close()
+        except Exception:
+            pass
+        try:
+            if self._cbs_sender:
+                self._cbs_sender.close()
+            if self._cbs_receiver:
+                self._cbs_receiver.close()
+        except Exception:
+            pass
+        try:
+            if self._conn:
+                self._conn.close()
+        except Exception:
+            pass
+
+    def on_transport_error(self, event):
+        self._fail_all(RuntimeError(f"Transport error: {event.transport.condition}"))
+
+    def on_connection_error(self, event):
+        cond = event.connection.remote_condition
+        self._fail_all(RuntimeError(f"Connection error: {cond}"))
+
+    def on_link_error(self, event):
+        cond = event.link.remote_condition
+        self._fail_all(RuntimeError(f"Link error on {event.link.name}: {cond}"))
+
+    def on_disconnected(self, event):
+        _cbs_logger.debug("[cbs] on_disconnected")
+        self._fail_all(RuntimeError("Disconnected"))
+        self._close_event.set()
+
+    def _fail_init(self, exc):
+        _cbs_logger.debug(f"[cbs] _fail_init: {exc!r}")
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+
+    def _fail_all(self, exc):
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+        # Drain queue
+        while True:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                break
+            if req is None:
+                continue
+            _, fut = req
+            if not fut.done():
+                fut.set_exception(exc)
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+from epa_uv_amqp_producer_data import HourlyForecast
+from epa_uv_amqp_producer_data import DailyForecast
+
+class USEPAUVIndexAmqpProducer:
+    """
+    Producer class to send messages in the `US.EPA.UVIndex.amqp` message group via AMQP 1.0 protocol.
+    """
+    
+    def __init__(self, 
+                 host: str,
+                 address: str,
+                 port: int = 5672,
+                 username: typing.Optional[str] = None,
+                 password: typing.Optional[str] = None,
+                 content_mode: typing.Literal['structured', 'binary'] = 'structured',
+                 format_type: str = 'application/json',
+                 credential: typing.Optional["TokenCredential"] = None,
+                 entra_audience: str = "https://servicebus.azure.net/.default",
+                 sas_key_name: typing.Optional[str] = None,
+                 sas_key: typing.Optional[str] = None,
+                 sas_token_ttl_seconds: int = 3600,
+                 use_tls: bool = True,
+                 ):
+        """
+        Initialize the AMQP producer
+        
+        Args:
+            host (str): The AMQP broker hostname
+            address (str): The AMQP address (queue or topic)
+            port (int): The AMQP broker port (default: 5672)
+            username (typing.Optional[str]): Optional username for SASL PLAIN authentication
+            password (typing.Optional[str]): Optional password for SASL PLAIN authentication
+            content_mode (typing.Literal['structured', 'binary']): CloudEvents content mode (default: 'structured')
+            format_type (str): Content type format for structured mode (default: 'application/json')
+            credential (typing.Optional[TokenCredential]): An azure-identity TokenCredential
+                (e.g. DefaultAzureCredential). When provided, SASL ANONYMOUS is used and an
+                Entra ID JWT is presented via AMQP CBS put-token (``type=jwt``). Mutually
+                exclusive with username/password and with sas_key_name/sas_key.
+            entra_audience (str): AAD scope used to acquire the JWT
+                (default: 'https://servicebus.azure.net/.default' -- targets Azure servicebus).
+                Override only when targeting a non-standard cloud or cross-targeting (e.g.
+                an Event Hubs client talking to a Service Bus entity, or vice-versa).
+            sas_key_name (typing.Optional[str]): SAS policy/key name (e.g.
+                ``RootManageSharedAccessKey``). When set with ``sas_key``, SASL ANONYMOUS
+                is used and a SAS token is presented via AMQP CBS put-token
+                (``type=servicebus.windows.net:sastoken``). Required for the Service Bus
+                emulator and for namespaces configured for SAS authentication.
+                Mutually exclusive with credential and with username/password.
+            sas_key (typing.Optional[str]): SAS key value (base64) used to sign the token.
+            sas_token_ttl_seconds (int): Lifetime of each minted SAS token (default: 3600).
+            use_tls (bool): If True (default), connect via amqps:// on port 5671 unless port
+                is explicitly set. Required for Azure servicebus; set to False
+                for the local Service Bus emulator (plain AMQP on 5672).
+        """
+        self.host = host
+        self.port = port
+        self.address = address
+        self.username = username
+        self.password = password
+        self.content_mode = content_mode
+        self.format_type = format_type
+        self._credential = credential
+        self._entra_audience = entra_audience
+        self._sas_key_name = sas_key_name
+        self._sas_key = sas_key
+        self._sas_token_ttl = int(sas_token_ttl_seconds)
+        self._use_tls = use_tls
+
+        _sas_configured = bool(sas_key_name or sas_key)
+        if _sas_configured and not (sas_key_name and sas_key):
+            raise ValueError(
+                "sas_key_name and sas_key must both be provided for SAS CBS auth."
+            )
+        if self._credential is not None and _sas_configured:
+            raise ValueError(
+                "credential is mutually exclusive with sas_key_name/sas_key. "
+                "Choose Entra ID OR SAS for CBS authentication."
+            )
+        if (self._credential is not None or _sas_configured) and (self.username or self.password):
+            raise ValueError(
+                "CBS auth (credential or SAS) is mutually exclusive with "
+                "username/password SASL PLAIN."
+            )
+        self._cbs_enabled = self._credential is not None or _sas_configured
+        if self._credential is not None and port == 5672:
+            # Default to AMQPS for Entra path; caller can override explicitly.
+            self.port = 5671
+        if self._cbs_enabled:
+            self._init_reactor()
+        else:
+            connection_url = self._build_connection_url()
+            self._connection = BlockingConnection(connection_url, timeout=30)
+            self._sender = self._connection.create_sender(self.address)
+
+    def _init_reactor(self):
+        """Start the proton reactor thread and block until CBS handshake completes.
+
+        On failure, the exception is propagated out of ``__init__`` so callers
+        get a clean error rather than discovering the problem on first send.
+        """
+        if self._credential is not None:
+            token_provider: _CbsTokenProvider = _JwtTokenProvider(
+                self._credential, self._entra_audience
+            )
+        else:
+            resource_uri = f"sb://{self.host}/{self.address}"
+            token_provider = _SasTokenProvider(
+                self._sas_key_name, self._sas_key, resource_uri,
+                ttl_seconds=self._sas_token_ttl,
+            )
+
+        self._send_queue: "queue.Queue" = queue.Queue()
+        self._init_future: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._close_event = threading.Event()
+        self._handler = _CbsAzureHandler(
+            host=self.host,
+            port=self.port,
+            address=self.address,
+            token_provider=token_provider,
+            use_tls=self._use_tls,
+            init_future=self._init_future,
+            send_queue=self._send_queue,
+            close_event=self._close_event,
+        )
+
+        def _run():
+            import traceback as _tb
+            try:
+                Container(self._handler).run()
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] reactor crashed: {exc!r}\n{_tb.format_exc()}")
+                if not self._init_future.done():
+                    self._init_future.set_exception(exc)
+            finally:
+                self._close_event.set()
+
+        self._reactor_thread = threading.Thread(
+            target=_run, name="amqp-cbs-reactor", daemon=True
+        )
+        self._reactor_thread.start()
+
+        try:
+            self._init_future.result(timeout=60)
+        except Exception:
+            try:
+                self._handler.request_close()
+            except Exception:
+                pass
+            self._close_event.wait(timeout=10)
+            raise
+
+    def _send_via_reactor(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        fut: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._send_queue.put((amqp_msg, fut))
+        fut.result(timeout=timeout)
+    
+    def _build_connection_url(self) -> str:
+        if self.username and self.password:
+            user = quote_plus(self.username)
+            pwd = quote_plus(self.password)
+            return f"amqp://{user}:{pwd}@{self.host}:{self.port}"
+        return f"amqp://{self.host}:{self.port}"
+
+    def _serialize_payload(self, data: typing.Any, content_type: str) -> bytes:
+        if data is None:
+            return b''
+        if hasattr(data, 'to_byte_array'):
+            payload = data.to_byte_array(content_type)
+        elif hasattr(data, 'to_dict'):
+            payload = json.dumps(data.to_dict())
+        elif isinstance(data, (bytes, bytearray)):
+            payload = bytes(data)
+        else:
+            payload = json.dumps(data)
+        # to_byte_array may return str for text content types (e.g. JSON);
+        # we always emit bytes so the AMQP body is a binary section rather
+        # than an AMQP string section containing escaped JSON.
+        if isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        return payload
+
+    @staticmethod
+    def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        """Translate cloudevents-sdk HTTP-style headers (``ce-foo``) into the
+        CloudEvents AMQP 1.0 Protocol Binding (v1.0.2 §3.1) form
+        (``cloudEvents:foo``). ``content-type`` is carried separately on the
+        AMQP properties section and is therefore dropped here.
+        """
+        out: typing.Dict[str, typing.Any] = {}
+        for k, v in (headers or {}).items():
+            if v is None:
+                continue
+            lk = str(k)
+            low = lk.lower()
+            if low.startswith('ce-'):
+                out['cloudEvents:' + lk[3:]] = v
+            elif low == 'content-type':
+                continue
+            else:
+                out[lk] = v
+        return out
+
+    
+    
+    def send_hourly_forecast(self,
+        data: HourlyForecast,
+        _location_id: str,
+        _state: str,
+        _city_slug: str,
+        _forecast_hour: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send the `US.EPA.UVIndex.amqp.HourlyForecast` message
+        An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast valid hour, normalized location identity, and UV index value for operational exposure planning.
+        
+        Args:
+            _location_id (str): Value for placeholder location_id in attribute subject
+            _state (str): Value for AMQP protocol option placeholder state
+            _city_slug (str): Value for AMQP protocol option placeholder city_slug
+            _forecast_hour (str): Value for AMQP protocol option placeholder forecast_hour
+            data (HourlyForecast): The message data object
+            content_type (str): The content type of the message data (default: 'application/json')
+        """
+        # Build CloudEvent attributes
+        attributes = {
+            "type":
+            "US.EPA.UVIndex.HourlyForecast",
+            "source":
+            "https://www.epa.gov/enviro/web-services",
+            "subject":
+            "{location_id}".format(location_id=_location_id),
+        }
+        
+        # Remove None values
+        attributes = {k: v for k, v in attributes.items() if v is not None}
+        
+        # Serialize data
+        byte_data = self._serialize_payload(data, content_type)
+        
+        # Create CloudEvent
+        cloud_event = CloudEvent(attributes, byte_data)
+        
+        # Convert to AMQP message based on content mode
+        if self.content_mode == 'structured':
+            headers, body = to_structured(cloud_event)
+            if isinstance(body, dict):
+                msg_body = json.dumps(body).encode('utf-8')
+            elif isinstance(body, bytes):
+                msg_body = body
+            else:
+                msg_body = str(body).encode('utf-8')
+            amqp_msg = Message(body=msg_body, inferred=True)
+            amqp_msg.content_type = self.format_type or headers.get('content-type')
+        else:  # binary mode
+            headers, body = to_binary(cloud_event)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
+            amqp_msg.content_type = content_type
+            if headers:
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{location_id}".format(location_id=_location_id)
+
+        app_properties = {}
+        app_properties["state"] = "{state}".format(state=_state)
+        app_properties["city_slug"] = "{city_slug}".format(city_slug=_city_slug)
+        app_properties["forecast_hour"] = "{forecast_hour}".format(forecast_hour=_forecast_hour)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
+        
+        # Send message
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+    
+    def send_hourly_forecast_batch(self,
+        data_array: typing.List[HourlyForecast],
+        _location_id: str,
+        _state: str,
+        _city_slug: str,
+        _forecast_hour: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send multiple `US.EPA.UVIndex.amqp.HourlyForecast` messages
+        
+        Args:
+            data_array (typing.List[HourlyForecast]): Array of message data objects
+            _location_id (str): Value for placeholder location_id in attribute subject
+            _state (str): Value for AMQP protocol option placeholder state
+            _city_slug (str): Value for AMQP protocol option placeholder city_slug
+            _forecast_hour (str): Value for AMQP protocol option placeholder forecast_hour
+            content_type (str): The content type of the message data
+        """
+        for data in data_array:
+            self.send_hourly_forecast(
+                data=data,
+                _location_id=_location_id,
+                _state=_state,
+                _city_slug=_city_slug,
+                _forecast_hour=_forecast_hour,
+                content_type=content_type)
+    
+    
+    def send_daily_forecast(self,
+        data: DailyForecast,
+        _location_id: str,
+        _state: str,
+        _city_slug: str,
+        _forecast_date: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send the `US.EPA.UVIndex.amqp.DailyForecast` message
+        A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning.
+        
+        Args:
+            _location_id (str): Value for placeholder location_id in attribute subject
+            _state (str): Value for AMQP protocol option placeholder state
+            _city_slug (str): Value for AMQP protocol option placeholder city_slug
+            _forecast_date (str): Value for AMQP protocol option placeholder forecast_date
+            data (DailyForecast): The message data object
+            content_type (str): The content type of the message data (default: 'application/json')
+        """
+        # Build CloudEvent attributes
+        attributes = {
+            "type":
+            "US.EPA.UVIndex.DailyForecast",
+            "source":
+            "https://www.epa.gov/enviro/web-services",
+            "subject":
+            "{location_id}".format(location_id=_location_id),
+        }
+        
+        # Remove None values
+        attributes = {k: v for k, v in attributes.items() if v is not None}
+        
+        # Serialize data
+        byte_data = self._serialize_payload(data, content_type)
+        
+        # Create CloudEvent
+        cloud_event = CloudEvent(attributes, byte_data)
+        
+        # Convert to AMQP message based on content mode
+        if self.content_mode == 'structured':
+            headers, body = to_structured(cloud_event)
+            if isinstance(body, dict):
+                msg_body = json.dumps(body).encode('utf-8')
+            elif isinstance(body, bytes):
+                msg_body = body
+            else:
+                msg_body = str(body).encode('utf-8')
+            amqp_msg = Message(body=msg_body, inferred=True)
+            amqp_msg.content_type = self.format_type or headers.get('content-type')
+        else:  # binary mode
+            headers, body = to_binary(cloud_event)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
+            amqp_msg.content_type = content_type
+            if headers:
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{location_id}".format(location_id=_location_id)
+
+        app_properties = {}
+        app_properties["state"] = "{state}".format(state=_state)
+        app_properties["city_slug"] = "{city_slug}".format(city_slug=_city_slug)
+        app_properties["forecast_date"] = "{forecast_date}".format(forecast_date=_forecast_date)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
+        
+        # Send message
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+    
+    def send_daily_forecast_batch(self,
+        data_array: typing.List[DailyForecast],
+        _location_id: str,
+        _state: str,
+        _city_slug: str,
+        _forecast_date: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send multiple `US.EPA.UVIndex.amqp.DailyForecast` messages
+        
+        Args:
+            data_array (typing.List[DailyForecast]): Array of message data objects
+            _location_id (str): Value for placeholder location_id in attribute subject
+            _state (str): Value for AMQP protocol option placeholder state
+            _city_slug (str): Value for AMQP protocol option placeholder city_slug
+            _forecast_date (str): Value for AMQP protocol option placeholder forecast_date
+            content_type (str): The content type of the message data
+        """
+        for data in data_array:
+            self.send_daily_forecast(
+                data=data,
+                _location_id=_location_id,
+                _state=_state,
+                _city_slug=_city_slug,
+                _forecast_date=_forecast_date,
+                content_type=content_type)
+    
+    
+    def close(self) -> None:
+        """
+        Close the producer and clean up resources
+        """
+        if getattr(self, "_handler", None) is not None:
+            try:
+                self._handler.request_close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._close_event.wait(timeout=10)
+            self._handler = None
+            return
+        if hasattr(self, '_sender') and self._sender:
+            try:
+                self._sender.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._sender = None
+        if hasattr(self, '_connection') and self._connection:
+            try:
+                self._connection.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._connection = None
+

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer/tests/test_producer.py
@@ -1,0 +1,360 @@
+
+# pylint: disable=missing-function-docstring, wrong-import-position, import-error, no-name-in-module, import-outside-toplevel, no-member, redefined-outer-name, unused-argument, unused-variable, invalid-name, missing-class-docstring
+
+"""
+Tests for epa_uv_amqp_producer_amqp_producer
+"""
+import base64
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from typing import Optional
+from urllib.parse import quote_plus
+
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+from proton.utils import BlockingConnection
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_amqp_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_amqp_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../epa_uv_amqp_producer_amqp_producer/src')))
+
+from epa_uv_amqp_producer_amqp_producer import *
+from epa_uv_amqp_producer_data import HourlyForecast
+from test_epa_uv_amqp_producer_data_hourlyforecast import Test_HourlyForecast
+from epa_uv_amqp_producer_data import DailyForecast
+from test_epa_uv_amqp_producer_data_dailyforecast import Test_DailyForecast
+
+
+
+def _rabbitmq_queue_address(queue_name: str) -> str:
+    return f"/queues/{queue_name}" if os.environ.get("RABBITMQ_VERSION", "4") != "3" else queue_name
+
+
+def _declare_rabbitmq_queue(host: str, mgmt_port: int, queue_name: str):
+    url = f"http://{host}:{mgmt_port}/api/queues/%2F/{queue_name}"
+    payload = b'{"auto_delete": false, "durable": true, "arguments": {}}'
+    auth = base64.b64encode(b"guest:guest").decode("ascii")
+    last_error = None
+    for _ in range(30):
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in (201, 204):
+                    return
+                last_error = RuntimeError(f"RabbitMQ queue declaration returned {response.status}")
+        except urllib.error.HTTPError as exc:
+            if exc.code in (201, 204):
+                return
+            last_error = exc
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out declaring RabbitMQ queue {queue_name}") from last_error
+
+ARTEMIS_BROKER_XML = """<?xml version='1.0'?>
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>0.0.0.0</name>
+        <persistence-enabled>false</persistence-enabled>
+        <acceptors>
+            <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP;saslMechanisms=PLAIN,ANONYMOUS</acceptor>
+        </acceptors>
+        <security-settings>
+            <security-setting match="#">
+                <permission type="createNonDurableQueue" roles="amq"/>
+                <permission type="deleteNonDurableQueue" roles="amq"/>
+                <permission type="createDurableQueue" roles="amq"/>
+                <permission type="deleteDurableQueue" roles="amq"/>
+                <permission type="createAddress" roles="amq"/>
+                <permission type="deleteAddress" roles="amq"/>
+                <permission type="consume" roles="amq"/>
+                <permission type="browse" roles="amq"/>
+                <permission type="send" roles="amq"/>
+                <permission type="manage" roles="amq"/>
+            </security-setting>
+        </security-settings>
+        <address-settings>
+            <address-setting match="#">
+                <dead-letter-address>DLQ</dead-letter-address>
+                <expiry-address>ExpiryQueue</expiry-address>
+                <auto-create-queues>true</auto-create-queues>
+                <auto-create-addresses>true</auto-create-addresses>
+            </address-setting>
+        </address-settings>
+        <addresses>
+            <address name="test-queue">
+                <anycast>
+                    <queue name="test-queue" />
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>
+"""
+
+@pytest.fixture(scope="module")
+def amqp_broker():
+    """Create and start an AMQP broker container for testing.
+    
+    Uses ActiveMQ Artemis by default.
+    Set AMQP_BROKER=rabbitmq environment variable to test with RabbitMQ.
+    Set RABBITMQ_VERSION=3 or RABBITMQ_VERSION=4 to choose RabbitMQ version (default: 4).
+    """
+    broker_type = os.environ.get("AMQP_BROKER", "artemis").lower()
+    
+    if broker_type == "rabbitmq":
+        rabbitmq_version = os.environ.get("RABBITMQ_VERSION", "4")
+        image_tag = "3-management" if rabbitmq_version == "3" else "4-management"
+        
+        container = DockerContainer(f"rabbitmq:{image_tag}")
+        container.with_bind_ports(5672, 5672)
+        container.with_bind_ports(15672, 15672)
+        container.with_env("RABBITMQ_DEFAULT_USER", "guest")
+        container.with_env("RABBITMQ_DEFAULT_PASS", "guest")
+        container.with_exposed_ports(5672, 15672)
+        
+        # RabbitMQ 3.x requires AMQP 1.0 plugin, RabbitMQ 4.0+ has native support
+        if rabbitmq_version == "3":
+            container.with_command(
+                "bash", "-c", 
+                "rabbitmq-plugins enable rabbitmq_amqp1_0 && docker-entrypoint.sh rabbitmq-server"
+            )
+        
+        container.start()
+        # Wait for RabbitMQ to be ready
+        wait_for_logs(container, "Server startup complete", timeout=120)
+        host = container.get_container_host_ip()
+        if rabbitmq_version != "3":
+            _declare_rabbitmq_queue(host, int(container.get_exposed_port(15672)), "test-queue")
+        
+        yield {
+            "host": host,
+            "port": int(container.get_exposed_port(5672)),
+            "username": "guest",
+            "password": "guest",
+            "address": _rabbitmq_queue_address("test-queue")
+        }
+        
+        container.stop()
+    else:
+        # Default: ActiveMQ Artemis
+        # Create temp file for broker configuration
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+            f.write(ARTEMIS_BROKER_XML)
+            config_file = f.name
+        
+        try:
+            container = DockerContainer("apache/activemq-artemis:latest")
+            container.with_bind_ports(5672, 5672)
+            container.with_env("ARTEMIS_USER", "guest")
+            container.with_env("ARTEMIS_PASSWORD", "guest")
+            container.with_volume_mapping(config_file, "/var/lib/artemis-instance/etc-override/broker.xml")
+            container.with_exposed_ports(5672)
+            
+            # Wait for Artemis to be ready
+            container.start()
+            # Wait for broker to log that it's ready (AMQ241004 = "Artemis Server is now live")
+            wait_for_logs(container, "AMQ241004", timeout=60)
+            
+            yield {
+                "host": container.get_container_host_ip(),
+                "port": int(container.get_exposed_port(5672)),
+                "username": "guest",
+                "password": "guest",
+                "address": "test-queue"
+            }
+            
+            container.stop()
+        finally:
+            if os.path.exists(config_file):
+                os.unlink(config_file)
+
+# Keep old fixture name for backwards compatibility
+@pytest.fixture(scope="module")
+def artemis_container(amqp_broker):
+    """Alias for amqp_broker for backwards compatibility"""
+    return amqp_broker
+
+def _connection_url(host: str, port: int, username: Optional[str] = None, password: Optional[str] = None) -> str:
+    if username and password:
+        return f"amqp://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}"
+    return f"amqp://{host}:{port}"
+
+
+def _receive_single_message(config: dict, timeout: int = 30):
+    connection = BlockingConnection(
+        _connection_url(
+            config["host"],
+            config["port"],
+            config.get("username"),
+            config.get("password"),
+        ),
+        timeout=timeout,
+    )
+    receiver = connection.create_receiver(config["address"], credit=1)
+    try:
+        message = receiver.receive(timeout=timeout)
+        receiver.accept()  # Explicitly accept/settle the message to remove it from the queue
+        return message
+    finally:
+        receiver.close()
+        connection.close()
+
+class TestUSEPAUVIndexAmqpProducer:
+    """Test cases for USEPAUVIndexAmqpProducer"""
+    
+    def test_producer_initialization(self, artemis_container):
+        """Test that producer initializes correctly"""
+        producer = USEPAUVIndexAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"]
+        )
+        assert producer is not None
+        assert producer.host == artemis_container["host"]
+        assert producer.address == artemis_container["address"]
+        assert producer.port == artemis_container["port"]
+        assert producer.username == artemis_container["username"]
+        producer.close()
+    
+    def test_send_hourly_forecast(self, artemis_container):
+        """Send and receive a HourlyForecast message via ActiveMQ Artemis."""
+        # Create valid test data using the test helper
+        payload = Test_HourlyForecast.create_instance()
+
+        producer = USEPAUVIndexAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='structured'
+        )
+        
+        try:
+            assert producer.host == artemis_container["host"]
+            assert producer.address == artemis_container["address"]
+            assert producer.port == artemis_container["port"]
+            assert producer.username == artemis_container["username"]
+            assert producer.content_mode == 'structured'
+            # Send 5 messages to test proper message settlement and ordering
+            for i in range(5):
+                producer.send_hourly_forecast(
+                    data=payload,
+                    _location_id="value",
+                    _state="value",
+                    _city_slug="value",
+                    _forecast_hour="value",
+                    content_type="application/json"
+                )
+
+            # Receive and verify all 5 messages
+            for i in range(5):
+                received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
+
+                if True:
+                    body = received.body
+                    if isinstance(body, memoryview):
+                        body_text = body.tobytes().decode('utf-8')
+                    elif isinstance(body, bytes):
+                        body_text = body.decode('utf-8')
+                    elif isinstance(body, str):
+                        body_text = body
+                    elif isinstance(body, dict):
+                        body_text = json.dumps(body)
+                    else:
+                        body_text = str(body)
+                    cloud_event_payload = json.loads(body_text)
+                    assert cloud_event_payload.get("type") == "US.EPA.UVIndex.amqp.HourlyForecast"
+                    # Verify data section exists (either as data or data_base64)
+                    assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
+                else:
+                    # Verify message body is not empty
+                    assert received.body is not None
+                assert received.subject == "{location_id}".format(location_id="value")
+                assert properties.get('state') == "{state}".format(state="value")
+                assert properties.get('city_slug') == "{city_slug}".format(city_slug="value")
+                assert properties.get('forecast_hour') == "{forecast_hour}".format(forecast_hour="value")
+        finally:
+            producer.close()
+    
+    def test_send_daily_forecast(self, artemis_container):
+        """Send and receive a DailyForecast message via ActiveMQ Artemis."""
+        # Create valid test data using the test helper
+        payload = Test_DailyForecast.create_instance()
+
+        producer = USEPAUVIndexAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='structured'
+        )
+        
+        try:
+            assert producer.host == artemis_container["host"]
+            assert producer.address == artemis_container["address"]
+            assert producer.port == artemis_container["port"]
+            assert producer.username == artemis_container["username"]
+            assert producer.content_mode == 'structured'
+            # Send 5 messages to test proper message settlement and ordering
+            for i in range(5):
+                producer.send_daily_forecast(
+                    data=payload,
+                    _location_id="value",
+                    _state="value",
+                    _city_slug="value",
+                    _forecast_date="value",
+                    content_type="application/json"
+                )
+
+            # Receive and verify all 5 messages
+            for i in range(5):
+                received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
+
+                if True:
+                    body = received.body
+                    if isinstance(body, memoryview):
+                        body_text = body.tobytes().decode('utf-8')
+                    elif isinstance(body, bytes):
+                        body_text = body.decode('utf-8')
+                    elif isinstance(body, str):
+                        body_text = body
+                    elif isinstance(body, dict):
+                        body_text = json.dumps(body)
+                    else:
+                        body_text = str(body)
+                    cloud_event_payload = json.loads(body_text)
+                    assert cloud_event_payload.get("type") == "US.EPA.UVIndex.amqp.DailyForecast"
+                    # Verify data section exists (either as data or data_base64)
+                    assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
+                else:
+                    # Verify message body is not empty
+                    assert received.body is not None
+                assert received.subject == "{location_id}".format(location_id="value")
+                assert properties.get('state') == "{state}".format(state="value")
+                assert properties.get('city_slug') == "{city_slug}".format(city_slug="value")
+                assert properties.get('forecast_date') == "{forecast_date}".format(forecast_date="value")
+        finally:
+            producer.close()
+

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/pyproject.toml
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "epa-uv-amqp-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "epa_uv_amqp_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/__init__.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .dailyforecast import DailyForecast
+from .hourlyforecast import HourlyForecast
+
+__all__ = ["DailyForecast", "HourlyForecast"]

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/dailyforecast.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/dailyforecast.py
@@ -1,0 +1,173 @@
+""" DailyForecast dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class DailyForecast:
+    """
+    Daily UV Index forecast and alert flag for a configured city and state from the EPA Envirofacts UV daily service.
+    
+    Attributes:
+        location_id (str)
+        city (str)
+        state (str)
+        forecast_date (str)
+        uv_index (int)
+        uv_alert (str)
+        city_slug (str)
+    """
+    
+    
+    location_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="location_id"))
+    city: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
+    forecast_date: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_date"))
+    uv_index: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_index"))
+    uv_alert: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_alert"))
+    city_slug: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city_slug"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'DailyForecast':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['DailyForecast']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return DailyForecast.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'DailyForecast':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            location_id='ibeokfyjimgrorsviqtr',
+            city='mhofevklwrtnctcrbccu',
+            state='vwywfzboxybupzomsrrx',
+            forecast_date='borfdbrbcugkrqhiiwip',
+            uv_index=int(40),
+            uv_alert='agmvbqguyapskjuyookh',
+            city_slug='ooyjnkiyzjpsnzukllca'
+        )

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/hourlyforecast.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/src/epa_uv_amqp_producer_data/hourlyforecast.py
@@ -1,0 +1,173 @@
+""" HourlyForecast dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class HourlyForecast:
+    """
+    Hourly UV Index forecast for a configured city and state from the EPA Envirofacts UV hourly service.
+    
+    Attributes:
+        location_id (str)
+        city (str)
+        state (str)
+        forecast_datetime (str)
+        uv_index (int)
+        city_slug (str)
+        forecast_hour (str)
+    """
+    
+    
+    location_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="location_id"))
+    city: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
+    forecast_datetime: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_datetime"))
+    uv_index: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="uv_index"))
+    city_slug: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="city_slug"))
+    forecast_hour: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="forecast_hour"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'HourlyForecast':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['HourlyForecast']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return HourlyForecast.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'HourlyForecast':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            location_id='mnedrkniysrpgegsbjrk',
+            city='rigfzbpllhkyufurbjhu',
+            state='eoofqentcxbhbupxzfjy',
+            forecast_datetime='bemyoixjffijihblsbhr',
+            uv_index=int(16),
+            city_slug='udwkmhoqbhznzefxkgnv',
+            forecast_hour='ljswugqxoewitjajjdgz'
+        )

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/tests/test_dailyforecast.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/tests/test_dailyforecast.py
@@ -1,0 +1,116 @@
+"""
+Test case for DailyForecast
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from epa_uv_amqp_producer_data.dailyforecast import DailyForecast
+
+
+class Test_DailyForecast(unittest.TestCase):
+    """
+    Test case for DailyForecast
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_DailyForecast.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of DailyForecast for testing
+        """
+        instance = DailyForecast(
+            location_id='ibeokfyjimgrorsviqtr',
+            city='mhofevklwrtnctcrbccu',
+            state='vwywfzboxybupzomsrrx',
+            forecast_date='borfdbrbcugkrqhiiwip',
+            uv_index=int(40),
+            uv_alert='agmvbqguyapskjuyookh',
+            city_slug='ooyjnkiyzjpsnzukllca'
+        )
+        return instance
+
+    
+    def test_location_id_property(self):
+        """
+        Test location_id property
+        """
+        test_value = 'ibeokfyjimgrorsviqtr'
+        self.instance.location_id = test_value
+        self.assertEqual(self.instance.location_id, test_value)
+    
+    def test_city_property(self):
+        """
+        Test city property
+        """
+        test_value = 'mhofevklwrtnctcrbccu'
+        self.instance.city = test_value
+        self.assertEqual(self.instance.city, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'vwywfzboxybupzomsrrx'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
+    
+    def test_forecast_date_property(self):
+        """
+        Test forecast_date property
+        """
+        test_value = 'borfdbrbcugkrqhiiwip'
+        self.instance.forecast_date = test_value
+        self.assertEqual(self.instance.forecast_date, test_value)
+    
+    def test_uv_index_property(self):
+        """
+        Test uv_index property
+        """
+        test_value = int(40)
+        self.instance.uv_index = test_value
+        self.assertEqual(self.instance.uv_index, test_value)
+    
+    def test_uv_alert_property(self):
+        """
+        Test uv_alert property
+        """
+        test_value = 'agmvbqguyapskjuyookh'
+        self.instance.uv_alert = test_value
+        self.assertEqual(self.instance.uv_alert, test_value)
+    
+    def test_city_slug_property(self):
+        """
+        Test city_slug property
+        """
+        test_value = 'ooyjnkiyzjpsnzukllca'
+        self.instance.city_slug = test_value
+        self.assertEqual(self.instance.city_slug, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = DailyForecast.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = DailyForecast.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/tests/test_hourlyforecast.py
+++ b/epa-uv/epa_uv_amqp_producer/epa_uv_amqp_producer_data/tests/test_hourlyforecast.py
@@ -1,0 +1,116 @@
+"""
+Test case for HourlyForecast
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from epa_uv_amqp_producer_data.hourlyforecast import HourlyForecast
+
+
+class Test_HourlyForecast(unittest.TestCase):
+    """
+    Test case for HourlyForecast
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_HourlyForecast.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of HourlyForecast for testing
+        """
+        instance = HourlyForecast(
+            location_id='mnedrkniysrpgegsbjrk',
+            city='rigfzbpllhkyufurbjhu',
+            state='eoofqentcxbhbupxzfjy',
+            forecast_datetime='bemyoixjffijihblsbhr',
+            uv_index=int(16),
+            city_slug='udwkmhoqbhznzefxkgnv',
+            forecast_hour='ljswugqxoewitjajjdgz'
+        )
+        return instance
+
+    
+    def test_location_id_property(self):
+        """
+        Test location_id property
+        """
+        test_value = 'mnedrkniysrpgegsbjrk'
+        self.instance.location_id = test_value
+        self.assertEqual(self.instance.location_id, test_value)
+    
+    def test_city_property(self):
+        """
+        Test city property
+        """
+        test_value = 'rigfzbpllhkyufurbjhu'
+        self.instance.city = test_value
+        self.assertEqual(self.instance.city, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'eoofqentcxbhbupxzfjy'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
+    
+    def test_forecast_datetime_property(self):
+        """
+        Test forecast_datetime property
+        """
+        test_value = 'bemyoixjffijihblsbhr'
+        self.instance.forecast_datetime = test_value
+        self.assertEqual(self.instance.forecast_datetime, test_value)
+    
+    def test_uv_index_property(self):
+        """
+        Test uv_index property
+        """
+        test_value = int(16)
+        self.instance.uv_index = test_value
+        self.assertEqual(self.instance.uv_index, test_value)
+    
+    def test_city_slug_property(self):
+        """
+        Test city_slug property
+        """
+        test_value = 'udwkmhoqbhznzefxkgnv'
+        self.instance.city_slug = test_value
+        self.assertEqual(self.instance.city_slug, test_value)
+    
+    def test_forecast_hour_property(self):
+        """
+        Test forecast_hour property
+        """
+        test_value = 'ljswugqxoewitjajjdgz'
+        self.instance.forecast_hour = test_value
+        self.assertEqual(self.instance.forecast_hour, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = HourlyForecast.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = HourlyForecast.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/epa-uv/epa_uv_amqp_producer/install.bat
+++ b/epa-uv/epa_uv_amqp_producer/install.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Installing epa_uv_amqp_producer_amqp_producer...
+
+REM Check if poetry is installed
+where poetry >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo Poetry is not installed. Installing Poetry...
+    powershell -Command "& {(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -}"
+)
+
+REM Install dependencies
+poetry install
+
+echo Installation complete!
+echo Run 'poetry run pytest' to run tests

--- a/epa-uv/epa_uv_amqp_producer/install.sh
+++ b/epa-uv/epa_uv_amqp_producer/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Installing epa_uv_amqp_producer_amqp_producer..."
+
+# Check if poetry is installed
+if ! command -v poetry &> /dev/null; then
+    echo "Poetry is not installed. Installing Poetry..."
+    curl -sSL https://install.python-poetry.org | python3 -
+fi
+
+# Install dependencies
+poetry install
+
+echo "Installation complete!"
+echo "Run 'poetry run pytest' to run tests"

--- a/epa-uv/epa_uv_amqp_producer/samples/sample.py
+++ b/epa-uv/epa_uv_amqp_producer/samples/sample.py
@@ -1,0 +1,65 @@
+
+"""
+Sample usage of epa_uv_amqp_producer_amqp_producer
+
+This example demonstrates how to send messages using the AMQP 1.0 producer.
+"""
+import sys
+from epa_uv_amqp_producer_amqp_producer import *
+
+def main():
+    """Main function"""
+    
+    
+    # Create producer
+    print("Creating AMQP producer...")
+    producer = USEPAUVIndexAmqpProducer(
+        host="localhost",  # Change to your AMQP broker hostname
+        address="my-queue",  # Change to your queue/topic name
+        port=5672,  # Use 5671 for TLS
+        username="guest",  # Change to your username
+        password="guest",  # Change to your password
+        content_mode='structured',  # or 'binary' for CloudEvents
+        format_type='application/json'
+    )
+    
+    try:
+        
+        
+        # Send HourlyForecast message
+        print("Sending HourlyForecast message...")
+        # TODO: Create a HourlyForecast instance with actual data
+        # data = HourlyForecast(...)
+        # producer.send_hourly_forecast(
+        #     data=data,
+        #     content_type="application/json"
+        # )
+        # print("HourlyForecast message sent successfully!")
+        
+        
+        
+        # Send DailyForecast message
+        print("Sending DailyForecast message...")
+        # TODO: Create a DailyForecast instance with actual data
+        # data = DailyForecast(...)
+        # producer.send_daily_forecast(
+        #     data=data,
+        #     content_type="application/json"
+        # )
+        # print("DailyForecast message sent successfully!")
+        
+        
+        print("\nAll messages sent successfully!")
+        
+    except Exception as e:
+        print(f"Error sending messages: {e}", file=sys.stderr)
+        return 1
+    finally:
+        producer.close()
+        print("Producer closed")
+    
+    return 0
+    
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/epa-uv/epa_uv_amqp_producer/scripts/build.py
+++ b/epa-uv/epa_uv_amqp_producer/scripts/build.py
@@ -1,0 +1,30 @@
+"""
+Build script for epa_uv_amqp_producer_amqp_producer
+"""
+import subprocess
+import sys
+
+def main():
+    """Main build function"""
+    print("Building epa_uv_amqp_producer_amqp_producer...")
+    
+    try:
+        # Install dependencies
+        subprocess.run(["poetry", "install"], check=True)
+        
+        # Run tests
+        print("\nRunning tests...")
+        subprocess.run(["poetry", "run", "pytest"], check=True)
+        
+        # Build package
+        print("\nBuilding package...")
+        subprocess.run(["poetry", "build"], check=True)
+        
+        print("\n✓ Build complete!")
+        return 0
+    except subprocess.CalledProcessError as e:
+        print(f"\n✗ Build failed: {e}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/epa-uv/generate_amqp_producer.ps1
+++ b/epa-uv/generate_amqp_producer.ps1
@@ -1,0 +1,13 @@
+# Regenerate the AMQP 1.0 producer (amqpproducer style) from the authoritative xreg manifest.
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style amqpproducer `
+    --language py `
+    --definitions xreg\epa_uv.xreg.json `
+    --endpoint US.EPA.UVIndex.Amqp `
+    --projectname epa_uv_amqp_producer `
+    --template-args azure_cbs_target=servicebus `
+    --output epa_uv_amqp_producer

--- a/epa-uv/infra/azure-template-amqp.json
+++ b/epa-uv/infra/azure-template-amqp.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the EPA UV Index AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'epa-uv'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "epa-uv",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for EPA UV Index feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "epa-uv",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all EPA UV Index CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-epa-uv-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "21600"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/epa_uv_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/epa-uv/xreg/epa_uv.xreg.json
+++ b/epa-uv/xreg/epa_uv.xreg.json
@@ -41,6 +41,28 @@
       "messagegroups": [
         "#/messagegroups/US.EPA.UVIndex.mqtt"
       ]
+    },
+    "US.EPA.UVIndex.Amqp": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "AMQP/1.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "amqps://localhost:5671/epa-uv"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/US.EPA.UVIndex.amqp"
+      ],
+      "description": "AMQP 1.0 producer endpoint for EPA UV Index CloudEvents on the configured broker address."
     }
   },
   "messagegroups": {
@@ -62,7 +84,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/US.EPA.UVIndex.jstruct/schemas/US.EPA.UVIndex.HourlyForecast"
+          "dataschemauri": "#/schemagroups/US.EPA.UVIndex.jstruct/schemas/US.EPA.UVIndex.HourlyForecast",
+          "description": "An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast valid hour, normalized location identity, and UV index value for operational exposure planning."
         },
         "US.EPA.UVIndex.DailyForecast": {
           "name": "DailyForecast",
@@ -80,7 +103,8 @@
             }
           },
           "dataschemaformat": "JsonStructure/draft-02",
-          "dataschemauri": "#/schemagroups/US.EPA.UVIndex.jstruct/schemas/US.EPA.UVIndex.DailyForecast"
+          "dataschemauri": "#/schemagroups/US.EPA.UVIndex.jstruct/schemas/US.EPA.UVIndex.DailyForecast",
+          "description": "A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning."
         }
       }
     },
@@ -96,7 +120,8 @@
             "qos": 1,
             "retain": true,
             "message_expiry_interval": 172800
-          }
+          },
+          "description": "An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast valid hour, normalized location identity, and UV index value for operational exposure planning."
         },
         "US.EPA.UVIndex.mqtt.DailyForecast": {
           "name": "DailyForecast",
@@ -107,7 +132,77 @@
             "qos": 1,
             "retain": true,
             "message_expiry_interval": 1209600
-          }
+          },
+          "description": "A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning."
+        }
+      }
+    },
+    "US.EPA.UVIndex.amqp": {
+      "description": "AMQP 1.0 variant of the EPA UV Index forecast events for queue-oriented consumers and Azure Service Bus deployments.",
+      "messages": {
+        "US.EPA.UVIndex.amqp.HourlyForecast": {
+          "name": "HourlyForecast",
+          "basemessageurl": "/messagegroups/US.EPA.UVIndex/messages/US.EPA.UVIndex.HourlyForecast",
+          "protocol": "AMQP/1.0",
+          "protocoloptions": {
+            "properties": {
+              "subject": {
+                "type": "uritemplate",
+                "value": "{location_id}",
+                "description": "AMQP message subject — stable entity identifier matching the CloudEvent subject and Kafka key for cross-transport correlation."
+              }
+            },
+            "application_properties": {
+              "state": {
+                "type": "uritemplate",
+                "value": "{state}",
+                "description": "Lowercase US state abbreviation used by consumers to filter EPA UV forecasts without parsing the JSON body."
+              },
+              "city_slug": {
+                "type": "uritemplate",
+                "value": "{city_slug}",
+                "description": "Topic-safe city slug used by consumers to filter EPA UV forecasts without parsing the JSON body."
+              },
+              "forecast_hour": {
+                "type": "uritemplate",
+                "value": "{forecast_hour}",
+                "description": "Forecast valid hour in compact YYYYMMDDTHH form for AMQP consumer filtering and diagnostics."
+              }
+            }
+          },
+          "description": "An hourly UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast valid hour, normalized location identity, and UV index value for operational exposure planning."
+        },
+        "US.EPA.UVIndex.amqp.DailyForecast": {
+          "name": "DailyForecast",
+          "basemessageurl": "/messagegroups/US.EPA.UVIndex/messages/US.EPA.UVIndex.DailyForecast",
+          "protocol": "AMQP/1.0",
+          "protocoloptions": {
+            "properties": {
+              "subject": {
+                "type": "uritemplate",
+                "value": "{location_id}",
+                "description": "AMQP message subject — stable entity identifier matching the CloudEvent subject and Kafka key for cross-transport correlation."
+              }
+            },
+            "application_properties": {
+              "state": {
+                "type": "uritemplate",
+                "value": "{state}",
+                "description": "Lowercase US state abbreviation used by consumers to filter EPA UV forecasts without parsing the JSON body."
+              },
+              "city_slug": {
+                "type": "uritemplate",
+                "value": "{city_slug}",
+                "description": "Topic-safe city slug used by consumers to filter EPA UV forecasts without parsing the JSON body."
+              },
+              "forecast_date": {
+                "type": "uritemplate",
+                "value": "{forecast_date}",
+                "description": "Forecast valid date in YYYY-MM-DD form for AMQP consumer filtering and diagnostics."
+              }
+            }
+          },
+          "description": "A daily UV Index forecast from the US EPA Envirofacts UV service for one configured city/state location. It carries the forecast date, normalized location identity, UV index value, and EPA UV alert indicator for public-health planning."
         }
       }
     }

--- a/hongkong-epd/CONTAINER.md
+++ b/hongkong-epd/CONTAINER.md
@@ -1,4 +1,4 @@
-# Hong Kong EPD AQHI — Container Deployment
+# Hong Kong EPD AQHI — Kafka, MQTT, and AMQP Container Deployment
 
 ## Upstream Source
 
@@ -113,3 +113,68 @@ air-quality/hk/epd/hongkong-epd/central-and-western/+/aqhi
 # Reference data for every station
 air-quality/hk/epd/hongkong-epd/+/+/info
 ```
+
+## AMQP 1.0 container variant
+
+Image: `ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest`
+
+The AMQP companion publishes Hong Kong EPD AQHI CloudEvents to generic AMQP 1.0 brokers with SASL PLAIN, Azure Service Bus with Entra ID CBS, or Service Bus-compatible SAS CBS. It uses the same event schemas as the Kafka and MQTT variants.
+
+### Generic AMQP broker
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=hongkong-epd \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest
+```
+
+### Azure Service Bus with Entra ID
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=<namespace>.servicebus.windows.net \
+  -e AMQP_PORT=5671 \
+  -e AMQP_TLS=true \
+  -e AMQP_ADDRESS=hongkong-epd \
+  -e AMQP_AUTH_MODE=entra \
+  -e AMQP_ENTRA_AUDIENCE=https://servicebus.azure.net/.default \
+  -e AMQP_ENTRA_CLIENT_ID=<managed-identity-client-id> \
+  ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest
+```
+
+### Service Bus emulator / SAS CBS
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=servicebus-emulator \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=hongkong-epd \
+  -e AMQP_AUTH_MODE=sas \
+  -e AMQP_SAS_KEY_NAME=RootManageSharedAccessKey \
+  -e AMQP_SAS_KEY=<key> \
+  ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest
+```
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `AMQP_BROKER_URL` | Optional `amqp://` or `amqps://` URL; path overrides `AMQP_ADDRESS`. | empty |
+| `AMQP_HOST` / `AMQP_PORT` | AMQP broker host and port when no broker URL is supplied. | `localhost` / `5672` (`5671` with TLS) |
+| `AMQP_ADDRESS` | Queue, topic, or link target address. | `hongkong-epd` |
+| `AMQP_AUTH_MODE` | `password`, `entra`, or `sas`. | `password` |
+| `AMQP_USERNAME` / `AMQP_PASSWORD` | SASL PLAIN credentials for generic brokers. | empty |
+| `AMQP_TLS` | Enable TLS; automatically true for Entra auth. | `false` |
+| `AMQP_ENTRA_AUDIENCE` | Token scope for CBS put-token. | `https://servicebus.azure.net/.default` |
+| `AMQP_ENTRA_CLIENT_ID` | Optional user-assigned managed identity client id. | empty |
+| `AMQP_SAS_KEY_NAME` / `AMQP_SAS_KEY` | SAS CBS credentials for Service Bus-compatible brokers. | empty |
+| `AMQP_CONTENT_MODE` | CloudEvents AMQP content mode. | `binary` |
+| `POLLING_INTERVAL` | Poll interval in seconds. | source-specific |
+| `STATE_FILE` | Persistent dedupe state file path. | source-specific |
+| `HONGKONG_EPD_MOCK` | Emit built-in sample events for Docker E2E and offline validation. | `false` |
+
+Use `azure-template-with-servicebus.json` or `infra/azure-template-amqp.json` for one-click Azure Service Bus deployment. The templates create a queue, Azure Files state share, ACI, user-assigned managed identity, and `Azure Service Bus Data Sender` role assignment scoped to the queue.
+

--- a/hongkong-epd/Dockerfile.amqp
+++ b/hongkong-epd/Dockerfile.amqp
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/hongkong-epd"
+LABEL org.opencontainers.image.title="Hong Kong EPD AQHI → AMQP 1.0 bridge"
+LABEL org.opencontainers.image.description="Polls Hong Kong EPD AQHI station and reading data and publishes CloudEvents over AMQP 1.0 for generic brokers and Azure Service Bus. Supports SASL PLAIN, Service Bus Entra ID CBS, and Service Bus SAS CBS authentication."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/hongkong-epd/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="amqp"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+RUN apt-get update  && apt-get install -y --no-install-recommends         build-essential cmake pkg-config swig         libssl-dev libsasl2-dev python3-dev         libsasl2-2 libsasl2-modules  && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data  && pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./hongkong_epd_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+
+ENV AMQP_BROKER_URL=""
+ENV AMQP_ADDRESS="hongkong-epd"
+
+CMD ["python", "-m", "hongkong_epd_amqp", "feed"]

--- a/hongkong-epd/EVENTS.md
+++ b/hongkong-epd/EVENTS.md
@@ -4,8 +4,8 @@ Hong Kong EPD Air Quality publishes air-quality health index and pollutant measu
 
 ## At a glance
 
-- **Event types:** 2 documented event types (4 transport bindings in the manifest).
-- **Transports:** KAFKA, MQTT/5.0
+- **Event types:** 2 documented event types (6 transport bindings in the manifest).
+- **Transports:** KAFKA, MQTT/5.0, AMQP/1.0
 - **Reference vs telemetry:** 0 reference/catalog event types and 2 telemetry event types.
 - **Identity:** `{station_id}` identifies the resource each event is about.
 - **Operations:** The checked-in guide documents a default polling interval of 3600 seconds.
@@ -43,6 +43,20 @@ c.loop_forever()
 ```
 
 Subscribe at QoS 1 with a stable client id, `CleanStart=false`, and a finite non-zero session expiry when you need at-least-once delivery across reconnects. Retained messages are delivered subject to MQTT 5 Retain Handling, and publishing an empty retained payload clears the retained value. MQTT 5 user properties carry CloudEvents metadata; MQTT 3.1.1 clients need structured CloudEvents because they do not have user properties.
+### AMQP 1.0
+
+Attach a link with `role=receiver` whose **source** is `hongkong-epd`. The source terminus is the broker-side node you consume from; source filters such as selectors, Event Hubs offsets, or subscription filters further select which messages flow. The target is your client-side terminus. Generic brokers use their advertised SASL mechanisms (often PLAIN over TLS, EXTERNAL with mTLS, or ANONYMOUS on trusted links). Azure Service Bus and Event Hubs can use SASL PLAIN for SAS credentials on short-lived connections; CBS `put-token` on `$cbs` installs and refreshes Entra ID JWTs or SAS tokens for long-lived AMQP connections.
+
+```python
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+class H(MessagingHandler):
+    def on_start(self,e): e.container.create_receiver('amqps://user:pass@localhost:5671/hongkong-epd')
+    def on_message(self,e): print(e.message.subject, e.message.properties, e.message.body)
+Container(H()).run()
+```
+
+The examples use AMQP binary content mode: the JSON payload is the message body, `datacontenttype` maps to the AMQP `content-type`, and CloudEvents attributes map to application properties named `cloudEvents:<attribute>`.
 
 ## Event catalog
 
@@ -64,6 +78,7 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 | --- | --- |
 | `KAFKA` | topic `hongkong-epd-aqhi`, key `{station_id}` |
 | `MQTT/5.0` | topic `air-quality/hk/epd/hongkong-epd/{district}/{station_id}/info`, retain `true`, QoS `1` |
+| `AMQP/1.0` | source address `amqps://localhost:5671/hongkong-epd`, message subject `{station_id}`; application properties district `{district}` |
 
 #### Payload
 
@@ -112,6 +127,7 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 | --- | --- |
 | `KAFKA` | topic `hongkong-epd-aqhi`, key `{station_id}` |
 | `MQTT/5.0` | topic `air-quality/hk/epd/hongkong-epd/{district}/{station_id}/aqhi`, retain `true`, QoS `1` |
+| `AMQP/1.0` | source address `amqps://localhost:5671/hongkong-epd`, message subject `{station_id}`; application properties district `{district}` |
 
 #### Payload
 

--- a/hongkong-epd/README.md
+++ b/hongkong-epd/README.md
@@ -2,7 +2,7 @@
 
 This bridge fetches the Hong Kong Environmental Protection Department's
 [Air Quality Health Index (AQHI)](https://www.aqhi.gov.hk/) feed and emits
-CloudEvents into Apache Kafka or Azure Event Hubs.
+CloudEvents into Apache Kafka or Azure Event Hubs, MQTT 5.0, and AMQP 1.0.
 
 ## Data Model
 
@@ -69,3 +69,23 @@ throughput unit) and event hub. The connection string is automatically
 configured.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fhongkong-epd%2Fazure-template-with-eventhub.json)
+
+## AMQP 1.0 companion feeder
+
+This source now ships Kafka, MQTT, and AMQP 1.0 transport variants. The AMQP container (`ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest`) publishes the same CloudEvents payloads as the Kafka and MQTT feeders to a single broker address named `hongkong-epd` by default, using binary-mode AMQP 1.0 for generic brokers or Azure Service Bus.
+
+Run locally against an AMQP 1.0 broker:
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=hongkong-epd \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest
+```
+
+Deploy to Azure Service Bus with `azure-template-with-servicebus.json` (also mirrored at `infra/azure-template-amqp.json`). The template provisions a Service Bus queue, storage-backed state share, a user-assigned managed identity, and an Azure Container Instance configured for AMQP CBS / Entra ID authentication.
+

--- a/hongkong-epd/azure-template-with-servicebus.json
+++ b/hongkong-epd/azure-template-with-servicebus.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the Hong Kong EPD AQHI AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'hongkong-epd'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "hongkong-epd",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for Hong Kong EPD AQHI feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "hongkong-epd",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all Hong Kong EPD AQHI CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "3600"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/hongkong_epd_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/hongkong-epd/generate_amqp_producer.ps1
+++ b/hongkong-epd/generate_amqp_producer.ps1
@@ -1,0 +1,13 @@
+# Regenerate the AMQP 1.0 producer (amqpproducer style) from the authoritative xreg manifest.
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style amqpproducer `
+    --language py `
+    --definitions xreg\hongkong_epd.xreg.json `
+    --endpoint HK.Gov.EPD.AQHI.Amqp `
+    --projectname hongkong_epd_amqp_producer `
+    --template-args azure_cbs_target=servicebus `
+    --output hongkong_epd_amqp_producer

--- a/hongkong-epd/hongkong_epd_amqp/hongkong_epd_amqp/__main__.py
+++ b/hongkong-epd/hongkong_epd_amqp/hongkong_epd_amqp/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/hongkong-epd/hongkong_epd_amqp/hongkong_epd_amqp/app.py
+++ b/hongkong-epd/hongkong_epd_amqp/hongkong_epd_amqp/app.py
@@ -1,0 +1,161 @@
+"""AMQP 1.0 feeder application for Hong Kong EPD AQHI."""
+
+from __future__ import annotations
+
+
+import argparse
+import logging
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+DEFAULT_ENTRA_AUDIENCE_SERVICEBUS = "https://servicebus.azure.net/.default"
+
+
+def _parse_amqp_broker_url(url: str) -> tuple[str, int, bool, Optional[str], Optional[str], Optional[str]]:
+    parsed = urlparse(url if "://" in url else f"amqp://{url}")
+    scheme = (parsed.scheme or "amqp").lower()
+    tls = scheme in ("amqps", "ssl", "tls")
+    port = parsed.port or (5671 if tls else 5672)
+    return parsed.hostname or "localhost", port, tls, parsed.username or None, parsed.password or None, (parsed.path or "").lstrip("/") or None
+
+
+def _build_amqp_producer(producer_cls, *, host: str, port: int, address: str, use_tls: bool, content_mode: str, auth_mode: str, username: Optional[str], password: Optional[str], entra_audience: str, entra_client_id: Optional[str], sas_key_name: Optional[str], sas_key: Optional[str]):
+    if auth_mode == "entra":
+        from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+        credential = ManagedIdentityCredential(client_id=entra_client_id) if entra_client_id else DefaultAzureCredential()
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, credential=credential, entra_audience=entra_audience, use_tls=use_tls)
+    if auth_mode == "sas":
+        if not sas_key_name or not sas_key:
+            raise RuntimeError("AMQP auth-mode=sas requires AMQP_SAS_KEY_NAME and AMQP_SAS_KEY")
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, sas_key_name=sas_key_name, sas_key=sas_key, use_tls=use_tls)
+    return producer_cls(host=host, address=address, port=port, username=username, password=password, content_mode=content_mode, use_tls=use_tls)
+
+
+def add_amqp_arguments(parser: argparse.ArgumentParser, default_address: str) -> None:
+    parser.add_argument("--broker-url", default=os.getenv("AMQP_BROKER_URL"))
+    parser.add_argument("--host", default=os.getenv("AMQP_HOST"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("AMQP_PORT", "0")) or None)
+    parser.add_argument("--address", default=os.getenv("AMQP_ADDRESS", default_address))
+    parser.add_argument("--username", default=os.getenv("AMQP_USERNAME"))
+    parser.add_argument("--password", default=os.getenv("AMQP_PASSWORD"))
+    parser.add_argument("--tls", action="store_true", default=os.getenv("AMQP_TLS", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("AMQP_CONTENT_MODE", "binary"))
+    parser.add_argument("--auth-mode", choices=("password", "entra", "sas"), default=os.getenv("AMQP_AUTH_MODE", "password"))
+    parser.add_argument("--entra-audience", default=os.getenv("AMQP_ENTRA_AUDIENCE", DEFAULT_ENTRA_AUDIENCE_SERVICEBUS))
+    parser.add_argument("--entra-client-id", default=os.getenv("AMQP_ENTRA_CLIENT_ID"))
+    parser.add_argument("--sas-key-name", default=os.getenv("AMQP_SAS_KEY_NAME"))
+    parser.add_argument("--sas-key", default=os.getenv("AMQP_SAS_KEY"))
+
+
+def create_amqp_producer(args: argparse.Namespace, producer_cls):
+    address = args.address
+    if args.broker_url:
+        host, port, tls, user, pwd, path = _parse_amqp_broker_url(args.broker_url)
+        username = args.username or user
+        password = args.password or pwd
+        if args.port:
+            port = args.port
+        if args.tls:
+            tls = True
+        if path:
+            address = path
+    else:
+        host = args.host or "localhost"
+        tls = bool(args.tls) or args.auth_mode == "entra"
+        port = args.port or (5671 if tls else 5672)
+        username = args.username
+        password = args.password
+    if not address:
+        raise RuntimeError("AMQP address is required")
+    logging.info("Connecting AMQP producer to %s:%s/%s auth=%s tls=%s", host, port, address, args.auth_mode, tls)
+    return _build_amqp_producer(producer_cls, host=host, port=port, address=address, use_tls=tls, content_mode=args.content_mode, auth_mode=args.auth_mode, username=username, password=password, entra_audience=args.entra_audience, entra_client_id=args.entra_client_id, sas_key_name=args.sas_key_name, sas_key=args.sas_key)
+
+
+import argparse
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+from hongkong_epd.hongkong_epd import HKEPDAQHIAPI, _load_state, _save_state
+STATION_ID_TO_DISTRICT = {
+    "central_western": "central-and-western", "eastern": "eastern", "kwai_chung": "kwai-tsing",
+    "kwun_tong": "kwun-tong", "north": "north", "sha_tin": "sha-tin",
+    "sham_shui_po": "sham-shui-po", "southern": "southern", "tai_po": "tai-po",
+    "tap_mun": "islands", "tseung_kwan_o": "sai-kung", "tsuen_wan": "tsuen-wan",
+    "tuen_mun": "tuen-mun", "tung_chung": "islands", "yuen_long": "yuen-long",
+    "causeway_bay": "wan-chai", "central": "central-and-western", "mong_kok": "yau-tsim-mong",
+}
+from hongkong_epd_amqp_producer_data import AQHIReading, Station
+from hongkong_epd_amqp_producer_amqp_producer.producer import HKGovEPDAQHIAmqpProducer
+
+logger = logging.getLogger(__name__)
+
+
+def _station_with_district(station_id: str, station) -> Station:
+    return Station(station_id=station.station_id, station_name=station.station_name, station_type=station.station_type, district=STATION_ID_TO_DISTRICT.get(station_id, "unknown"), latitude=station.latitude, longitude=station.longitude)
+
+
+def _reading_with_district(station_id: str, reading) -> AQHIReading:
+    return AQHIReading(station_id=reading.station_id, station_name=reading.station_name, station_type=reading.station_type, district=STATION_ID_TO_DISTRICT.get(station_id, "unknown"), reading_time=reading.reading_time, aqhi=reading.aqhi, health_risk_category=reading.health_risk_category)
+
+
+def _sample_events() -> tuple[list[Station], list[AQHIReading]]:
+    station = Station(station_id="central", station_name="Central", station_type="Roadside Stations", district="central-and-western", latitude=22.2836, longitude=114.1571)
+    reading = AQHIReading(station_id="central", station_name="Central", station_type="Roadside Stations", district="central-and-western", reading_time=datetime(2026, 1, 1, tzinfo=timezone.utc), aqhi=3, health_risk_category="Low")
+    return [station], [reading]
+
+
+def _publish(producer: HKGovEPDAQHIAmqpProducer, stations: list[Station], readings: list[AQHIReading]) -> tuple[int, int]:
+    for station in stations:
+        producer.send_station(data=station, _station_id=station.station_id, _district=station.district)
+    for reading in readings:
+        producer.send_aqhireading(data=reading, _station_id=reading.station_id, _district=reading.district)
+    return len(stations), len(readings)
+
+
+def feed(args: argparse.Namespace) -> None:
+    producer = create_amqp_producer(args, HKGovEPDAQHIAmqpProducer)
+    api = HKEPDAQHIAPI(polling_interval=args.polling_interval)
+    previous_readings = _load_state(args.state_file)
+    try:
+        while True:
+            if args.mock_mode:
+                stations, readings = _sample_events()
+            else:
+                stations = [_station_with_district(station_id, station) for station_id, station in api.get_stations().items()]
+                readings = []
+                for station_id, reading in sorted(api.get_latest_readings().items()):
+                    reading_key = f"{station_id}:{reading.reading_time.isoformat()}"
+                    if reading_key in previous_readings:
+                        continue
+                    readings.append(_reading_with_district(station_id, reading))
+                    previous_readings[reading_key] = reading.reading_time.isoformat()
+                _save_state(args.state_file, previous_readings)
+            station_count, reading_count = _publish(producer, stations, readings)
+            logger.info("Published %d stations and %d AQHI readings to AMQP", station_count, reading_count)
+            if args.once:
+                break
+            time.sleep(args.polling_interval)
+    finally:
+        producer.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper(), format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Hong Kong EPD AQHI AMQP 1.0 bridge")
+    parser.add_argument("feed_command", nargs="?", default="feed")
+    add_amqp_arguments(parser, "hongkong-epd")
+    parser.add_argument("--polling-interval", type=int, default=int(os.getenv("POLLING_INTERVAL", "3600")))
+    parser.add_argument("--state-file", default=os.getenv("STATE_FILE", "/var/lib/hongkong-epd/state.json"))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--mock-mode", action="store_true", default=os.getenv("HONGKONG_EPD_MOCK", "").lower() in ("1", "true", "yes"))
+    args = parser.parse_args()
+    if args.feed_command != "feed":
+        parser.error("only the 'feed' command is supported")
+    feed(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/hongkong-epd/hongkong_epd_amqp/pyproject.toml
+++ b/hongkong-epd/hongkong_epd_amqp/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hongkong-epd-amqp"
+version = "0.1.0"
+description = "AMQP 1.0 feeder for Hong Kong EPD AQHI"
+requires-python = ">=3.10"
+dependencies = [
+    "python-qpid-proton>=0.40.0",
+    "cloudevents>=1.11.0,<2.0.0",
+    "dataclasses_json>=0.6.7",
+    "avro>=1.11.3",
+    "azure-identity>=1.17.0",
+    "azure-core>=1.30.0",
+    "requests>=2.32.0"
+]
+
+[project.scripts]
+hongkong-epd-amqp = "hongkong_epd_amqp.app:main"
+
+[tool.setuptools.packages.find]
+include = ["hongkong_epd_amqp*"]

--- a/hongkong-epd/hongkong_epd_amqp_producer/Makefile
+++ b/hongkong-epd/hongkong_epd_amqp_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install test
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./hongkong_epd_amqp_producer_data ./hongkong_epd_amqp_producer_amqp_producer
+
+install: build
+	cd hongkong_epd_amqp_producer_data && poetry install
+	cd hongkong_epd_amqp_producer_amqp_producer && poetry install
+	pip install ./hongkong_epd_amqp_producer_data ./hongkong_epd_amqp_producer_amqp_producer
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./hongkong_epd_amqp_producer_amqp_producer/tests ./hongkong_epd_amqp_producer_data/tests

--- a/hongkong-epd/hongkong_epd_amqp_producer/README.md
+++ b/hongkong-epd/hongkong_epd_amqp_producer/README.md
@@ -1,0 +1,487 @@
+
+# Hongkong_epd_amqp_producer - AMQP 1.0 Producer
+
+Auto-generated Python producer for sending messages via AMQP 1.0 protocol.
+
+## Overview
+
+This module provides a type-safe AMQP 1.0 producer for sending events with optional CloudEvents envelope format. Built
+on the `python-qpid-proton` library for Python.
+
+## What is AMQP 1.0?
+
+**AMQP (Advanced Message Queuing Protocol) 1.0** is an open standard for business messaging that supports:
+- **Protocol-level interoperability** between different platforms and vendors
+- **Reliable message delivery** with settlement modes and flow control
+- **Multiple messaging patterns** including queues, topics, and request-reply
+- **Built-in security** with SASL authentication and TLS encryption
+
+Use cases: Enterprise integration, IoT messaging, financial services, cloud-native applications.
+
+**Supported AMQP 1.0 Brokers:**
+- Apache ActiveMQ Artemis (native AMQP 1.0)
+- Apache Qpid (native AMQP 1.0)
+- Azure Service Bus (native AMQP 1.0)
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-
+cli/blob/main/docs/rabbitmq_amqp_setup.md))
+
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup
+Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+
+
+## Azure Entra ID (CBS) Authentication — enabled
+
+This producer was generated with `--template-args azure_cbs_target=servicebus`,
+which wires in AMQP CBS (Claims-Based Security) put-token flow for **Azure Event Hubs** and
+**Azure Service Bus** using `azure-identity` token credentials.
+
+```python
+from azure.identity import DefaultAzureCredential
+producer = <Group>Producer(
+    host="my-namespace.servicebus.windows.net",   # EH or SB FQDN
+    address="my-hub-or-queue",                    # entity path
+    credential=DefaultAzureCredential(),
+)
+producer.send_my_event(...)
+producer.close()
+```
+
+CBS audience: `https://servicebus.azure.net/.default`
+(override with `--template-args azure_cbs_audience=<scope>` at code-gen time)
+
+Required RBAC role on the entity or namespace, e.g.:
+- Event Hubs: **Azure Event Hubs Data Sender**
+- Service Bus: **Azure Service Bus Data Sender**
+
+Debug logging:
+
+```python
+import logging
+logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
+```
+
+**Known limitations of the v1 CBS implementation:**
+- Token is acquired once at `__init__` time; there is no background refresh. Recreate the
+  producer (or open a fresh one) before token expiry (~60 min for Entra ID).
+- On Windows, the official `python-qpid-proton` PyPI wheel (verified on 0.40.0,
+  the latest release at the time of writing) is linked against SChannel via the
+  legacy `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service
+  Bus namespaces with `minimumTlsVersion=1.3` will return
+  `amqp:unauthorized-access "Invalid TLS version"` at AMQP open. Tracked
+  upstream as [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933).
+
+  Until the upstream wheel is fixed, install the OpenSSL-backed Windows
+  wheel published from `xregistry/codegen`:
+
+  ```
+  pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton
+  ```
+
+  pip will pick the `0.40.0+xrcgN` build automatically on Windows; Linux and
+  macOS continue to install the stock `0.40.0` from PyPI.
+- A reactor-based handler is used on the CBS path; the non-CBS path keeps the
+  `BlockingConnection` implementation unchanged.
+
+
+## Installation
+
+```bash
+pip install python-qpid-proton cloudevents azure-identity azure-core
+```
+
+### Windows: TLS 1.3 — extra index URL required
+
+The official `python-qpid-proton` Windows wheel does not support TLS 1.3
+(it links against SChannel via a deprecated API). If your AMQP broker
+requires TLS 1.3 — most notably Azure Service Bus namespaces with
+`minimumTlsVersion=1.3` — install with our OpenSSL-backed patched wheel:
+
+```bash
+pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton cloudevents azure-
+identity azure-core
+```
+
+pip selects the patched wheel only on Windows (it has a strictly higher
+PEP 440 local version `0.40.0+xrcgN`); Linux and macOS continue to install
+the stock release from PyPI. The patched wheel will be retired as soon as
+upstream proton ships a Windows wheel with TLS 1.3 support.
+
+## Generated Producers
+
+
+
+### HKGovEPDAQHIAmqpProducer
+
+`HKGovEPDAQHIAmqpProducer` sends messages for the HK.Gov.EPD.AQHI.amqp message group.
+
+#### Quick Start
+
+```python
+from hongkong_epd_amqp_producer import HKGovEPDAQHIAmqpProducer
+
+# Create producer
+producer = HKGovEPDAQHIAmqpProducer(
+    host="localhost",
+    address="my-queue",
+    port=5672,
+    username="guest",
+    password="guest"
+)
+
+# Send a message
+
+producer.send_station(
+    data=Station(...),
+    content_type="application/json"
+)
+
+producer.send_aqhireading(
+    data=AQHIReading(...),
+    content_type="application/json"
+)
+
+
+# Close producer
+producer.close()
+```
+
+#### Configuration Options
+
+The producer constructor accepts:
+
+- `host` (str): AMQP broker hostname
+- `address` (str): AMQP address (queue or topic name)
+- `port` (int): AMQP broker port (default: 5672, for TLS typically 5671)
+- `username` (Optional[str]): Username for SASL authentication
+- `password` (Optional[str]): Password for SASL authentication
+- `content_mode` (Literal['structured', 'binary']): CloudEvents encoding mode (default: 'structured')
+  - **structured**: Entire CloudEvent as JSON in message body
+  - **binary**: Event data in body, CloudEvents attributes in AMQP application properties
+- `format_type` (str): Content type for structured mode (default: 'application/json')
+
+#### Available Methods
+
+
+
+##### `send_station()`
+A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and
+route the live measurement or forecast events.
+
+**Parameters:**
+- `data` (Station): The message data object
+- `_station_id` (str): Value for placeholder station_id in attribute subject
+- `content_type` (str): Content type of the message data (default: 'application/json')
+
+##### `send_station_batch()`
+
+Send multiple Station messages in sequence.
+
+**Parameters:**
+- `data_array` (List[Station]): Array of message data objects
+- `_station_id` (str): Value for placeholder station_id in attribute subject
+- `content_type` (str): Content type of the message data
+
+
+
+##### `send_aqhireading()`
+A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health
+index and pollutant measurements when the upstream feed reports a new or refreshed value.
+
+**Parameters:**
+- `data` (AQHIReading): The message data object
+- `_station_id` (str): Value for placeholder station_id in attribute subject
+- `content_type` (str): Content type of the message data (default: 'application/json')
+
+##### `send_aqhireading_batch()`
+
+Send multiple AQHIReading messages in sequence.
+
+**Parameters:**
+- `data_array` (List[AQHIReading]): Array of message data objects
+- `_station_id` (str): Value for placeholder station_id in attribute subject
+- `content_type` (str): Content type of the message data
+
+
+
+
+## AMQP Broker Compatibility
+
+This library has been tested with:
+- **Azure Service Bus** (AMQP 1.0 over TLS on port 5671)
+- **Apache ActiveMQ Artemis** (AMQP 1.0 on port 5672)
+- **Apache Qpid Broker-J** (AMQP 1.0 on port 5672)
+
+## Security Considerations
+
+- Always use TLS/SSL encryption in production (port 5671)
+- Store credentials securely (environment variables, key vaults)
+- Use SASL authentication mechanisms appropriate for your broker
+- Consider using token-based authentication (OAuth, JWT) where supported
+
+## Advanced Usage
+
+### Batch Sending with Concurrency Control
+
+Send multiple messages efficiently with rate limiting:
+
+```python
+import asyncio
+from typing import List
+
+
+class BatchProducer:
+    def __init__(self, producer: HKGovEPDAQHIAmqpProducer, max_concurrency: int = 10):
+        self.producer = producer
+        self.semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def send_batch_async(self, data_array: List[Station]):
+        """Send multiple messages with concurrency control."""
+        async def send_one(data):
+            async with self.semaphore:
+                await asyncio.to_thread(
+                    self.producer.send_station,
+                    data
+                )
+
+        tasks = [send_one(data) for data in data_array]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+# Usage
+producer = HKGovEPDAQHIAmqpProducer(host="localhost", address="my-queue")
+batch_producer = BatchProducer(producer, max_concurrency=20)
+
+data_list = [Station(...) for _ in range(100)]
+asyncio.run(batch_producer.send_batch_async(data_list))
+```
+
+
+### Connection Pooling
+
+Reuse producer connections across your application:
+
+```python
+from threading import Lock
+
+
+class ProducerPool:
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance.producer = HKGovEPDAQHIAmqpProducer(
+                        host="localhost",
+                        address="my-queue",
+                        username="guest",
+                        password="guest"
+                    )
+        return cls._instance
+
+    def get_producer(self) -> HKGovEPDAQHIAmqpProducer:
+        return self.producer
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+# Use from anywhere
+pool = ProducerPool()
+producer = pool.get_producer()
+
+```
+
+### Connection Resilience
+
+Automatically reconnect on connection failures:
+
+```python
+import time
+from typing import Optional
+
+
+class ResilientProducer:
+    def __init__(self, host: str, address: str, **kwargs):
+        self.host = host
+        self.address = address
+        self.kwargs = kwargs
+        self.producer: Optional[HKGovEPDAQHIAmqpProducer] = None
+        self._connect()
+
+    def _connect(self):
+        """Establish connection to AMQP broker."""
+        if self.producer:
+            try:
+                self.producer.close()
+            except:
+                pass
+
+        self.producer = HKGovEPDAQHIAmqpProducer(
+            host=self.host,
+            address=self.address,
+            **self.kwargs
+        )
+
+    def send_with_retry(self, data: Station, max_retries: int = 3):
+        """Send message with automatic retry on connection failure."""
+        for attempt in range(max_retries):
+            try:
+                self.producer.send_station(data)
+                return
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    time.sleep(2 ** attempt)  # Exponential backoff
+                    self._connect()  # Reconnect
+                else:
+                    raise Exception(f"Failed after {max_retries} attempts") from e
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+```
+
+### Custom CloudEvents Attributes
+
+Add extension attributes to CloudEvents:
+
+```python
+
+
+producer = HKGovEPDAQHIAmqpProducer(host="localhost", address="my-queue")
+
+# CloudEvents extension attributes can be added via metadata
+producer.send_station(
+    data=data,
+    _tenant="contoso",           # Custom extension attribute
+    _deviceid="device-001",      # Custom extension attribute
+    _region="us-west-2",         # Custom extension attribute
+    _priority="high",            # Custom extension attribute
+    content_type="application/json"
+)
+
+```
+
+## Error Handling
+
+### Basic Error Handling
+
+```python
+from uamqp import errors
+
+try:
+    producer.send_message(data)
+except errors.AMQPConnectionError as e:
+    print(f"Connection error: {e}")
+except errors.MessageException as e:
+    print(f"Message error: {e}")
+finally:
+    producer.close()
+```
+
+### Retry with Exponential Backoff
+
+```python
+import time
+from typing import Any
+
+
+def send_with_retry(
+    producer: HKGovEPDAQHIAmqpProducer,
+    data: Station,
+    max_retries: int = 5,
+    initial_delay: float = 1.0,
+    max_delay: float = 60.0
+) -> None:
+    """
+    Send message with exponential backoff retry.
+
+    Args:
+        producer: The producer instance
+        data: Message data to send
+        max_retries: Maximum number of retry attempts
+        initial_delay: Initial delay in seconds
+        max_delay: Maximum delay between retries
+
+    Raises:
+        Exception: If all retries are exhausted
+    """
+    for attempt in range(max_retries):
+        try:
+            producer.send_station(data)
+            return  # Success
+        except errors.AMQPConnectionError as e:
+            if attempt < max_retries - 1:
+                delay = min(initial_delay * (2 ** attempt), max_delay)
+                print(f"Attempt {attempt + 1}/{max_retries} failed. Retrying in {delay}s...")
+                time.sleep(delay)
+            else:
+                raise Exception(f"Failed after {max_retries} attempts") from e
+
+```
+
+### Circuit Breaker Pattern
+
+```python
+from datetime import datetime, timedelta
+
+
+class CircuitBreakerProducer:
+    """Producer with circuit breaker to prevent cascading failures."""
+
+    def __init__(self, producer: HKGovEPDAQHIAmqpProducer, threshold: int = 5, timeout: int = 60):
+        self.producer = producer
+        self.threshold = threshold
+        self.timeout = timedelta(seconds=timeout)
+        self.failure_count = 0
+        self.last_failure_time = None
+        self.is_open = False
+
+    def send(self, data: Station):
+        """Send message with circuit breaker protection."""
+        # Check if circuit breaker is open
+        if self.is_open:
+            if datetime.now() - self.last_failure_time < self.timeout:
+                raise Exception("Circuit breaker is open. Too many consecutive failures.")
+            else:
+                # Try to close the circuit
+                self.is_open = False
+                self.failure_count = 0
+
+        try:
+            self.producer.send_station(data)
+            self.failure_count = 0  # Reset on success
+        except Exception as e:
+            self.failure_count += 1
+            self.last_failure_time = datetime.now()
+
+            if self.failure_count >= self.threshold:
+                self.is_open = True
+            raise
+
+```
+
+## Building and Testing
+
+```bash
+# Install dependencies
+poetry install
+
+# Run tests
+poetry run pytest
+
+# Build package
+poetry build
+```
+
+## Dependencies
+
+- `uamqp>=1.6.10` - AMQP 1.0 client library
+- `cloudevents>=1.10.1` - CloudEvents SDK
+- Python 3.10+
+
+## License
+
+This generated code is provided as-is for use in your projects.

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/pyproject.toml
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/pyproject.toml
@@ -1,0 +1,33 @@
+
+[tool.poetry]
+name = "hongkong-epd-amqp-producer-amqp-producer"
+description = "hongkong_epd_amqp_producer_amqp_producer AMQP 1.0 producer library (Azure servicebus CBS/Entra ID enabled)"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "hongkong_epd_amqp_producer_amqp_producer", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+hongkong-epd-amqp-producer-data = {path = "../hongkong_epd_amqp_producer_data", develop = true}  
+python-qpid-proton = ">=0.39.0"
+cloudevents = ">=1.10.1,<2.0.0"
+azure-identity = ">=1.15.0"
+azure-core = ">=1.30.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+filterwarnings = [
+    "ignore::DeprecationWarning:testcontainers.core.waiting_utils"
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/src/hongkong_epd_amqp_producer_amqp_producer/__init__.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/src/hongkong_epd_amqp_producer_amqp_producer/__init__.py
@@ -1,0 +1,9 @@
+"""
+hongkong_epd_amqp_producer_amqp_producer - AMQP 1.0 Producer
+"""
+
+from .producer import *
+
+__all__ = [
+    "HKGovEPDAQHIAmqpProducer",
+]

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/src/hongkong_epd_amqp_producer_amqp_producer/producer.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/src/hongkong_epd_amqp_producer_amqp_producer/producer.py
@@ -1,0 +1,809 @@
+
+
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+
+"""
+Producer module for sending messages via AMQP 1.0 protocol.
+
+Generated with Azure CBS support (target: servicebus).
+Supports Entra ID (Azure AD) authentication via Claims-Based Security (CBS)
+put-token, in addition to SASL PLAIN and SAS connection-string auth.
+"""
+
+import sys
+import typing
+import uuid
+import json
+import threading
+import queue
+import concurrent.futures
+from urllib.parse import quote_plus
+from proton import Message
+from proton.utils import BlockingConnection
+from cloudevents.http import CloudEvent
+from cloudevents.conversion import to_binary, to_structured
+
+# --- Azure CBS support (azure_cbs_target=servicebus) ---
+# Two CBS auth modes are supported:
+#   1. Entra ID (Azure AD) JWT bearer via an azure-identity TokenCredential
+#      (``type=jwt``) -- works against live Azure Service Bus / Event Hubs.
+#   2. SAS token (``type=servicebus.windows.net:sastoken``) -- works against
+#      both live Azure namespaces configured for SAS and the local Service Bus
+#      emulator, which validates the ``type`` field strictly and refuses JWT.
+import base64
+import hashlib
+import hmac
+import logging
+import time as _cbs_time
+from urllib.parse import quote
+from proton import Endpoint, symbol
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, AtLeastOnce
+
+try:  # azure-identity is optional when only SAS auth is used
+    from azure.core.credentials import TokenCredential  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    TokenCredential = typing.Any  # type: ignore
+
+_cbs_logger = logging.getLogger("amqp.cbs")
+
+
+class _CbsTokenProvider:
+    """Abstract provider that mints a CBS put-token body + metadata."""
+
+    token_type: str = ""
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        """Return (token_body, absolute_expiry_unix_seconds)."""
+        raise NotImplementedError
+
+
+class _JwtTokenProvider(_CbsTokenProvider):
+    """Entra ID JWT acquired from an azure-identity ``TokenCredential``."""
+
+    token_type = "jwt"
+
+    def __init__(self, credential, audience: str):
+        self._credential = credential
+        self._audience = audience
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        token = self._credential.get_token(self._audience)
+        return token.token, int(token.expires_on)
+
+
+class _SasTokenProvider(_CbsTokenProvider):
+    """SAS token minted from a shared-access key + key name.
+
+    Produces a token of the form::
+
+        SharedAccessSignature sr=<url-quoted resource_uri>
+                              &sig=<url-quoted base64 HMAC-SHA256>
+                              &se=<expiry-unix-seconds>
+                              &skn=<key name>
+    """
+
+    token_type = "servicebus.windows.net:sastoken"
+
+    def __init__(self, key_name: str, key: str, resource_uri: str,
+                 ttl_seconds: int = 3600):
+        if not key_name or not key:
+            raise ValueError("SAS auth requires both key_name and key")
+        self._key_name = key_name
+        self._key = key
+        self._resource_uri = resource_uri
+        self._ttl = int(ttl_seconds)
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        expiry = int(_cbs_time.time()) + self._ttl
+        encoded_uri = quote(self._resource_uri, safe="")
+        string_to_sign = (encoded_uri + "\n" + str(expiry)).encode("utf-8")
+        try:
+            signing_key = self._key.encode("utf-8")
+        except AttributeError:
+            signing_key = bytes(self._key)
+        signature = base64.b64encode(
+            hmac.new(signing_key, string_to_sign, hashlib.sha256).digest()
+        )
+        encoded_sig = quote(signature, safe="")
+        token = (
+            "SharedAccessSignature "
+            f"sr={encoded_uri}&sig={encoded_sig}&se={expiry}"
+            f"&skn={quote(self._key_name, safe='')}"
+        )
+        return token, expiry
+
+
+class _CbsAzureHandler(MessagingHandler):
+    """Reactor handler that establishes an Azure CBS-authenticated AMQP connection.
+
+    State machine:
+      1. ``on_start``                -> open SASL ANONYMOUS amqps:// connection.
+      2. ``on_connection_opened``    -> attach ``$cbs`` sender + receiver pair
+                                       (receiver source AND target pinned to ``$cbs``).
+      3. both CBS links opened       -> send put-token request (with correlation id).
+      4. CBS reply (status 200/202)  -> attach main sender to ``self._address``
+                                       (with AtLeastOnce so we get accepted/rejected).
+      5. main sender opened          -> signal ``_init_future`` ready.
+      6. ``on_sendable`` / injected  -> drain outbound queue, track each delivery.
+      7. ``on_accepted/rejected``    -> resolve the per-send ``Future``.
+      8. ``on_disconnected``         -> fail everything (v1: no reconnect).
+    """
+
+    def __init__(self, host, port, address, token_provider, use_tls,
+                 init_future, send_queue, close_event):
+        super().__init__(auto_settle=False, auto_accept=False)
+        self._host = host
+        self._port = port
+        self._address = address
+        self._token_provider = token_provider
+        self._use_tls = use_tls
+        self._init_future = init_future
+        self._send_queue = send_queue
+        self._close_event = close_event
+        self._close_requested = False
+
+        self._container = None
+        self._conn = None
+        self._cbs_sender = None
+        self._cbs_receiver = None
+        self._main_sender = None
+        self._cbs_sender_opened = False
+        self._cbs_receiver_opened = False
+        self._cbs_request_id = None
+        self._pending: typing.Dict[bytes, concurrent.futures.Future] = {}
+        self._failed = False
+
+    # ---- lifecycle ----
+
+    def on_start(self, event):
+        self._container = event.container
+        scheme = "amqps" if self._use_tls else "amqp"
+        url = f"{scheme}://{self._host}:{self._port}"
+        # SASL ANONYMOUS: Azure broker accepts the connection without creds;
+        # authn is established by the subsequent CBS put-token exchange.
+        self._conn = self._container.connect(
+            url,
+            sasl_enabled=True,
+            allowed_mechs="ANONYMOUS",
+            reconnect=False,
+        )
+        # Cross-thread wakeup: poll the send-queue + close-flag periodically.
+        # EventInjector is not portable on Windows (needs a real socketpair),
+        # so a 25ms recurring timer is used instead. Latency overhead is
+        # negligible for non-bulk workloads.
+        self._container.schedule(0.025, self)
+
+    def on_timer_task(self, event):
+        if self._close_requested:
+            self._begin_close()
+            return
+        if self._main_sender is not None and self._main_sender.credit > 0:
+            self._pump()
+        self._container.schedule(0.025, self)
+
+    def on_connection_opened(self, event):
+        _cbs_logger.debug("[cbs] on_connection_opened")
+        # Attach the CBS sender + receiver. Both terminus addresses pinned to "$cbs".
+        self._cbs_sender = self._container.create_sender(self._conn, "$cbs", name="cbs-sender")
+        self._cbs_receiver = self._container.create_receiver(
+            self._conn, "$cbs", name="cbs-receiver"
+        )
+        # Pin the receiver target explicitly (Azure rejects dynamic terminus).
+        self._cbs_receiver.target.address = "$cbs"
+        self._cbs_receiver.target.dynamic = False
+
+    def on_link_opened(self, event):
+        _cbs_logger.debug(f"[cbs] on_link_opened {event.link.name}")
+        try:
+            link_name = event.link.name
+            if link_name == "cbs-sender":
+                self._cbs_sender_opened = True
+            elif link_name == "cbs-receiver":
+                self._cbs_receiver_opened = True
+            elif link_name == "main-sender":
+                if not self._init_future.done():
+                    self._init_future.set_result(True)
+                return
+            if self._cbs_sender_opened and self._cbs_receiver_opened and self._cbs_request_id is None:
+                self._send_put_token()
+        except Exception as exc:
+            self._fail_init(exc)
+
+    def _send_put_token(self):
+        _cbs_logger.debug(
+            "[cbs] _send_put_token: acquiring token (type=%s)",
+            self._token_provider.token_type,
+        )
+        try:
+            token_body, expires_on = self._token_provider.acquire()
+        except Exception as exc:
+            self._fail_init(exc)
+            return
+        _cbs_logger.debug(f"[cbs] _send_put_token: token len={len(token_body)} exp={expires_on}")
+        resource_uri = f"sb://{self._host}/{self._address}"
+        self._cbs_request_id = str(uuid.uuid4())
+        msg = Message(body=token_body)
+        msg.address = "$cbs"
+        msg.reply_to = "$cbs"
+        msg.id = self._cbs_request_id
+        msg.properties = {
+            "operation": "put-token",
+            "type": self._token_provider.token_type,
+            "name": resource_uri,
+            "expiration": int(expires_on),
+        }
+        try:
+            self._cbs_sender.send(msg)
+            _cbs_logger.debug("[cbs] _send_put_token: sent")
+        except Exception as exc:
+            _cbs_logger.debug(f"[cbs] _send_put_token: send raised {exc!r}")
+            self._fail_init(RuntimeError(f"CBS put-token send failed: {exc}"))
+
+    def on_message(self, event):
+        _cbs_logger.debug(f"[cbs] on_message link={event.link.name}")
+        # Only CBS replies are expected on this handler's receiver.
+        if event.link.name != "cbs-receiver":
+            return
+        reply = event.message
+        _cbs_logger.debug(f"[cbs] on_message correlation_id={reply.correlation_id!r} expected={self._cbs_request_id!r} props={dict(reply.properties or {})}")
+        try:
+            event.delivery.update(event.delivery.ACCEPTED)
+            event.delivery.settle()
+        except Exception:
+            pass
+        # Correlate: only accept the reply matching our put-token request id.
+        # Compare as strings to tolerate UUID/bytes/str shapes.
+        if str(reply.correlation_id) != str(self._cbs_request_id):
+            _cbs_logger.debug("[cbs] on_message: correlation mismatch, ignoring")
+            return
+        props = reply.properties or {}
+        status_code = props.get("status-code") or props.get(symbol("status-code")) or 0
+        status_desc = props.get("status-description") or props.get(symbol("status-description")) or ""
+        _cbs_logger.debug(f"[cbs] on_message: status_code={status_code} desc={status_desc!r}")
+        if status_code in (200, 202):
+            try:
+                self._main_sender = self._container.create_sender(
+                    self._conn, self._address, name="main-sender", options=AtLeastOnce()
+                )
+                _cbs_logger.debug("[cbs] on_message: main-sender create requested")
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] on_message: create_sender raised {exc!r}")
+                self._fail_init(exc)
+        else:
+            self._fail_init(RuntimeError(
+                f"CBS put-token rejected: status_code={status_code} {status_desc!r}"
+            ))
+
+    # ---- outbound sends ----
+
+    def on_sendable(self, event):
+        if event.link is self._main_sender:
+            self._pump()
+
+    def _pump(self):
+        if self._main_sender is None or self._failed:
+            return
+        while self._main_sender.credit > 0:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                return
+            if req is None:  # close sentinel
+                self._begin_close()
+                return
+            msg, fut = req
+            tag = str(uuid.uuid4()).encode()
+            try:
+                delivery = self._main_sender.send(msg, tag=tag)
+            except Exception as exc:
+                if not fut.done():
+                    fut.set_exception(exc)
+                continue
+            self._pending[tag] = fut
+            # delivery.tag is what comes back on disposition events
+            self._pending[delivery.tag] = fut
+
+    def on_accepted(self, event):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_result(True)
+
+    def on_rejected(self, event):
+        self._fail_delivery(event, "rejected")
+
+    def on_released(self, event):
+        self._fail_delivery(event, "released")
+
+    def on_modified(self, event):
+        self._fail_delivery(event, "modified")
+
+    def _fail_delivery(self, event, reason):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_exception(RuntimeError(f"Send failed: {reason}"))
+
+    # ---- error / close ----
+
+    def on_inject_close(self, event):
+        self._begin_close()
+
+    def request_close(self):
+        """Called from the producer thread; reactor picks it up on next timer tick."""
+        self._close_requested = True
+
+    def _begin_close(self):
+        try:
+            if self._main_sender:
+                self._main_sender.close()
+        except Exception:
+            pass
+        try:
+            if self._cbs_sender:
+                self._cbs_sender.close()
+            if self._cbs_receiver:
+                self._cbs_receiver.close()
+        except Exception:
+            pass
+        try:
+            if self._conn:
+                self._conn.close()
+        except Exception:
+            pass
+
+    def on_transport_error(self, event):
+        self._fail_all(RuntimeError(f"Transport error: {event.transport.condition}"))
+
+    def on_connection_error(self, event):
+        cond = event.connection.remote_condition
+        self._fail_all(RuntimeError(f"Connection error: {cond}"))
+
+    def on_link_error(self, event):
+        cond = event.link.remote_condition
+        self._fail_all(RuntimeError(f"Link error on {event.link.name}: {cond}"))
+
+    def on_disconnected(self, event):
+        _cbs_logger.debug("[cbs] on_disconnected")
+        self._fail_all(RuntimeError("Disconnected"))
+        self._close_event.set()
+
+    def _fail_init(self, exc):
+        _cbs_logger.debug(f"[cbs] _fail_init: {exc!r}")
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+
+    def _fail_all(self, exc):
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+        # Drain queue
+        while True:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                break
+            if req is None:
+                continue
+            _, fut = req
+            if not fut.done():
+                fut.set_exception(exc)
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+from hongkong_epd_amqp_producer_data import Station
+from hongkong_epd_amqp_producer_data import AQHIReading
+
+class HKGovEPDAQHIAmqpProducer:
+    """
+    Producer class to send messages in the `HK.Gov.EPD.AQHI.amqp` message group via AMQP 1.0 protocol.
+    """
+    
+    def __init__(self, 
+                 host: str,
+                 address: str,
+                 port: int = 5672,
+                 username: typing.Optional[str] = None,
+                 password: typing.Optional[str] = None,
+                 content_mode: typing.Literal['structured', 'binary'] = 'structured',
+                 format_type: str = 'application/json',
+                 credential: typing.Optional["TokenCredential"] = None,
+                 entra_audience: str = "https://servicebus.azure.net/.default",
+                 sas_key_name: typing.Optional[str] = None,
+                 sas_key: typing.Optional[str] = None,
+                 sas_token_ttl_seconds: int = 3600,
+                 use_tls: bool = True,
+                 ):
+        """
+        Initialize the AMQP producer
+        
+        Args:
+            host (str): The AMQP broker hostname
+            address (str): The AMQP address (queue or topic)
+            port (int): The AMQP broker port (default: 5672)
+            username (typing.Optional[str]): Optional username for SASL PLAIN authentication
+            password (typing.Optional[str]): Optional password for SASL PLAIN authentication
+            content_mode (typing.Literal['structured', 'binary']): CloudEvents content mode (default: 'structured')
+            format_type (str): Content type format for structured mode (default: 'application/json')
+            credential (typing.Optional[TokenCredential]): An azure-identity TokenCredential
+                (e.g. DefaultAzureCredential). When provided, SASL ANONYMOUS is used and an
+                Entra ID JWT is presented via AMQP CBS put-token (``type=jwt``). Mutually
+                exclusive with username/password and with sas_key_name/sas_key.
+            entra_audience (str): AAD scope used to acquire the JWT
+                (default: 'https://servicebus.azure.net/.default' -- targets Azure servicebus).
+                Override only when targeting a non-standard cloud or cross-targeting (e.g.
+                an Event Hubs client talking to a Service Bus entity, or vice-versa).
+            sas_key_name (typing.Optional[str]): SAS policy/key name (e.g.
+                ``RootManageSharedAccessKey``). When set with ``sas_key``, SASL ANONYMOUS
+                is used and a SAS token is presented via AMQP CBS put-token
+                (``type=servicebus.windows.net:sastoken``). Required for the Service Bus
+                emulator and for namespaces configured for SAS authentication.
+                Mutually exclusive with credential and with username/password.
+            sas_key (typing.Optional[str]): SAS key value (base64) used to sign the token.
+            sas_token_ttl_seconds (int): Lifetime of each minted SAS token (default: 3600).
+            use_tls (bool): If True (default), connect via amqps:// on port 5671 unless port
+                is explicitly set. Required for Azure servicebus; set to False
+                for the local Service Bus emulator (plain AMQP on 5672).
+        """
+        self.host = host
+        self.port = port
+        self.address = address
+        self.username = username
+        self.password = password
+        self.content_mode = content_mode
+        self.format_type = format_type
+        self._credential = credential
+        self._entra_audience = entra_audience
+        self._sas_key_name = sas_key_name
+        self._sas_key = sas_key
+        self._sas_token_ttl = int(sas_token_ttl_seconds)
+        self._use_tls = use_tls
+
+        _sas_configured = bool(sas_key_name or sas_key)
+        if _sas_configured and not (sas_key_name and sas_key):
+            raise ValueError(
+                "sas_key_name and sas_key must both be provided for SAS CBS auth."
+            )
+        if self._credential is not None and _sas_configured:
+            raise ValueError(
+                "credential is mutually exclusive with sas_key_name/sas_key. "
+                "Choose Entra ID OR SAS for CBS authentication."
+            )
+        if (self._credential is not None or _sas_configured) and (self.username or self.password):
+            raise ValueError(
+                "CBS auth (credential or SAS) is mutually exclusive with "
+                "username/password SASL PLAIN."
+            )
+        self._cbs_enabled = self._credential is not None or _sas_configured
+        if self._credential is not None and port == 5672:
+            # Default to AMQPS for Entra path; caller can override explicitly.
+            self.port = 5671
+        if self._cbs_enabled:
+            self._init_reactor()
+        else:
+            connection_url = self._build_connection_url()
+            self._connection = BlockingConnection(connection_url, timeout=30)
+            self._sender = self._connection.create_sender(self.address)
+
+    def _init_reactor(self):
+        """Start the proton reactor thread and block until CBS handshake completes.
+
+        On failure, the exception is propagated out of ``__init__`` so callers
+        get a clean error rather than discovering the problem on first send.
+        """
+        if self._credential is not None:
+            token_provider: _CbsTokenProvider = _JwtTokenProvider(
+                self._credential, self._entra_audience
+            )
+        else:
+            resource_uri = f"sb://{self.host}/{self.address}"
+            token_provider = _SasTokenProvider(
+                self._sas_key_name, self._sas_key, resource_uri,
+                ttl_seconds=self._sas_token_ttl,
+            )
+
+        self._send_queue: "queue.Queue" = queue.Queue()
+        self._init_future: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._close_event = threading.Event()
+        self._handler = _CbsAzureHandler(
+            host=self.host,
+            port=self.port,
+            address=self.address,
+            token_provider=token_provider,
+            use_tls=self._use_tls,
+            init_future=self._init_future,
+            send_queue=self._send_queue,
+            close_event=self._close_event,
+        )
+
+        def _run():
+            import traceback as _tb
+            try:
+                Container(self._handler).run()
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] reactor crashed: {exc!r}\n{_tb.format_exc()}")
+                if not self._init_future.done():
+                    self._init_future.set_exception(exc)
+            finally:
+                self._close_event.set()
+
+        self._reactor_thread = threading.Thread(
+            target=_run, name="amqp-cbs-reactor", daemon=True
+        )
+        self._reactor_thread.start()
+
+        try:
+            self._init_future.result(timeout=60)
+        except Exception:
+            try:
+                self._handler.request_close()
+            except Exception:
+                pass
+            self._close_event.wait(timeout=10)
+            raise
+
+    def _send_via_reactor(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        fut: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._send_queue.put((amqp_msg, fut))
+        fut.result(timeout=timeout)
+    
+    def _build_connection_url(self) -> str:
+        if self.username and self.password:
+            user = quote_plus(self.username)
+            pwd = quote_plus(self.password)
+            return f"amqp://{user}:{pwd}@{self.host}:{self.port}"
+        return f"amqp://{self.host}:{self.port}"
+
+    def _serialize_payload(self, data: typing.Any, content_type: str) -> bytes:
+        if data is None:
+            return b''
+        if hasattr(data, 'to_byte_array'):
+            payload = data.to_byte_array(content_type)
+        elif hasattr(data, 'to_dict'):
+            payload = json.dumps(data.to_dict())
+        elif isinstance(data, (bytes, bytearray)):
+            payload = bytes(data)
+        else:
+            payload = json.dumps(data)
+        # to_byte_array may return str for text content types (e.g. JSON);
+        # we always emit bytes so the AMQP body is a binary section rather
+        # than an AMQP string section containing escaped JSON.
+        if isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        return payload
+
+    @staticmethod
+    def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        """Translate cloudevents-sdk HTTP-style headers (``ce-foo``) into the
+        CloudEvents AMQP 1.0 Protocol Binding (v1.0.2 §3.1) form
+        (``cloudEvents:foo``). ``content-type`` is carried separately on the
+        AMQP properties section and is therefore dropped here.
+        """
+        out: typing.Dict[str, typing.Any] = {}
+        for k, v in (headers or {}).items():
+            if v is None:
+                continue
+            lk = str(k)
+            low = lk.lower()
+            if low.startswith('ce-'):
+                out['cloudEvents:' + lk[3:]] = v
+            elif low == 'content-type':
+                continue
+            else:
+                out[lk] = v
+        return out
+
+    
+    
+    def send_station(self,
+        data: Station,
+        _station_id: str,
+        _district: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send the `HK.Gov.EPD.AQHI.amqp.Station` message
+        A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and route the live measurement or forecast events.
+        
+        Args:
+            _station_id (str): Value for placeholder station_id in attribute subject
+            _district (str): Value for AMQP protocol option placeholder district
+            data (Station): The message data object
+            content_type (str): The content type of the message data (default: 'application/json')
+        """
+        # Build CloudEvent attributes
+        attributes = {
+            "type":
+            "HK.Gov.EPD.AQHI.Station",
+            "source":
+            "https://www.aqhi.gov.hk",
+            "subject":
+            "{station_id}".format(station_id=_station_id),
+        }
+        
+        # Remove None values
+        attributes = {k: v for k, v in attributes.items() if v is not None}
+        
+        # Serialize data
+        byte_data = self._serialize_payload(data, content_type)
+        
+        # Create CloudEvent
+        cloud_event = CloudEvent(attributes, byte_data)
+        
+        # Convert to AMQP message based on content mode
+        if self.content_mode == 'structured':
+            headers, body = to_structured(cloud_event)
+            if isinstance(body, dict):
+                msg_body = json.dumps(body).encode('utf-8')
+            elif isinstance(body, bytes):
+                msg_body = body
+            else:
+                msg_body = str(body).encode('utf-8')
+            amqp_msg = Message(body=msg_body, inferred=True)
+            amqp_msg.content_type = self.format_type or headers.get('content-type')
+        else:  # binary mode
+            headers, body = to_binary(cloud_event)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
+            amqp_msg.content_type = content_type
+            if headers:
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{station_id}".format(station_id=_station_id)
+
+        app_properties = {}
+        app_properties["district"] = "{district}".format(district=_district)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
+        
+        # Send message
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+    
+    def send_station_batch(self,
+        data_array: typing.List[Station],
+        _station_id: str,
+        _district: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send multiple `HK.Gov.EPD.AQHI.amqp.Station` messages
+        
+        Args:
+            data_array (typing.List[Station]): Array of message data objects
+            _station_id (str): Value for placeholder station_id in attribute subject
+            _district (str): Value for AMQP protocol option placeholder district
+            content_type (str): The content type of the message data
+        """
+        for data in data_array:
+            self.send_station(
+                data=data,
+                _station_id=_station_id,
+                _district=_district,
+                content_type=content_type)
+    
+    
+    def send_aqhireading(self,
+        data: AQHIReading,
+        _station_id: str,
+        _district: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send the `HK.Gov.EPD.AQHI.amqp.AQHIReading` message
+        A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health index and pollutant measurements when the upstream feed reports a new or refreshed value.
+        
+        Args:
+            _station_id (str): Value for placeholder station_id in attribute subject
+            _district (str): Value for AMQP protocol option placeholder district
+            data (AQHIReading): The message data object
+            content_type (str): The content type of the message data (default: 'application/json')
+        """
+        # Build CloudEvent attributes
+        attributes = {
+            "type":
+            "HK.Gov.EPD.AQHI.AQHIReading",
+            "source":
+            "https://www.aqhi.gov.hk",
+            "subject":
+            "{station_id}".format(station_id=_station_id),
+        }
+        
+        # Remove None values
+        attributes = {k: v for k, v in attributes.items() if v is not None}
+        
+        # Serialize data
+        byte_data = self._serialize_payload(data, content_type)
+        
+        # Create CloudEvent
+        cloud_event = CloudEvent(attributes, byte_data)
+        
+        # Convert to AMQP message based on content mode
+        if self.content_mode == 'structured':
+            headers, body = to_structured(cloud_event)
+            if isinstance(body, dict):
+                msg_body = json.dumps(body).encode('utf-8')
+            elif isinstance(body, bytes):
+                msg_body = body
+            else:
+                msg_body = str(body).encode('utf-8')
+            amqp_msg = Message(body=msg_body, inferred=True)
+            amqp_msg.content_type = self.format_type or headers.get('content-type')
+        else:  # binary mode
+            headers, body = to_binary(cloud_event)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
+            amqp_msg.content_type = content_type
+            if headers:
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{station_id}".format(station_id=_station_id)
+
+        app_properties = {}
+        app_properties["district"] = "{district}".format(district=_district)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
+        
+        # Send message
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+    
+    def send_aqhireading_batch(self,
+        data_array: typing.List[AQHIReading],
+        _station_id: str,
+        _district: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send multiple `HK.Gov.EPD.AQHI.amqp.AQHIReading` messages
+        
+        Args:
+            data_array (typing.List[AQHIReading]): Array of message data objects
+            _station_id (str): Value for placeholder station_id in attribute subject
+            _district (str): Value for AMQP protocol option placeholder district
+            content_type (str): The content type of the message data
+        """
+        for data in data_array:
+            self.send_aqhireading(
+                data=data,
+                _station_id=_station_id,
+                _district=_district,
+                content_type=content_type)
+    
+    
+    def close(self) -> None:
+        """
+        Close the producer and clean up resources
+        """
+        if getattr(self, "_handler", None) is not None:
+            try:
+                self._handler.request_close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._close_event.wait(timeout=10)
+            self._handler = None
+            return
+        if hasattr(self, '_sender') and self._sender:
+            try:
+                self._sender.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._sender = None
+        if hasattr(self, '_connection') and self._connection:
+            try:
+                self._connection.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._connection = None
+

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer/tests/test_producer.py
@@ -1,0 +1,352 @@
+
+# pylint: disable=missing-function-docstring, wrong-import-position, import-error, no-name-in-module, import-outside-toplevel, no-member, redefined-outer-name, unused-argument, unused-variable, invalid-name, missing-class-docstring
+
+"""
+Tests for hongkong_epd_amqp_producer_amqp_producer
+"""
+import base64
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from typing import Optional
+from urllib.parse import quote_plus
+
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+from proton.utils import BlockingConnection
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../hongkong_epd_amqp_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../hongkong_epd_amqp_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../hongkong_epd_amqp_producer_amqp_producer/src')))
+
+from hongkong_epd_amqp_producer_amqp_producer import *
+from hongkong_epd_amqp_producer_data import Station
+from test_hongkong_epd_amqp_producer_data_station import Test_Station
+from hongkong_epd_amqp_producer_data import AQHIReading
+from test_hongkong_epd_amqp_producer_data_aqhireading import Test_AQHIReading
+
+
+
+def _rabbitmq_queue_address(queue_name: str) -> str:
+    return f"/queues/{queue_name}" if os.environ.get("RABBITMQ_VERSION", "4") != "3" else queue_name
+
+
+def _declare_rabbitmq_queue(host: str, mgmt_port: int, queue_name: str):
+    url = f"http://{host}:{mgmt_port}/api/queues/%2F/{queue_name}"
+    payload = b'{"auto_delete": false, "durable": true, "arguments": {}}'
+    auth = base64.b64encode(b"guest:guest").decode("ascii")
+    last_error = None
+    for _ in range(30):
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in (201, 204):
+                    return
+                last_error = RuntimeError(f"RabbitMQ queue declaration returned {response.status}")
+        except urllib.error.HTTPError as exc:
+            if exc.code in (201, 204):
+                return
+            last_error = exc
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out declaring RabbitMQ queue {queue_name}") from last_error
+
+ARTEMIS_BROKER_XML = """<?xml version='1.0'?>
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>0.0.0.0</name>
+        <persistence-enabled>false</persistence-enabled>
+        <acceptors>
+            <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP;saslMechanisms=PLAIN,ANONYMOUS</acceptor>
+        </acceptors>
+        <security-settings>
+            <security-setting match="#">
+                <permission type="createNonDurableQueue" roles="amq"/>
+                <permission type="deleteNonDurableQueue" roles="amq"/>
+                <permission type="createDurableQueue" roles="amq"/>
+                <permission type="deleteDurableQueue" roles="amq"/>
+                <permission type="createAddress" roles="amq"/>
+                <permission type="deleteAddress" roles="amq"/>
+                <permission type="consume" roles="amq"/>
+                <permission type="browse" roles="amq"/>
+                <permission type="send" roles="amq"/>
+                <permission type="manage" roles="amq"/>
+            </security-setting>
+        </security-settings>
+        <address-settings>
+            <address-setting match="#">
+                <dead-letter-address>DLQ</dead-letter-address>
+                <expiry-address>ExpiryQueue</expiry-address>
+                <auto-create-queues>true</auto-create-queues>
+                <auto-create-addresses>true</auto-create-addresses>
+            </address-setting>
+        </address-settings>
+        <addresses>
+            <address name="test-queue">
+                <anycast>
+                    <queue name="test-queue" />
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>
+"""
+
+@pytest.fixture(scope="module")
+def amqp_broker():
+    """Create and start an AMQP broker container for testing.
+    
+    Uses ActiveMQ Artemis by default.
+    Set AMQP_BROKER=rabbitmq environment variable to test with RabbitMQ.
+    Set RABBITMQ_VERSION=3 or RABBITMQ_VERSION=4 to choose RabbitMQ version (default: 4).
+    """
+    broker_type = os.environ.get("AMQP_BROKER", "artemis").lower()
+    
+    if broker_type == "rabbitmq":
+        rabbitmq_version = os.environ.get("RABBITMQ_VERSION", "4")
+        image_tag = "3-management" if rabbitmq_version == "3" else "4-management"
+        
+        container = DockerContainer(f"rabbitmq:{image_tag}")
+        container.with_bind_ports(5672, 5672)
+        container.with_bind_ports(15672, 15672)
+        container.with_env("RABBITMQ_DEFAULT_USER", "guest")
+        container.with_env("RABBITMQ_DEFAULT_PASS", "guest")
+        container.with_exposed_ports(5672, 15672)
+        
+        # RabbitMQ 3.x requires AMQP 1.0 plugin, RabbitMQ 4.0+ has native support
+        if rabbitmq_version == "3":
+            container.with_command(
+                "bash", "-c", 
+                "rabbitmq-plugins enable rabbitmq_amqp1_0 && docker-entrypoint.sh rabbitmq-server"
+            )
+        
+        container.start()
+        # Wait for RabbitMQ to be ready
+        wait_for_logs(container, "Server startup complete", timeout=120)
+        host = container.get_container_host_ip()
+        if rabbitmq_version != "3":
+            _declare_rabbitmq_queue(host, int(container.get_exposed_port(15672)), "test-queue")
+        
+        yield {
+            "host": host,
+            "port": int(container.get_exposed_port(5672)),
+            "username": "guest",
+            "password": "guest",
+            "address": _rabbitmq_queue_address("test-queue")
+        }
+        
+        container.stop()
+    else:
+        # Default: ActiveMQ Artemis
+        # Create temp file for broker configuration
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+            f.write(ARTEMIS_BROKER_XML)
+            config_file = f.name
+        
+        try:
+            container = DockerContainer("apache/activemq-artemis:latest")
+            container.with_bind_ports(5672, 5672)
+            container.with_env("ARTEMIS_USER", "guest")
+            container.with_env("ARTEMIS_PASSWORD", "guest")
+            container.with_volume_mapping(config_file, "/var/lib/artemis-instance/etc-override/broker.xml")
+            container.with_exposed_ports(5672)
+            
+            # Wait for Artemis to be ready
+            container.start()
+            # Wait for broker to log that it's ready (AMQ241004 = "Artemis Server is now live")
+            wait_for_logs(container, "AMQ241004", timeout=60)
+            
+            yield {
+                "host": container.get_container_host_ip(),
+                "port": int(container.get_exposed_port(5672)),
+                "username": "guest",
+                "password": "guest",
+                "address": "test-queue"
+            }
+            
+            container.stop()
+        finally:
+            if os.path.exists(config_file):
+                os.unlink(config_file)
+
+# Keep old fixture name for backwards compatibility
+@pytest.fixture(scope="module")
+def artemis_container(amqp_broker):
+    """Alias for amqp_broker for backwards compatibility"""
+    return amqp_broker
+
+def _connection_url(host: str, port: int, username: Optional[str] = None, password: Optional[str] = None) -> str:
+    if username and password:
+        return f"amqp://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}"
+    return f"amqp://{host}:{port}"
+
+
+def _receive_single_message(config: dict, timeout: int = 30):
+    connection = BlockingConnection(
+        _connection_url(
+            config["host"],
+            config["port"],
+            config.get("username"),
+            config.get("password"),
+        ),
+        timeout=timeout,
+    )
+    receiver = connection.create_receiver(config["address"], credit=1)
+    try:
+        message = receiver.receive(timeout=timeout)
+        receiver.accept()  # Explicitly accept/settle the message to remove it from the queue
+        return message
+    finally:
+        receiver.close()
+        connection.close()
+
+class TestHKGovEPDAQHIAmqpProducer:
+    """Test cases for HKGovEPDAQHIAmqpProducer"""
+    
+    def test_producer_initialization(self, artemis_container):
+        """Test that producer initializes correctly"""
+        producer = HKGovEPDAQHIAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"]
+        )
+        assert producer is not None
+        assert producer.host == artemis_container["host"]
+        assert producer.address == artemis_container["address"]
+        assert producer.port == artemis_container["port"]
+        assert producer.username == artemis_container["username"]
+        producer.close()
+    
+    def test_send_station(self, artemis_container):
+        """Send and receive a Station message via ActiveMQ Artemis."""
+        # Create valid test data using the test helper
+        payload = Test_Station.create_instance()
+
+        producer = HKGovEPDAQHIAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='structured'
+        )
+        
+        try:
+            assert producer.host == artemis_container["host"]
+            assert producer.address == artemis_container["address"]
+            assert producer.port == artemis_container["port"]
+            assert producer.username == artemis_container["username"]
+            assert producer.content_mode == 'structured'
+            # Send 5 messages to test proper message settlement and ordering
+            for i in range(5):
+                producer.send_station(
+                    data=payload,
+                    _station_id="value",
+                    _district="value",
+                    content_type="application/json"
+                )
+
+            # Receive and verify all 5 messages
+            for i in range(5):
+                received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
+
+                if True:
+                    body = received.body
+                    if isinstance(body, memoryview):
+                        body_text = body.tobytes().decode('utf-8')
+                    elif isinstance(body, bytes):
+                        body_text = body.decode('utf-8')
+                    elif isinstance(body, str):
+                        body_text = body
+                    elif isinstance(body, dict):
+                        body_text = json.dumps(body)
+                    else:
+                        body_text = str(body)
+                    cloud_event_payload = json.loads(body_text)
+                    assert cloud_event_payload.get("type") == "HK.Gov.EPD.AQHI.amqp.Station"
+                    # Verify data section exists (either as data or data_base64)
+                    assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
+                else:
+                    # Verify message body is not empty
+                    assert received.body is not None
+                assert received.subject == "{station_id}".format(station_id="value")
+                assert properties.get('district') == "{district}".format(district="value")
+        finally:
+            producer.close()
+    
+    def test_send_aqhireading(self, artemis_container):
+        """Send and receive a AQHIReading message via ActiveMQ Artemis."""
+        # Create valid test data using the test helper
+        payload = Test_AQHIReading.create_instance()
+
+        producer = HKGovEPDAQHIAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='structured'
+        )
+        
+        try:
+            assert producer.host == artemis_container["host"]
+            assert producer.address == artemis_container["address"]
+            assert producer.port == artemis_container["port"]
+            assert producer.username == artemis_container["username"]
+            assert producer.content_mode == 'structured'
+            # Send 5 messages to test proper message settlement and ordering
+            for i in range(5):
+                producer.send_aqhireading(
+                    data=payload,
+                    _station_id="value",
+                    _district="value",
+                    content_type="application/json"
+                )
+
+            # Receive and verify all 5 messages
+            for i in range(5):
+                received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
+
+                if True:
+                    body = received.body
+                    if isinstance(body, memoryview):
+                        body_text = body.tobytes().decode('utf-8')
+                    elif isinstance(body, bytes):
+                        body_text = body.decode('utf-8')
+                    elif isinstance(body, str):
+                        body_text = body
+                    elif isinstance(body, dict):
+                        body_text = json.dumps(body)
+                    else:
+                        body_text = str(body)
+                    cloud_event_payload = json.loads(body_text)
+                    assert cloud_event_payload.get("type") == "HK.Gov.EPD.AQHI.amqp.AQHIReading"
+                    # Verify data section exists (either as data or data_base64)
+                    assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
+                else:
+                    # Verify message body is not empty
+                    assert received.body is not None
+                assert received.subject == "{station_id}".format(station_id="value")
+                assert properties.get('district') == "{district}".format(district="value")
+        finally:
+            producer.close()
+

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/pyproject.toml
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "hongkong-epd-amqp-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "hongkong_epd_amqp_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/__init__.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/__init__.py
@@ -1,0 +1,4 @@
+from .station import Station
+from .aqhireading import AQHIReading
+
+__all__ = ["Station", "AQHIReading"]

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/aqhireading.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/aqhireading.py
@@ -1,0 +1,175 @@
+""" AQHIReading dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
+import json
+import datetime
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class AQHIReading:
+    """
+    A current environmental measurement from Hong Kong's Environmental Protection Department. It carries air-quality health index and pollutant measurements when the upstream feed reports a new or refreshed value.
+    
+    Attributes:
+        station_id (str)
+        station_name (str)
+        station_type (str)
+        district (str)
+        reading_time (datetime.datetime)
+        aqhi (int)
+        health_risk_category (typing.Optional[str])
+    """
+    
+    
+    station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    station_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_name"))
+    station_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_type"))
+    district: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="district"))
+    reading_time: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="reading_time", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    aqhi: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="aqhi"))
+    health_risk_category: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="health_risk_category"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'AQHIReading':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['AQHIReading']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return AQHIReading.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'AQHIReading':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            station_id='cxxnkrtyezaympjcvchs',
+            station_name='gmjibrgijkqlegmrbxci',
+            station_type='eqvurrwiqozsipsttezk',
+            district='mmfpkokvqyqaohqkjykl',
+            reading_time=datetime.datetime.now(datetime.timezone.utc),
+            aqhi=int(67),
+            health_risk_category='ilkqiuhrrytryeotitpe'
+        )

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/station.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/src/hongkong_epd_amqp_producer_data/station.py
@@ -1,0 +1,170 @@
+""" Station dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+import json
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Station:
+    """
+    A reference record published by Hong Kong's Environmental Protection Department. It lets consumers label, group, and route the live measurement or forecast events.
+    
+    Attributes:
+        station_id (str)
+        station_name (str)
+        station_type (str)
+        district (str)
+        latitude (typing.Optional[float])
+        longitude (typing.Optional[float])
+    """
+    
+    
+    station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    station_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_name"))
+    station_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_type"))
+    district: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="district"))
+    latitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
+    longitude: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'Station':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['Station']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return Station.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'Station':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            station_id='jhcvhpwhrenvucnhsglu',
+            station_name='ffszrlzxzzvclmmijaqh',
+            station_type='frplyjlvsmfhxonfjaad',
+            district='bqtsrvzpysfyjmgasgnu',
+            latitude=float(77.67144122358134),
+            longitude=float(96.7886373234753)
+        )

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/tests/test_aqhireading.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/tests/test_aqhireading.py
@@ -1,0 +1,117 @@
+"""
+Test case for AQHIReading
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from hongkong_epd_amqp_producer_data.aqhireading import AQHIReading
+import datetime
+
+
+class Test_AQHIReading(unittest.TestCase):
+    """
+    Test case for AQHIReading
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_AQHIReading.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of AQHIReading for testing
+        """
+        instance = AQHIReading(
+            station_id='cxxnkrtyezaympjcvchs',
+            station_name='gmjibrgijkqlegmrbxci',
+            station_type='eqvurrwiqozsipsttezk',
+            district='mmfpkokvqyqaohqkjykl',
+            reading_time=datetime.datetime.now(datetime.timezone.utc),
+            aqhi=int(67),
+            health_risk_category='ilkqiuhrrytryeotitpe'
+        )
+        return instance
+
+    
+    def test_station_id_property(self):
+        """
+        Test station_id property
+        """
+        test_value = 'cxxnkrtyezaympjcvchs'
+        self.instance.station_id = test_value
+        self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_station_name_property(self):
+        """
+        Test station_name property
+        """
+        test_value = 'gmjibrgijkqlegmrbxci'
+        self.instance.station_name = test_value
+        self.assertEqual(self.instance.station_name, test_value)
+    
+    def test_station_type_property(self):
+        """
+        Test station_type property
+        """
+        test_value = 'eqvurrwiqozsipsttezk'
+        self.instance.station_type = test_value
+        self.assertEqual(self.instance.station_type, test_value)
+    
+    def test_district_property(self):
+        """
+        Test district property
+        """
+        test_value = 'mmfpkokvqyqaohqkjykl'
+        self.instance.district = test_value
+        self.assertEqual(self.instance.district, test_value)
+    
+    def test_reading_time_property(self):
+        """
+        Test reading_time property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.reading_time = test_value
+        self.assertEqual(self.instance.reading_time, test_value)
+    
+    def test_aqhi_property(self):
+        """
+        Test aqhi property
+        """
+        test_value = int(67)
+        self.instance.aqhi = test_value
+        self.assertEqual(self.instance.aqhi, test_value)
+    
+    def test_health_risk_category_property(self):
+        """
+        Test health_risk_category property
+        """
+        test_value = 'ilkqiuhrrytryeotitpe'
+        self.instance.health_risk_category = test_value
+        self.assertEqual(self.instance.health_risk_category, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = AQHIReading.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = AQHIReading.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/tests/test_station.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data/tests/test_station.py
@@ -1,0 +1,107 @@
+"""
+Test case for Station
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from hongkong_epd_amqp_producer_data.station import Station
+
+
+class Test_Station(unittest.TestCase):
+    """
+    Test case for Station
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_Station.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of Station for testing
+        """
+        instance = Station(
+            station_id='jhcvhpwhrenvucnhsglu',
+            station_name='ffszrlzxzzvclmmijaqh',
+            station_type='frplyjlvsmfhxonfjaad',
+            district='bqtsrvzpysfyjmgasgnu',
+            latitude=float(77.67144122358134),
+            longitude=float(96.7886373234753)
+        )
+        return instance
+
+    
+    def test_station_id_property(self):
+        """
+        Test station_id property
+        """
+        test_value = 'jhcvhpwhrenvucnhsglu'
+        self.instance.station_id = test_value
+        self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_station_name_property(self):
+        """
+        Test station_name property
+        """
+        test_value = 'ffszrlzxzzvclmmijaqh'
+        self.instance.station_name = test_value
+        self.assertEqual(self.instance.station_name, test_value)
+    
+    def test_station_type_property(self):
+        """
+        Test station_type property
+        """
+        test_value = 'frplyjlvsmfhxonfjaad'
+        self.instance.station_type = test_value
+        self.assertEqual(self.instance.station_type, test_value)
+    
+    def test_district_property(self):
+        """
+        Test district property
+        """
+        test_value = 'bqtsrvzpysfyjmgasgnu'
+        self.instance.district = test_value
+        self.assertEqual(self.instance.district, test_value)
+    
+    def test_latitude_property(self):
+        """
+        Test latitude property
+        """
+        test_value = float(77.67144122358134)
+        self.instance.latitude = test_value
+        self.assertEqual(self.instance.latitude, test_value)
+    
+    def test_longitude_property(self):
+        """
+        Test longitude property
+        """
+        test_value = float(96.7886373234753)
+        self.instance.longitude = test_value
+        self.assertEqual(self.instance.longitude, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = Station.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = Station.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/hongkong-epd/hongkong_epd_amqp_producer/install.bat
+++ b/hongkong-epd/hongkong_epd_amqp_producer/install.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Installing hongkong_epd_amqp_producer_amqp_producer...
+
+REM Check if poetry is installed
+where poetry >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo Poetry is not installed. Installing Poetry...
+    powershell -Command "& {(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -}"
+)
+
+REM Install dependencies
+poetry install
+
+echo Installation complete!
+echo Run 'poetry run pytest' to run tests

--- a/hongkong-epd/hongkong_epd_amqp_producer/install.sh
+++ b/hongkong-epd/hongkong_epd_amqp_producer/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Installing hongkong_epd_amqp_producer_amqp_producer..."
+
+# Check if poetry is installed
+if ! command -v poetry &> /dev/null; then
+    echo "Poetry is not installed. Installing Poetry..."
+    curl -sSL https://install.python-poetry.org | python3 -
+fi
+
+# Install dependencies
+poetry install
+
+echo "Installation complete!"
+echo "Run 'poetry run pytest' to run tests"

--- a/hongkong-epd/hongkong_epd_amqp_producer/samples/sample.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/samples/sample.py
@@ -1,0 +1,65 @@
+
+"""
+Sample usage of hongkong_epd_amqp_producer_amqp_producer
+
+This example demonstrates how to send messages using the AMQP 1.0 producer.
+"""
+import sys
+from hongkong_epd_amqp_producer_amqp_producer import *
+
+def main():
+    """Main function"""
+    
+    
+    # Create producer
+    print("Creating AMQP producer...")
+    producer = HKGovEPDAQHIAmqpProducer(
+        host="localhost",  # Change to your AMQP broker hostname
+        address="my-queue",  # Change to your queue/topic name
+        port=5672,  # Use 5671 for TLS
+        username="guest",  # Change to your username
+        password="guest",  # Change to your password
+        content_mode='structured',  # or 'binary' for CloudEvents
+        format_type='application/json'
+    )
+    
+    try:
+        
+        
+        # Send Station message
+        print("Sending Station message...")
+        # TODO: Create a Station instance with actual data
+        # data = Station(...)
+        # producer.send_station(
+        #     data=data,
+        #     content_type="application/json"
+        # )
+        # print("Station message sent successfully!")
+        
+        
+        
+        # Send AQHIReading message
+        print("Sending AQHIReading message...")
+        # TODO: Create a AQHIReading instance with actual data
+        # data = AQHIReading(...)
+        # producer.send_aqhireading(
+        #     data=data,
+        #     content_type="application/json"
+        # )
+        # print("AQHIReading message sent successfully!")
+        
+        
+        print("\nAll messages sent successfully!")
+        
+    except Exception as e:
+        print(f"Error sending messages: {e}", file=sys.stderr)
+        return 1
+    finally:
+        producer.close()
+        print("Producer closed")
+    
+    return 0
+    
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hongkong-epd/hongkong_epd_amqp_producer/scripts/build.py
+++ b/hongkong-epd/hongkong_epd_amqp_producer/scripts/build.py
@@ -1,0 +1,30 @@
+"""
+Build script for hongkong_epd_amqp_producer_amqp_producer
+"""
+import subprocess
+import sys
+
+def main():
+    """Main build function"""
+    print("Building hongkong_epd_amqp_producer_amqp_producer...")
+    
+    try:
+        # Install dependencies
+        subprocess.run(["poetry", "install"], check=True)
+        
+        # Run tests
+        print("\nRunning tests...")
+        subprocess.run(["poetry", "run", "pytest"], check=True)
+        
+        # Build package
+        print("\nBuilding package...")
+        subprocess.run(["poetry", "build"], check=True)
+        
+        print("\n✓ Build complete!")
+        return 0
+    except subprocess.CalledProcessError as e:
+        print(f"\n✗ Build failed: {e}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hongkong-epd/infra/azure-template-amqp.json
+++ b/hongkong-epd/infra/azure-template-amqp.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the Hong Kong EPD AQHI AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'hongkong-epd'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "hongkong-epd",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for Hong Kong EPD AQHI feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "hongkong-epd",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all Hong Kong EPD AQHI CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-hongkong-epd-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "3600"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/hongkong_epd_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/hongkong-epd/xreg/hongkong_epd.xreg.json
+++ b/hongkong-epd/xreg/hongkong_epd.xreg.json
@@ -43,6 +43,28 @@
         "#/messagegroups/HK.Gov.EPD.AQHI.mqtt"
       ],
       "description": "MQTT 5 producer endpoint for Hong Kong EPD Air Quality CloudEvents using the source topic hierarchy and retain settings declared in this manifest."
+    },
+    "HK.Gov.EPD.AQHI.Amqp": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "AMQP/1.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "amqps://localhost:5671/hongkong-epd"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/HK.Gov.EPD.AQHI.amqp"
+      ],
+      "description": "AMQP 1.0 producer endpoint for Hong Kong EPD AQHI CloudEvents on the configured broker address."
     }
   },
   "messagegroups": {
@@ -110,6 +132,53 @@
             "topic_name": "air-quality/hk/epd/hongkong-epd/{district}/{station_id}/aqhi",
             "qos": 1,
             "retain": true
+          }
+        }
+      }
+    },
+    "HK.Gov.EPD.AQHI.amqp": {
+      "description": "AMQP 1.0 variant of the Hong Kong EPD air-quality events for queue-oriented consumers and Azure Service Bus deployments.",
+      "messages": {
+        "HK.Gov.EPD.AQHI.amqp.Station": {
+          "name": "Station",
+          "basemessageurl": "/messagegroups/HK.Gov.EPD.AQHI/messages/HK.Gov.EPD.AQHI.Station",
+          "protocol": "AMQP/1.0",
+          "protocoloptions": {
+            "properties": {
+              "subject": {
+                "type": "uritemplate",
+                "value": "{station_id}",
+                "description": "AMQP message subject — stable entity identifier matching the CloudEvent subject and Kafka key for cross-transport correlation."
+              }
+            },
+            "application_properties": {
+              "district": {
+                "type": "uritemplate",
+                "value": "{district}",
+                "description": "Hong Kong 18-district administrative area normalized for routing and Service Bus subscription filters."
+              }
+            }
+          }
+        },
+        "HK.Gov.EPD.AQHI.amqp.AQHIReading": {
+          "name": "AQHIReading",
+          "basemessageurl": "/messagegroups/HK.Gov.EPD.AQHI/messages/HK.Gov.EPD.AQHI.AQHIReading",
+          "protocol": "AMQP/1.0",
+          "protocoloptions": {
+            "properties": {
+              "subject": {
+                "type": "uritemplate",
+                "value": "{station_id}",
+                "description": "AMQP message subject — stable entity identifier matching the CloudEvent subject and Kafka key for cross-transport correlation."
+              }
+            },
+            "application_properties": {
+              "district": {
+                "type": "uritemplate",
+                "value": "{district}",
+                "description": "Hong Kong 18-district administrative area normalized for routing and Service Bus subscription filters."
+              }
+            }
           }
         }
       }

--- a/meteoalarm/CONTAINER.md
+++ b/meteoalarm/CONTAINER.md
@@ -1,4 +1,4 @@
-# Meteoalarm Container
+# Meteoalarm Kafka, MQTT, and AMQP Container
 
 ## Quick Start
 
@@ -11,7 +11,7 @@ docker run --rm -e CONNECTION_STRING="<your-connection-string>" meteoalarm
 
 This container bridges severe weather warnings from the EUMETNET Meteoalarm
 system to Kafka-compatible endpoints (Apache Kafka, Azure Event Hubs,
-Microsoft Fabric Event Streams) as CloudEvents.
+Microsoft Fabric Event Streams), MQTT 5.0, and AMQP 1.0 as CloudEvents.
 
 It polls the Meteoalarm JSON API for warnings from 30+ European national
 meteorological services and emits them as structured CloudEvents using the
@@ -113,3 +113,68 @@ Deploy the MQTT container against an existing MQTT 5 broker:
 Deploy the MQTT container with a new Azure Event Grid namespace MQTT broker:
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fclemensv%2Freal-time-sources%2Fmain%2Fmeteoalarm%2Fazure-template-with-eventgrid-mqtt.json)
+
+## AMQP 1.0 container variant
+
+Image: `ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest`
+
+The AMQP companion publishes Meteoalarm CloudEvents to generic AMQP 1.0 brokers with SASL PLAIN, Azure Service Bus with Entra ID CBS, or Service Bus-compatible SAS CBS. It uses the same event schemas as the Kafka and MQTT variants.
+
+### Generic AMQP broker
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=meteoalarm \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest
+```
+
+### Azure Service Bus with Entra ID
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=<namespace>.servicebus.windows.net \
+  -e AMQP_PORT=5671 \
+  -e AMQP_TLS=true \
+  -e AMQP_ADDRESS=meteoalarm \
+  -e AMQP_AUTH_MODE=entra \
+  -e AMQP_ENTRA_AUDIENCE=https://servicebus.azure.net/.default \
+  -e AMQP_ENTRA_CLIENT_ID=<managed-identity-client-id> \
+  ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest
+```
+
+### Service Bus emulator / SAS CBS
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=servicebus-emulator \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=meteoalarm \
+  -e AMQP_AUTH_MODE=sas \
+  -e AMQP_SAS_KEY_NAME=RootManageSharedAccessKey \
+  -e AMQP_SAS_KEY=<key> \
+  ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest
+```
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `AMQP_BROKER_URL` | Optional `amqp://` or `amqps://` URL; path overrides `AMQP_ADDRESS`. | empty |
+| `AMQP_HOST` / `AMQP_PORT` | AMQP broker host and port when no broker URL is supplied. | `localhost` / `5672` (`5671` with TLS) |
+| `AMQP_ADDRESS` | Queue, topic, or link target address. | `meteoalarm` |
+| `AMQP_AUTH_MODE` | `password`, `entra`, or `sas`. | `password` |
+| `AMQP_USERNAME` / `AMQP_PASSWORD` | SASL PLAIN credentials for generic brokers. | empty |
+| `AMQP_TLS` | Enable TLS; automatically true for Entra auth. | `false` |
+| `AMQP_ENTRA_AUDIENCE` | Token scope for CBS put-token. | `https://servicebus.azure.net/.default` |
+| `AMQP_ENTRA_CLIENT_ID` | Optional user-assigned managed identity client id. | empty |
+| `AMQP_SAS_KEY_NAME` / `AMQP_SAS_KEY` | SAS CBS credentials for Service Bus-compatible brokers. | empty |
+| `AMQP_CONTENT_MODE` | CloudEvents AMQP content mode. | `binary` |
+| `POLLING_INTERVAL` | Poll interval in seconds. | source-specific |
+| `STATE_FILE` | Persistent dedupe state file path. | source-specific |
+| `METEOALARM_MOCK` | Emit built-in sample events for Docker E2E and offline validation. | `false` |
+
+Use `azure-template-with-servicebus.json` or `infra/azure-template-amqp.json` for one-click Azure Service Bus deployment. The templates create a queue, Azure Files state share, ACI, user-assigned managed identity, and `Azure Service Bus Data Sender` role assignment scoped to the queue.
+

--- a/meteoalarm/Dockerfile.amqp
+++ b/meteoalarm/Dockerfile.amqp
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.source="https://github.com/clemensv/real-time-sources/tree/main/meteoalarm"
+LABEL org.opencontainers.image.title="Meteoalarm → AMQP 1.0 bridge"
+LABEL org.opencontainers.image.description="Polls Meteoalarm CAP warning feeds and publishes severe-weather CloudEvents over AMQP 1.0 for generic brokers and Azure Service Bus. Supports SASL PLAIN, Service Bus Entra ID CBS, and Service Bus SAS CBS authentication."
+LABEL org.opencontainers.image.documentation="https://github.com/clemensv/real-time-sources/blob/main/meteoalarm/CONTAINER.md"
+LABEL org.opencontainers.image.license="MIT"
+LABEL source.transport="amqp"
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+RUN apt-get update  && apt-get install -y --no-install-recommends         build-essential cmake pkg-config swig         libssl-dev libsasl2-dev python3-dev         libsasl2-2 libsasl2-modules  && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+
+RUN pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_data  && pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./meteoalarm_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+
+ENV AMQP_BROKER_URL=""
+ENV AMQP_ADDRESS="meteoalarm"
+
+CMD ["python", "-m", "meteoalarm_amqp", "feed"]

--- a/meteoalarm/EVENTS.md
+++ b/meteoalarm/EVENTS.md
@@ -4,8 +4,8 @@ Meteoalarm publishes official weather warnings from the European Meteoalarm netw
 
 ## At a glance
 
-- **Event types:** 1 documented event type (2 transport bindings in the manifest).
-- **Transports:** KAFKA, MQTT/5.0
+- **Event types:** 1 documented event type (3 transport bindings in the manifest).
+- **Transports:** KAFKA, MQTT/5.0, AMQP/1.0
 - **Reference vs telemetry:** 0 reference/catalog event types and 1 telemetry event type.
 - **Identity:** `{identifier}` identifies the resource each event is about.
 - **Operations:** The bridge keeps dedupe state so repeated upstream records are not intentionally republished as new events.
@@ -43,6 +43,20 @@ c.loop_forever()
 ```
 
 Subscribe at QoS 1 with a stable client id, `CleanStart=false`, and a finite non-zero session expiry when you need at-least-once delivery across reconnects. Retained messages are delivered subject to MQTT 5 Retain Handling, and publishing an empty retained payload clears the retained value. MQTT 5 user properties carry CloudEvents metadata; MQTT 3.1.1 clients need structured CloudEvents because they do not have user properties.
+### AMQP 1.0
+
+Attach a link with `role=receiver` whose **source** is `meteoalarm`. The source terminus is the broker-side node you consume from; source filters such as selectors, Event Hubs offsets, or subscription filters further select which messages flow. The target is your client-side terminus. Generic brokers use their advertised SASL mechanisms (often PLAIN over TLS, EXTERNAL with mTLS, or ANONYMOUS on trusted links). Azure Service Bus and Event Hubs can use SASL PLAIN for SAS credentials on short-lived connections; CBS `put-token` on `$cbs` installs and refreshes Entra ID JWTs or SAS tokens for long-lived AMQP connections.
+
+```python
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+class H(MessagingHandler):
+    def on_start(self,e): e.container.create_receiver('amqps://user:pass@localhost:5671/meteoalarm')
+    def on_message(self,e): print(e.message.subject, e.message.properties, e.message.body)
+Container(H()).run()
+```
+
+The examples use AMQP binary content mode: the JSON payload is the message body, `datacontenttype` maps to the AMQP `content-type`, and CloudEvents attributes map to application properties named `cloudEvents:<attribute>`.
 
 ## Event catalog
 
@@ -64,6 +78,7 @@ Each event identifies the real-world resource with `{identifier}`. `{identifier}
 | --- | --- |
 | `KAFKA` | topic `meteoalarm`, key `{identifier}` |
 | `MQTT/5.0` | topic `alerts/intl/meteoalarm/meteoalarm/{country}/{severity}/{awareness_type}/{identifier}/warning`, retain `false`, QoS `1` |
+| `AMQP/1.0` | source address `amqps://localhost:5671/meteoalarm`, message subject `{identifier}`; application properties country `{country}`, severity `{severity}`, awareness_type `{awareness_type}` |
 
 #### Payload
 

--- a/meteoalarm/README.md
+++ b/meteoalarm/README.md
@@ -2,7 +2,7 @@
 
 This bridge polls the EUMETNET Meteoalarm API for severe weather warnings from
 30+ European national meteorological services and forwards them to Apache
-Kafka, Azure Event Hubs, or Microsoft Fabric Event Streams as CloudEvents.
+Kafka, Azure Event Hubs, Microsoft Fabric Event Streams, MQTT 5.0, or AMQP 1.0 as CloudEvents.
 
 ## Data Source
 
@@ -95,3 +95,23 @@ Four Azure Container Instance deployment shapes are documented for this source:
 | MQTT, create an Azure Event Grid namespace MQTT broker | `azure-template-with-eventgrid-mqtt.json` |
 
 See [CONTAINER.md](CONTAINER.md) for runtime environment variables and deployment badges, and [EVENTS.md](EVENTS.md) for the full CloudEvents and MQTT topic contract.
+
+## AMQP 1.0 companion feeder
+
+This source now ships Kafka, MQTT, and AMQP 1.0 transport variants. The AMQP container (`ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest`) publishes the same CloudEvents payloads as the Kafka and MQTT feeders to a single broker address named `meteoalarm` by default, using binary-mode AMQP 1.0 for generic brokers or Azure Service Bus.
+
+Run locally against an AMQP 1.0 broker:
+
+```bash
+docker run --rm \
+  -e AMQP_HOST=broker \
+  -e AMQP_PORT=5672 \
+  -e AMQP_ADDRESS=meteoalarm \
+  -e AMQP_USERNAME=admin \
+  -e AMQP_PASSWORD=admin \
+  -e AMQP_AUTH_MODE=password \
+  ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest
+```
+
+Deploy to Azure Service Bus with `azure-template-with-servicebus.json` (also mirrored at `infra/azure-template-amqp.json`). The template provisions a Service Bus queue, storage-backed state share, a user-assigned managed identity, and an Azure Container Instance configured for AMQP CBS / Entra ID authentication.
+

--- a/meteoalarm/azure-template-with-servicebus.json
+++ b/meteoalarm/azure-template-with-servicebus.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the Meteoalarm AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'meteoalarm'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "meteoalarm",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for Meteoalarm feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "meteoalarm",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all Meteoalarm CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "300"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/meteoalarm_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/meteoalarm/generate_amqp_producer.ps1
+++ b/meteoalarm/generate_amqp_producer.ps1
@@ -1,0 +1,13 @@
+# Regenerate the AMQP 1.0 producer (amqpproducer style) from the authoritative xreg manifest.
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot "..\tools\require-xrcg.ps1")
+Assert-XrcgVersion
+
+xrcg generate `
+    --style amqpproducer `
+    --language py `
+    --definitions xreg\meteoalarm.xreg.json `
+    --endpoint Meteoalarm.Warnings.Amqp `
+    --projectname meteoalarm_amqp_producer `
+    --template-args azure_cbs_target=servicebus `
+    --output meteoalarm_amqp_producer

--- a/meteoalarm/infra/azure-template-amqp.json
+++ b/meteoalarm/infra/azure-template-amqp.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "description": "Deploys the Meteoalarm AMQP 1.0 bridge against a new Azure Service Bus namespace with a queue named 'meteoalarm'. A user-assigned managed identity holds Azure Service Bus Data Sender on the queue and the container authenticates via Entra ID over AMQP CBS."
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "meteoalarm",
+      "minLength": 3,
+      "maxLength": 24,
+      "metadata": {
+        "description": "Base name for all resources."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    },
+    "serviceBusSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "Service Bus namespace SKU. Standard is sufficient for Meteoalarm feeder throughput."
+      }
+    },
+    "queueName": {
+      "type": "string",
+      "defaultValue": "meteoalarm",
+      "minLength": 1,
+      "maxLength": 50,
+      "metadata": {
+        "description": "Service Bus queue name. The bridge writes all Meteoalarm CloudEvents into this queue."
+      }
+    },
+    "imageName": {
+      "type": "string",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-meteoalarm-amqp:latest",
+      "metadata": {
+        "description": "Container image reference for the AMQP companion feeder."
+      }
+    }
+  },
+  "variables": {
+    "namespaceName": "[concat(parameters('namePrefix'), '-sb')]",
+    "userIdentityName": "[concat(parameters('namePrefix'), '-mi')]",
+    "containerGroupName": "[parameters('namePrefix')]",
+    "storageAccountName": "[take(concat(replace(replace(parameters('namePrefix'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
+    "fileShareName": "bridge-state",
+    "logAnalyticsWorkspaceName": "[concat(parameters('namePrefix'), '-logs')]",
+    "sbDataSenderRoleId": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+    "userIdentityResourceId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userIdentityName'))]",
+    "namespaceResourceId": "[resourceId('Microsoft.ServiceBus/namespaces', variables('namespaceName'))]",
+    "queueResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('namespaceName'), parameters('queueName'))]",
+    "roleAssignmentName": "[guid(variables('queueResourceId'), variables('userIdentityResourceId'), variables('sbDataSenderRoleId'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('userIdentityName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[variables('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "sku": {
+          "name": "PerGB2018"
+        },
+        "retentionInDays": 30
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "minimumTlsVersion": "TLS1_2"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-05-01",
+      "name": "[concat(variables('storageAccountName'), '/default/', variables('fileShareName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "shareQuota": 1
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('namespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('serviceBusSku')]",
+        "tier": "[parameters('serviceBusSku')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[concat(variables('namespaceName'), '/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('namespaceResourceId')]"
+      ],
+      "properties": {
+        "lockDuration": "PT1M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P14D",
+        "deadLetteringOnMessageExpiration": true,
+        "maxDeliveryCount": 10,
+        "enableBatchedOperations": true
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "scope": "[concat('Microsoft.ServiceBus/namespaces/', variables('namespaceName'), '/queues/', parameters('queueName'))]",
+      "dependsOn": [
+        "[variables('queueResourceId')]",
+        "[variables('userIdentityResourceId')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables('sbDataSenderRoleId')]",
+        "principalId": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]",
+        "principalType": "ServicePrincipal"
+      }
+    },
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('containerGroupName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('userIdentityResourceId')]": {}
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('fileShareName'))]",
+        "[variables('namespaceResourceId')]",
+        "[variables('queueResourceId')]",
+        "[extensionResourceId(variables('queueResourceId'), 'Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+      ],
+      "properties": {
+        "osType": "Linux",
+        "restartPolicy": "Always",
+        "diagnostics": {
+          "logAnalytics": {
+            "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+            "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+            "logType": "ContainerInstanceLogs"
+          }
+        },
+        "containers": [
+          {
+            "name": "[variables('containerGroupName')]",
+            "properties": {
+              "image": "[parameters('imageName')]",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.0
+                }
+              },
+              "environmentVariables": [
+                {
+                  "name": "AMQP_HOST",
+                  "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+                },
+                {
+                  "name": "AMQP_PORT",
+                  "value": "5671"
+                },
+                {
+                  "name": "AMQP_TLS",
+                  "value": "true"
+                },
+                {
+                  "name": "AMQP_ADDRESS",
+                  "value": "[parameters('queueName')]"
+                },
+                {
+                  "name": "AMQP_AUTH_MODE",
+                  "value": "entra"
+                },
+                {
+                  "name": "AMQP_ENTRA_AUDIENCE",
+                  "value": "https://servicebus.azure.net/.default"
+                },
+                {
+                  "name": "AMQP_ENTRA_CLIENT_ID",
+                  "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+                },
+                {
+                  "name": "AMQP_CONTENT_MODE",
+                  "value": "binary"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "300"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/meteoalarm_state.json"
+                },
+                {
+                  "name": "LOG_LEVEL",
+                  "value": "INFO"
+                },
+                {
+                  "name": "PYTHONUNBUFFERED",
+                  "value": "1"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "bridge-state",
+                  "mountPath": "/mnt/bridge-state"
+                }
+              ]
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "name": "bridge-state",
+            "azureFile": {
+              "shareName": "[variables('fileShareName')]",
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-05-01').keys[0].value]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "namespaceName": {
+      "type": "string",
+      "value": "[variables('namespaceName')]"
+    },
+    "serviceBusHostname": {
+      "type": "string",
+      "value": "[concat(variables('namespaceName'), '.servicebus.windows.net')]"
+    },
+    "queueName": {
+      "type": "string",
+      "value": "[parameters('queueName')]"
+    },
+    "managedIdentityClientId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').clientId]"
+    },
+    "managedIdentityPrincipalId": {
+      "type": "string",
+      "value": "[reference(variables('userIdentityResourceId'), '2023-01-31').principalId]"
+    },
+    "containerGroupId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('containerGroupName'))]"
+    }
+  }
+}

--- a/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/__main__.py
+++ b/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/app.py
+++ b/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/app.py
@@ -1,0 +1,161 @@
+"""AMQP 1.0 feeder application for Meteoalarm warnings."""
+
+from __future__ import annotations
+
+
+import argparse
+import logging
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+DEFAULT_ENTRA_AUDIENCE_SERVICEBUS = "https://servicebus.azure.net/.default"
+
+
+def _parse_amqp_broker_url(url: str) -> tuple[str, int, bool, Optional[str], Optional[str], Optional[str]]:
+    parsed = urlparse(url if "://" in url else f"amqp://{url}")
+    scheme = (parsed.scheme or "amqp").lower()
+    tls = scheme in ("amqps", "ssl", "tls")
+    port = parsed.port or (5671 if tls else 5672)
+    return parsed.hostname or "localhost", port, tls, parsed.username or None, parsed.password or None, (parsed.path or "").lstrip("/") or None
+
+
+def _build_amqp_producer(producer_cls, *, host: str, port: int, address: str, use_tls: bool, content_mode: str, auth_mode: str, username: Optional[str], password: Optional[str], entra_audience: str, entra_client_id: Optional[str], sas_key_name: Optional[str], sas_key: Optional[str]):
+    if auth_mode == "entra":
+        from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
+        credential = ManagedIdentityCredential(client_id=entra_client_id) if entra_client_id else DefaultAzureCredential()
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, credential=credential, entra_audience=entra_audience, use_tls=use_tls)
+    if auth_mode == "sas":
+        if not sas_key_name or not sas_key:
+            raise RuntimeError("AMQP auth-mode=sas requires AMQP_SAS_KEY_NAME and AMQP_SAS_KEY")
+        return producer_cls(host=host, address=address, port=port, content_mode=content_mode, sas_key_name=sas_key_name, sas_key=sas_key, use_tls=use_tls)
+    return producer_cls(host=host, address=address, port=port, username=username, password=password, content_mode=content_mode, use_tls=use_tls)
+
+
+def add_amqp_arguments(parser: argparse.ArgumentParser, default_address: str) -> None:
+    parser.add_argument("--broker-url", default=os.getenv("AMQP_BROKER_URL"))
+    parser.add_argument("--host", default=os.getenv("AMQP_HOST"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("AMQP_PORT", "0")) or None)
+    parser.add_argument("--address", default=os.getenv("AMQP_ADDRESS", default_address))
+    parser.add_argument("--username", default=os.getenv("AMQP_USERNAME"))
+    parser.add_argument("--password", default=os.getenv("AMQP_PASSWORD"))
+    parser.add_argument("--tls", action="store_true", default=os.getenv("AMQP_TLS", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--content-mode", choices=("binary", "structured"), default=os.getenv("AMQP_CONTENT_MODE", "binary"))
+    parser.add_argument("--auth-mode", choices=("password", "entra", "sas"), default=os.getenv("AMQP_AUTH_MODE", "password"))
+    parser.add_argument("--entra-audience", default=os.getenv("AMQP_ENTRA_AUDIENCE", DEFAULT_ENTRA_AUDIENCE_SERVICEBUS))
+    parser.add_argument("--entra-client-id", default=os.getenv("AMQP_ENTRA_CLIENT_ID"))
+    parser.add_argument("--sas-key-name", default=os.getenv("AMQP_SAS_KEY_NAME"))
+    parser.add_argument("--sas-key", default=os.getenv("AMQP_SAS_KEY"))
+
+
+def create_amqp_producer(args: argparse.Namespace, producer_cls):
+    address = args.address
+    if args.broker_url:
+        host, port, tls, user, pwd, path = _parse_amqp_broker_url(args.broker_url)
+        username = args.username or user
+        password = args.password or pwd
+        if args.port:
+            port = args.port
+        if args.tls:
+            tls = True
+        if path:
+            address = path
+    else:
+        host = args.host or "localhost"
+        tls = bool(args.tls) or args.auth_mode == "entra"
+        port = args.port or (5671 if tls else 5672)
+        username = args.username
+        password = args.password
+    if not address:
+        raise RuntimeError("AMQP address is required")
+    logging.info("Connecting AMQP producer to %s:%s/%s auth=%s tls=%s", host, port, address, args.auth_mode, tls)
+    return _build_amqp_producer(producer_cls, host=host, port=port, address=address, use_tls=tls, content_mode=args.content_mode, auth_mode=args.auth_mode, username=username, password=password, entra_audience=args.entra_audience, entra_client_id=args.entra_client_id, sas_key_name=args.sas_key_name, sas_key=args.sas_key)
+
+
+import argparse
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+import aiohttp
+
+from meteoalarm.meteoalarm import DEFAULT_COUNTRIES, DEFAULT_POLL_INTERVAL, DEFAULT_STATE_FILE, MeteoalarmPoller, normalize_warning
+def _topic_segment(value):
+    text = (str(value) if value is not None else "unknown").strip() or "unknown"
+    for forbidden in ("/", "+", "#", "\x00"):
+        text = text.replace(forbidden, "-")
+    return "-".join(text.split()) or "unknown"
+from meteoalarm_amqp_producer_data import CategoryEnum, CertaintyEnum, MsgTypeenum, ScopeEnum, SeverityEnum, StatusEnum, UrgencyEnum, WeatherWarning
+from meteoalarm_amqp_producer_amqp_producer.producer import MeteoalarmWarningsAmqpProducer
+
+logger = logging.getLogger(__name__)
+
+
+def _sample_warning() -> WeatherWarning:
+    return WeatherWarning(identifier="sample-warning", sender="sample@example.invalid", sent=datetime(2026, 1, 1, tzinfo=timezone.utc), status=StatusEnum.Actual, msg_type=MsgTypeenum.Alert, scope=ScopeEnum.Public, country="germany", event="Wind", category=CategoryEnum.Met, severity=SeverityEnum.Severe, urgency=UrgencyEnum.Expected, certainty=CertaintyEnum.Likely, headline="Sample wind warning", description="Sample warning for AMQP Docker E2E validation.", instruction="Avoid exposed areas.", effective=datetime(2026, 1, 1, tzinfo=timezone.utc), onset=datetime(2026, 1, 1, tzinfo=timezone.utc), expires=datetime(2026, 1, 2, tzinfo=timezone.utc), web="https://feeds.meteoalarm.org", contact=None, awareness_level="3; orange", awareness_type="wind", area_desc="Sample area", geocodes="DE000", language="en", awareness_type_raw="wind")
+
+
+def _send(producer: MeteoalarmWarningsAmqpProducer, warning) -> None:
+    producer.send_weather_warning(data=warning, _identifier=_topic_segment(warning.identifier), _country=_topic_segment(warning.country), _severity=_topic_segment(warning.severity.value if hasattr(warning.severity, "value") else warning.severity), _awareness_type=_topic_segment(warning.awareness_type))
+
+
+async def _poll_once(poller: MeteoalarmPoller, producer: MeteoalarmWarningsAmqpProducer) -> int:
+    state = poller.load_state()
+    count = 0
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        for country in poller.countries:
+            raw_warnings = await poller.fetch_country(session, country)
+            for item in raw_warnings:
+                alert_obj = item.get("alert", item)
+                warning = normalize_warning(alert_obj, country)
+                if warning is None:
+                    continue
+                sent_str = warning.sent or ""
+                if state.get(warning.identifier) is not None and state[warning.identifier] >= sent_str:
+                    continue
+                _send(producer, warning)
+                state[warning.identifier] = sent_str
+                count += 1
+    poller.save_state(state)
+    return count
+
+
+async def feed(args: argparse.Namespace) -> None:
+    producer = create_amqp_producer(args, MeteoalarmWarningsAmqpProducer)
+    try:
+        if args.mock_mode:
+            _send(producer, _sample_warning())
+            return
+        poller = MeteoalarmPoller(kafka_config=None, kafka_topic="amqp", state_file=args.state_file, poll_interval=args.polling_interval, countries=args.countries)
+        while True:
+            started = time.monotonic()
+            count = await _poll_once(poller, producer)
+            logger.info("Published %d Meteoalarm warning(s) to AMQP", count)
+            if args.once:
+                break
+            await asyncio.sleep(max(0, args.polling_interval - (time.monotonic() - started)))
+    finally:
+        producer.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper(), format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Meteoalarm AMQP 1.0 bridge")
+    parser.add_argument("feed_command", nargs="?", default="feed")
+    add_amqp_arguments(parser, "meteoalarm")
+    parser.add_argument("--polling-interval", type=int, default=int(os.getenv("POLLING_INTERVAL", os.getenv("METEOALARM_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL)))))
+    parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE.replace(".json", "_amqp.json")))
+    parser.add_argument("--countries", default=os.getenv("METEOALARM_COUNTRIES", ",".join(DEFAULT_COUNTRIES)))
+    parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    parser.add_argument("--mock-mode", action="store_true", default=os.getenv("METEOALARM_MOCK", "").lower() in ("1", "true", "yes"))
+    args = parser.parse_args()
+    if args.feed_command != "feed":
+        parser.error("only the 'feed' command is supported")
+    args.countries = [part.strip() for part in args.countries.split(",") if part.strip()]
+    asyncio.run(feed(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/meteoalarm/meteoalarm_amqp/pyproject.toml
+++ b/meteoalarm/meteoalarm_amqp/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "meteoalarm-amqp"
+version = "0.1.0"
+description = "AMQP 1.0 feeder for Meteoalarm"
+requires-python = ">=3.10"
+dependencies = [
+    "python-qpid-proton>=0.40.0",
+    "cloudevents>=1.11.0,<2.0.0",
+    "dataclasses_json>=0.6.7",
+    "avro>=1.11.3",
+    "azure-identity>=1.17.0",
+    "azure-core>=1.30.0",
+    "aiohttp>=3.9.0"
+]
+
+[project.scripts]
+meteoalarm-amqp = "meteoalarm_amqp.app:main"
+
+[tool.setuptools.packages.find]
+include = ["meteoalarm_amqp*"]

--- a/meteoalarm/meteoalarm_amqp_producer/Makefile
+++ b/meteoalarm/meteoalarm_amqp_producer/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build install test
+
+build:
+	pip install wheel poetry poetry-plugin-export
+	pip wheel -w whl ./meteoalarm_amqp_producer_data ./meteoalarm_amqp_producer_amqp_producer
+
+install: build
+	cd meteoalarm_amqp_producer_data && poetry install
+	cd meteoalarm_amqp_producer_amqp_producer && poetry install
+	pip install ./meteoalarm_amqp_producer_data ./meteoalarm_amqp_producer_amqp_producer
+	pip install pytest-asyncio>=0.23.7
+
+test: install
+	pytest ./meteoalarm_amqp_producer_amqp_producer/tests ./meteoalarm_amqp_producer_data/tests

--- a/meteoalarm/meteoalarm_amqp_producer/README.md
+++ b/meteoalarm/meteoalarm_amqp_producer/README.md
@@ -1,0 +1,463 @@
+
+# Meteoalarm_amqp_producer - AMQP 1.0 Producer
+
+Auto-generated Python producer for sending messages via AMQP 1.0 protocol.
+
+## Overview
+
+This module provides a type-safe AMQP 1.0 producer for sending events with optional CloudEvents envelope format. Built
+on the `python-qpid-proton` library for Python.
+
+## What is AMQP 1.0?
+
+**AMQP (Advanced Message Queuing Protocol) 1.0** is an open standard for business messaging that supports:
+- **Protocol-level interoperability** between different platforms and vendors
+- **Reliable message delivery** with settlement modes and flow control
+- **Multiple messaging patterns** including queues, topics, and request-reply
+- **Built-in security** with SASL authentication and TLS encryption
+
+Use cases: Enterprise integration, IoT messaging, financial services, cloud-native applications.
+
+**Supported AMQP 1.0 Brokers:**
+- Apache ActiveMQ Artemis (native AMQP 1.0)
+- Apache Qpid (native AMQP 1.0)
+- Azure Service Bus (native AMQP 1.0)
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-
+cli/blob/main/docs/rabbitmq_amqp_setup.md))
+
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup
+Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+
+
+## Azure Entra ID (CBS) Authentication — enabled
+
+This producer was generated with `--template-args azure_cbs_target=servicebus`,
+which wires in AMQP CBS (Claims-Based Security) put-token flow for **Azure Event Hubs** and
+**Azure Service Bus** using `azure-identity` token credentials.
+
+```python
+from azure.identity import DefaultAzureCredential
+producer = <Group>Producer(
+    host="my-namespace.servicebus.windows.net",   # EH or SB FQDN
+    address="my-hub-or-queue",                    # entity path
+    credential=DefaultAzureCredential(),
+)
+producer.send_my_event(...)
+producer.close()
+```
+
+CBS audience: `https://servicebus.azure.net/.default`
+(override with `--template-args azure_cbs_audience=<scope>` at code-gen time)
+
+Required RBAC role on the entity or namespace, e.g.:
+- Event Hubs: **Azure Event Hubs Data Sender**
+- Service Bus: **Azure Service Bus Data Sender**
+
+Debug logging:
+
+```python
+import logging
+logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
+```
+
+**Known limitations of the v1 CBS implementation:**
+- Token is acquired once at `__init__` time; there is no background refresh. Recreate the
+  producer (or open a fresh one) before token expiry (~60 min for Entra ID).
+- On Windows, the official `python-qpid-proton` PyPI wheel (verified on 0.40.0,
+  the latest release at the time of writing) is linked against SChannel via the
+  legacy `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service
+  Bus namespaces with `minimumTlsVersion=1.3` will return
+  `amqp:unauthorized-access "Invalid TLS version"` at AMQP open. Tracked
+  upstream as [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933).
+
+  Until the upstream wheel is fixed, install the OpenSSL-backed Windows
+  wheel published from `xregistry/codegen`:
+
+  ```
+  pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton
+  ```
+
+  pip will pick the `0.40.0+xrcgN` build automatically on Windows; Linux and
+  macOS continue to install the stock `0.40.0` from PyPI.
+- A reactor-based handler is used on the CBS path; the non-CBS path keeps the
+  `BlockingConnection` implementation unchanged.
+
+
+## Installation
+
+```bash
+pip install python-qpid-proton cloudevents azure-identity azure-core
+```
+
+### Windows: TLS 1.3 — extra index URL required
+
+The official `python-qpid-proton` Windows wheel does not support TLS 1.3
+(it links against SChannel via a deprecated API). If your AMQP broker
+requires TLS 1.3 — most notably Azure Service Bus namespaces with
+`minimumTlsVersion=1.3` — install with our OpenSSL-backed patched wheel:
+
+```bash
+pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton cloudevents azure-
+identity azure-core
+```
+
+pip selects the patched wheel only on Windows (it has a strictly higher
+PEP 440 local version `0.40.0+xrcgN`); Linux and macOS continue to install
+the stock release from PyPI. The patched wheel will be retired as soon as
+upstream proton ships a Windows wheel with TLS 1.3 support.
+
+## Generated Producers
+
+
+
+### MeteoalarmWarningsAmqpProducer
+
+`MeteoalarmWarningsAmqpProducer` sends messages for the Meteoalarm.Warnings.amqp message group.
+
+#### Quick Start
+
+```python
+from meteoalarm_amqp_producer import MeteoalarmWarningsAmqpProducer
+
+# Create producer
+producer = MeteoalarmWarningsAmqpProducer(
+    host="localhost",
+    address="my-queue",
+    port=5672,
+    username="guest",
+    password="guest"
+)
+
+# Send a message
+
+producer.send_weather_warning(
+    data=WeatherWarning(...),
+    content_type="application/json"
+)
+
+
+# Close producer
+producer.close()
+```
+
+#### Configuration Options
+
+The producer constructor accepts:
+
+- `host` (str): AMQP broker hostname
+- `address` (str): AMQP address (queue or topic name)
+- `port` (int): AMQP broker port (default: 5672, for TLS typically 5671)
+- `username` (Optional[str]): Username for SASL authentication
+- `password` (Optional[str]): Password for SASL authentication
+- `content_mode` (Literal['structured', 'binary']): CloudEvents encoding mode (default: 'structured')
+  - **structured**: Entire CloudEvent as JSON in message body
+  - **binary**: Event data in body, CloudEvents attributes in AMQP application properties
+- `format_type` (str): Content type for structured mode (default: 'application/json')
+
+#### Available Methods
+
+
+
+##### `send_weather_warning()`
+A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national
+meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and
+hazard types.
+
+**Parameters:**
+- `data` (WeatherWarning): The message data object
+- `_identifier` (str): Value for placeholder identifier in attribute subject
+- `content_type` (str): Content type of the message data (default: 'application/json')
+
+##### `send_weather_warning_batch()`
+
+Send multiple WeatherWarning messages in sequence.
+
+**Parameters:**
+- `data_array` (List[WeatherWarning]): Array of message data objects
+- `_identifier` (str): Value for placeholder identifier in attribute subject
+- `content_type` (str): Content type of the message data
+
+
+
+
+## AMQP Broker Compatibility
+
+This library has been tested with:
+- **Azure Service Bus** (AMQP 1.0 over TLS on port 5671)
+- **Apache ActiveMQ Artemis** (AMQP 1.0 on port 5672)
+- **Apache Qpid Broker-J** (AMQP 1.0 on port 5672)
+
+## Security Considerations
+
+- Always use TLS/SSL encryption in production (port 5671)
+- Store credentials securely (environment variables, key vaults)
+- Use SASL authentication mechanisms appropriate for your broker
+- Consider using token-based authentication (OAuth, JWT) where supported
+
+## Advanced Usage
+
+### Batch Sending with Concurrency Control
+
+Send multiple messages efficiently with rate limiting:
+
+```python
+import asyncio
+from typing import List
+
+
+class BatchProducer:
+    def __init__(self, producer: MeteoalarmWarningsAmqpProducer, max_concurrency: int = 10):
+        self.producer = producer
+        self.semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def send_batch_async(self, data_array: List[WeatherWarning]):
+        """Send multiple messages with concurrency control."""
+        async def send_one(data):
+            async with self.semaphore:
+                await asyncio.to_thread(
+                    self.producer.send_weather_warning,
+                    data
+                )
+
+        tasks = [send_one(data) for data in data_array]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+# Usage
+producer = MeteoalarmWarningsAmqpProducer(host="localhost", address="my-queue")
+batch_producer = BatchProducer(producer, max_concurrency=20)
+
+data_list = [WeatherWarning(...) for _ in range(100)]
+asyncio.run(batch_producer.send_batch_async(data_list))
+```
+
+
+### Connection Pooling
+
+Reuse producer connections across your application:
+
+```python
+from threading import Lock
+
+
+class ProducerPool:
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance.producer = MeteoalarmWarningsAmqpProducer(
+                        host="localhost",
+                        address="my-queue",
+                        username="guest",
+                        password="guest"
+                    )
+        return cls._instance
+
+    def get_producer(self) -> MeteoalarmWarningsAmqpProducer:
+        return self.producer
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+# Use from anywhere
+pool = ProducerPool()
+producer = pool.get_producer()
+
+```
+
+### Connection Resilience
+
+Automatically reconnect on connection failures:
+
+```python
+import time
+from typing import Optional
+
+
+class ResilientProducer:
+    def __init__(self, host: str, address: str, **kwargs):
+        self.host = host
+        self.address = address
+        self.kwargs = kwargs
+        self.producer: Optional[MeteoalarmWarningsAmqpProducer] = None
+        self._connect()
+
+    def _connect(self):
+        """Establish connection to AMQP broker."""
+        if self.producer:
+            try:
+                self.producer.close()
+            except:
+                pass
+
+        self.producer = MeteoalarmWarningsAmqpProducer(
+            host=self.host,
+            address=self.address,
+            **self.kwargs
+        )
+
+    def send_with_retry(self, data: WeatherWarning, max_retries: int = 3):
+        """Send message with automatic retry on connection failure."""
+        for attempt in range(max_retries):
+            try:
+                self.producer.send_weather_warning(data)
+                return
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    time.sleep(2 ** attempt)  # Exponential backoff
+                    self._connect()  # Reconnect
+                else:
+                    raise Exception(f"Failed after {max_retries} attempts") from e
+
+    def close(self):
+        if self.producer:
+            self.producer.close()
+
+```
+
+### Custom CloudEvents Attributes
+
+Add extension attributes to CloudEvents:
+
+```python
+
+
+producer = MeteoalarmWarningsAmqpProducer(host="localhost", address="my-queue")
+
+# CloudEvents extension attributes can be added via metadata
+producer.send_weather_warning(
+    data=data,
+    _tenant="contoso",           # Custom extension attribute
+    _deviceid="device-001",      # Custom extension attribute
+    _region="us-west-2",         # Custom extension attribute
+    _priority="high",            # Custom extension attribute
+    content_type="application/json"
+)
+
+```
+
+## Error Handling
+
+### Basic Error Handling
+
+```python
+from uamqp import errors
+
+try:
+    producer.send_message(data)
+except errors.AMQPConnectionError as e:
+    print(f"Connection error: {e}")
+except errors.MessageException as e:
+    print(f"Message error: {e}")
+finally:
+    producer.close()
+```
+
+### Retry with Exponential Backoff
+
+```python
+import time
+from typing import Any
+
+
+def send_with_retry(
+    producer: MeteoalarmWarningsAmqpProducer,
+    data: WeatherWarning,
+    max_retries: int = 5,
+    initial_delay: float = 1.0,
+    max_delay: float = 60.0
+) -> None:
+    """
+    Send message with exponential backoff retry.
+
+    Args:
+        producer: The producer instance
+        data: Message data to send
+        max_retries: Maximum number of retry attempts
+        initial_delay: Initial delay in seconds
+        max_delay: Maximum delay between retries
+
+    Raises:
+        Exception: If all retries are exhausted
+    """
+    for attempt in range(max_retries):
+        try:
+            producer.send_weather_warning(data)
+            return  # Success
+        except errors.AMQPConnectionError as e:
+            if attempt < max_retries - 1:
+                delay = min(initial_delay * (2 ** attempt), max_delay)
+                print(f"Attempt {attempt + 1}/{max_retries} failed. Retrying in {delay}s...")
+                time.sleep(delay)
+            else:
+                raise Exception(f"Failed after {max_retries} attempts") from e
+
+```
+
+### Circuit Breaker Pattern
+
+```python
+from datetime import datetime, timedelta
+
+
+class CircuitBreakerProducer:
+    """Producer with circuit breaker to prevent cascading failures."""
+
+    def __init__(self, producer: MeteoalarmWarningsAmqpProducer, threshold: int = 5, timeout: int = 60):
+        self.producer = producer
+        self.threshold = threshold
+        self.timeout = timedelta(seconds=timeout)
+        self.failure_count = 0
+        self.last_failure_time = None
+        self.is_open = False
+
+    def send(self, data: WeatherWarning):
+        """Send message with circuit breaker protection."""
+        # Check if circuit breaker is open
+        if self.is_open:
+            if datetime.now() - self.last_failure_time < self.timeout:
+                raise Exception("Circuit breaker is open. Too many consecutive failures.")
+            else:
+                # Try to close the circuit
+                self.is_open = False
+                self.failure_count = 0
+
+        try:
+            self.producer.send_weather_warning(data)
+            self.failure_count = 0  # Reset on success
+        except Exception as e:
+            self.failure_count += 1
+            self.last_failure_time = datetime.now()
+
+            if self.failure_count >= self.threshold:
+                self.is_open = True
+            raise
+
+```
+
+## Building and Testing
+
+```bash
+# Install dependencies
+poetry install
+
+# Run tests
+poetry run pytest
+
+# Build package
+poetry build
+```
+
+## Dependencies
+
+- `uamqp>=1.6.10` - AMQP 1.0 client library
+- `cloudevents>=1.10.1` - CloudEvents SDK
+- Python 3.10+
+
+## License
+
+This generated code is provided as-is for use in your projects.

--- a/meteoalarm/meteoalarm_amqp_producer/install.bat
+++ b/meteoalarm/meteoalarm_amqp_producer/install.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Installing meteoalarm_amqp_producer_amqp_producer...
+
+REM Check if poetry is installed
+where poetry >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo Poetry is not installed. Installing Poetry...
+    powershell -Command "& {(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -}"
+)
+
+REM Install dependencies
+poetry install
+
+echo Installation complete!
+echo Run 'poetry run pytest' to run tests

--- a/meteoalarm/meteoalarm_amqp_producer/install.sh
+++ b/meteoalarm/meteoalarm_amqp_producer/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Installing meteoalarm_amqp_producer_amqp_producer..."
+
+# Check if poetry is installed
+if ! command -v poetry &> /dev/null; then
+    echo "Poetry is not installed. Installing Poetry..."
+    curl -sSL https://install.python-poetry.org | python3 -
+fi
+
+# Install dependencies
+poetry install
+
+echo "Installation complete!"
+echo "Run 'poetry run pytest' to run tests"

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/pyproject.toml
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/pyproject.toml
@@ -1,0 +1,33 @@
+
+[tool.poetry]
+name = "meteoalarm-amqp-producer-amqp-producer"
+description = "meteoalarm_amqp_producer_amqp_producer AMQP 1.0 producer library (Azure servicebus CBS/Entra ID enabled)"
+authors = ["Your Name <your.email@example.com>"]
+version = "0.1.0"  # Placeholder version, dynamic versioning can be handled with plugins
+packages = [{include = "meteoalarm_amqp_producer_amqp_producer", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+meteoalarm-amqp-producer-data = {path = "../meteoalarm_amqp_producer_data", develop = true}  
+python-qpid-proton = ">=0.39.0"
+cloudevents = ">=1.10.1,<2.0.0"
+azure-identity = ">=1.15.0"
+azure-core = ">=1.30.0"
+
+[tool.poetry.dev-dependencies]
+pytest = ">=8.2.2"
+flake8 = ">=7.1.0"
+pylint = ">=3.2.3"
+mypy = ">=1.10.0"
+testcontainers = ">=4.5.1"
+pytest-asyncio = ">=0.23.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+filterwarnings = [
+    "ignore::DeprecationWarning:testcontainers.core.waiting_utils"
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/src/meteoalarm_amqp_producer_amqp_producer/__init__.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/src/meteoalarm_amqp_producer_amqp_producer/__init__.py
@@ -1,0 +1,9 @@
+"""
+meteoalarm_amqp_producer_amqp_producer - AMQP 1.0 Producer
+"""
+
+from .producer import *
+
+__all__ = [
+    "MeteoalarmWarningsAmqpProducer",
+]

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/src/meteoalarm_amqp_producer_amqp_producer/producer.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/src/meteoalarm_amqp_producer_amqp_producer/producer.py
@@ -1,0 +1,729 @@
+
+
+# pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
+
+"""
+Producer module for sending messages via AMQP 1.0 protocol.
+
+Generated with Azure CBS support (target: servicebus).
+Supports Entra ID (Azure AD) authentication via Claims-Based Security (CBS)
+put-token, in addition to SASL PLAIN and SAS connection-string auth.
+"""
+
+import sys
+import typing
+import uuid
+import json
+import threading
+import queue
+import concurrent.futures
+from urllib.parse import quote_plus
+from proton import Message
+from proton.utils import BlockingConnection
+from cloudevents.http import CloudEvent
+from cloudevents.conversion import to_binary, to_structured
+
+# --- Azure CBS support (azure_cbs_target=servicebus) ---
+# Two CBS auth modes are supported:
+#   1. Entra ID (Azure AD) JWT bearer via an azure-identity TokenCredential
+#      (``type=jwt``) -- works against live Azure Service Bus / Event Hubs.
+#   2. SAS token (``type=servicebus.windows.net:sastoken``) -- works against
+#      both live Azure namespaces configured for SAS and the local Service Bus
+#      emulator, which validates the ``type`` field strictly and refuses JWT.
+import base64
+import hashlib
+import hmac
+import logging
+import time as _cbs_time
+from urllib.parse import quote
+from proton import Endpoint, symbol
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, AtLeastOnce
+
+try:  # azure-identity is optional when only SAS auth is used
+    from azure.core.credentials import TokenCredential  # type: ignore
+except Exception:  # pragma: no cover - optional dep
+    TokenCredential = typing.Any  # type: ignore
+
+_cbs_logger = logging.getLogger("amqp.cbs")
+
+
+class _CbsTokenProvider:
+    """Abstract provider that mints a CBS put-token body + metadata."""
+
+    token_type: str = ""
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        """Return (token_body, absolute_expiry_unix_seconds)."""
+        raise NotImplementedError
+
+
+class _JwtTokenProvider(_CbsTokenProvider):
+    """Entra ID JWT acquired from an azure-identity ``TokenCredential``."""
+
+    token_type = "jwt"
+
+    def __init__(self, credential, audience: str):
+        self._credential = credential
+        self._audience = audience
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        token = self._credential.get_token(self._audience)
+        return token.token, int(token.expires_on)
+
+
+class _SasTokenProvider(_CbsTokenProvider):
+    """SAS token minted from a shared-access key + key name.
+
+    Produces a token of the form::
+
+        SharedAccessSignature sr=<url-quoted resource_uri>
+                              &sig=<url-quoted base64 HMAC-SHA256>
+                              &se=<expiry-unix-seconds>
+                              &skn=<key name>
+    """
+
+    token_type = "servicebus.windows.net:sastoken"
+
+    def __init__(self, key_name: str, key: str, resource_uri: str,
+                 ttl_seconds: int = 3600):
+        if not key_name or not key:
+            raise ValueError("SAS auth requires both key_name and key")
+        self._key_name = key_name
+        self._key = key
+        self._resource_uri = resource_uri
+        self._ttl = int(ttl_seconds)
+
+    def acquire(self) -> typing.Tuple[str, int]:
+        expiry = int(_cbs_time.time()) + self._ttl
+        encoded_uri = quote(self._resource_uri, safe="")
+        string_to_sign = (encoded_uri + "\n" + str(expiry)).encode("utf-8")
+        try:
+            signing_key = self._key.encode("utf-8")
+        except AttributeError:
+            signing_key = bytes(self._key)
+        signature = base64.b64encode(
+            hmac.new(signing_key, string_to_sign, hashlib.sha256).digest()
+        )
+        encoded_sig = quote(signature, safe="")
+        token = (
+            "SharedAccessSignature "
+            f"sr={encoded_uri}&sig={encoded_sig}&se={expiry}"
+            f"&skn={quote(self._key_name, safe='')}"
+        )
+        return token, expiry
+
+
+class _CbsAzureHandler(MessagingHandler):
+    """Reactor handler that establishes an Azure CBS-authenticated AMQP connection.
+
+    State machine:
+      1. ``on_start``                -> open SASL ANONYMOUS amqps:// connection.
+      2. ``on_connection_opened``    -> attach ``$cbs`` sender + receiver pair
+                                       (receiver source AND target pinned to ``$cbs``).
+      3. both CBS links opened       -> send put-token request (with correlation id).
+      4. CBS reply (status 200/202)  -> attach main sender to ``self._address``
+                                       (with AtLeastOnce so we get accepted/rejected).
+      5. main sender opened          -> signal ``_init_future`` ready.
+      6. ``on_sendable`` / injected  -> drain outbound queue, track each delivery.
+      7. ``on_accepted/rejected``    -> resolve the per-send ``Future``.
+      8. ``on_disconnected``         -> fail everything (v1: no reconnect).
+    """
+
+    def __init__(self, host, port, address, token_provider, use_tls,
+                 init_future, send_queue, close_event):
+        super().__init__(auto_settle=False, auto_accept=False)
+        self._host = host
+        self._port = port
+        self._address = address
+        self._token_provider = token_provider
+        self._use_tls = use_tls
+        self._init_future = init_future
+        self._send_queue = send_queue
+        self._close_event = close_event
+        self._close_requested = False
+
+        self._container = None
+        self._conn = None
+        self._cbs_sender = None
+        self._cbs_receiver = None
+        self._main_sender = None
+        self._cbs_sender_opened = False
+        self._cbs_receiver_opened = False
+        self._cbs_request_id = None
+        self._pending: typing.Dict[bytes, concurrent.futures.Future] = {}
+        self._failed = False
+
+    # ---- lifecycle ----
+
+    def on_start(self, event):
+        self._container = event.container
+        scheme = "amqps" if self._use_tls else "amqp"
+        url = f"{scheme}://{self._host}:{self._port}"
+        # SASL ANONYMOUS: Azure broker accepts the connection without creds;
+        # authn is established by the subsequent CBS put-token exchange.
+        self._conn = self._container.connect(
+            url,
+            sasl_enabled=True,
+            allowed_mechs="ANONYMOUS",
+            reconnect=False,
+        )
+        # Cross-thread wakeup: poll the send-queue + close-flag periodically.
+        # EventInjector is not portable on Windows (needs a real socketpair),
+        # so a 25ms recurring timer is used instead. Latency overhead is
+        # negligible for non-bulk workloads.
+        self._container.schedule(0.025, self)
+
+    def on_timer_task(self, event):
+        if self._close_requested:
+            self._begin_close()
+            return
+        if self._main_sender is not None and self._main_sender.credit > 0:
+            self._pump()
+        self._container.schedule(0.025, self)
+
+    def on_connection_opened(self, event):
+        _cbs_logger.debug("[cbs] on_connection_opened")
+        # Attach the CBS sender + receiver. Both terminus addresses pinned to "$cbs".
+        self._cbs_sender = self._container.create_sender(self._conn, "$cbs", name="cbs-sender")
+        self._cbs_receiver = self._container.create_receiver(
+            self._conn, "$cbs", name="cbs-receiver"
+        )
+        # Pin the receiver target explicitly (Azure rejects dynamic terminus).
+        self._cbs_receiver.target.address = "$cbs"
+        self._cbs_receiver.target.dynamic = False
+
+    def on_link_opened(self, event):
+        _cbs_logger.debug(f"[cbs] on_link_opened {event.link.name}")
+        try:
+            link_name = event.link.name
+            if link_name == "cbs-sender":
+                self._cbs_sender_opened = True
+            elif link_name == "cbs-receiver":
+                self._cbs_receiver_opened = True
+            elif link_name == "main-sender":
+                if not self._init_future.done():
+                    self._init_future.set_result(True)
+                return
+            if self._cbs_sender_opened and self._cbs_receiver_opened and self._cbs_request_id is None:
+                self._send_put_token()
+        except Exception as exc:
+            self._fail_init(exc)
+
+    def _send_put_token(self):
+        _cbs_logger.debug(
+            "[cbs] _send_put_token: acquiring token (type=%s)",
+            self._token_provider.token_type,
+        )
+        try:
+            token_body, expires_on = self._token_provider.acquire()
+        except Exception as exc:
+            self._fail_init(exc)
+            return
+        _cbs_logger.debug(f"[cbs] _send_put_token: token len={len(token_body)} exp={expires_on}")
+        resource_uri = f"sb://{self._host}/{self._address}"
+        self._cbs_request_id = str(uuid.uuid4())
+        msg = Message(body=token_body)
+        msg.address = "$cbs"
+        msg.reply_to = "$cbs"
+        msg.id = self._cbs_request_id
+        msg.properties = {
+            "operation": "put-token",
+            "type": self._token_provider.token_type,
+            "name": resource_uri,
+            "expiration": int(expires_on),
+        }
+        try:
+            self._cbs_sender.send(msg)
+            _cbs_logger.debug("[cbs] _send_put_token: sent")
+        except Exception as exc:
+            _cbs_logger.debug(f"[cbs] _send_put_token: send raised {exc!r}")
+            self._fail_init(RuntimeError(f"CBS put-token send failed: {exc}"))
+
+    def on_message(self, event):
+        _cbs_logger.debug(f"[cbs] on_message link={event.link.name}")
+        # Only CBS replies are expected on this handler's receiver.
+        if event.link.name != "cbs-receiver":
+            return
+        reply = event.message
+        _cbs_logger.debug(f"[cbs] on_message correlation_id={reply.correlation_id!r} expected={self._cbs_request_id!r} props={dict(reply.properties or {})}")
+        try:
+            event.delivery.update(event.delivery.ACCEPTED)
+            event.delivery.settle()
+        except Exception:
+            pass
+        # Correlate: only accept the reply matching our put-token request id.
+        # Compare as strings to tolerate UUID/bytes/str shapes.
+        if str(reply.correlation_id) != str(self._cbs_request_id):
+            _cbs_logger.debug("[cbs] on_message: correlation mismatch, ignoring")
+            return
+        props = reply.properties or {}
+        status_code = props.get("status-code") or props.get(symbol("status-code")) or 0
+        status_desc = props.get("status-description") or props.get(symbol("status-description")) or ""
+        _cbs_logger.debug(f"[cbs] on_message: status_code={status_code} desc={status_desc!r}")
+        if status_code in (200, 202):
+            try:
+                self._main_sender = self._container.create_sender(
+                    self._conn, self._address, name="main-sender", options=AtLeastOnce()
+                )
+                _cbs_logger.debug("[cbs] on_message: main-sender create requested")
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] on_message: create_sender raised {exc!r}")
+                self._fail_init(exc)
+        else:
+            self._fail_init(RuntimeError(
+                f"CBS put-token rejected: status_code={status_code} {status_desc!r}"
+            ))
+
+    # ---- outbound sends ----
+
+    def on_sendable(self, event):
+        if event.link is self._main_sender:
+            self._pump()
+
+    def _pump(self):
+        if self._main_sender is None or self._failed:
+            return
+        while self._main_sender.credit > 0:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                return
+            if req is None:  # close sentinel
+                self._begin_close()
+                return
+            msg, fut = req
+            tag = str(uuid.uuid4()).encode()
+            try:
+                delivery = self._main_sender.send(msg, tag=tag)
+            except Exception as exc:
+                if not fut.done():
+                    fut.set_exception(exc)
+                continue
+            self._pending[tag] = fut
+            # delivery.tag is what comes back on disposition events
+            self._pending[delivery.tag] = fut
+
+    def on_accepted(self, event):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_result(True)
+
+    def on_rejected(self, event):
+        self._fail_delivery(event, "rejected")
+
+    def on_released(self, event):
+        self._fail_delivery(event, "released")
+
+    def on_modified(self, event):
+        self._fail_delivery(event, "modified")
+
+    def _fail_delivery(self, event, reason):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_exception(RuntimeError(f"Send failed: {reason}"))
+
+    # ---- error / close ----
+
+    def on_inject_close(self, event):
+        self._begin_close()
+
+    def request_close(self):
+        """Called from the producer thread; reactor picks it up on next timer tick."""
+        self._close_requested = True
+
+    def _begin_close(self):
+        try:
+            if self._main_sender:
+                self._main_sender.close()
+        except Exception:
+            pass
+        try:
+            if self._cbs_sender:
+                self._cbs_sender.close()
+            if self._cbs_receiver:
+                self._cbs_receiver.close()
+        except Exception:
+            pass
+        try:
+            if self._conn:
+                self._conn.close()
+        except Exception:
+            pass
+
+    def on_transport_error(self, event):
+        self._fail_all(RuntimeError(f"Transport error: {event.transport.condition}"))
+
+    def on_connection_error(self, event):
+        cond = event.connection.remote_condition
+        self._fail_all(RuntimeError(f"Connection error: {cond}"))
+
+    def on_link_error(self, event):
+        cond = event.link.remote_condition
+        self._fail_all(RuntimeError(f"Link error on {event.link.name}: {cond}"))
+
+    def on_disconnected(self, event):
+        _cbs_logger.debug("[cbs] on_disconnected")
+        self._fail_all(RuntimeError("Disconnected"))
+        self._close_event.set()
+
+    def _fail_init(self, exc):
+        _cbs_logger.debug(f"[cbs] _fail_init: {exc!r}")
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+
+    def _fail_all(self, exc):
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+        # Drain queue
+        while True:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                break
+            if req is None:
+                continue
+            _, fut = req
+            if not fut.done():
+                fut.set_exception(exc)
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+from meteoalarm_amqp_producer_data import WeatherWarning
+
+class MeteoalarmWarningsAmqpProducer:
+    """
+    Producer class to send messages in the `Meteoalarm.Warnings.amqp` message group via AMQP 1.0 protocol.
+    """
+    
+    def __init__(self, 
+                 host: str,
+                 address: str,
+                 port: int = 5672,
+                 username: typing.Optional[str] = None,
+                 password: typing.Optional[str] = None,
+                 content_mode: typing.Literal['structured', 'binary'] = 'structured',
+                 format_type: str = 'application/json',
+                 credential: typing.Optional["TokenCredential"] = None,
+                 entra_audience: str = "https://servicebus.azure.net/.default",
+                 sas_key_name: typing.Optional[str] = None,
+                 sas_key: typing.Optional[str] = None,
+                 sas_token_ttl_seconds: int = 3600,
+                 use_tls: bool = True,
+                 ):
+        """
+        Initialize the AMQP producer
+        
+        Args:
+            host (str): The AMQP broker hostname
+            address (str): The AMQP address (queue or topic)
+            port (int): The AMQP broker port (default: 5672)
+            username (typing.Optional[str]): Optional username for SASL PLAIN authentication
+            password (typing.Optional[str]): Optional password for SASL PLAIN authentication
+            content_mode (typing.Literal['structured', 'binary']): CloudEvents content mode (default: 'structured')
+            format_type (str): Content type format for structured mode (default: 'application/json')
+            credential (typing.Optional[TokenCredential]): An azure-identity TokenCredential
+                (e.g. DefaultAzureCredential). When provided, SASL ANONYMOUS is used and an
+                Entra ID JWT is presented via AMQP CBS put-token (``type=jwt``). Mutually
+                exclusive with username/password and with sas_key_name/sas_key.
+            entra_audience (str): AAD scope used to acquire the JWT
+                (default: 'https://servicebus.azure.net/.default' -- targets Azure servicebus).
+                Override only when targeting a non-standard cloud or cross-targeting (e.g.
+                an Event Hubs client talking to a Service Bus entity, or vice-versa).
+            sas_key_name (typing.Optional[str]): SAS policy/key name (e.g.
+                ``RootManageSharedAccessKey``). When set with ``sas_key``, SASL ANONYMOUS
+                is used and a SAS token is presented via AMQP CBS put-token
+                (``type=servicebus.windows.net:sastoken``). Required for the Service Bus
+                emulator and for namespaces configured for SAS authentication.
+                Mutually exclusive with credential and with username/password.
+            sas_key (typing.Optional[str]): SAS key value (base64) used to sign the token.
+            sas_token_ttl_seconds (int): Lifetime of each minted SAS token (default: 3600).
+            use_tls (bool): If True (default), connect via amqps:// on port 5671 unless port
+                is explicitly set. Required for Azure servicebus; set to False
+                for the local Service Bus emulator (plain AMQP on 5672).
+        """
+        self.host = host
+        self.port = port
+        self.address = address
+        self.username = username
+        self.password = password
+        self.content_mode = content_mode
+        self.format_type = format_type
+        self._credential = credential
+        self._entra_audience = entra_audience
+        self._sas_key_name = sas_key_name
+        self._sas_key = sas_key
+        self._sas_token_ttl = int(sas_token_ttl_seconds)
+        self._use_tls = use_tls
+
+        _sas_configured = bool(sas_key_name or sas_key)
+        if _sas_configured and not (sas_key_name and sas_key):
+            raise ValueError(
+                "sas_key_name and sas_key must both be provided for SAS CBS auth."
+            )
+        if self._credential is not None and _sas_configured:
+            raise ValueError(
+                "credential is mutually exclusive with sas_key_name/sas_key. "
+                "Choose Entra ID OR SAS for CBS authentication."
+            )
+        if (self._credential is not None or _sas_configured) and (self.username or self.password):
+            raise ValueError(
+                "CBS auth (credential or SAS) is mutually exclusive with "
+                "username/password SASL PLAIN."
+            )
+        self._cbs_enabled = self._credential is not None or _sas_configured
+        if self._credential is not None and port == 5672:
+            # Default to AMQPS for Entra path; caller can override explicitly.
+            self.port = 5671
+        if self._cbs_enabled:
+            self._init_reactor()
+        else:
+            connection_url = self._build_connection_url()
+            self._connection = BlockingConnection(connection_url, timeout=30)
+            self._sender = self._connection.create_sender(self.address)
+
+    def _init_reactor(self):
+        """Start the proton reactor thread and block until CBS handshake completes.
+
+        On failure, the exception is propagated out of ``__init__`` so callers
+        get a clean error rather than discovering the problem on first send.
+        """
+        if self._credential is not None:
+            token_provider: _CbsTokenProvider = _JwtTokenProvider(
+                self._credential, self._entra_audience
+            )
+        else:
+            resource_uri = f"sb://{self.host}/{self.address}"
+            token_provider = _SasTokenProvider(
+                self._sas_key_name, self._sas_key, resource_uri,
+                ttl_seconds=self._sas_token_ttl,
+            )
+
+        self._send_queue: "queue.Queue" = queue.Queue()
+        self._init_future: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._close_event = threading.Event()
+        self._handler = _CbsAzureHandler(
+            host=self.host,
+            port=self.port,
+            address=self.address,
+            token_provider=token_provider,
+            use_tls=self._use_tls,
+            init_future=self._init_future,
+            send_queue=self._send_queue,
+            close_event=self._close_event,
+        )
+
+        def _run():
+            import traceback as _tb
+            try:
+                Container(self._handler).run()
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] reactor crashed: {exc!r}\n{_tb.format_exc()}")
+                if not self._init_future.done():
+                    self._init_future.set_exception(exc)
+            finally:
+                self._close_event.set()
+
+        self._reactor_thread = threading.Thread(
+            target=_run, name="amqp-cbs-reactor", daemon=True
+        )
+        self._reactor_thread.start()
+
+        try:
+            self._init_future.result(timeout=60)
+        except Exception:
+            try:
+                self._handler.request_close()
+            except Exception:
+                pass
+            self._close_event.wait(timeout=10)
+            raise
+
+    def _send_via_reactor(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        fut: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._send_queue.put((amqp_msg, fut))
+        fut.result(timeout=timeout)
+    
+    def _build_connection_url(self) -> str:
+        if self.username and self.password:
+            user = quote_plus(self.username)
+            pwd = quote_plus(self.password)
+            return f"amqp://{user}:{pwd}@{self.host}:{self.port}"
+        return f"amqp://{self.host}:{self.port}"
+
+    def _serialize_payload(self, data: typing.Any, content_type: str) -> bytes:
+        if data is None:
+            return b''
+        if hasattr(data, 'to_byte_array'):
+            payload = data.to_byte_array(content_type)
+        elif hasattr(data, 'to_dict'):
+            payload = json.dumps(data.to_dict())
+        elif isinstance(data, (bytes, bytearray)):
+            payload = bytes(data)
+        else:
+            payload = json.dumps(data)
+        # to_byte_array may return str for text content types (e.g. JSON);
+        # we always emit bytes so the AMQP body is a binary section rather
+        # than an AMQP string section containing escaped JSON.
+        if isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        return payload
+
+    @staticmethod
+    def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        """Translate cloudevents-sdk HTTP-style headers (``ce-foo``) into the
+        CloudEvents AMQP 1.0 Protocol Binding (v1.0.2 §3.1) form
+        (``cloudEvents:foo``). ``content-type`` is carried separately on the
+        AMQP properties section and is therefore dropped here.
+        """
+        out: typing.Dict[str, typing.Any] = {}
+        for k, v in (headers or {}).items():
+            if v is None:
+                continue
+            lk = str(k)
+            low = lk.lower()
+            if low.startswith('ce-'):
+                out['cloudEvents:' + lk[3:]] = v
+            elif low == 'content-type':
+                continue
+            else:
+                out[lk] = v
+        return out
+
+    
+    
+    def send_weather_warning(self,
+        data: WeatherWarning,
+        _identifier: str,
+        _country: str,
+        _severity: str,
+        _awareness_type: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send the `Meteoalarm.Warnings.amqp.WeatherWarning` message
+        A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and hazard types.
+        
+        Args:
+            _identifier (str): Value for placeholder identifier in attribute subject
+            _country (str): Value for AMQP protocol option placeholder country
+            _severity (str): Value for AMQP protocol option placeholder severity
+            _awareness_type (str): Value for AMQP protocol option placeholder awareness_type
+            data (WeatherWarning): The message data object
+            content_type (str): The content type of the message data (default: 'application/json')
+        """
+        # Build CloudEvent attributes
+        attributes = {
+            "type":
+            "Meteoalarm.WeatherWarning",
+            "source":
+            "https://feeds.meteoalarm.org",
+            "subject":
+            "{identifier}".format(identifier=_identifier),
+        }
+        
+        # Remove None values
+        attributes = {k: v for k, v in attributes.items() if v is not None}
+        
+        # Serialize data
+        byte_data = self._serialize_payload(data, content_type)
+        
+        # Create CloudEvent
+        cloud_event = CloudEvent(attributes, byte_data)
+        
+        # Convert to AMQP message based on content mode
+        if self.content_mode == 'structured':
+            headers, body = to_structured(cloud_event)
+            if isinstance(body, dict):
+                msg_body = json.dumps(body).encode('utf-8')
+            elif isinstance(body, bytes):
+                msg_body = body
+            else:
+                msg_body = str(body).encode('utf-8')
+            amqp_msg = Message(body=msg_body, inferred=True)
+            amqp_msg.content_type = self.format_type or headers.get('content-type')
+        else:  # binary mode
+            headers, body = to_binary(cloud_event)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
+            amqp_msg.content_type = content_type
+            if headers:
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        amqp_msg.subject = "{identifier}".format(identifier=_identifier)
+
+        app_properties = {}
+        app_properties["country"] = "{country}".format(country=_country)
+        app_properties["severity"] = "{severity}".format(severity=_severity)
+        app_properties["awareness_type"] = "{awareness_type}".format(awareness_type=_awareness_type)
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
+        
+        # Send message
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+    
+    def send_weather_warning_batch(self,
+        data_array: typing.List[WeatherWarning],
+        _identifier: str,
+        _country: str,
+        _severity: str,
+        _awareness_type: str,
+        content_type: str = 'application/json') -> None:
+        """
+        Send multiple `Meteoalarm.Warnings.amqp.WeatherWarning` messages
+        
+        Args:
+            data_array (typing.List[WeatherWarning]): Array of message data objects
+            _identifier (str): Value for placeholder identifier in attribute subject
+            _country (str): Value for AMQP protocol option placeholder country
+            _severity (str): Value for AMQP protocol option placeholder severity
+            _awareness_type (str): Value for AMQP protocol option placeholder awareness_type
+            content_type (str): The content type of the message data
+        """
+        for data in data_array:
+            self.send_weather_warning(
+                data=data,
+                _identifier=_identifier,
+                _country=_country,
+                _severity=_severity,
+                _awareness_type=_awareness_type,
+                content_type=content_type)
+    
+    
+    def close(self) -> None:
+        """
+        Close the producer and clean up resources
+        """
+        if getattr(self, "_handler", None) is not None:
+            try:
+                self._handler.request_close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._close_event.wait(timeout=10)
+            self._handler = None
+            return
+        if hasattr(self, '_sender') and self._sender:
+            try:
+                self._sender.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._sender = None
+        if hasattr(self, '_connection') and self._connection:
+            try:
+                self._connection.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            finally:
+                self._connection = None
+

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer/tests/test_producer.py
@@ -1,0 +1,296 @@
+
+# pylint: disable=missing-function-docstring, wrong-import-position, import-error, no-name-in-module, import-outside-toplevel, no-member, redefined-outer-name, unused-argument, unused-variable, invalid-name, missing-class-docstring
+
+"""
+Tests for meteoalarm_amqp_producer_amqp_producer
+"""
+import base64
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from typing import Optional
+from urllib.parse import quote_plus
+
+import pytest
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+from proton.utils import BlockingConnection
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../meteoalarm_amqp_producer_data/src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../meteoalarm_amqp_producer_data/tests')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../meteoalarm_amqp_producer_amqp_producer/src')))
+
+from meteoalarm_amqp_producer_amqp_producer import *
+from meteoalarm_amqp_producer_data import WeatherWarning
+from test_meteoalarm_amqp_producer_data_weatherwarning import Test_WeatherWarning
+
+
+
+def _rabbitmq_queue_address(queue_name: str) -> str:
+    return f"/queues/{queue_name}" if os.environ.get("RABBITMQ_VERSION", "4") != "3" else queue_name
+
+
+def _declare_rabbitmq_queue(host: str, mgmt_port: int, queue_name: str):
+    url = f"http://{host}:{mgmt_port}/api/queues/%2F/{queue_name}"
+    payload = b'{"auto_delete": false, "durable": true, "arguments": {}}'
+    auth = base64.b64encode(b"guest:guest").decode("ascii")
+    last_error = None
+    for _ in range(30):
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in (201, 204):
+                    return
+                last_error = RuntimeError(f"RabbitMQ queue declaration returned {response.status}")
+        except urllib.error.HTTPError as exc:
+            if exc.code in (201, 204):
+                return
+            last_error = exc
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out declaring RabbitMQ queue {queue_name}") from last_error
+
+ARTEMIS_BROKER_XML = """<?xml version='1.0'?>
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>0.0.0.0</name>
+        <persistence-enabled>false</persistence-enabled>
+        <acceptors>
+            <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP;saslMechanisms=PLAIN,ANONYMOUS</acceptor>
+        </acceptors>
+        <security-settings>
+            <security-setting match="#">
+                <permission type="createNonDurableQueue" roles="amq"/>
+                <permission type="deleteNonDurableQueue" roles="amq"/>
+                <permission type="createDurableQueue" roles="amq"/>
+                <permission type="deleteDurableQueue" roles="amq"/>
+                <permission type="createAddress" roles="amq"/>
+                <permission type="deleteAddress" roles="amq"/>
+                <permission type="consume" roles="amq"/>
+                <permission type="browse" roles="amq"/>
+                <permission type="send" roles="amq"/>
+                <permission type="manage" roles="amq"/>
+            </security-setting>
+        </security-settings>
+        <address-settings>
+            <address-setting match="#">
+                <dead-letter-address>DLQ</dead-letter-address>
+                <expiry-address>ExpiryQueue</expiry-address>
+                <auto-create-queues>true</auto-create-queues>
+                <auto-create-addresses>true</auto-create-addresses>
+            </address-setting>
+        </address-settings>
+        <addresses>
+            <address name="test-queue">
+                <anycast>
+                    <queue name="test-queue" />
+                </anycast>
+            </address>
+        </addresses>
+    </core>
+</configuration>
+"""
+
+@pytest.fixture(scope="module")
+def amqp_broker():
+    """Create and start an AMQP broker container for testing.
+    
+    Uses ActiveMQ Artemis by default.
+    Set AMQP_BROKER=rabbitmq environment variable to test with RabbitMQ.
+    Set RABBITMQ_VERSION=3 or RABBITMQ_VERSION=4 to choose RabbitMQ version (default: 4).
+    """
+    broker_type = os.environ.get("AMQP_BROKER", "artemis").lower()
+    
+    if broker_type == "rabbitmq":
+        rabbitmq_version = os.environ.get("RABBITMQ_VERSION", "4")
+        image_tag = "3-management" if rabbitmq_version == "3" else "4-management"
+        
+        container = DockerContainer(f"rabbitmq:{image_tag}")
+        container.with_bind_ports(5672, 5672)
+        container.with_bind_ports(15672, 15672)
+        container.with_env("RABBITMQ_DEFAULT_USER", "guest")
+        container.with_env("RABBITMQ_DEFAULT_PASS", "guest")
+        container.with_exposed_ports(5672, 15672)
+        
+        # RabbitMQ 3.x requires AMQP 1.0 plugin, RabbitMQ 4.0+ has native support
+        if rabbitmq_version == "3":
+            container.with_command(
+                "bash", "-c", 
+                "rabbitmq-plugins enable rabbitmq_amqp1_0 && docker-entrypoint.sh rabbitmq-server"
+            )
+        
+        container.start()
+        # Wait for RabbitMQ to be ready
+        wait_for_logs(container, "Server startup complete", timeout=120)
+        host = container.get_container_host_ip()
+        if rabbitmq_version != "3":
+            _declare_rabbitmq_queue(host, int(container.get_exposed_port(15672)), "test-queue")
+        
+        yield {
+            "host": host,
+            "port": int(container.get_exposed_port(5672)),
+            "username": "guest",
+            "password": "guest",
+            "address": _rabbitmq_queue_address("test-queue")
+        }
+        
+        container.stop()
+    else:
+        # Default: ActiveMQ Artemis
+        # Create temp file for broker configuration
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+            f.write(ARTEMIS_BROKER_XML)
+            config_file = f.name
+        
+        try:
+            container = DockerContainer("apache/activemq-artemis:latest")
+            container.with_bind_ports(5672, 5672)
+            container.with_env("ARTEMIS_USER", "guest")
+            container.with_env("ARTEMIS_PASSWORD", "guest")
+            container.with_volume_mapping(config_file, "/var/lib/artemis-instance/etc-override/broker.xml")
+            container.with_exposed_ports(5672)
+            
+            # Wait for Artemis to be ready
+            container.start()
+            # Wait for broker to log that it's ready (AMQ241004 = "Artemis Server is now live")
+            wait_for_logs(container, "AMQ241004", timeout=60)
+            
+            yield {
+                "host": container.get_container_host_ip(),
+                "port": int(container.get_exposed_port(5672)),
+                "username": "guest",
+                "password": "guest",
+                "address": "test-queue"
+            }
+            
+            container.stop()
+        finally:
+            if os.path.exists(config_file):
+                os.unlink(config_file)
+
+# Keep old fixture name for backwards compatibility
+@pytest.fixture(scope="module")
+def artemis_container(amqp_broker):
+    """Alias for amqp_broker for backwards compatibility"""
+    return amqp_broker
+
+def _connection_url(host: str, port: int, username: Optional[str] = None, password: Optional[str] = None) -> str:
+    if username and password:
+        return f"amqp://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}"
+    return f"amqp://{host}:{port}"
+
+
+def _receive_single_message(config: dict, timeout: int = 30):
+    connection = BlockingConnection(
+        _connection_url(
+            config["host"],
+            config["port"],
+            config.get("username"),
+            config.get("password"),
+        ),
+        timeout=timeout,
+    )
+    receiver = connection.create_receiver(config["address"], credit=1)
+    try:
+        message = receiver.receive(timeout=timeout)
+        receiver.accept()  # Explicitly accept/settle the message to remove it from the queue
+        return message
+    finally:
+        receiver.close()
+        connection.close()
+
+class TestMeteoalarmWarningsAmqpProducer:
+    """Test cases for MeteoalarmWarningsAmqpProducer"""
+    
+    def test_producer_initialization(self, artemis_container):
+        """Test that producer initializes correctly"""
+        producer = MeteoalarmWarningsAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"]
+        )
+        assert producer is not None
+        assert producer.host == artemis_container["host"]
+        assert producer.address == artemis_container["address"]
+        assert producer.port == artemis_container["port"]
+        assert producer.username == artemis_container["username"]
+        producer.close()
+    
+    def test_send_weather_warning(self, artemis_container):
+        """Send and receive a WeatherWarning message via ActiveMQ Artemis."""
+        # Create valid test data using the test helper
+        payload = Test_WeatherWarning.create_instance()
+
+        producer = MeteoalarmWarningsAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='structured'
+        )
+        
+        try:
+            assert producer.host == artemis_container["host"]
+            assert producer.address == artemis_container["address"]
+            assert producer.port == artemis_container["port"]
+            assert producer.username == artemis_container["username"]
+            assert producer.content_mode == 'structured'
+            # Send 5 messages to test proper message settlement and ordering
+            for i in range(5):
+                producer.send_weather_warning(
+                    data=payload,
+                    _identifier="value",
+                    _country="value",
+                    _severity="value",
+                    _awareness_type="value",
+                    content_type="application/json"
+                )
+
+            # Receive and verify all 5 messages
+            for i in range(5):
+                received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
+
+                if True:
+                    body = received.body
+                    if isinstance(body, memoryview):
+                        body_text = body.tobytes().decode('utf-8')
+                    elif isinstance(body, bytes):
+                        body_text = body.decode('utf-8')
+                    elif isinstance(body, str):
+                        body_text = body
+                    elif isinstance(body, dict):
+                        body_text = json.dumps(body)
+                    else:
+                        body_text = str(body)
+                    cloud_event_payload = json.loads(body_text)
+                    assert cloud_event_payload.get("type") == "Meteoalarm.Warnings.amqp.WeatherWarning"
+                    # Verify data section exists (either as data or data_base64)
+                    assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
+                else:
+                    # Verify message body is not empty
+                    assert received.body is not None
+                assert received.subject == "{identifier}".format(identifier="value")
+                assert properties.get('country') == "{country}".format(country="value")
+                assert properties.get('severity') == "{severity}".format(severity="value")
+                assert properties.get('awareness_type') == "{awareness_type}".format(awareness_type="value")
+        finally:
+            producer.close()
+

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/pyproject.toml
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "meteoalarm-amqp-producer-data"
+version = "0.1.0"
+description = "A package for handling JSON Structure schema data"
+authors = ["Your Name"]
+license = "MIT"
+packages = [ { include = "meteoalarm_amqp_producer_data", from="src" } ]
+
+[tool.poetry.dependencies]
+python = "<4.0,>=3.10"
+dataclasses-json = "^0.6.7"
+
+[tool.poetry.dev-dependencies]
+pylint = "^3.2.3"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/__init__.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/__init__.py
@@ -1,0 +1,10 @@
+from .statusenum import StatusEnum
+from .msgtypeenum import MsgTypeenum
+from .scopeenum import ScopeEnum
+from .categoryenum import CategoryEnum
+from .severityenum import SeverityEnum
+from .urgencyenum import UrgencyEnum
+from .certaintyenum import CertaintyEnum
+from .weatherwarning import WeatherWarning
+
+__all__ = ["StatusEnum", "MsgTypeenum", "ScopeEnum", "CategoryEnum", "SeverityEnum", "UrgencyEnum", "CertaintyEnum", "WeatherWarning"]

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/categoryenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/categoryenum.py
@@ -1,0 +1,54 @@
+from enum import Enum
+
+
+class CategoryEnum(Enum):
+    """
+    The CAP alert category. 'Met' for meteorological warnings.
+    """
+    Met = 'Met'
+    Geo = 'Geo'
+    Safety = 'Safety'
+    Security = 'Security'
+    Rescue = 'Rescue'
+    Fire = 'Fire'
+    Health = 'Health'
+    Env = 'Env'
+    Transport = 'Transport'
+    Infra = 'Infra'
+    CBRNE = 'CBRNE'
+    Other = 'Other'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'CategoryEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'CategoryEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (CategoryEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/certaintyenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/certaintyenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class CertaintyEnum(Enum):
+    """
+    The CAP certainty level indicating the confidence in the forecast.
+    """
+    Observed = 'Observed'
+    Likely = 'Likely'
+    Possible = 'Possible'
+    Unlikely = 'Unlikely'
+    Unknown = 'Unknown'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'CertaintyEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'CertaintyEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (CertaintyEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/msgtypeenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/msgtypeenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class MsgTypeenum(Enum):
+    """
+    The CAP message type indicating the nature of the alert.
+    """
+    Alert = 'Alert'
+    Update = 'Update'
+    Cancel = 'Cancel'
+    Ack = 'Ack'
+    Error = 'Error'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'MsgTypeenum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'MsgTypeenum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (MsgTypeenum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/scopeenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/scopeenum.py
@@ -1,0 +1,45 @@
+from enum import Enum
+
+
+class ScopeEnum(Enum):
+    """
+    The CAP scope of the alert. Typically 'Public' for weather warnings.
+    """
+    Public = 'Public'
+    Restricted = 'Restricted'
+    Private = 'Private'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'ScopeEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'ScopeEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (ScopeEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/severityenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/severityenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class SeverityEnum(Enum):
+    """
+    Native CAP severity level (Minor, Moderate, Severe, Extreme, or Unknown). Matches the {severity} MQTT topic axis without further bucketing.
+    """
+    Extreme = 'Extreme'
+    Severe = 'Severe'
+    Moderate = 'Moderate'
+    Minor = 'Minor'
+    Unknown = 'Unknown'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'SeverityEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'SeverityEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (SeverityEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/statusenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/statusenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class StatusEnum(Enum):
+    """
+    The CAP alert status. 'Actual' for real warnings, 'Test' for test messages.
+    """
+    Actual = 'Actual'
+    Exercise = 'Exercise'
+    System = 'System'
+    Test = 'Test'
+    Draft = 'Draft'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StatusEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StatusEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StatusEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/urgencyenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/urgencyenum.py
@@ -1,0 +1,47 @@
+from enum import Enum
+
+
+class UrgencyEnum(Enum):
+    """
+    The CAP urgency level indicating the time-frame for protective action.
+    """
+    Immediate = 'Immediate'
+    Expected = 'Expected'
+    Future = 'Future'
+    Past = 'Past'
+    Unknown = 'Unknown'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'UrgencyEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'UrgencyEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (UrgencyEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/weatherwarning.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/src/meteoalarm_amqp_producer_data/weatherwarning.py
@@ -1,0 +1,239 @@
+""" WeatherWarning dataclass. """
+
+# pylint: disable=too-many-lines, too-many-locals, too-many-branches, too-many-statements, too-many-arguments, line-too-long, wildcard-import
+from __future__ import annotations
+import io
+import gzip
+import enum
+import typing
+import dataclasses
+from dataclasses import dataclass
+import dataclasses_json
+from dataclasses_json import Undefined, dataclass_json
+from marshmallow import fields
+import json
+from meteoalarm_amqp_producer_data.severityenum import SeverityEnum
+from meteoalarm_amqp_producer_data.urgencyenum import UrgencyEnum
+from meteoalarm_amqp_producer_data.certaintyenum import CertaintyEnum
+from meteoalarm_amqp_producer_data.scopeenum import ScopeEnum
+from meteoalarm_amqp_producer_data.categoryenum import CategoryEnum
+from meteoalarm_amqp_producer_data.msgtypeenum import MsgTypeenum
+from meteoalarm_amqp_producer_data.statusenum import StatusEnum
+import datetime
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class WeatherWarning:
+    """
+    A severe weather warning from the EUMETNET Meteoalarm system, aggregating warnings from 30+ European national meteorological services. Each warning follows the CAP (Common Alerting Protocol) structure with awareness levels and hazard types.
+    
+    Attributes:
+        identifier (str)
+        sender (str)
+        sent (datetime.datetime)
+        status (StatusEnum)
+        msg_type (MsgTypeenum)
+        scope (ScopeEnum)
+        country (str)
+        event (str)
+        category (typing.Optional[CategoryEnum])
+        severity (SeverityEnum)
+        urgency (UrgencyEnum)
+        certainty (CertaintyEnum)
+        headline (typing.Optional[str])
+        description (typing.Optional[str])
+        instruction (typing.Optional[str])
+        effective (typing.Optional[datetime.datetime])
+        onset (typing.Optional[datetime.datetime])
+        expires (typing.Optional[datetime.datetime])
+        web (typing.Optional[str])
+        contact (typing.Optional[str])
+        awareness_level (typing.Optional[str])
+        awareness_type (str)
+        area_desc (str)
+        geocodes (typing.Optional[str])
+        language (typing.Optional[str])
+        awareness_type_raw (typing.Optional[str])
+    """
+    
+    
+    identifier: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="identifier"))
+    sender: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sender"))
+    sent: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sent", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    status: StatusEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="status"))
+    msg_type: MsgTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="msg_type"))
+    scope: ScopeEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="scope"))
+    country: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="country"))
+    event: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    category: typing.Optional[CategoryEnum]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="category"))
+    severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
+    urgency: UrgencyEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="urgency"))
+    certainty: CertaintyEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="certainty"))
+    headline: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="headline"))
+    description: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="description"))
+    instruction: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="instruction"))
+    effective: typing.Optional[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="effective", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    onset: typing.Optional[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="onset", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    expires: typing.Optional[datetime.datetime]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="expires", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
+    web: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="web"))
+    contact: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="contact"))
+    awareness_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="awareness_level"))
+    awareness_type: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="awareness_type"))
+    area_desc: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_desc"))
+    geocodes: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geocodes"))
+    language: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="language"))
+    awareness_type_raw: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="awareness_type_raw"))
+
+    @classmethod
+    def from_serializer_dict(cls, data: dict) -> 'WeatherWarning':
+        """
+        Converts a dictionary to a dataclass instance.
+        
+        Args:
+            data: The dictionary to convert to a dataclass.
+        
+        Returns:
+            The dataclass representation of the dataclass.
+        """
+        return cls(**data)
+
+    def to_serializer_dict(self) -> dict:
+        """
+        Converts the dataclass to a dictionary.
+
+        Returns:
+            The dictionary representation of the dataclass.
+        """
+        asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        return asdict_result
+
+    def _dict_resolver(self, data):
+        """
+        Helps resolving the Enum values to their actual values and fixes the key names.
+        """ 
+        def _resolve_enum(v):
+            if isinstance(v, enum.Enum):
+                return v.value
+            return v
+        def _fix_key(k):
+            return k[:-1] if k.endswith('_') else k
+        return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
+
+    def to_byte_array(self, content_type_string: str) -> bytes:
+        """
+        Converts the dataclass to a byte array based on the content type string.
+        
+        Args:
+            content_type_string: The content type string to convert the dataclass to.
+                Supported content types:
+                    'application/json': Encodes the data to JSON format.
+                Supported content type extensions:
+                    '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
+
+        Returns:
+            The byte array representation of the dataclass.        
+        """
+        content_type = content_type_string.split(';')[0].strip()
+        result = None
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            #pylint: disable=no-member
+            result = self.to_json()
+            #pylint: enable=no-member
+
+        if result is not None and content_type.endswith('+gzip'):
+            # Handle string result from to_json()
+            if isinstance(result, str):
+                result = result.encode('utf-8')
+            with io.BytesIO() as stream:
+                with gzip.GzipFile(fileobj=stream, mode='wb') as gzip_file:
+                    gzip_file.write(result)
+                result = stream.getvalue()
+
+        if result is None:
+            raise NotImplementedError(f"Unsupported media type {content_type}")
+
+        return result
+
+    @classmethod
+    def from_data(cls, data: typing.Any, content_type_string: typing.Optional[str] = None) -> typing.Optional['WeatherWarning']:
+        """
+        Converts the data to a dataclass based on the content type string.
+        
+        Args:
+            data: The data to convert to a dataclass.
+            content_type_string: The content type string to convert the data to. 
+                Supported content types:
+                    'application/json': Attempts to decode the data from JSON encoded format.
+                Supported content type extensions:
+                    '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
+        Returns:
+            The dataclass representation of the data.
+        """
+        if data is None:
+            return None
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_serializer_dict(data)
+
+        content_type = (content_type_string or 'application/octet-stream').split(';')[0].strip()
+
+        if content_type.endswith('+gzip'):
+            if isinstance(data, (bytes, io.BytesIO)):
+                stream = io.BytesIO(data) if isinstance(data, bytes) else data
+            else:
+                raise NotImplementedError('Data is not of a supported type for gzip decompression')
+            with gzip.GzipFile(fileobj=stream, mode='rb') as gzip_file:
+                data = gzip_file.read()
+        
+        # Strip compression suffix for base type matching
+        base_content_type = content_type.replace('+gzip', '')
+        if base_content_type == 'application/json':
+            if isinstance(data, (bytes, str)):
+                data_str = data.decode('utf-8') if isinstance(data, bytes) else data
+                _record = json.loads(data_str)
+                return WeatherWarning.from_serializer_dict(_record)
+            else:
+                raise NotImplementedError('Data is not of a supported type for JSON deserialization')
+        raise NotImplementedError(f'Unsupported media type {content_type}')
+
+    @classmethod
+    def create_instance(cls) -> 'WeatherWarning':
+        """
+        Creates an instance of the dataclass with test values.
+        
+        Returns:
+            An instance of the dataclass.
+        """
+        return cls(
+            identifier='hsemlppmsdxvhxuqrfay',
+            sender='mxswgnpjqkmewidzgagg',
+            sent=datetime.datetime.now(datetime.timezone.utc),
+            status=StatusEnum.Actual,
+            msg_type=MsgTypeenum.Alert,
+            scope=ScopeEnum.Public,
+            country='pvxajpxcuabvvailkkxp',
+            event='gilnvjazxcdztizqfngv',
+            category=CategoryEnum.Met,
+            severity=SeverityEnum.Extreme,
+            urgency=UrgencyEnum.Immediate,
+            certainty=CertaintyEnum.Observed,
+            headline='oxjxwiazwbsdclkqhrxg',
+            description='ygtdgqxsajphnybkqvhr',
+            instruction='mbycaozqssbciluixmzh',
+            effective=datetime.datetime.now(datetime.timezone.utc),
+            onset=datetime.datetime.now(datetime.timezone.utc),
+            expires=datetime.datetime.now(datetime.timezone.utc),
+            web='uzxoatbwfsesvyrxmyxt',
+            contact='qciogubsvzrndbyywbwy',
+            awareness_level='evrscpslhygxxyhxihiv',
+            awareness_type='fyitypkfofbumqchibqt',
+            area_desc='zicnovnqedfazrzkucrq',
+            geocodes='opbdmipuuapzibnevyrh',
+            language='tjansmeonchtnflkhthv',
+            awareness_type_raw='esnxxayzrcjhqduwznof'
+        )

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_categoryenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_categoryenum.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.categoryenum import CategoryEnum
+
+
+class Test_CategoryEnum(unittest.TestCase):
+    """
+    Test case for CategoryEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = CategoryEnum.Met
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of CategoryEnum
+        """
+        return CategoryEnum.Met
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(CategoryEnum.Met.value, 'Met')
+        self.assertEqual(CategoryEnum.Geo.value, 'Geo')
+        self.assertEqual(CategoryEnum.Safety.value, 'Safety')
+        self.assertEqual(CategoryEnum.Security.value, 'Security')
+        self.assertEqual(CategoryEnum.Rescue.value, 'Rescue')
+        self.assertEqual(CategoryEnum.Fire.value, 'Fire')
+        self.assertEqual(CategoryEnum.Health.value, 'Health')
+        self.assertEqual(CategoryEnum.Env.value, 'Env')
+        self.assertEqual(CategoryEnum.Transport.value, 'Transport')
+        self.assertEqual(CategoryEnum.Infra.value, 'Infra')
+        self.assertEqual(CategoryEnum.CBRNE.value, 'CBRNE')
+        self.assertEqual(CategoryEnum.Other.value, 'Other')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_certaintyenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_certaintyenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.certaintyenum import CertaintyEnum
+
+
+class Test_CertaintyEnum(unittest.TestCase):
+    """
+    Test case for CertaintyEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = CertaintyEnum.Observed
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of CertaintyEnum
+        """
+        return CertaintyEnum.Observed
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(CertaintyEnum.Observed.value, 'Observed')
+        self.assertEqual(CertaintyEnum.Likely.value, 'Likely')
+        self.assertEqual(CertaintyEnum.Possible.value, 'Possible')
+        self.assertEqual(CertaintyEnum.Unlikely.value, 'Unlikely')
+        self.assertEqual(CertaintyEnum.Unknown.value, 'Unknown')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_msgtypeenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_msgtypeenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.msgtypeenum import MsgTypeenum
+
+
+class Test_MsgTypeenum(unittest.TestCase):
+    """
+    Test case for MsgTypeenum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = MsgTypeenum.Alert
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of MsgTypeenum
+        """
+        return MsgTypeenum.Alert
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(MsgTypeenum.Alert.value, 'Alert')
+        self.assertEqual(MsgTypeenum.Update.value, 'Update')
+        self.assertEqual(MsgTypeenum.Cancel.value, 'Cancel')
+        self.assertEqual(MsgTypeenum.Ack.value, 'Ack')
+        self.assertEqual(MsgTypeenum.Error.value, 'Error')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_scopeenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_scopeenum.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.scopeenum import ScopeEnum
+
+
+class Test_ScopeEnum(unittest.TestCase):
+    """
+    Test case for ScopeEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = ScopeEnum.Public
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of ScopeEnum
+        """
+        return ScopeEnum.Public
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(ScopeEnum.Public.value, 'Public')
+        self.assertEqual(ScopeEnum.Restricted.value, 'Restricted')
+        self.assertEqual(ScopeEnum.Private.value, 'Private')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_severityenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_severityenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.severityenum import SeverityEnum
+
+
+class Test_SeverityEnum(unittest.TestCase):
+    """
+    Test case for SeverityEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = SeverityEnum.Extreme
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of SeverityEnum
+        """
+        return SeverityEnum.Extreme
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(SeverityEnum.Extreme.value, 'Extreme')
+        self.assertEqual(SeverityEnum.Severe.value, 'Severe')
+        self.assertEqual(SeverityEnum.Moderate.value, 'Moderate')
+        self.assertEqual(SeverityEnum.Minor.value, 'Minor')
+        self.assertEqual(SeverityEnum.Unknown.value, 'Unknown')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_statusenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_statusenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.statusenum import StatusEnum
+
+
+class Test_StatusEnum(unittest.TestCase):
+    """
+    Test case for StatusEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = StatusEnum.Actual
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of StatusEnum
+        """
+        return StatusEnum.Actual
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(StatusEnum.Actual.value, 'Actual')
+        self.assertEqual(StatusEnum.Exercise.value, 'Exercise')
+        self.assertEqual(StatusEnum.System.value, 'System')
+        self.assertEqual(StatusEnum.Test.value, 'Test')
+        self.assertEqual(StatusEnum.Draft.value, 'Draft')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_urgencyenum.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_urgencyenum.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.urgencyenum import UrgencyEnum
+
+
+class Test_UrgencyEnum(unittest.TestCase):
+    """
+    Test case for UrgencyEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = UrgencyEnum.Immediate
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of UrgencyEnum
+        """
+        return UrgencyEnum.Immediate
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(UrgencyEnum.Immediate.value, 'Immediate')
+        self.assertEqual(UrgencyEnum.Expected.value, 'Expected')
+        self.assertEqual(UrgencyEnum.Future.value, 'Future')
+        self.assertEqual(UrgencyEnum.Past.value, 'Past')
+        self.assertEqual(UrgencyEnum.Unknown.value, 'Unknown')

--- a/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_weatherwarning.py
+++ b/meteoalarm/meteoalarm_amqp_producer/meteoalarm_amqp_producer_data/tests/test_weatherwarning.py
@@ -1,0 +1,295 @@
+"""
+Test case for WeatherWarning
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from meteoalarm_amqp_producer_data.weatherwarning import WeatherWarning
+from meteoalarm_amqp_producer_data.severityenum import SeverityEnum
+from meteoalarm_amqp_producer_data.urgencyenum import UrgencyEnum
+from meteoalarm_amqp_producer_data.certaintyenum import CertaintyEnum
+from meteoalarm_amqp_producer_data.scopeenum import ScopeEnum
+from meteoalarm_amqp_producer_data.categoryenum import CategoryEnum
+from meteoalarm_amqp_producer_data.msgtypeenum import MsgTypeenum
+from meteoalarm_amqp_producer_data.statusenum import StatusEnum
+import datetime
+
+
+class Test_WeatherWarning(unittest.TestCase):
+    """
+    Test case for WeatherWarning
+    """
+
+    def setUp(self):
+        """
+        Set up test case
+        """
+        self.instance = Test_WeatherWarning.create_instance()
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WeatherWarning for testing
+        """
+        instance = WeatherWarning(
+            identifier='hsemlppmsdxvhxuqrfay',
+            sender='mxswgnpjqkmewidzgagg',
+            sent=datetime.datetime.now(datetime.timezone.utc),
+            status=StatusEnum.Actual,
+            msg_type=MsgTypeenum.Alert,
+            scope=ScopeEnum.Public,
+            country='pvxajpxcuabvvailkkxp',
+            event='gilnvjazxcdztizqfngv',
+            category=CategoryEnum.Met,
+            severity=SeverityEnum.Extreme,
+            urgency=UrgencyEnum.Immediate,
+            certainty=CertaintyEnum.Observed,
+            headline='oxjxwiazwbsdclkqhrxg',
+            description='ygtdgqxsajphnybkqvhr',
+            instruction='mbycaozqssbciluixmzh',
+            effective=datetime.datetime.now(datetime.timezone.utc),
+            onset=datetime.datetime.now(datetime.timezone.utc),
+            expires=datetime.datetime.now(datetime.timezone.utc),
+            web='uzxoatbwfsesvyrxmyxt',
+            contact='qciogubsvzrndbyywbwy',
+            awareness_level='evrscpslhygxxyhxihiv',
+            awareness_type='fyitypkfofbumqchibqt',
+            area_desc='zicnovnqedfazrzkucrq',
+            geocodes='opbdmipuuapzibnevyrh',
+            language='tjansmeonchtnflkhthv',
+            awareness_type_raw='esnxxayzrcjhqduwznof'
+        )
+        return instance
+
+    
+    def test_identifier_property(self):
+        """
+        Test identifier property
+        """
+        test_value = 'hsemlppmsdxvhxuqrfay'
+        self.instance.identifier = test_value
+        self.assertEqual(self.instance.identifier, test_value)
+    
+    def test_sender_property(self):
+        """
+        Test sender property
+        """
+        test_value = 'mxswgnpjqkmewidzgagg'
+        self.instance.sender = test_value
+        self.assertEqual(self.instance.sender, test_value)
+    
+    def test_sent_property(self):
+        """
+        Test sent property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.sent = test_value
+        self.assertEqual(self.instance.sent, test_value)
+    
+    def test_status_property(self):
+        """
+        Test status property
+        """
+        test_value = StatusEnum.Actual
+        self.instance.status = test_value
+        self.assertEqual(self.instance.status, test_value)
+    
+    def test_msg_type_property(self):
+        """
+        Test msg_type property
+        """
+        test_value = MsgTypeenum.Alert
+        self.instance.msg_type = test_value
+        self.assertEqual(self.instance.msg_type, test_value)
+    
+    def test_scope_property(self):
+        """
+        Test scope property
+        """
+        test_value = ScopeEnum.Public
+        self.instance.scope = test_value
+        self.assertEqual(self.instance.scope, test_value)
+    
+    def test_country_property(self):
+        """
+        Test country property
+        """
+        test_value = 'pvxajpxcuabvvailkkxp'
+        self.instance.country = test_value
+        self.assertEqual(self.instance.country, test_value)
+    
+    def test_event_property(self):
+        """
+        Test event property
+        """
+        test_value = 'gilnvjazxcdztizqfngv'
+        self.instance.event = test_value
+        self.assertEqual(self.instance.event, test_value)
+    
+    def test_category_property(self):
+        """
+        Test category property
+        """
+        test_value = CategoryEnum.Met
+        self.instance.category = test_value
+        self.assertEqual(self.instance.category, test_value)
+    
+    def test_severity_property(self):
+        """
+        Test severity property
+        """
+        test_value = SeverityEnum.Extreme
+        self.instance.severity = test_value
+        self.assertEqual(self.instance.severity, test_value)
+    
+    def test_urgency_property(self):
+        """
+        Test urgency property
+        """
+        test_value = UrgencyEnum.Immediate
+        self.instance.urgency = test_value
+        self.assertEqual(self.instance.urgency, test_value)
+    
+    def test_certainty_property(self):
+        """
+        Test certainty property
+        """
+        test_value = CertaintyEnum.Observed
+        self.instance.certainty = test_value
+        self.assertEqual(self.instance.certainty, test_value)
+    
+    def test_headline_property(self):
+        """
+        Test headline property
+        """
+        test_value = 'oxjxwiazwbsdclkqhrxg'
+        self.instance.headline = test_value
+        self.assertEqual(self.instance.headline, test_value)
+    
+    def test_description_property(self):
+        """
+        Test description property
+        """
+        test_value = 'ygtdgqxsajphnybkqvhr'
+        self.instance.description = test_value
+        self.assertEqual(self.instance.description, test_value)
+    
+    def test_instruction_property(self):
+        """
+        Test instruction property
+        """
+        test_value = 'mbycaozqssbciluixmzh'
+        self.instance.instruction = test_value
+        self.assertEqual(self.instance.instruction, test_value)
+    
+    def test_effective_property(self):
+        """
+        Test effective property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.effective = test_value
+        self.assertEqual(self.instance.effective, test_value)
+    
+    def test_onset_property(self):
+        """
+        Test onset property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.onset = test_value
+        self.assertEqual(self.instance.onset, test_value)
+    
+    def test_expires_property(self):
+        """
+        Test expires property
+        """
+        test_value = datetime.datetime.now(datetime.timezone.utc)
+        self.instance.expires = test_value
+        self.assertEqual(self.instance.expires, test_value)
+    
+    def test_web_property(self):
+        """
+        Test web property
+        """
+        test_value = 'uzxoatbwfsesvyrxmyxt'
+        self.instance.web = test_value
+        self.assertEqual(self.instance.web, test_value)
+    
+    def test_contact_property(self):
+        """
+        Test contact property
+        """
+        test_value = 'qciogubsvzrndbyywbwy'
+        self.instance.contact = test_value
+        self.assertEqual(self.instance.contact, test_value)
+    
+    def test_awareness_level_property(self):
+        """
+        Test awareness_level property
+        """
+        test_value = 'evrscpslhygxxyhxihiv'
+        self.instance.awareness_level = test_value
+        self.assertEqual(self.instance.awareness_level, test_value)
+    
+    def test_awareness_type_property(self):
+        """
+        Test awareness_type property
+        """
+        test_value = 'fyitypkfofbumqchibqt'
+        self.instance.awareness_type = test_value
+        self.assertEqual(self.instance.awareness_type, test_value)
+    
+    def test_area_desc_property(self):
+        """
+        Test area_desc property
+        """
+        test_value = 'zicnovnqedfazrzkucrq'
+        self.instance.area_desc = test_value
+        self.assertEqual(self.instance.area_desc, test_value)
+    
+    def test_geocodes_property(self):
+        """
+        Test geocodes property
+        """
+        test_value = 'opbdmipuuapzibnevyrh'
+        self.instance.geocodes = test_value
+        self.assertEqual(self.instance.geocodes, test_value)
+    
+    def test_language_property(self):
+        """
+        Test language property
+        """
+        test_value = 'tjansmeonchtnflkhthv'
+        self.instance.language = test_value
+        self.assertEqual(self.instance.language, test_value)
+    
+    def test_awareness_type_raw_property(self):
+        """
+        Test awareness_type_raw property
+        """
+        test_value = 'esnxxayzrcjhqduwznof'
+        self.instance.awareness_type_raw = test_value
+        self.assertEqual(self.instance.awareness_type_raw, test_value)
+    
+    def test_to_byte_array_json(self):
+        """
+        Test to_byte_array method with json media type
+        """
+        media_type = "application/json"
+        bytes_data = self.instance.to_byte_array(media_type)
+        new_instance = WeatherWarning.from_data(bytes_data, media_type)
+        bytes_data2 = new_instance.to_byte_array(media_type)
+        self.assertEqual(bytes_data, bytes_data2)
+
+    def test_to_json(self):
+        """
+        Test to_json method
+        """
+        json_data = self.instance.to_json()
+        new_instance = WeatherWarning.from_json(json_data)
+        json_data2 = new_instance.to_json()
+        self.assertEqual(json_data, json_data2)
+

--- a/meteoalarm/meteoalarm_amqp_producer/samples/sample.py
+++ b/meteoalarm/meteoalarm_amqp_producer/samples/sample.py
@@ -1,0 +1,53 @@
+
+"""
+Sample usage of meteoalarm_amqp_producer_amqp_producer
+
+This example demonstrates how to send messages using the AMQP 1.0 producer.
+"""
+import sys
+from meteoalarm_amqp_producer_amqp_producer import *
+
+def main():
+    """Main function"""
+    
+    
+    # Create producer
+    print("Creating AMQP producer...")
+    producer = MeteoalarmWarningsAmqpProducer(
+        host="localhost",  # Change to your AMQP broker hostname
+        address="my-queue",  # Change to your queue/topic name
+        port=5672,  # Use 5671 for TLS
+        username="guest",  # Change to your username
+        password="guest",  # Change to your password
+        content_mode='structured',  # or 'binary' for CloudEvents
+        format_type='application/json'
+    )
+    
+    try:
+        
+        
+        # Send WeatherWarning message
+        print("Sending WeatherWarning message...")
+        # TODO: Create a WeatherWarning instance with actual data
+        # data = WeatherWarning(...)
+        # producer.send_weather_warning(
+        #     data=data,
+        #     content_type="application/json"
+        # )
+        # print("WeatherWarning message sent successfully!")
+        
+        
+        print("\nAll messages sent successfully!")
+        
+    except Exception as e:
+        print(f"Error sending messages: {e}", file=sys.stderr)
+        return 1
+    finally:
+        producer.close()
+        print("Producer closed")
+    
+    return 0
+    
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/meteoalarm/meteoalarm_amqp_producer/scripts/build.py
+++ b/meteoalarm/meteoalarm_amqp_producer/scripts/build.py
@@ -1,0 +1,30 @@
+"""
+Build script for meteoalarm_amqp_producer_amqp_producer
+"""
+import subprocess
+import sys
+
+def main():
+    """Main build function"""
+    print("Building meteoalarm_amqp_producer_amqp_producer...")
+    
+    try:
+        # Install dependencies
+        subprocess.run(["poetry", "install"], check=True)
+        
+        # Run tests
+        print("\nRunning tests...")
+        subprocess.run(["poetry", "run", "pytest"], check=True)
+        
+        # Build package
+        print("\nBuilding package...")
+        subprocess.run(["poetry", "build"], check=True)
+        
+        print("\n✓ Build complete!")
+        return 0
+    except subprocess.CalledProcessError as e:
+        print(f"\n✗ Build failed: {e}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/meteoalarm/xreg/meteoalarm.xreg.json
+++ b/meteoalarm/xreg/meteoalarm.xreg.json
@@ -41,6 +41,28 @@
         }
       ],
       "description": "MQTT 5 producer endpoint for Meteoalarm CloudEvents using the alert topic hierarchy and retain settings declared in this manifest."
+    },
+    "Meteoalarm.Warnings.Amqp": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "AMQP/1.0",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "binary"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": [
+          {
+            "uri": "amqps://localhost:5671/meteoalarm"
+          }
+        ]
+      },
+      "messagegroups": [
+        "#/messagegroups/Meteoalarm.Warnings.amqp"
+      ],
+      "description": "AMQP 1.0 producer endpoint for Meteoalarm warning CloudEvents on the configured broker address."
     }
   },
   "messagegroups": {
@@ -79,6 +101,42 @@
             "topic_name": "alerts/intl/meteoalarm/meteoalarm/{country}/{severity}/{awareness_type}/{identifier}/warning",
             "qos": 1,
             "retain": false
+          }
+        }
+      }
+    },
+    "Meteoalarm.Warnings.amqp": {
+      "description": "AMQP 1.0 variant of the Meteoalarm weather-warning events for queue-oriented consumers and Azure Service Bus deployments.",
+      "messages": {
+        "Meteoalarm.Warnings.amqp.WeatherWarning": {
+          "name": "WeatherWarning",
+          "basemessageurl": "/messagegroups/Meteoalarm.Warnings/messages/Meteoalarm.WeatherWarning",
+          "protocol": "AMQP/1.0",
+          "protocoloptions": {
+            "properties": {
+              "subject": {
+                "type": "uritemplate",
+                "value": "{identifier}",
+                "description": "AMQP message subject — stable entity identifier matching the CloudEvent subject and Kafka key for cross-transport correlation."
+              }
+            },
+            "application_properties": {
+              "country": {
+                "type": "uritemplate",
+                "value": "{country}",
+                "description": "Country feed slug for Service Bus subscription filters and AMQP consumer routing."
+              },
+              "severity": {
+                "type": "uritemplate",
+                "value": "{severity}",
+                "description": "CAP severity level for Service Bus subscription filters and AMQP consumer routing."
+              },
+              "awareness_type": {
+                "type": "uritemplate",
+                "value": "{awareness_type}",
+                "description": "Meteoalarm awareness type slug for Service Bus subscription filters and AMQP consumer routing."
+              }
+            }
           }
         }
       }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -528,6 +528,12 @@
       "image": "hongkong-epd-amqp",
       "file": "Dockerfile.amqp",
       "module": "hongkong_epd_amqp"
+    },
+    {
+      "dir": "meteoalarm",
+      "image": "meteoalarm-amqp",
+      "file": "Dockerfile.amqp",
+      "module": "meteoalarm_amqp"
     }
   ],
   "flow": [
@@ -1009,6 +1015,13 @@
       "file": "Dockerfile.amqp",
       "test_file": "test_docker_amqp_flow.py",
       "test_class": "TestHongkongEpdAmqpDockerFlow"
+    },
+    {
+      "dir": "meteoalarm",
+      "image": "meteoalarm-amqp",
+      "file": "Dockerfile.amqp",
+      "test_file": "test_docker_amqp_flow.py",
+      "test_class": "TestMeteoalarmAmqpDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -516,6 +516,12 @@
       "image": "aisstream-amqp",
       "file": "Dockerfile.amqp",
       "module": "aisstream_amqp"
+    },
+    {
+      "dir": "epa-uv",
+      "image": "epa-uv-amqp",
+      "file": "Dockerfile.amqp",
+      "module": "epa_uv_amqp"
     }
   ],
   "flow": [
@@ -983,6 +989,13 @@
       "file": "Dockerfile.amqp",
       "test_file": "test_docker_amqp_flow.py",
       "test_class": "TestAisstreamAmqpDockerFlow"
+    },
+    {
+      "dir": "epa-uv",
+      "image": "epa-uv-amqp",
+      "file": "Dockerfile.amqp",
+      "test_file": "test_docker_amqp_flow.py",
+      "test_class": "TestEpaUvAmqpDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -522,6 +522,12 @@
       "image": "epa-uv-amqp",
       "file": "Dockerfile.amqp",
       "module": "epa_uv_amqp"
+    },
+    {
+      "dir": "hongkong-epd",
+      "image": "hongkong-epd-amqp",
+      "file": "Dockerfile.amqp",
+      "module": "hongkong_epd_amqp"
     }
   ],
   "flow": [
@@ -996,6 +1002,13 @@
       "file": "Dockerfile.amqp",
       "test_file": "test_docker_amqp_flow.py",
       "test_class": "TestEpaUvAmqpDockerFlow"
+    },
+    {
+      "dir": "hongkong-epd",
+      "image": "hongkong-epd-amqp",
+      "file": "Dockerfile.amqp",
+      "test_file": "test_docker_amqp_flow.py",
+      "test_class": "TestHongkongEpdAmqpDockerFlow"
     }
   ]
 }

--- a/tests/docker_e2e/test_docker_amqp_flow.py
+++ b/tests/docker_e2e/test_docker_amqp_flow.py
@@ -189,3 +189,11 @@ class TestEpaUvAmqpDockerFlow(AmqpDockerFlowBase):
     expected_types = {"US.EPA.UVIndex.HourlyForecast", "US.EPA.UVIndex.DailyForecast"}
     expected_count = 2
 
+
+class TestHongkongEpdAmqpDockerFlow(AmqpDockerFlowBase):
+    source_dir = "hongkong-epd"
+    image = "hongkong-epd-amqp"
+    env = {"HONGKONG_EPD_MOCK": "true", "ONCE_MODE": "true"}
+    expected_types = {"HK.Gov.EPD.AQHI.Station", "HK.Gov.EPD.AQHI.AQHIReading"}
+    expected_count = 2
+

--- a/tests/docker_e2e/test_docker_amqp_flow.py
+++ b/tests/docker_e2e/test_docker_amqp_flow.py
@@ -197,3 +197,11 @@ class TestHongkongEpdAmqpDockerFlow(AmqpDockerFlowBase):
     expected_types = {"HK.Gov.EPD.AQHI.Station", "HK.Gov.EPD.AQHI.AQHIReading"}
     expected_count = 2
 
+
+class TestMeteoalarmAmqpDockerFlow(AmqpDockerFlowBase):
+    source_dir = "meteoalarm"
+    image = "meteoalarm-amqp"
+    env = {"METEOALARM_MOCK": "true", "ONCE_MODE": "true"}
+    expected_types = {"Meteoalarm.WeatherWarning"}
+    expected_count = 1
+

--- a/tests/docker_e2e/test_docker_amqp_flow.py
+++ b/tests/docker_e2e/test_docker_amqp_flow.py
@@ -181,3 +181,11 @@ class TestAisstreamAmqpDockerFlow(AmqpDockerFlowBase):
     image = "aisstream-amqp"
     env = {"AISSTREAM_MOCK": "true"}
     expected_types = {"IO.AISstream.mqtt.PositionReport", "IO.AISstream.mqtt.ShipStatic", "IO.AISstream.mqtt.AidToNavigation"}
+
+class TestEpaUvAmqpDockerFlow(AmqpDockerFlowBase):
+    source_dir = "epa-uv"
+    image = "epa-uv-amqp"
+    env = {"EPA_UV_MOCK": "true", "ONCE_MODE": "true"}
+    expected_types = {"US.EPA.UVIndex.HourlyForecast", "US.EPA.UVIndex.DailyForecast"}
+    expected_count = 2
+


### PR DESCRIPTION
## Summary
- Add AMQP 1.0 companion feeders for epa-uv, hongkong-epd, and meteoalarm.
- Add xRegistry AMQP endpoints/messagegroups, generated producers, runtime apps, Dockerfiles, Service Bus templates, docs, EVENTS.md, catalog flags, and Docker E2E matrix coverage.

## Validation
- `python -m py_compile epa-uv\epa_uv_amqp\epa_uv_amqp\app.py hongkong-epd\hongkong_epd_amqp\hongkong_epd_amqp\app.py meteoalarm\meteoalarm_amqp\meteoalarm_amqp\app.py tests\docker_e2e\test_docker_amqp_flow.py`
- `python -m pytest tests\docker_e2e\test_docker_amqp_flow.py::TestEpaUvAmqpDockerFlow tests\docker_e2e\test_docker_amqp_flow.py::TestHongkongEpdAmqpDockerFlow tests\docker_e2e\test_docker_amqp_flow.py::TestMeteoalarmAmqpDockerFlow -q` (3 passed)
- `pwsh -NoProfile -File tools\generate-events-md.ps1 -Source epa-uv|hongkong-epd|meteoalarm`