### PR TITLE
fix(amqp): add missing urlparse import in 3 feeders

### DIFF
--- a/carbon-intensity/carbon_intensity_amqp/carbon_intensity_amqp/app.py
+++ b/carbon-intensity/carbon_intensity_amqp/carbon_intensity_amqp/app.py
@@ -1,6 +1,7 @@
 """AMQP feeder for Carbon Intensity UK."""
 from __future__ import annotations
 import argparse, asyncio, logging, os
+from urllib.parse import urlparse
 from carbon_intensity.carbon_intensity import CarbonIntensityPoller, POLL_INTERVAL_SECONDS
 from carbon_intensity_amqp_producer_amqp_producer.producer import UkOrgCarbonintensityAmqpProducer
 logger=logging.getLogger(__name__)

--- a/german-waters/german_waters_amqp/german_waters_amqp/app.py
+++ b/german-waters/german_waters_amqp/german_waters_amqp/app.py
@@ -17,6 +17,7 @@ import time
 import logging
 import os
 import sys
+from urllib.parse import urlparse
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 

--- a/rss/rssbridge_amqp/rssbridge_amqp/app.py
+++ b/rss/rssbridge_amqp/rssbridge_amqp/app.py
@@ -1,7 +1,7 @@
 """AMQP feeder for RSS/Atom feeds."""
 from __future__ import annotations
 import argparse, asyncio, logging, os
-from rssbridge.rssbridge import load_feedstore, load_state, poll_feeds, save_feedstore, save_state
+from urllib.parse import urlparse
 import rssbridge.rssbridge as bridge
 from rssbridge_amqp_producer_data.microsoft.opendata.rssfeeds.feeditem import FeedItem
 from rssbridge_amqp_producer_amqp_producer.producer import MicrosoftOpenDataRssFeedsAmqpProducer


### PR DESCRIPTION
Three AMQP feeders (rss, carbon-intensity, german-waters) reference urlparse without importing it. Bug landed via PR 412 and 416 because mock/once mode did not exercise the parse_endpoint code path. Caught by CI on PR 422.