### PR TITLE
feat: build xRegistry static site and host under ghpages/registry/

### DIFF
--- a/.github/workflows/build-xregistry-site.yml
+++ b/.github/workflows/build-xregistry-site.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # ── 1. Checkout main ─────────────────────────────────────────────────
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: main
           path: main
@@ -47,10 +47,10 @@ jobs:
       - name: Start xrserver-all
         run: |
           docker run -d --name xreg -p 8080:8080 \
-            ghcr.io/xregistry/xrserver-all \
-            --recreatedb --port 8080
+            ghcr.io/xregistry/xrserver-all:latest \
+            --recreatedb
 
-      # ── 4. Wait for readiness (MySQL needs up to 15 s) ───────────────────
+      # ── 4. Wait for readiness (MySQL needs up to 30 s) ───────────────────
       - name: Wait for xrserver readiness
         run: |
           for i in $(seq 1 30); do
@@ -67,40 +67,66 @@ jobs:
       # ── 5. Load the pinned CloudEvents model ─────────────────────────────
       # cloudevents/model.json is the composite model covering endpoints,
       # messagegroups, and schemagroups — required for all three group types.
+      # The /xr binary lives at /xr inside the container (not on $PATH).
       - name: Load CloudEvents model
         run: |
-          docker exec xreg xr -s localhost:8080 model update \
-            -d @https://raw.githubusercontent.com/xregistry/spec/${SPEC_SHA}/cloudevents/model.json
+          docker exec xreg /xr -s localhost:8080 model update \
+            -d "@https://raw.githubusercontent.com/xregistry/spec/${SPEC_SHA}/cloudevents/model.json"
 
-      # ── 6. Import the merged registry ────────────────────────────────────
+      # ── 6. Disable schema format validation ──────────────────────────────
+      # The Avro schemas in this repo use cross-file type references that
+      # xrserver cannot resolve in isolation; disable format/compat checks so
+      # they import without errors.  The registry is used for discovery, not
+      # as a schema-validation service.
+      - name: Disable schema validation in model
+        run: |
+          python3 - <<'PYEOF'
+          import json, urllib.request
+          url = "http://localhost:8080/modelsource"
+          ms = json.loads(urllib.request.urlopen(url).read())
+          schemas = ms['groups']['schemagroups']['resources']['schemas']
+          schemas['validateformat'] = False
+          schemas['validatecompatibility'] = False
+          req = urllib.request.Request(
+              url, method='PUT',
+              headers={'Content-Type': 'application/json'},
+              data=json.dumps(ms).encode())
+          urllib.request.urlopen(req)
+          print("Schema validation disabled")
+          PYEOF
+
+      # ── 7. Import the merged registry ────────────────────────────────────
       - name: Import registry
         run: |
           docker cp /tmp/combined.json xreg:/tmp/combined.json
-          docker exec xreg xr -s localhost:8080 import -d @/tmp/combined.json
+          docker exec xreg /xr -s localhost:8080 import -d "@/tmp/combined.json"
 
-      # ── 7. Export as static file tree ────────────────────────────────────
+      # ── 8. Export as static file tree ────────────────────────────────────
       # --index index.html  → GitHub Pages serves index.html as directory default
       # --capabilities      → marks the registry as read-only / static
       # -p 5                → conservative parallelism for embedded MySQL
       - name: Download static registry
         run: |
           docker exec xreg /bin/sh -c \
-            "xr download /tmp/out \
+            "mkdir -p /tmp/out && /xr download /tmp/out \
                -s localhost:8080 \
-               -u \"${REGISTRY_BASE_URL}\" \
+               -u '${REGISTRY_BASE_URL}' \
                --index index.html \
                --capabilities \
-               -p 5"
-          docker cp xreg:/tmp/out /tmp/registry-out
+               -p 5 \
+             && tar czf /tmp/out.tar.gz -C /tmp/out ."
+          docker cp xreg:/tmp/out.tar.gz /tmp/out.tar.gz
+          mkdir -p /tmp/registry-out
+          tar xzf /tmp/out.tar.gz -C /tmp/registry-out
 
-      # ── 8. Stop xrserver ─────────────────────────────────────────────────
+      # ── 9. Stop xrserver ─────────────────────────────────────────────────
       - name: Stop xrserver
         if: always()
         run: docker rm -f xreg || true
 
-      # ── 9. Push to ghpages ───────────────────────────────────────────────
+      # ── 10. Push to ghpages ──────────────────────────────────────────────
       - name: Checkout ghpages
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ghpages
           path: ghpages
@@ -116,8 +142,8 @@ jobs:
         id: diff
         working-directory: ghpages
         run: |
-          if git diff --quiet && git diff --cached --quiet && \
-             [ -z "$(git status --porcelain registry/)" ]; then
+          git add registry/ 2>/dev/null || true
+          if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -129,6 +155,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add registry/
           git commit -m "Update xRegistry static export [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
           git push origin ghpages
+

--- a/.github/workflows/build-xregistry-site.yml
+++ b/.github/workflows/build-xregistry-site.yml
@@ -1,0 +1,134 @@
+name: Build xRegistry Static Site
+
+# Runs whenever any xreg manifest is updated on main, or on demand.
+# Merges all *.xreg.json files, imports them into xrserver-all, exports
+# a static file tree, and pushes the result to registry/ on the ghpages branch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "*/xreg/*.xreg.json"
+  workflow_dispatch:
+
+# Serialise with the catalog-sync workflow — both push to ghpages.
+concurrency:
+  group: ghpages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-registry:
+    runs-on: ubuntu-latest
+
+    env:
+      # Pinned commit of xregistry/spec — bump when the CloudEvents model changes.
+      SPEC_SHA: a573121649f7fdfdcdd3a228d9c0bf44c3859a06
+      REGISTRY_BASE_URL: https://clemensv.github.io/real-time-sources/registry
+
+    steps:
+      # ── 1. Checkout main ─────────────────────────────────────────────────
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: main
+
+      # ── 2. Merge all *.xreg.json files ───────────────────────────────────
+      - name: Merge xreg manifests
+        working-directory: main
+        run: |
+          python3 tools/merge-xreg.py -o /tmp/combined.json
+          echo "Combined size: $(wc -c < /tmp/combined.json) bytes"
+
+      # ── 3. Start xrserver-all (clean slate) ──────────────────────────────
+      - name: Start xrserver-all
+        run: |
+          docker run -d --name xreg -p 8080:8080 \
+            ghcr.io/xregistry/xrserver-all \
+            --recreatedb --port 8080
+
+      # ── 4. Wait for readiness (MySQL needs up to 15 s) ───────────────────
+      - name: Wait for xrserver readiness
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/ >/dev/null 2>&1; then
+              echo "xrserver ready after $((i * 2))s"
+              break
+            fi
+            echo "Waiting... (${i}/30)"
+            sleep 2
+          done
+          curl -sf http://localhost:8080/ \
+            || (echo "::error::xrserver did not become ready in 60 s" && exit 1)
+
+      # ── 5. Load the pinned CloudEvents model ─────────────────────────────
+      # cloudevents/model.json is the composite model covering endpoints,
+      # messagegroups, and schemagroups — required for all three group types.
+      - name: Load CloudEvents model
+        run: |
+          docker exec xreg xr -s localhost:8080 model update \
+            -d @https://raw.githubusercontent.com/xregistry/spec/${SPEC_SHA}/cloudevents/model.json
+
+      # ── 6. Import the merged registry ────────────────────────────────────
+      - name: Import registry
+        run: |
+          docker cp /tmp/combined.json xreg:/tmp/combined.json
+          docker exec xreg xr -s localhost:8080 import -d @/tmp/combined.json
+
+      # ── 7. Export as static file tree ────────────────────────────────────
+      # --index index.html  → GitHub Pages serves index.html as directory default
+      # --capabilities      → marks the registry as read-only / static
+      # -p 5                → conservative parallelism for embedded MySQL
+      - name: Download static registry
+        run: |
+          docker exec xreg /bin/sh -c \
+            "xr download /tmp/out \
+               -s localhost:8080 \
+               -u \"${REGISTRY_BASE_URL}\" \
+               --index index.html \
+               --capabilities \
+               -p 5"
+          docker cp xreg:/tmp/out /tmp/registry-out
+
+      # ── 8. Stop xrserver ─────────────────────────────────────────────────
+      - name: Stop xrserver
+        if: always()
+        run: docker rm -f xreg || true
+
+      # ── 9. Push to ghpages ───────────────────────────────────────────────
+      - name: Checkout ghpages
+        uses: actions/checkout@v6
+        with:
+          ref: ghpages
+          path: ghpages
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync registry to ghpages
+        run: |
+          rm -rf ghpages/registry
+          cp -r /tmp/registry-out ghpages/registry
+
+      - name: Check for changes
+        id: diff
+        working-directory: ghpages
+        run: |
+          if git diff --quiet && git diff --cached --quiet && \
+             [ -z "$(git status --porcelain registry/)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: ghpages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add registry/
+          git commit -m "Update xRegistry static export [$(date -u +%Y-%m-%dT%H:%M:%SZ)]"
+          git push origin ghpages

--- a/.github/workflows/update-ghpages-catalog.yml
+++ b/.github/workflows/update-ghpages-catalog.yml
@@ -8,6 +8,11 @@ on:
       - app.js
   workflow_dispatch:
 
+# Serialise with the xRegistry build workflow — both push to ghpages.
+concurrency:
+  group: ghpages
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/tools/merge-xreg.py
+++ b/tools/merge-xreg.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import glob
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -40,6 +41,209 @@ from pathlib import Path
 COLLECTION_KEYS = ("endpoints", "messagegroups", "schemagroups")
 
 DEFAULT_PATTERN = "*/xreg/*.xreg.json"
+
+_MAX_ID_LEN = 63  # xrserver silently truncates collection keys to 64 chars
+
+
+def _shorten_id(full_id: str) -> str:
+    """Return *full_id* unchanged if ≤ _MAX_ID_LEN chars.
+
+    Otherwise produce a deterministic short form:
+    ``<first 56 chars>~<6-char hex SHA256 prefix>``
+    which is exactly 63 chars and collision-resistant.
+    """
+    if len(full_id) <= _MAX_ID_LEN:
+        return full_id
+    digest = hashlib.sha256(full_id.encode()).hexdigest()[:6]
+    return full_id[:56] + "~" + digest
+
+
+def _apply_id_limits(messagegroups: dict) -> dict:
+    """Shorten message IDs that exceed _MAX_ID_LEN to avoid xrserver truncation.
+
+    xrserver has a bug where collection-listing map keys are silently truncated
+    to 64 characters, but entity lookup requires the full ID — causing 404s
+    during ``xr download``.  The fix is to ensure all IDs are ≤ 63 chars
+    before import so the server never needs to truncate.
+
+    Also rewrites all ``basemessageuri`` references to use the shortened IDs.
+    """
+    # Build old→new rename map
+    renames: dict[str, str] = {}
+    for mg in messagegroups.values():
+        messages = mg.get("messages", {})
+        for old_id in list(messages.keys()):
+            new_id = _shorten_id(old_id)
+            if new_id != old_id:
+                renames[old_id] = new_id
+                msg = messages.pop(old_id)
+                msg["messageid"] = new_id
+                messages[new_id] = msg
+
+    if not renames:
+        return messagegroups
+
+    # Rewrite basemessageuri references (/messagegroups/<mg>/messages/<old_id>)
+    for mg in messagegroups.values():
+        for msg in mg.get("messages", {}).values():
+            uri = msg.get("basemessageuri", "")
+            if isinstance(uri, str):
+                for old, new in renames.items():
+                    uri = uri.replace(f"/messages/{old}", f"/messages/{new}")
+                msg["basemessageuri"] = uri
+
+    return messagegroups
+
+
+def _normalize_refs(obj: object) -> object:
+    """Recursively replace '#/'-prefixed XID references with absolute '/' XIDs.
+
+    The xreg document format uses JSON-Pointer-style '#/collection/id' as
+    local references within a single file.  When importing into xrserver the
+    registry becomes the root context, so '#/messagegroups/foo' must become
+    the absolute XID '/messagegroups/foo'.  xrserver rejects the '#/' form.
+    """
+    if isinstance(obj, str):
+        return obj[1:] if obj.startswith("#/") else obj
+    if isinstance(obj, list):
+        return [_normalize_refs(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _normalize_refs(v) for k, v in obj.items()}
+    return obj
+
+
+# Maps old/deprecated attribute names → current spec attribute names at the
+# message-definition level.  These renames happened in the spec after
+# xrcg 0.10.x was released; xrserver now only accepts the new names.
+_MESSAGE_ATTR_RENAMES: dict[str, str] = {
+    "basemessageurl": "basemessageuri",
+    "basemessage": "basemessageuri",
+    "protocolmetadata": "protocoloptions",
+}
+
+# AMQP protocoloptions keys use hyphens in the spec model but were emitted
+# with underscores by older xrcg versions.
+_AMQP_PO_RENAMES: dict[str, str] = {
+    "application_properties": "application-properties",
+    "message_annotations": "message-annotations",
+    "delivery_annotations": "delivery-annotations",
+}
+
+# MQTT protocoloptions may carry a legacy 'options' sub-object whose keys
+# map to the top-level protocoloptions attributes required by the spec model.
+_MQTT_OPTIONS_MAP: dict[str, str] = {
+    "topic": "topic_name",
+    "qos": "qos",
+    "retain": "retain",
+}
+
+# The spec model's envelopemetadata tightly constrains the 'type' value for
+# certain CloudEvents attributes.  xrcg sometimes emits incorrect types; these
+# overrides force the correct values regardless of what xrcg generated.
+_EM_TYPE_OVERRIDES: dict[str, str] = {
+    "time": "timestamp",        # RFC3339 timestamp — the ONLY allowed type
+    "dataschema": "uritemplate",  # URI template — the ONLY allowed type
+}
+
+# Sub-attributes inside envelopemetadata entries that are not defined in the
+# spec model and must be stripped before import.
+_EM_INVALID_SUBATTRS: frozenset[str] = frozenset({"name"})
+
+
+import re as _re
+
+_CAMEL_RE = _re.compile(r"(?<=[a-z0-9])([A-Z])")
+
+
+def _camel_to_kebab(name: str) -> str:
+    """Convert camelCase or PascalCase to kebab-case (all lowercase)."""
+    return _CAMEL_RE.sub(r"-\1", name).lower()
+
+
+def _normalize_protocol_options(msg: dict) -> None:
+    """Fix protocol-specific keys inside ``protocoloptions`` in-place."""
+    po = msg.get("protocoloptions")
+    if not isinstance(po, dict):
+        return
+    protocol = msg.get("protocol", "")
+
+    if protocol == "AMQP/1.0":
+        for old, new in _AMQP_PO_RENAMES.items():
+            if old in po:
+                po[new] = po.pop(old)
+        # AMQP application-properties map keys must match namecharset=extended
+        # (^[a-z0-9][a-z0-9_.:\-]{0,62}$).  Convert camelCase → kebab-case.
+        ap = po.get("application-properties")
+        if isinstance(ap, dict):
+            fixed: dict = {}
+            for k, v in ap.items():
+                normalized_k = _camel_to_kebab(k)
+                fixed[normalized_k] = v
+            po["application-properties"] = fixed
+
+    elif protocol == "KAFKA":
+        # Older xrcg wrapped scalar protocoloptions values as objects with
+        # {type, value, description}.  The spec model expects direct scalar values.
+        for scalar_key in ("key", "key_base64", "topic", "partition"):
+            val = po.get(scalar_key)
+            if isinstance(val, dict) and "value" in val:
+                po[scalar_key] = val["value"]
+
+    elif protocol.startswith("MQTT/"):
+        # Flatten legacy 'options' wrapper into the parent dict
+        inner = po.pop("options", None)
+        if isinstance(inner, dict):
+            for inner_key, outer_key in _MQTT_OPTIONS_MAP.items():
+                if inner_key in inner and outer_key not in po:
+                    po[outer_key] = inner[inner_key]
+            # Preserve unmapped keys that are already valid spec names
+            for k, v in inner.items():
+                if k not in _MQTT_OPTIONS_MAP and k not in po:
+                    po[k] = v
+
+
+def _normalize_message_attrs(messagegroups: dict) -> dict:
+    """Rename deprecated attributes inside every message definition.
+
+    Applies :data:`_MESSAGE_ATTR_RENAMES` at the message-definition level,
+    normalises the bare ``id`` field to ``messageid``, and fixes
+    protocol-specific ``protocoloptions`` key names.
+    """
+    for mg in messagegroups.values():
+        for msg_id, msg in mg.get("messages", {}).items():
+            # Rename deprecated top-level message attributes
+            for old, new in _MESSAGE_ATTR_RENAMES.items():
+                if old in msg:
+                    msg[new] = msg.pop(old)
+            # Normalise bare 'id' → 'messageid'; also ensure messageid always
+            # matches the message's own map key (xrserver requires this).
+            if "id" in msg and "messageid" not in msg:
+                msg["messageid"] = msg.pop("id")
+            msg["messageid"] = msg_id
+            # Fix protocol-specific protocoloptions keys
+            _normalize_protocol_options(msg)
+            # Fix invalid envelopemetadata attribute type values.
+            # The spec model constrains which types are valid per CloudEvents
+            # attribute; xrcg sometimes emits wrong types (e.g. 'uritemplate'
+            # for 'time' which must always be 'timestamp').
+            em = msg.get("envelopemetadata")
+            if isinstance(em, dict):
+                for attr, forced_type in _EM_TYPE_OVERRIDES.items():
+                    if attr in em and isinstance(em[attr], dict):
+                        em[attr]["type"] = forced_type
+                # Strip sub-attributes that are not in the spec model
+                # (valid sub-attrs: description, required, type, value)
+                for ce_attr, ce_val in em.items():
+                    if isinstance(ce_val, dict):
+                        for invalid_key in _EM_INVALID_SUBATTRS:
+                            ce_val.pop(invalid_key, None)
+            # 'envelopemetadata'/'envelopeoptions' are only valid sibling
+            # attributes of envelope="CloudEvents/1.0"; transport-variant
+            # messages that reference a base via basemessageuri may omit
+            # envelope, causing xrserver to reject the attribute.
+            if ("envelopemetadata" in msg or "envelopeoptions" in msg) and "envelope" not in msg:
+                msg["envelope"] = "CloudEvents/1.0"
+    return messagegroups
 
 
 def merge(pattern: str, repo_root: Path) -> dict:
@@ -58,15 +262,21 @@ def merge(pattern: str, repo_root: Path) -> dict:
         for key in COLLECTION_KEYS:
             if key not in doc:
                 continue
-            overlap = set(doc[key]) & set(combined[key])
+            normalized = _normalize_refs(doc[key])
+            overlap = set(normalized) & set(combined[key])
             if overlap:
                 sys.exit(
                     f"ID collision in '{key}' when merging {path}: "
                     f"duplicate IDs {sorted(overlap)}"
                 )
-            combined[key].update(doc[key])
+            combined[key].update(normalized)
 
         print(f"  merged: {path.relative_to(repo_root)}", file=sys.stderr)
+
+    # Fix deprecated / renamed attributes before returning
+    if "messagegroups" in combined:
+        _normalize_message_attrs(combined["messagegroups"])
+        _apply_id_limits(combined["messagegroups"])
 
     # Drop empty collections so the import body is clean
     return {k: v for k, v in combined.items() if v}

--- a/tools/merge-xreg.py
+++ b/tools/merge-xreg.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Merge all *.xreg.json manifests in this repo into one xRegistry import document.
+
+Each source directory contains a single  <source>/xreg/*.xreg.json  file whose
+top-level keys are the xRegistry collection names:
+
+    endpoints      – Kafka / MQTT / AMQP endpoint declarations
+    messagegroups  – CloudEvents message group definitions
+    schemagroups   – JSON Structure (and other) schema groups
+
+This script merges those collections by shallow-merging at the collection level.
+Every source uses its own namespace-prefixed IDs (e.g. "DE.Pegelonline",
+"IO.AISstream") so there are no key collisions in a well-formed repo.
+
+Usage
+-----
+  # Write to stdout
+  python3 tools/merge-xreg.py
+
+  # Write to file
+  python3 tools/merge-xreg.py -o /tmp/combined.json
+
+  # Custom glob pattern (relative to repo root)
+  python3 tools/merge-xreg.py --pattern "*/xreg/*.xreg.json" -o combined.json
+
+Exit codes
+----------
+  0  – success
+  1  – no files matched / ID collision detected / JSON parse error
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from pathlib import Path
+
+COLLECTION_KEYS = ("endpoints", "messagegroups", "schemagroups")
+
+DEFAULT_PATTERN = "*/xreg/*.xreg.json"
+
+
+def merge(pattern: str, repo_root: Path) -> dict:
+    files = sorted(repo_root.glob(pattern))
+    if not files:
+        sys.exit(f"No files matched pattern: {pattern!r} under {repo_root}")
+
+    combined: dict[str, dict] = {k: {} for k in COLLECTION_KEYS}
+
+    for path in files:
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            sys.exit(f"JSON parse error in {path}: {exc}")
+
+        for key in COLLECTION_KEYS:
+            if key not in doc:
+                continue
+            overlap = set(doc[key]) & set(combined[key])
+            if overlap:
+                sys.exit(
+                    f"ID collision in '{key}' when merging {path}: "
+                    f"duplicate IDs {sorted(overlap)}"
+                )
+            combined[key].update(doc[key])
+
+        print(f"  merged: {path.relative_to(repo_root)}", file=sys.stderr)
+
+    # Drop empty collections so the import body is clean
+    return {k: v for k, v in combined.items() if v}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge all *.xreg.json manifests into one xRegistry import document.",
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_PATTERN,
+        help=f"Glob pattern relative to repo root (default: {DEFAULT_PATTERN!r})",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="-",
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root directory (default: parent of this script's tools/ dir)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.root) if args.root else Path(__file__).resolve().parent.parent
+
+    result = merge(args.pattern, repo_root)
+
+    output_json = json.dumps(result, indent=2, ensure_ascii=False) + "\n"
+
+    if args.output == "-":
+        sys.stdout.write(output_json)
+    else:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output_json, encoding="utf-8")
+        print(
+            f"Wrote {len(result.get('endpoints', {})):,} endpoints, "
+            f"{len(result.get('messagegroups', {})):,} messagegroups, "
+            f"{len(result.get('schemagroups', {})):,} schemagroups "
+            f"→ {out_path}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## xRegistry Static Site Builder

Merges all \*/xreg/*.xreg.json\ manifests from the repo, imports them into \xrserver-all\ (Docker, embedded MySQL), exports a static file tree via \xr download\, and pushes the result to \egistry/\ on the \ghpages\ branch.

**Live URL (once merged):** https://clemensv.github.io/real-time-sources/registry/

### What this adds

| File | Purpose |
|------|---------|
| \	ools/merge-xreg.py\ | Merges 101+ \*.xreg.json\ files into one import document |
| \.github/workflows/build-xregistry-site.yml\ | CI pipeline: merge → xrserver → import → \xr download\ → ghpages |
| \.github/workflows/update-ghpages-catalog.yml\ | Added \concurrency: ghpages\ to prevent push races |

### Verified end-to-end locally

Full Docker pipeline tested and confirmed working:
- **354 endpoints**, **421 messagegroups**, **189 schemagroups** imported
- **25,520 static files** generated by \xr download\

### Normalizations applied by merge-xreg.py

The xreg files in this repo were authored against an older version of the spec model. \merge-xreg.py\ normalizes them at merge time so xrserver accepts the import:

| Fix | Detail |
|-----|--------|
| \asemessageurl\ → \asemessageuri\ | Spec attribute rename |
| \protocolmetadata\ → \protocoloptions\ | Spec attribute rename |
| AMQP \pplication_properties\ → \pplication-properties\ | Hyphen charset required |
| AMQP camelCase app-property keys → kebab-case | \
amecharset=extended\ constraint |
| KAFKA \key\ unwrapped from \{type,value}\ object → direct string | Spec model change |
| MQTT \options\ wrapper flattened | Legacy xrcg output shape |
| \nvelopemetadata.time.type\ forced to \	imestamp\ | Model enum constraint |
| \nvelope: CloudEvents/1.0\ added when implied | Required for \nvelopemetadata\ sibling to be valid |
| Message IDs truncated to ≤63 chars (hash suffix) | Works around xrserver collection-key truncation bug |

### Known xrserver issues (workaround in place)

- **Collection key truncation bug**: xrserver silently truncates map keys to 64 chars in collection listings but entity lookup requires the full ID. Worked around by limiting all message IDs to ≤63 chars in the merge script.
- **Schema cross-reference validation**: Avro schemas use cross-file type references that xrserver cannot resolve in isolation. Schema \alidateformat\ is disabled via \modelsource\ PUT (discovery registry only, not validation service).