### PR TITLE
xreg conformance: set explicit CloudEvents envelope on MQTT/AMQP transport variants (v2)

### DIFF
--- a/aviationweather/xreg/aviationweather.xreg.json
+++ b/aviationweather/xreg/aviationweather.xreg.json
@@ -148,7 +148,8 @@
             "topic_name": "aviation/intl/noaa/aviationweather/{icao_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "gov.noaa.aviationweather.mqtt.Metar": {
           "name": "Metar",
@@ -170,7 +171,8 @@
             "topic_name": "aviation/intl/noaa/aviationweather/{icao_id}/metar",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "gov.noaa.aviationweather.mqtt.Sigmet": {
           "name": "Sigmet",
@@ -192,7 +194,8 @@
             "topic_name": "aviation/intl/noaa/aviationweather/sigmets/{region}/{sigmet_id}/sigmet",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -224,7 +227,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "gov.noaa.aviationweather.amqp.Metar": {
           "name": "Metar",
@@ -251,7 +255,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "gov.noaa.aviationweather.amqp.Sigmet": {
           "name": "Sigmet",
@@ -278,7 +283,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/bom-australia/xreg/bom_australia.xreg.json
+++ b/bom-australia/xreg/bom_australia.xreg.json
@@ -175,7 +175,8 @@
             "topic_name": "weather/au/bom/bom-australia/{state}/{station_wmo}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "AU.Gov.BOM.Weather.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -197,7 +198,8 @@
             "topic_name": "weather/au/bom/bom-australia/{state}/{station_wmo}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -235,7 +237,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "AU.Gov.BOM.Weather.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -268,7 +271,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -295,7 +299,8 @@
             "topic_name": "alerts/au/bom/bom-australia/{state}/{severity}/{warning_id}/warning",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -327,7 +332,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/dwd-pollenflug/xreg/dwd_pollenflug.xreg.json
+++ b/dwd-pollenflug/xreg/dwd_pollenflug.xreg.json
@@ -134,7 +134,8 @@
             "topic_name": "air-quality/de/dwd/dwd-pollenflug/{region_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Pollenflug.mqtt.PollenForecast": {
           "name": "PollenForecast",
@@ -156,7 +157,8 @@
             "topic_name": "air-quality/de/dwd/dwd-pollenflug/{region_id}/{pollen_type}/pollen-forecast",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -188,7 +190,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Pollenflug.amqp.PollenForecast": {
           "name": "PollenForecast",
@@ -215,7 +218,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/dwd/xreg/dwd.xreg.json
+++ b/dwd/xreg/dwd.xreg.json
@@ -430,7 +430,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.AirTemperature10Min": {
           "name": "AirTemperature10Min",
@@ -452,7 +453,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/air-temperature-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.Precipitation10Min": {
           "name": "Precipitation10Min",
@@ -474,7 +476,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/precipitation-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.Wind10Min": {
           "name": "Wind10Min",
@@ -496,7 +499,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/wind-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.Solar10Min": {
           "name": "Solar10Min",
@@ -518,7 +522,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/solar-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.HourlyObservation": {
           "name": "HourlyObservation",
@@ -540,7 +545,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/hourly-observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.ExtremeWind10Min": {
           "name": "ExtremeWind10Min",
@@ -562,7 +568,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/extreme-wind-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.mqtt.ExtremeTemperature10Min": {
           "name": "ExtremeTemperature10Min",
@@ -584,7 +591,8 @@
             "topic_name": "weather/de/dwd/dwd/{state}/{station_id}/extreme-temperature-10min",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -622,7 +630,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.AirTemperature10Min": {
           "name": "AirTemperature10Min",
@@ -655,7 +664,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.Precipitation10Min": {
           "name": "Precipitation10Min",
@@ -688,7 +698,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.Wind10Min": {
           "name": "Wind10Min",
@@ -721,7 +732,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.Solar10Min": {
           "name": "Solar10Min",
@@ -754,7 +766,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.HourlyObservation": {
           "name": "HourlyObservation",
@@ -787,7 +800,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.ExtremeWind10Min": {
           "name": "ExtremeWind10Min",
@@ -820,7 +834,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.CDC.amqp.ExtremeTemperature10Min": {
           "name": "ExtremeTemperature10Min",
@@ -853,7 +868,8 @@
                 "description": "Routing value for state."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -880,7 +896,8 @@
             "topic_name": "alerts/de/dwd/dwd/{state}/{severity}/{identifier}/alert",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -912,7 +929,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -939,7 +957,8 @@
             "topic_name": "weather/de/dwd/dwd/catalogs/{kind}/catalog",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Radar.mqtt.RadarFileProduct": {
           "name": "RadarFileProduct",
@@ -961,7 +980,8 @@
             "topic_name": "weather/de/dwd/dwd/products/radar/{product_type}/{file_id}/file",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -993,7 +1013,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Radar.amqp.RadarFileProduct": {
           "name": "RadarFileProduct",
@@ -1020,7 +1041,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -1047,7 +1069,8 @@
             "topic_name": "weather/de/dwd/dwd/catalogs/{kind}/catalog",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Forecast.mqtt.IconD2ForecastFile": {
           "name": "IconD2ForecastFile",
@@ -1069,7 +1092,8 @@
             "topic_name": "weather/de/dwd/dwd/products/icon-d2/{variable}/{file_id}/file",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -1101,7 +1125,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "DE.DWD.Forecast.amqp.IconD2ForecastFile": {
           "name": "IconD2ForecastFile",
@@ -1128,7 +1153,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/environment-canada/xreg/environment_canada.xreg.json
+++ b/environment-canada/xreg/environment_canada.xreg.json
@@ -134,7 +134,8 @@
             "topic_name": "weather/ca/eccc/environment-canada/{province}/{msc_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "CA.Gov.ECCC.Weather.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -156,7 +157,8 @@
             "topic_name": "weather/ca/eccc/environment-canada/{province}/{msc_id}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -194,7 +196,8 @@
                 "description": "Routing value for province."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "CA.Gov.ECCC.Weather.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -227,7 +230,8 @@
                 "description": "Routing value for province."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/geosphere-austria/xreg/geosphere-austria.xreg.json
+++ b/geosphere-austria/xreg/geosphere-austria.xreg.json
@@ -137,7 +137,8 @@
             "topic_name": "weather/at/geosphere/geosphere-austria/{bundesland}/{station_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "at.geosphere.tawes.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -160,7 +161,8 @@
             "topic_name": "weather/at/geosphere/geosphere-austria/{bundesland}/{station_id}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -199,7 +201,8 @@
                 "description": "Routing value for bundesland."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "at.geosphere.tawes.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -233,7 +236,8 @@
                 "description": "Routing value for bundesland."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/hko-hong-kong/xreg/hko_hong_kong.xreg.json
+++ b/hko-hong-kong/xreg/hko_hong_kong.xreg.json
@@ -134,7 +134,8 @@
             "topic_name": "weather/hk/hko/hko-hong-kong/{district}/{place_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "HK.Gov.HKO.Weather.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -156,7 +157,8 @@
             "topic_name": "weather/hk/hko/hko-hong-kong/{district}/{place_id}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -194,7 +196,8 @@
                 "description": "Routing value for district."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "HK.Gov.HKO.Weather.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -227,7 +230,8 @@
                 "description": "Routing value for district."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/jma-japan/xreg/jma_japan.xreg.json
+++ b/jma-japan/xreg/jma_japan.xreg.json
@@ -115,7 +115,8 @@
             "topic_name": "weather/jp/jma/jma-japan/{office}/{bulletin_id}/bulletin",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -147,7 +148,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/kmi-belgium/xreg/kmi_belgium.xreg.json
+++ b/kmi-belgium/xreg/kmi_belgium.xreg.json
@@ -134,7 +134,8 @@
             "topic_name": "weather/be/kmi/kmi-belgium/{region}/{station_code}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "BE.Gov.KMI.Weather.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -156,7 +157,8 @@
             "topic_name": "weather/be/kmi/kmi-belgium/{region}/{station_code}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -194,7 +196,8 @@
                 "description": "Routing value for region."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "BE.Gov.KMI.Weather.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -227,7 +230,8 @@
                 "description": "Routing value for region."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/noaa-nws/xreg/noaa_nws.xreg.json
+++ b/noaa-nws/xreg/noaa_nws.xreg.json
@@ -218,7 +218,8 @@
             "topic_name": "alerts/us/noaa/noaa-nws/{state}/{severity}/{event_type}/{alert_id}/alert",
             "qos": 1,
             "retain": false
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -250,7 +251,8 @@
               }
             },
             "application-properties": {}
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -277,7 +279,8 @@
             "topic_name": "weather/us/noaa/noaa-nws/{state}/{zone_id}/{station_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "Microsoft.OpenData.US.NOAA.NWS.Observations.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -299,7 +302,8 @@
             "topic_name": "weather/us/noaa/noaa-nws/{state}/{zone_id}/{station_id}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -342,7 +346,8 @@
                 "description": "Routing value for zone_id."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "Microsoft.OpenData.US.NOAA.NWS.Observations.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -380,7 +385,8 @@
                 "description": "Routing value for zone_id."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/smhi-weather/xreg/smhi_weather.xreg.json
+++ b/smhi-weather/xreg/smhi_weather.xreg.json
@@ -134,7 +134,8 @@
             "topic_name": "weather/se/smhi/smhi-weather/{lan}/{station_id}/info",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "SE.Gov.SMHI.Weather.mqtt.WeatherObservation": {
           "name": "WeatherObservation",
@@ -156,7 +157,8 @@
             "topic_name": "weather/se/smhi/smhi-weather/{lan}/{station_id}/observation",
             "qos": 1,
             "retain": true
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },
@@ -194,7 +196,8 @@
                 "description": "Routing value for lan."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         },
         "SE.Gov.SMHI.Weather.amqp.WeatherObservation": {
           "name": "WeatherObservation",
@@ -227,7 +230,8 @@
                 "description": "Routing value for lan."
               }
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     }

--- a/tests/test_xreg_transport_variant_envelopes.py
+++ b/tests/test_xreg_transport_variant_envelopes.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_transport_variants_with_envelope_metadata_set_cloudevents_envelope():
+    repo_root = Path(__file__).resolve().parents[1]
+    errors: list[str] = []
+
+    for manifest_path in sorted(repo_root.glob("*/xreg/*.xreg.json")):
+        document = json.loads(manifest_path.read_text(encoding="utf-8"))
+        messagegroups = document.get("messagegroups") or {}
+        for messagegroup_id, messagegroup in messagegroups.items():
+            messages = messagegroup.get("messages") or {}
+            for message_id, message in messages.items():
+                protocol = message.get("protocol")
+                if protocol not in {"MQTT/5.0", "AMQP/1.0"}:
+                    continue
+                if "envelopemetadata" not in message and "envelopeoptions" not in message:
+                    continue
+                if message.get("envelope") != "CloudEvents/1.0":
+                    errors.append(
+                        f"{manifest_path.relative_to(repo_root).as_posix()}::{messagegroup_id}/{message_id}"
+                    )
+
+    assert not errors, (
+        "MQTT/AMQP transport-variant messages with envelopemetadata/envelopeoptions must set "
+        '"envelope": "CloudEvents/1.0". Offenders:\n' + "\n".join(errors)
+    )

--- a/wikimedia-eventstreams/xreg/wikimedia_eventstreams.xreg.json
+++ b/wikimedia-eventstreams/xreg/wikimedia_eventstreams.xreg.json
@@ -111,7 +111,8 @@
               "qos": 0,
               "retain": false
             }
-          }
+          },
+          "envelope": "CloudEvents/1.0"
         }
       }
     },


### PR DESCRIPTION
Rebased and reopened version of #471.

## Problem

xrserver validates message entities independently and does not resolve \asemessageuri\ inheritance, so transport variants carrying \nvelopemetadata\ or \nvelopeoptions\ were rejected when \nvelope\ was omitted.

According to the xRegistry spec model:
- \nvelopemetadata\ and \nvelopeoptions\ are **conditional attributes** — only valid when \nvelope == "CloudEvents/1.0"\
- xrserver validates each message entity **in isolation** without resolving \asemessageuri\ inheritance
- Result: xrserver rejects imports with *"An unknown attribute (envelopemetadata)"* when \nvelope\ is omitted

## Solution

Added \"envelope": "CloudEvents/1.0"\ to all transport-variant message definitions with protocol \MQTT/5.0\ or \AMQP/1.0\ that define \nvelopemetadata\ or \nvelopeoptions\.

## Changes

- **12 manifests updated**, covering **71 message definitions**
- Added conformance test (\	ests/test_xreg_transport_variant_envelopes.py\) to enforce this requirement
- Rebased onto main to incorporate all 8 merged spec-drift PRs (#468-#470, #472-#476)

## Representative change

\\\json
{
  "name": "RecentChange",
  "basemessageuri": "/messagegroups/Wikimedia.EventStreams/messages/Wikimedia.EventStreams.RecentChange",
  "protocol": "MQTT/5.0",
  "envelope": "CloudEvents/1.0",
  "envelopemetadata": {
    "subject": {
      "value": "{wiki}/{namespace}/{event_id}",
      "type": "uritemplate"
    }
  },
  "protocoloptions": {
    "options": {
      "topic": "social/intl/wikimedia/wikimedia-eventstreams/{wiki}/{namespace}/{event_id}/recent-change",
      "qos": 0,
      "retain": false
    }
  }
}
\\\

Fixes #462
Supersedes #471