### PR TITLE
Fix australia-wildfires audit findings

### DIFF
--- a/feeders/australia-wildfires/azure-template-with-eventhub.json
+++ b/feeders/australia-wildfires/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives Australia Wildfires CloudEvents."
       }
     },
     "location": {

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -343,6 +343,12 @@
     },
     {
       "dir": "feeders/australia-wildfires",
+      "image": "australia-wildfires-kafka",
+      "file": "Dockerfile",
+      "module": "australia_wildfires"
+    },
+    {
+      "dir": "feeders/australia-wildfires",
       "image": "australia-wildfires-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "australia_wildfires_mqtt"
@@ -1723,6 +1729,13 @@
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
       "test_class": "TestParisBicycleCountersMqttDockerFlow"
+    },
+    {
+      "dir": "feeders/australia-wildfires",
+      "image": "australia-wildfires-kafka",
+      "file": "Dockerfile",
+      "test_file": "test_docker_kafka_flow.py",
+      "test_class": "TestAustraliaWildfiresDockerFlow"
     },
     {
       "dir": "feeders/australia-wildfires",


### PR DESCRIPTION
## Summary
- add the missing Kafka build + flow rows for `australia-wildfires` to `tests/docker_e2e/matrix.json`
- replace the stub Event Hubs SKU description in `feeders/australia-wildfires/azure-template-with-eventhub.json`

Closes #608.

## Note on the original audit issue
- The `missing xreg` and `missing kql` bullets in #608 were audit false positives: this feeder already ships `feeders/australia-wildfires/xreg/australia_wildfires.xreg.json` and `feeders/australia-wildfires/kql/australia_wildfires.kql` under the source's existing underscore naming convention.
- I corrected the local audit runner before validating this PR so the remaining scope reflects only real feeder defects.

## Validation
- `python -m pytest feeders/australia-wildfires/tests -q --maxfail=1`
- `pwsh -NoProfile -File tools/validate-arm-templates.ps1 -FeederSlug australia-wildfires`
- `python C:\Users\clemensv\.copilot\session-state\cb5ea344-87f5-406e-a13a-a66811763074\files\run_objective_release_audit.py --slug australia-wildfires`
- `python -m pytest tests/docker_e2e/test_docker_kafka_flow.py -k TestAustraliaWildfiresDockerFlow -q`
- `pwsh -NoProfile -File tools/verify-arm-template.ps1 -FeederSlug australia-wildfires -Variant eventhub`

## Canary evidence
- `australia-wildfires:eventhub` canary: PASS (`Deployment state: Succeeded`, `Container group is Running`, `Container log evidence: Sent 48 fire incident events`)
