### PR TITLE
Fix autobahn audit findings

### DIFF
--- a/feeders/autobahn/azure-template-with-eventhub.json
+++ b/feeders/autobahn/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives Autobahn traffic CloudEvents."
       }
     },
     "location": {

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -265,6 +265,12 @@
     },
     {
       "dir": "feeders/autobahn",
+      "image": "autobahn-kafka",
+      "file": "Dockerfile",
+      "module": "autobahn"
+    },
+    {
+      "dir": "feeders/autobahn",
       "image": "autobahn-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "autobahn_mqtt"
@@ -1632,6 +1638,13 @@
     {
       "dir": "feeders/xceed",
       "test_class": "TestXceedDockerFlow"
+    },
+    {
+      "dir": "feeders/autobahn",
+      "image": "autobahn-kafka",
+      "file": "Dockerfile",
+      "test_file": "test_docker_kafka_flow.py",
+      "test_class": "TestAutobahnDockerFlow"
     },
     {
       "dir": "feeders/autobahn",


### PR DESCRIPTION
## Summary
- add the missing Kafka build + flow rows for `autobahn` to `tests/docker_e2e/matrix.json`
- replace the stub Event Hubs SKU description in `feeders/autobahn/azure-template-with-eventhub.json`

Closes #609.

## Validation
- `python -m pytest feeders/autobahn/tests -q --maxfail=1`
- `pwsh -NoProfile -File tools/validate-arm-templates.ps1 -FeederSlug autobahn`
- `python C:\Users\clemensv\.copilot\session-state\cb5ea344-87f5-406e-a13a-a66811763074\files\run_objective_release_audit.py --slug autobahn`
- `python -m pytest tests/docker_e2e/test_docker_kafka_flow.py -k TestAutobahnDockerFlow -q`
- `pwsh -NoProfile -File tools/verify-arm-template.ps1 -FeederSlug autobahn -Variant eventhub`

## Canary evidence
- `autobahn:eventhub` canary: PASS (`Deployment state: Succeeded`, `Container group is Running`, `Event Hubs receive evidence: received=4`)
