### PR TITLE
Fix aviationweather audit findings

### DIFF
--- a/feeders/aviationweather/CONTAINER.md
+++ b/feeders/aviationweather/CONTAINER.md
@@ -132,6 +132,7 @@ docker run --rm   -v "$PWD/state:/state"   -e AVIATIONWEATHER_LAST_POLLED_FILE=/
 | Variable | Description |
 |---|---|
 | `AVIATIONWEATHER_LAST_POLLED_FILE` | Path to the dedupe/resume state file. Mount `/state` so it survives restarts. |
+| `AVIATIONWEATHER_STATIONS` | Comma-separated upstream station identifiers to include; empty means all available stations. |
 | `POLLING_INTERVAL` | Seconds between polling cycles. |
 
 ### Kafka image

--- a/feeders/aviationweather/aviationweather/aviationweather.py
+++ b/feeders/aviationweather/aviationweather/aviationweather.py
@@ -317,6 +317,8 @@ class AviationWeatherPoller:
             severity=cls.safe_int(raw.get("severity")),
             raw_sigmet=raw.get("rawAirSigmet"),
             coords=coords_str,
+            sigmet_id=series_id.lower(),
+            region=icao_id.lower(),
         )
 
     @classmethod
@@ -358,6 +360,8 @@ class AviationWeatherPoller:
             severity=None,
             raw_sigmet=raw.get("rawSigmet"),
             coords=coords_str,
+            sigmet_id=series_id.lower(),
+            region=icao_id.lower(),
         )
 
     @staticmethod

--- a/feeders/aviationweather/azure-template-with-eventhub.json
+++ b/feeders/aviationweather/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives AviationWeather.gov CloudEvents."
       }
     },
     "location": {
@@ -31,6 +31,13 @@
       "metadata": {
         "description": "Azure region for all resources."
       }
+    },
+    "aviationweatherStations": {
+      "type": "string",
+      "metadata": {
+        "description": "Comma-separated upstream station identifiers to include; empty means all available stations."
+      },
+      "defaultValue": "KJFK,KLAX,KORD,KATL,EGLL,LFPG,EDDF,RJTT,YSSY,ZBAA"
     }
   },
   "variables": {
@@ -175,6 +182,10 @@
                 {
                   "name": "AVIATIONWEATHER_LAST_POLLED_FILE",
                   "value": "/mnt/bridge-state/aviationweather_last_polled.json"
+                },
+                {
+                  "name": "AVIATIONWEATHER_STATIONS",
+                  "value": "[parameters('aviationweatherStations')]"
                 },
                 {
                   "name": "PYTHONUNBUFFERED",

--- a/feeders/aviationweather/azure-template.json
+++ b/feeders/aviationweather/azure-template.json
@@ -27,6 +27,13 @@
       "metadata": {
         "description": "Azure region for all resources."
       }
+    },
+    "aviationweatherStations": {
+      "type": "string",
+      "metadata": {
+        "description": "Comma-separated upstream station identifiers to include; empty means all available stations."
+      },
+      "defaultValue": "KJFK,KLAX,KORD,KATL,EGLL,LFPG,EDDF,RJTT,YSSY,ZBAA"
     }
   },
   "variables": {
@@ -124,6 +131,10 @@
                 {
                   "name": "AVIATIONWEATHER_LAST_POLLED_FILE",
                   "value": "/mnt/bridge-state/aviationweather_last_polled.json"
+                },
+                {
+                  "name": "AVIATIONWEATHER_STATIONS",
+                  "value": "[parameters('aviationweatherStations')]"
                 },
                 {
                   "name": "PYTHONUNBUFFERED",

--- a/feeders/aviationweather/tests/test_aviationweather_unit.py
+++ b/feeders/aviationweather/tests/test_aviationweather_unit.py
@@ -462,6 +462,8 @@ class TestParseUsSigmet:
         assert sigmet.movement_spd == "40"
         assert sigmet.severity == 5
         assert sigmet.qualifier is None
+        assert sigmet.sigmet_id == "6w"
+        assert sigmet.region == "kkci"
         assert "2026-04-08" in sigmet.valid_time_from
         assert "2026-04-08" in sigmet.valid_time_to
 
@@ -509,6 +511,8 @@ class TestParseIntlSigmet:
         assert sigmet.movement_dir == "NE"
         assert sigmet.movement_spd == "32"
         assert sigmet.severity is None
+        assert sigmet.sigmet_id == "8"
+        assert sigmet.region == "zhwh"
 
     def test_parse_intl_sigmet_coords(self):
         sigmet = AviationWeatherPoller.parse_intl_sigmet(SAMPLE_ISIGMET_RESPONSE[0])
@@ -547,6 +551,8 @@ class TestSigmetDedupKey:
             severity=5,
             raw_sigmet="test",
             coords=None,
+            sigmet_id="6w",
+            region="kkci",
         )
         key = AviationWeatherPoller.sigmet_dedup_key(sigmet)
         assert key == "KKCI:6W:2026-04-08T19:55:00+00:00:2026-04-08T21:55:00+00:00"
@@ -560,6 +566,7 @@ class TestSigmetDedupKey:
             altitude_hi=None, altitude_low=None,
             movement_dir=None, movement_spd=None,
             severity=None, raw_sigmet=None, coords=None,
+            sigmet_id="6w", region="kkci",
         )
         sigmet2 = Sigmet(
             icao_id="KKCI", series_id="7W",
@@ -569,6 +576,7 @@ class TestSigmetDedupKey:
             altitude_hi=None, altitude_low=None,
             movement_dir=None, movement_spd=None,
             severity=None, raw_sigmet=None, coords=None,
+            sigmet_id="7w", region="kkci",
         )
         assert AviationWeatherPoller.sigmet_dedup_key(sigmet1) != AviationWeatherPoller.sigmet_dedup_key(sigmet2)
 
@@ -820,6 +828,7 @@ class TestDataclassSerialization:
             altitude_hi=32000, altitude_low=None, movement_dir="180",
             movement_spd="40", severity=5, raw_sigmet="test",
             coords='[{"lat":41.88,"lon":-123.70}]',
+            sigmet_id="6w", region="kkci",
         )
         data = json.loads(sigmet.to_json())
         assert data["icao_id"] == "KKCI"

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -1251,6 +1251,12 @@
     },
     {
       "dir": "feeders/aviationweather",
+      "image": "aviationweather-kafka",
+      "file": "Dockerfile",
+      "module": "aviationweather"
+    },
+    {
+      "dir": "feeders/aviationweather",
       "image": "aviationweather-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "aviationweather_mqtt"
@@ -2824,6 +2830,13 @@
       "dir": "feeders/uba-airdata",
       "test_class": "TestUbaAirdataAmqpDockerFlow",
       "test_file": "test_docker_amqp_flow.py"
+    },
+    {
+      "dir": "feeders/aviationweather",
+      "image": "aviationweather-kafka",
+      "file": "Dockerfile",
+      "test_file": "test_docker_kafka_flow.py",
+      "test_class": "TestAviationweatherDockerFlow"
     },
     {
       "dir": "feeders/aviationweather",


### PR DESCRIPTION
## Summary
- fix US and international SIGMET parsing so the shared `Sigmet` payload includes the required normalized routing fields `sigmet_id` and `region`
- add `AVIATIONWEATHER_STATIONS` wiring to the Kafka and Event Hubs ARM templates and document it in `feeders/aviationweather/CONTAINER.md`
- add the missing Kafka build + flow rows for `aviationweather` to `tests/docker_e2e/matrix.json`
- replace the stub Event Hubs SKU description in `feeders/aviationweather/azure-template-with-eventhub.json`

Closes #610.

## Validation
- `python -m pytest feeders/aviationweather/tests -q --maxfail=1`
- `pwsh -NoProfile -File tools/validate-arm-templates.ps1 -FeederSlug aviationweather`
- `python C:\Users\clemensv\.copilot\session-state\cb5ea344-87f5-406e-a13a-a66811763074\files\run_objective_release_audit.py --slug aviationweather`
- `python -m pytest tests/docker_e2e/test_docker_kafka_flow.py -k TestAviationweatherDockerFlow -q`
- `pwsh -NoProfile -File tools/verify-arm-template.ps1 -FeederSlug aviationweather -Variant eventhub`

## Canary evidence
- `aviationweather:eventhub` canary: PASS (`Deployment state: Succeeded`, `Container group is Running`, `Container log evidence: Sent 10 station(s) as reference data | Sent 10 new METAR(s)`)
