### PR TITLE
Fix bafu-hydro audit findings

### DIFF
--- a/feeders/bafu-hydro/azure-template-with-eventhub.json
+++ b/feeders/bafu-hydro/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives BAFU Hydro CloudEvents."
       }
     },
     "location": {

--- a/feeders/bafu-hydro/azure-template-with-servicebus.json
+++ b/feeders/bafu-hydro/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "Azure Service Bus queue name that receives BAFU Hydro AMQP messages."
       }
     },
     "imageName": {

--- a/feeders/bafu-hydro/infra/azure-template-amqp.json
+++ b/feeders/bafu-hydro/infra/azure-template-amqp.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "Azure Service Bus queue name that receives BAFU Hydro AMQP messages."
       }
     },
     "imageName": {

--- a/feeders/bafu-hydro/tests/test_bafu_hydro_unit.py
+++ b/feeders/bafu-hydro/tests/test_bafu_hydro_unit.py
@@ -200,6 +200,7 @@ class TestDataClasses:
     def test_water_level_observation_roundtrip(self):
         obs = WaterLevelObservation(
             station_id="2018",
+            water_body_name="Rhein",
             water_level=2.56,
             water_level_unit="m",
             water_level_timestamp="2023-11-14T22:13:20+00:00",
@@ -350,6 +351,7 @@ class TestProducerClient:
         prod = CHBAFUHydrologyEventProducer(mock_kafka, "bafu-topic")
         obs = WaterLevelObservation(
             station_id="2018",
+            water_body_name="Rhein",
             water_level=2.56, water_level_unit="m",
             water_level_timestamp="2023-11-14T22:13:20+00:00",
             discharge=None, discharge_unit="m3/s", discharge_timestamp="",

--- a/feeders/bafu-hydro/xreg/bafu_hydro.xreg.json
+++ b/feeders/bafu-hydro/xreg/bafu_hydro.xreg.json
@@ -261,7 +261,10 @@
                     "description": "Name of the water body the station observes (BAFU/FOEN 'water-body-name' field, e.g. 'Rhein', 'Aare', 'Bodensee'). Sourced by the bridge from the station catalog (existenz.ch /apiv1/hydro/locations endpoint, details.water-body-name) and propagated onto every observation so subscribers do not need an out-of-band catalog join to route by river / lake. Used as the {water_body_name} segment of the MQTT/UNS topic and normalized to lowercase kebab-case before publishing."
                   },
                   "water_level": {
-                    "type": "double",
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Current water level reported for the station."
                   },
                   "water_level_unit": {
@@ -269,11 +272,17 @@
                     "description": "Unit used for the water-level value."
                   },
                   "water_level_timestamp": {
-                    "type": "datetime",
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Time associated with the water-level measurement."
                   },
                   "discharge": {
-                    "type": "double",
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Current streamflow or discharge reported for the station."
                   },
                   "discharge_unit": {
@@ -281,11 +290,17 @@
                     "description": "Unit used for the discharge value."
                   },
                   "discharge_timestamp": {
-                    "type": "datetime",
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Time associated with the discharge measurement."
                   },
                   "water_temperature": {
-                    "type": "double",
+                    "type": [
+                      "double",
+                      "null"
+                    ],
                     "description": "Current water temperature reported for the station."
                   },
                   "water_temperature_unit": {
@@ -293,7 +308,10 @@
                     "description": "Unit used for the water-temperature value."
                   },
                   "water_temperature_timestamp": {
-                    "type": "datetime",
+                    "type": [
+                      "datetime",
+                      "null"
+                    ],
                     "description": "Time associated with the water-temperature measurement."
                   }
                 },

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -75,6 +75,12 @@
     },
     {
       "dir": "feeders/bafu-hydro",
+      "image": "bafu-hydro-kafka",
+      "file": "Dockerfile",
+      "module": "bafu_hydro"
+    },
+    {
+      "dir": "feeders/bafu-hydro",
       "image": "bafu-hydro-mqtt",
       "file": "Dockerfile.mqtt",
       "module": "bafu_hydro_mqtt"
@@ -1469,6 +1475,13 @@
       "file": "Dockerfile.amqp",
       "test_file": "test_docker_amqp_flow.py",
       "test_class": "TestBfsOdlAmqpDockerFlow"
+    },
+    {
+      "dir": "feeders/bafu-hydro",
+      "image": "bafu-hydro-kafka",
+      "file": "Dockerfile",
+      "test_file": "test_docker_kafka_flow.py",
+      "test_class": "TestBafuHydroDockerFlow"
     },
     {
       "dir": "feeders/bafu-hydro",


### PR DESCRIPTION
## Summary
- add the missing Kafka build + flow rows for `bafu-hydro` to `tests/docker_e2e/matrix.json`
- replace the stub ARM descriptions for the Event Hubs SKU and the Service Bus / AMQP `queueName` parameters
- update the direct `WaterLevelObservation(...)` unit-test fixtures to include the now-required `water_body_name`
- relax the `CH.BAFU.Hydrology.WaterLevelObservation` JsonStructure schema so measurement values/timestamps can be `null`, matching the actual runtime output and the already-nullable Avro schema

Closes #611.

## Note on the original audit issue
- The `missing xreg` and `missing kql` bullets in #611 were audit false positives: this feeder already ships `feeders/bafu-hydro/xreg/bafu_hydro.xreg.json` and `feeders/bafu-hydro/kql/bafu_hydro.kql` under the source's underscore naming convention.

## Validation
- `python -m pytest feeders/bafu-hydro/tests -q --maxfail=1`
- `pwsh -NoProfile -File tools/validate-arm-templates.ps1 -FeederSlug bafu-hydro`
- `python C:\Users\clemensv\.copilot\session-state\cb5ea344-87f5-406e-a13a-a66811763074\files\run_objective_release_audit.py --slug bafu-hydro`
- `python -m pytest tests/docker_e2e/test_docker_kafka_flow.py -k TestBAFUHydroDockerFlow -q`
- `pwsh -NoProfile -File tools/verify-arm-template.ps1 -FeederSlug bafu-hydro -Variant eventhub`
- `pwsh -NoProfile -File tools/verify-arm-template.ps1 -FeederSlug bafu-hydro -Variant servicebus`

## Canary evidence
- `bafu-hydro:eventhub` canary: PASS (`Deployment state: Succeeded`, `Container group is Running`, `Container log evidence: Sent 246 station events | Sent 226 observation events`)
- `bafu-hydro:servicebus` canary: PASS (`Deployment state: Succeeded`, `Container group is Running`, `Service Bus queue evidence: 472 active message(s)`)
