### PR TITLE
Add ENTSO-E Fabric map + dashboard to deployment scripts

### DIFF
--- a/feeders/entsoe/entsoe_core/entsoe_core/acquisition.py
+++ b/feeders/entsoe/entsoe_core/entsoe_core/acquisition.py
@@ -26,21 +26,187 @@ USER_AGENT = os.environ.get("USER_AGENT") or (
 BASE_URL = "https://web-api.tp.entsoe.eu/api"
 
 DEFAULT_DOMAINS = [
-    "10YDE-AT-LU---Q", "10YFR-RTE------C", "10YNL----------L",
+    "10YDE-AT-LU---Q", "10Y1001A1001A82H", "10YFR-RTE------C", "10YNL----------L",
     "10YES-REE------0", "10Y1001A1001A83F",
 ]
 DEFAULT_DOCUMENT_TYPES = ["A75", "A44", "A65", "A69", "A70", "A71", "A72", "A73", "A74", "A68", "A11"]
 DEFAULT_CROSS_BORDER_PAIRS = [
-    ("10YFR-RTE------C", "10YES-REE------0"), ("10YES-REE------0", "10YFR-RTE------C"),
-    ("10YFR-RTE------C", "10Y1001A1001A83F"), ("10Y1001A1001A83F", "10YFR-RTE------C"),
-    ("10Y1001A1001A83F", "10YNL----------L"), ("10YNL----------L", "10Y1001A1001A83F"),
-    ("10YFR-RTE------C", "10YGB----------A"), ("10YGB----------A", "10YFR-RTE------C"),
-    ("10YNL----------L", "10YGB----------A"), ("10YGB----------A", "10YNL----------L"),
-    ("10Y1001A1001A83F", "10YDK-1--------W"), ("10YDK-1--------W", "10Y1001A1001A83F"),
-    ("10Y1001A1001A83F", "10YPL-AREA-----S"), ("10YPL-AREA-----S", "10Y1001A1001A83F"),
-    ("10Y1001A1001A83F", "10YCH-SWISSGRIDZ"), ("10YCH-SWISSGRIDZ", "10Y1001A1001A83F"),
-    ("10Y1001A1001A83F", "10YAT-APG------L"), ("10YAT-APG------L", "10Y1001A1001A83F"),
-    ("10Y1001A1001A83F", "10YCZ-CEPS-----N"), ("10YCZ-CEPS-----N", "10Y1001A1001A83F"),
+    ("10YAL-KESH-----5", "10YGR-HTSO-----Y"),
+    ("10YGR-HTSO-----Y", "10YAL-KESH-----5"),
+    ("10YAL-KESH-----5", "10YCS-CG-TSO---S"),
+    ("10YCS-CG-TSO---S", "10YAL-KESH-----5"),
+    ("10YAL-KESH-----5", "10Y1001C--00100H"),
+    ("10Y1001C--00100H", "10YAL-KESH-----5"),
+    ("10YAT-APG------L", "10YCH-SWISSGRIDZ"),
+    ("10YCH-SWISSGRIDZ", "10YAT-APG------L"),
+    ("10YAT-APG------L", "10YCZ-CEPS-----N"),
+    ("10YCZ-CEPS-----N", "10YAT-APG------L"),
+    ("10YAT-APG------L", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YAT-APG------L"),
+    ("10YAT-APG------L", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10YAT-APG------L"),
+    ("10YAT-APG------L", "10Y1001A1001A73I"),
+    ("10Y1001A1001A73I", "10YAT-APG------L"),
+    ("10YAT-APG------L", "10YSI-ELES-----O"),
+    ("10YSI-ELES-----O", "10YAT-APG------L"),
+    ("10YBA-JPCC-----D", "10YHR-HEP------M"),
+    ("10YHR-HEP------M", "10YBA-JPCC-----D"),
+    ("10YBA-JPCC-----D", "10YCS-CG-TSO---S"),
+    ("10YCS-CG-TSO---S", "10YBA-JPCC-----D"),
+    ("10YBA-JPCC-----D", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YBA-JPCC-----D"),
+    ("10YBE----------2", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YBE----------2"),
+    ("10YBE----------2", "10YFR-RTE------C"),
+    ("10YFR-RTE------C", "10YBE----------2"),
+    ("10YBE----------2", "10YGB----------A"),
+    ("10YGB----------A", "10YBE----------2"),
+    ("10YBE----------2", "10YNL----------L"),
+    ("10YNL----------L", "10YBE----------2"),
+    ("10YCA-BULGARIA-R", "10YGR-HTSO-----Y"),
+    ("10YGR-HTSO-----Y", "10YCA-BULGARIA-R"),
+    ("10YCA-BULGARIA-R", "10YMK-MEPSO----8"),
+    ("10YMK-MEPSO----8", "10YCA-BULGARIA-R"),
+    ("10YCA-BULGARIA-R", "10YRO-TEL------P"),
+    ("10YRO-TEL------P", "10YCA-BULGARIA-R"),
+    ("10YCA-BULGARIA-R", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YCA-BULGARIA-R"),
+    ("10YCA-BULGARIA-R", "10YTR-TEIAS----W"),
+    ("10YTR-TEIAS----W", "10YCA-BULGARIA-R"),
+    ("10YCH-SWISSGRIDZ", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YCH-SWISSGRIDZ"),
+    ("10YCH-SWISSGRIDZ", "10YFR-RTE------C"),
+    ("10YFR-RTE------C", "10YCH-SWISSGRIDZ"),
+    ("10YCH-SWISSGRIDZ", "10Y1001A1001A73I"),
+    ("10Y1001A1001A73I", "10YCH-SWISSGRIDZ"),
+    ("10YCZ-CEPS-----N", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YCZ-CEPS-----N"),
+    ("10YCZ-CEPS-----N", "10YPL-AREA-----S"),
+    ("10YPL-AREA-----S", "10YCZ-CEPS-----N"),
+    ("10YCZ-CEPS-----N", "10YSK-SEPS-----K"),
+    ("10YSK-SEPS-----K", "10YCZ-CEPS-----N"),
+    ("10Y1001A1001A83F", "10YFR-RTE------C"),
+    ("10YFR-RTE------C", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YNL----------L"),
+    ("10YNL----------L", "10Y1001A1001A83F"),
+    ("10Y1001A1001A83F", "10YPL-AREA-----S"),
+    ("10YPL-AREA-----S", "10Y1001A1001A83F"),
+    ("10YDK-1--------W", "10YDK-2--------M"),
+    ("10YDK-2--------M", "10YDK-1--------W"),
+    ("10YDK-1--------W", "10YGB----------A"),
+    ("10YGB----------A", "10YDK-1--------W"),
+    ("10YDK-1--------W", "10YNL----------L"),
+    ("10YNL----------L", "10YDK-1--------W"),
+    ("10YDK-1--------W", "10YNO-2--------T"),
+    ("10YNO-2--------T", "10YDK-1--------W"),
+    ("10YDK-1--------W", "10Y1001A1001A46L"),
+    ("10Y1001A1001A46L", "10YDK-1--------W"),
+    ("10YDK-2--------M", "10Y1001A1001A47J"),
+    ("10Y1001A1001A47J", "10YDK-2--------M"),
+    ("10Y1001A1001A39I", "10YFI-1--------U"),
+    ("10YFI-1--------U", "10Y1001A1001A39I"),
+    ("10Y1001A1001A39I", "10YLV-1001A00074"),
+    ("10YLV-1001A00074", "10Y1001A1001A39I"),
+    ("10YES-REE------0", "10YFR-RTE------C"),
+    ("10YFR-RTE------C", "10YES-REE------0"),
+    ("10YES-REE------0", "10YPT-REN------W"),
+    ("10YPT-REN------W", "10YES-REE------0"),
+    ("10YFI-1--------U", "10YNO-4--------9"),
+    ("10YNO-4--------9", "10YFI-1--------U"),
+    ("10YFI-1--------U", "10Y1001A1001A44P"),
+    ("10Y1001A1001A44P", "10YFI-1--------U"),
+    ("10YFI-1--------U", "10Y1001A1001A46L"),
+    ("10Y1001A1001A46L", "10YFI-1--------U"),
+    ("10YFR-RTE------C", "10YGB----------A"),
+    ("10YGB----------A", "10YFR-RTE------C"),
+    ("10YFR-RTE------C", "10Y1001A1001A73I"),
+    ("10Y1001A1001A73I", "10YFR-RTE------C"),
+    ("10YGB----------A", "10YNL----------L"),
+    ("10YNL----------L", "10YGB----------A"),
+    ("10YGB----------A", "10YNO-2--------T"),
+    ("10YNO-2--------T", "10YGB----------A"),
+    ("10YGR-HTSO-----Y", "10YMK-MEPSO----8"),
+    ("10YMK-MEPSO----8", "10YGR-HTSO-----Y"),
+    ("10YGR-HTSO-----Y", "10YTR-TEIAS----W"),
+    ("10YTR-TEIAS----W", "10YGR-HTSO-----Y"),
+    ("10YHR-HEP------M", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10YHR-HEP------M"),
+    ("10YHR-HEP------M", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YHR-HEP------M"),
+    ("10YHR-HEP------M", "10YSI-ELES-----O"),
+    ("10YSI-ELES-----O", "10YHR-HEP------M"),
+    ("10YHU-MAVIR----U", "10YRO-TEL------P"),
+    ("10YRO-TEL------P", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10YSI-ELES-----O"),
+    ("10YSI-ELES-----O", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10YSK-SEPS-----K"),
+    ("10YSK-SEPS-----K", "10YHU-MAVIR----U"),
+    ("10YHU-MAVIR----U", "10Y1001C--00003F"),
+    ("10Y1001C--00003F", "10YHU-MAVIR----U"),
+    ("10Y1001A1001A73I", "10YSI-ELES-----O"),
+    ("10YSI-ELES-----O", "10Y1001A1001A73I"),
+    ("10YLT-1001A0008Q", "10YLV-1001A00074"),
+    ("10YLV-1001A00074", "10YLT-1001A0008Q"),
+    ("10YLT-1001A0008Q", "10YPL-AREA-----S"),
+    ("10YPL-AREA-----S", "10YLT-1001A0008Q"),
+    ("10Y1001A1001A990", "10YRO-TEL------P"),
+    ("10YRO-TEL------P", "10Y1001A1001A990"),
+    ("10Y1001A1001A990", "10Y1001C--00003F"),
+    ("10Y1001C--00003F", "10Y1001A1001A990"),
+    ("10YCS-CG-TSO---S", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YCS-CG-TSO---S"),
+    ("10YCS-CG-TSO---S", "10Y1001C--00100H"),
+    ("10Y1001C--00100H", "10YCS-CG-TSO---S"),
+    ("10YMK-MEPSO----8", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YMK-MEPSO----8"),
+    ("10YMK-MEPSO----8", "10Y1001C--00100H"),
+    ("10Y1001C--00100H", "10YMK-MEPSO----8"),
+    ("10YNL----------L", "10YNO-2--------T"),
+    ("10YNO-2--------T", "10YNL----------L"),
+    ("10YNO-1--------2", "10YNO-2--------T"),
+    ("10YNO-2--------T", "10YNO-1--------2"),
+    ("10YNO-1--------2", "10YNO-3--------J"),
+    ("10YNO-3--------J", "10YNO-1--------2"),
+    ("10YNO-1--------2", "10Y1001A1001A48H"),
+    ("10Y1001A1001A48H", "10YNO-1--------2"),
+    ("10YNO-1--------2", "10Y1001A1001A46L"),
+    ("10Y1001A1001A46L", "10YNO-1--------2"),
+    ("10YNO-2--------T", "10Y1001A1001A48H"),
+    ("10Y1001A1001A48H", "10YNO-2--------T"),
+    ("10YNO-3--------J", "10YNO-4--------9"),
+    ("10YNO-4--------9", "10YNO-3--------J"),
+    ("10YNO-3--------J", "10Y1001A1001A48H"),
+    ("10Y1001A1001A48H", "10YNO-3--------J"),
+    ("10YNO-3--------J", "10Y1001A1001A45N"),
+    ("10Y1001A1001A45N", "10YNO-3--------J"),
+    ("10YNO-4--------9", "10Y1001A1001A44P"),
+    ("10Y1001A1001A44P", "10YNO-4--------9"),
+    ("10YNO-4--------9", "10Y1001A1001A45N"),
+    ("10Y1001A1001A45N", "10YNO-4--------9"),
+    ("10YPL-AREA-----S", "10Y1001A1001A47J"),
+    ("10Y1001A1001A47J", "10YPL-AREA-----S"),
+    ("10YPL-AREA-----S", "10YSK-SEPS-----K"),
+    ("10YSK-SEPS-----K", "10YPL-AREA-----S"),
+    ("10YPL-AREA-----S", "10Y1001C--00003F"),
+    ("10Y1001C--00003F", "10YPL-AREA-----S"),
+    ("10YRO-TEL------P", "10YCS-SERBIATSOV"),
+    ("10YCS-SERBIATSOV", "10YRO-TEL------P"),
+    ("10YRO-TEL------P", "10Y1001C--00003F"),
+    ("10Y1001C--00003F", "10YRO-TEL------P"),
+    ("10YCS-SERBIATSOV", "10Y1001C--00100H"),
+    ("10Y1001C--00100H", "10YCS-SERBIATSOV"),
+    ("10YSK-SEPS-----K", "10Y1001C--00003F"),
+    ("10Y1001C--00003F", "10YSK-SEPS-----K"),
+    ("10Y1001A1001A82H", "10YDK-1--------W"),
+    ("10YDK-1--------W", "10Y1001A1001A82H"),
+    ("10Y1001A1001A82H", "10YDK-2--------M"),
+    ("10YDK-2--------M", "10Y1001A1001A82H"),
+    ("10Y1001A1001A82H", "10Y1001A1001A47J"),
+    ("10Y1001A1001A47J", "10Y1001A1001A82H"),
+    ("10YGB----------A", "10YIE-1001A00010"),
+    ("10YIE-1001A00010", "10YGB----------A"),
 ]
 DOC_TYPE_NAMES = {
     "A75": "ActualGenerationPerType", "A44": "DayAheadPrices", "A65": "ActualTotalLoad",
@@ -101,23 +267,42 @@ class PointPublisher(Protocol):
 
 
 class EntsoeAPI:
-    def __init__(self, security_token: str, base_url: str = BASE_URL):
+    def __init__(self, security_token: str, base_url: str = BASE_URL,
+                 request_delay: float = 0.25, max_retries: int = 3):
         self.security_token = security_token
         self.base_url = base_url
+        # ENTSO-E enforces ~400 requests/minute per token. With the expanded
+        # cross-border catalog a single cycle issues well over a hundred calls,
+        # so pace requests and back off on throttling responses.
+        self.request_delay = request_delay
+        self.max_retries = max_retries
 
     def query(self, document_type: str, domain: str, period_start: datetime, period_end: datetime,
               out_domain: Optional[str] = None) -> Optional[str]:
         url = build_api_url(self.base_url, self.security_token, document_type, domain, period_start, period_end, out_domain=out_domain)
-        try:
-            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
-            if response.status_code == 400:
-                logger.debug("No data for %s/%s", document_type, domain)
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
+                if response.status_code == 400:
+                    logger.debug("No data for %s/%s", document_type, domain)
+                    return None
+                if response.status_code in (429, 503):
+                    retry_after = response.headers.get("Retry-After")
+                    wait = float(retry_after) if retry_after and retry_after.isdigit() else 2.0 * (2 ** attempt)
+                    logger.warning("Throttled (%s) for %s/%s; backing off %.1fs (attempt %d/%d)",
+                                   response.status_code, document_type, domain, wait, attempt + 1, self.max_retries)
+                    time.sleep(wait)
+                    continue
+                response.raise_for_status()
+                return response.text
+            except requests.RequestException as err:
+                logger.error("API request failed for %s/%s: %s", document_type, domain, err)
                 return None
-            response.raise_for_status()
-            return response.text
-        except requests.RequestException as err:
-            logger.error("API request failed for %s/%s: %s", document_type, domain, err)
-            return None
+            finally:
+                if self.request_delay:
+                    time.sleep(self.request_delay)
+        logger.error("Giving up on %s/%s after %d throttled attempts", document_type, domain, self.max_retries)
+        return None
 
 
 class EntsoePoller:

--- a/feeders/entsoe/entsoe_core/entsoe_core/xml_parser.py
+++ b/feeders/entsoe/entsoe_core/entsoe_core/xml_parser.py
@@ -84,12 +84,20 @@ def parse_entsoe_xml(xml_text: str, document_type: str) -> List[TimeSeriesPoint]
         in_domain_el = ts.find(_ns(ns, "inBiddingZone_Domain.mRID"))
         if in_domain_el is None:
             in_domain_el = ts.find(_ns(ns, "in_Domain.mRID"))
-        in_domain = in_domain_el.text if in_domain_el is not None else ""
 
         out_domain_el = ts.find(_ns(ns, "outBiddingZone_Domain.mRID"))
         if out_domain_el is None:
             out_domain_el = ts.find(_ns(ns, "out_Domain.mRID"))
-        out_domain = out_domain_el.text if out_domain_el is not None else None
+
+        if in_domain_el is None and document_type in LOAD_DOMAIN_DOC_TYPES:
+            # Load documents (A65/A70) identify the bidding zone via
+            # ``outBiddingZone_Domain`` only; promote it to the subject domain
+            # (which is the Kafka key) and leave the out-domain unset.
+            in_domain = out_domain_el.text if out_domain_el is not None else ""
+            out_domain = None
+        else:
+            in_domain = in_domain_el.text if in_domain_el is not None else ""
+            out_domain = out_domain_el.text if out_domain_el is not None else None
 
         # PSR type (generation per type only)
         psr_type = ""
@@ -168,15 +176,27 @@ def parse_entsoe_xml(xml_text: str, document_type: str) -> List[TimeSeriesPoint]
     return points
 
 
-def _process_type_for_document(document_type: str) -> str:
-    """Return the appropriate processType for the given ENTSO-E document type."""
+# Document types whose subject bidding zone is supplied via
+# ``outBiddingZone_Domain`` rather than ``in_Domain`` (the ENTSO-E load family).
+LOAD_DOMAIN_DOC_TYPES = ("A65", "A70")
+
+
+def _process_type_for_document(document_type: str) -> Optional[str]:
+    """Return the appropriate processType for the given ENTSO-E document type.
+
+    Day-ahead prices (A44) are queried without a ``processType`` parameter; the
+    Transparency Platform returns HTTP 400 if one is supplied.
+    """
+    # Day-ahead prices take no processType.
+    if document_type == "A44":
+        return None
     # Forecast types use day-ahead process
     if document_type in ("A69", "A70", "A71"):
         return "A01"
     # Installed capacity uses year-ahead
     if document_type == "A68":
         return "A33"
-    # Everything else (A75, A65, A73, A74, A72, A11, A44) uses realised
+    # Everything else (A75, A65, A73, A74, A72, A11) uses realised
     return "A16"
 
 
@@ -205,13 +225,26 @@ def build_api_url(base_url: str, security_token: str, document_type: str,
     process_type = _process_type_for_document(document_type)
 
     url = (f"{base_url}?securityToken={security_token}"
-           f"&documentType={document_type}"
-           f"&processType={process_type}"
-           f"&in_Domain={in_domain}"
-           f"&periodStart={start_str}"
-           f"&periodEnd={end_str}")
+           f"&documentType={document_type}")
 
-    if out_domain:
+    if process_type:
+        url += f"&processType={process_type}"
+
+    # The load family (A65 actual load, A70 load-forecast margin) identifies the
+    # bidding zone via ``outBiddingZone_Domain``; everything else uses ``in_Domain``.
+    if document_type in LOAD_DOMAIN_DOC_TYPES:
+        url += f"&outBiddingZone_Domain={in_domain}"
+    else:
+        url += f"&in_Domain={in_domain}"
+
+    url += (f"&periodStart={start_str}"
+            f"&periodEnd={end_str}")
+
+    if document_type == "A44":
+        # Day-ahead prices require out_Domain to equal in_Domain.
+        url += f"&out_Domain={out_domain or in_domain}"
+    elif out_domain:
+        # Cross-border physical flows (A11) carry a distinct out_Domain.
         url += f"&out_Domain={out_domain}"
 
     if psr_type:

--- a/feeders/entsoe/entsoe_kafka/entsoe_kafka/app.py
+++ b/feeders/entsoe/entsoe_kafka/entsoe_kafka/app.py
@@ -159,7 +159,11 @@ def main():
         bootstrap=args.kafka_bootstrap_servers; topic=args.kafka_topic; user=args.sasl_username; pwd=args.sasl_password; cfg={}
     if not bootstrap: raise SystemExit('Kafka bootstrap servers required')
     if not topic: raise SystemExit('Kafka topic required')
-    kafka_config={'bootstrap.servers': bootstrap, 'enable.idempotence': 'true', 'acks': 'all', 'compression.type': 'lz4', 'linger.ms': '20'}; kafka_config.update({k:v for k,v in cfg.items() if k not in ('kafka_topic',)})
+    kafka_config={'bootstrap.servers': bootstrap}; kafka_config.update({k:v for k,v in cfg.items() if k not in ('kafka_topic',)})
+    if args.connection_string:
+        # Azure Event Hubs / Fabric Event Stream Kafka endpoints reject the
+        # idempotent producer (UNSUPPORTED_FOR_MESSAGE_FORMAT); disable it.
+        kafka_config['enable.idempotence'] = False
     if user and pwd:
         kafka_config.update({'sasl.mechanisms':'PLAIN','security.protocol':'SASL_SSL' if os.getenv('KAFKA_ENABLE_TLS','true').lower() not in ('false','0','no') else 'SASL_PLAINTEXT','sasl.username':user,'sasl.password':pwd})
     elif os.getenv('KAFKA_ENABLE_TLS','true').lower() not in ('false','0','no'):

--- a/feeders/entsoe/fabric/README.md
+++ b/feeders/entsoe/fabric/README.md
@@ -1,0 +1,125 @@
+# ENTSO-E Fabric assets
+
+Post-deploy artefacts for the **entsoe** real-time-sources bridge: a 3-page
+Fabric **Real-Time Dashboard** and a Fabric **Map** that visualise the live
+state of the pan-European wholesale electricity market — day-ahead prices,
+generation mix, system load, and cross-border physical flows from the
+[ENTSO-E Transparency Platform](https://transparency.entsoe.eu/).
+
+The data plane (ACI/notebook + Event Hubs/Eventstream + KQL database into
+`_cloudevents_dispatch`) is handled by the generic
+`tools/deploy-fabric/deploy-fabric.ps1` (and `deploy-feeder-notebook.ps1`)
+scripts, which also apply `kql/entsoe.kql` (the typed tables and
+materialized views the dashboard and map consume). The generic deployer
+auto-discovers `feeders/entsoe/fabric/post-deploy.ps1` via the common
+`{source}/fabric/post-deploy.ps1` hook convention and calls it at the end of
+a successful deploy.
+
+## Files
+
+| File | Purpose |
+| ---- | ------- |
+| `post-deploy.ps1` | Hook auto-invoked by `tools/deploy-fabric/deploy-fabric.ps1` and `deploy-feeder-notebook.ps1`. Acquires a Kusto management token, applies the five helper functions in `helpers.kql` to the live `entsoe` database (one `.create-or-alter` per call), then runs `build_dashboard.py` and `build_map.py` with the workspace / KQL-db / cluster IDs taken from the deployer's `-Context` hashtable. Idempotent; can also be run standalone after a tweak. |
+| `build_dashboard.py` | Idempotently creates/updates the 3-page `KQLDashboard` item *ENTSO-E European Electricity Market*. Every tile binds to a real table / materialized view / helper function and a validated KQL query. |
+| `build_map.py` | Idempotently creates/updates the `Map` item *ENTSO-E Market Map*: a directional cross-border physical-flow arrow layer plus a day-ahead price-bubble layer, both Kusto-backed. |
+| `helpers.kql` | Five reference / geometry helper functions consumed by both the dashboard and the map: `PsrType()`, `EICZone()`, `PriceColor()`, `ZonePriceMarkers()`, `ZoneFlowLines()`. Re-applied on every deploy by the hook. |
+
+## Prerequisites
+
+1. The generic per-source bootstrap has already run for `entsoe`, e.g.:
+
+   ```powershell
+   ./tools/deploy-fabric/deploy-feeder-notebook.ps1 -Source entsoe -Workspace <ws-guid>
+   ```
+
+   This creates the `entsoe` KQL database, applies `kql/entsoe.kql` (the
+   `DayAheadPricesLatest`, `ActualGenerationPerTypeLatest`,
+   `WindSolarGenerationLatest`, `ActualTotalLoadLatest`, and
+   `CrossBorderPhysicalFlowsLatest` materialized views the tiles bind to),
+   creates the Eventstream + `_cloudevents_dispatch` destination, and starts
+   the feeder. Cross-border flow and day-ahead price data require a valid
+   ENTSO-E Transparency Platform security token (`ENTSOE_API_TOKEN`).
+
+2. **A blank Fabric Map item exists** in the workspace. The Fabric REST API
+   does not (yet) expose programmatic creation of Map items, so create one
+   once via the portal (`+ New > Map`) and note its item ID, or pass the
+   map name to `build_map.py` (it reuses an existing item of that name).
+
+## Auto-invocation
+
+```powershell
+./tools/deploy-fabric/deploy-feeder-notebook.ps1 -Source entsoe -Workspace "<ws-guid>"
+# ...generic bootstrap stages...
+# [6/6] Running post-deploy hook (entsoe/fabric/post-deploy.ps1)...
+#   [1/3] Applying helpers.kql ...
+#         applied PsrType / EICZone / PriceColor / ZonePriceMarkers / ZoneFlowLines
+#   [2/3] Building Real-Time Dashboard ...
+#   [3/3] Building Map ...
+#   Done. Open the items from the Real-Time Open Data workspace.
+```
+
+Skip with `-SkipPostDeployHook` if needed.
+
+## Standalone re-build
+
+After tweaking helper bodies, colour ramps, tile queries, or map layers:
+
+```powershell
+./feeders/entsoe/fabric/post-deploy.ps1 `
+    -WorkspaceId   "<workspace-guid>" `
+    -KqlDatabaseId "<kql-db-guid>" `
+    -KustoUri      "https://trd-xxxxxxxx.z2.kusto.fabric.microsoft.com" `
+    -KustoDatabase entsoe
+```
+
+Both `build_dashboard.py` and `build_map.py` update the existing item in
+place when one of the same display name already exists, so re-runs are safe.
+
+## What the dashboard looks like
+
+3 pages, every tile backed by a `kql/entsoe.kql` materialized view (and the
+`helpers.kql` reference functions for zone / fuel / colour lookups).
+
+| Page | Focus | Representative tiles |
+| ---- | ----- | -------------------- |
+| **Prices & Market** | Day-ahead wholesale price per bidding zone | Price multistat, cheapest→dearest ranking, geographic price map, per-zone detail table, price spread / extremes congestion signal |
+| **Generation Mix & Renewables** | What is being generated and how green it is | Renewable-share headline, current fuel-mix pie, wind & solar forecast-vs-actual columns, generation by zone & fuel stacked column |
+| **System Balance & Cross-Border** | Imports, exports and interconnector load | Net position per zone (import +/export −), actual total load per zone, top interconnector flows, full cross-border flow matrix |
+
+## What the map looks like
+
+2 Kusto-backed layers, both driven by the helper functions in `helpers.kql`.
+
+| Layer | Geometry | Encoding | Source function |
+| ----- | -------- | -------- | --------------- |
+| Cross-border physical flows | Directional arrow line per ordered zone pair (left-offset so opposite directions don't overlap) | 5-bucket dark magnitude ramp on \|MW\| (`<200` → `≥2500`); compact `OUT→IN MW` label | `ZoneFlowLines()` |
+| Day-ahead price bubbles | Point per bidding-zone centroid | Green→red ramp on €/MWh | `ZonePriceMarkers()` + `PriceColor()` |
+
+### Colour rationale
+
+* **Flow magnitude** uses a dark, multi-hue 5-class ramp so heavy
+  interconnectors read instantly and low flows recede:
+  `≥2500 MW #67001f` → `≥1200 #b2182b` → `≥600 #762a83` →
+  `≥200 #225ea8` → `<200 #2b8cbe`. The diverging blue→red progression keeps
+  the busiest borders (e.g. NO2↔GB, FR↔ES) loud against the basemap while
+  the long tail of small exchanges stays legible.
+* **Day-ahead price** uses a green→amber→red ramp anchored so cheap zones
+  are calm green and scarcity-priced zones are loud red, matching the
+  intuition that red = expensive.
+
+### Flow geometry
+
+`ZoneFlowLines()` projects each ordered exporter→importer pair onto a local
+equirectangular plane (`lon × cos(mean lat)`), draws the shaft from t=0.16 to
+t=0.80 of the great-circle chord, offsets it to the left of the direction of
+travel so the opposing flow on the same border renders as a separate arrow,
+and caps the arrowhead size (`hb = min(0.22, 0.08·L)`) so short borders don't
+get oversized heads. Labels carry the direction and magnitude
+(`DK2→SE4 521`) and use overlap-avoidance so dense regions stay readable.
+
+### Reference data
+
+Zone centroids and fuel/production-type lookups are baked into the
+`EICZone()` and `PsrType()` helper functions (EIC bidding-zone code →
+zone / country / lat / lon, and ENTSO-E B-code → fuel / renewable flag /
+colour). Edit those functions and re-run the hook to extend coverage.

--- a/feeders/entsoe/fabric/build_dashboard.py
+++ b/feeders/entsoe/fabric/build_dashboard.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Build and deploy the ENTSO-E Real-Time (KQLDashboard) item into Fabric.
+
+Creates a 3-page Fabric Real-Time Dashboard bound to the live `entsoe` KQL
+database. Every tile maps to a real table / materialized view / helper
+function and a validated KQL query. Idempotent: updates the dashboard
+definition in place if an item of the same display name already exists.
+
+Auth: uses `az account get-access-token` for the Fabric API. Run `az login`
+first. All infra IDs are taken from the deployed Real-Time Open Data
+workspace and can be overridden via environment variables / CLI flags.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+import uuid
+
+FABRIC = "https://api.fabric.microsoft.com/v1"
+
+# --- deployed infra (Real-Time Open Data workspace) -------------------------
+WORKSPACE = "c98acd97-4363-4296-8323-b6ab21e53903"
+KQL_DB_ID = "a08303ed-4148-4c4d-b0fd-7ad5eb882e68"           # entsoe KQL DB item
+CLUSTER_URI = "https://trd-fssgb36e98qh3fk58u.z2.kusto.fabric.microsoft.com"
+DISPLAY_NAME = "ENTSO-E European Electricity Market"
+DESCRIPTION = "European wholesale electricity market — day-ahead prices, generation mix, cross-border flows (ENTSO-E Transparency Platform)."
+
+DS_ID = "11111111-1111-4111-8111-000000000001"   # dataSource id (referenced by queries)
+
+
+def tok(resource: str) -> str:
+    out = subprocess.run(
+        ["az", "account", "get-access-token", "--resource", resource,
+         "--query", "accessToken", "-o", "tsv"],
+        capture_output=True, text=True, check=True, shell=True)
+    return out.stdout.strip()
+
+
+def api(method: str, url: str, token: str, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        resp = urllib.request.urlopen(req)
+        raw = resp.read().decode()
+        return resp.status, dict(resp.headers), (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        return e.code, dict(e.headers), (json.loads(raw) if raw else {"error": raw})
+
+
+def poll_lro(headers: dict, token: str):
+    loc = headers.get("Location")
+    if not loc:
+        return None
+    while True:
+        time.sleep(2)
+        st, _, body = api("GET", loc, token)
+        if body.get("status") in ("Succeeded", "Completed"):
+            s2, _, res = api("GET", loc + "/result", token)
+            return res
+        if body.get("status") in ("Failed", "Cancelled"):
+            raise RuntimeError(f"LRO failed: {json.dumps(body)}")
+
+
+# --- query/tile/param builders ---------------------------------------------
+_qids: dict[str, str] = {}
+
+
+def qid(name: str) -> str:
+    return _qids.setdefault(name, str(uuid.uuid4()))
+
+
+def Q(name: str, text: str, used=None) -> dict:
+    return {
+        "dataSource": {"kind": "inline", "dataSourceId": DS_ID},
+        "text": text.strip() + "\n",
+        "id": qid(name),
+        "usedVariables": used or [],
+    }
+
+
+def tile(title, vtype, page, x, y, w, h, qname, opts) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "title": title,
+        "visualType": vtype,
+        "pageId": page,
+        "layout": {"x": x, "y": y, "width": w, "height": h},
+        "queryRef": {"kind": "query", "queryId": qid(qname)},
+        "visualOptions": opts,
+    }
+
+
+def yaxes(label=""):
+    return {"base": {"id": "-1", "label": label, "columns": [],
+                     "yAxisMaximumValue": None, "yAxisMinimumValue": None,
+                     "yAxisScale": "linear", "horizontalLines": []},
+            "additional": [], "showMultiplePanels": False}
+
+
+def bar_opts(xcol, ycol, label="", series=None, vtype_legend=False):
+    return {"multipleYAxes": yaxes(label), "hideLegend": not vtype_legend,
+            "legendLocation": "bottom", "xColumnTitle": "", "xColumn": xcol,
+            "yColumns": [ycol], "seriesColumns": series, "xAxisScale": "linear",
+            "verticalLine": "", "crossFilter": [], "crossFilterDisabled": False,
+            "drillthroughDisabled": False, "drillthrough": []}
+
+
+def pie_opts(label_col, value_col, series=None):
+    return {"hideLegend": False, "legendLocation": "right", "xColumn": label_col,
+            "yColumns": [value_col], "seriesColumns": series or [label_col],
+            "crossFilterDisabled": False, "drillthroughDisabled": False,
+            "labelDisabled": False, "pie__label": ["name", "value"],
+            "tooltipDisabled": False, "pie__tooltip": ["percentage", "value", "name"],
+            "pie__orderBy": "none", "pie__kind": "pie", "pie__topNSlices": None,
+            "crossFilter": [], "drillthrough": []}
+
+
+def multistat_opts(label_col, value_col, slot_w=3):
+    return {"multiStat__textSize": "auto", "multiStat__valueColumn": value_col,
+            "colorRulesDisabled": True, "colorStyle": "light",
+            "multiStat__displayOrientation": "horizontal",
+            "multiStat__labelColumn": label_col,
+            "multiStat__slot": {"width": slot_w, "height": 1},
+            "colorRules": [], "crossFilter": [], "drillthrough": [],
+            "crossFilterDisabled": False, "drillthroughDisabled": False}
+
+
+def table_opts():
+    return {"table__enableRenderLinks": True, "colorRulesDisabled": True,
+            "colorStyle": "light", "crossFilterDisabled": False,
+            "drillthroughDisabled": False, "crossFilter": [], "drillthrough": [],
+            "table__renderLinks": [], "colorRules": [],
+            "selectedDataOnLoad": {"all": True, "limit": 30}}
+
+
+def map_opts(lat, lon, label, size=None):
+    return {"map__latitudeColumn": lat, "map__longitudeColumn": lon,
+            "map__labelColumn": label,
+            "map__sizeColumn": size, "map__sizeDisabled": size is None,
+            "map__geoType": "numeric", "map__geoPointColumn": None}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", default=WORKSPACE)
+    ap.add_argument("--db", default=KQL_DB_ID)
+    ap.add_argument("--cluster", default=CLUSTER_URI)
+    ap.add_argument("--name", default=DISPLAY_NAME)
+    args = ap.parse_args()
+
+    p1 = str(uuid.uuid4())  # Prices & Market
+    p2 = str(uuid.uuid4())  # Generation Mix & Renewables
+    p3 = str(uuid.uuid4())  # System Balance & Cross-Border
+
+    zone1_var = "Zone1"
+    p_zone1 = str(uuid.uuid4())
+    p_time = str(uuid.uuid4())
+
+    # ---- queries -----------------------------------------------------------
+    queries = [
+        Q("p1_price_multistat",
+          "['eu.entsoe.transparency.DayAheadPricesLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| project zone, price=round(price,2)\n| sort by price desc"),
+        Q("p1_price_bar",
+          "['eu.entsoe.transparency.DayAheadPricesLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| project zone, ['€/MWh']=round(price,2)\n| sort by ['€/MWh'] asc"),
+        Q("p1_spread",
+          "let p = ['eu.entsoe.transparency.DayAheadPricesLatest'];\n"
+          "p | summarize metric='Price spread €/MWh', value=round(max(price)-min(price),2)\n"
+          "| union (p | summarize metric='Highest €/MWh', value=round(max(price),2))\n"
+          "| union (p | summarize metric='Lowest €/MWh', value=round(min(price),2))"),
+        Q("p1_price_table",
+          "['eu.entsoe.transparency.DayAheadPricesLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| project Zone=zone, Country=country, ['€/MWh']=round(price,2), Currency=currency, Resolution=resolution\n"
+          "| sort by ['€/MWh'] desc"),
+        Q("p1_price_map",
+          "['eu.entsoe.transparency.DayAheadPricesLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| project zone, latitude=lat, longitude=lon, price=round(price,1)"),
+        # page 2 (Zone1 variable)
+        Q("p2_res_multistat",
+          "let m = ['eu.entsoe.transparency.ActualGenerationPerTypeLatest']\n"
+          f"| where inDomain == {zone1_var}\n"
+          "| join kind=inner (PsrType()) on $left.psrType==$right.code\n"
+          "| summarize total=sum(quantity), res=sumif(quantity,isRenewable), "
+          "wind=sumif(quantity,fuel has 'Wind'), solar=sumif(quantity,fuel=='Solar');\n"
+          "m | project metric='RES share %', value=round(100.0*res/total,1)\n"
+          "| union (m | project metric='Wind MW', value=round(wind,0))\n"
+          "| union (m | project metric='Solar MW', value=round(solar,0))\n"
+          "| union (m | project metric='Total generation MW', value=round(total,0))",
+          [zone1_var]),
+        Q("p2_mix_donut",
+          "['eu.entsoe.transparency.ActualGenerationPerTypeLatest']\n"
+          f"| where inDomain == {zone1_var}\n"
+          "| join kind=inner (PsrType()) on $left.psrType==$right.code\n"
+          "| summarize MW=round(sum(quantity),0) by fuel\n| where MW>0\n| sort by MW desc",
+          [zone1_var]),
+        Q("p2_windsolar",
+          "let act = ['eu.entsoe.transparency.WindSolarGenerationLatest']\n"
+          f"| where inDomain == {zone1_var}\n"
+          "| join kind=inner (PsrType()) on $left.psrType==$right.code\n"
+          "| summarize MW=round(sum(quantity),0) by fuel | extend series='Actual';\n"
+          "let fc = ['eu.entsoe.transparency.WindSolarForecastLatest']\n"
+          f"| where inDomain == {zone1_var}\n"
+          "| join kind=inner (PsrType()) on $left.psrType==$right.code\n"
+          "| summarize MW=round(sum(quantity),0) by fuel | extend series='Forecast';\n"
+          "union act, fc | project fuel, series, MW",
+          [zone1_var]),
+        Q("p2_gen_by_zone",
+          "['eu.entsoe.transparency.ActualGenerationPerTypeLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| join kind=inner (PsrType()) on $left.psrType==$right.code\n"
+          "| summarize MW=round(sum(quantity),0) by zone, fuel\n| where MW>0"),
+        # page 3
+        Q("p3_netpos",
+          "let flows = ['eu.entsoe.transparency.CrossBorderPhysicalFlowsLatest'];\n"
+          "let imp = flows | summarize imp=sum(quantity) by eic=inDomain;\n"
+          "let exp = flows | summarize exp=sum(quantity) by eic=outDomain;\n"
+          "imp | join kind=fullouter exp on eic\n"
+          "| extend eic=coalesce(eic,eic1), net=coalesce(imp,0.0)-coalesce(exp,0.0)\n"
+          "| join kind=inner (EICZone()) on $left.eic==$right.eic\n"
+          "| project zone, ['Net position MW']=round(net,0)\n| sort by ['Net position MW'] desc"),
+        Q("p3_load_bar",
+          "['eu.entsoe.transparency.ActualTotalLoadLatest']\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| project zone, ['Load MW']=round(quantity,0)\n| sort by ['Load MW'] asc"),
+        Q("p3_top_flows",
+          "['eu.entsoe.transparency.CrossBorderPhysicalFlowsLatest']\n"
+          "| join kind=inner (EICZone() | project ineic=eic, in_zone=zone) on $left.inDomain==$right.ineic\n"
+          "| join kind=inner (EICZone() | project outeic=eic, out_zone=zone) on $left.outDomain==$right.outeic\n"
+          "| extend border=strcat(out_zone,' → ',in_zone)\n"
+          "| project border, ['Flow MW']=round(quantity,0)\n| top 12 by ['Flow MW']"),
+        Q("p3_flow_matrix",
+          "['eu.entsoe.transparency.CrossBorderPhysicalFlowsLatest']\n"
+          "| join kind=inner (EICZone() | project ineic=eic, To=zone) on $left.inDomain==$right.ineic\n"
+          "| join kind=inner (EICZone() | project outeic=eic, From=zone) on $left.outDomain==$right.outeic\n"
+          "| project From, To, ['Flow MW']=round(quantity,0)\n| sort by ['Flow MW'] desc"),
+        # parameter source
+        Q("param_zone1",
+          "['eu.entsoe.transparency.ActualGenerationPerTypeLatest']\n"
+          "| distinct inDomain\n"
+          "| join kind=inner (EICZone()) on $left.inDomain==$right.eic\n"
+          "| extend ord=iff(zone=='DE-LU',0,1)\n| sort by ord asc, zone asc\n"
+          "| project value=inDomain, label=zone"),
+    ]
+
+    # ---- tiles -------------------------------------------------------------
+    tiles = [
+        # Page 1 — Prices & Market
+        tile("Day-ahead price by bidding zone (€/MWh)", "multistat", p1, 0, 0, 24, 4,
+             "p1_price_multistat", multistat_opts("zone", "price", slot_w=4)),
+        tile("Price ranking — cheapest → most expensive", "bar", p1, 0, 4, 8, 9,
+             "p1_price_bar", bar_opts("zone", "€/MWh", "€/MWh")),
+        tile("Geographic price map", "map", p1, 8, 4, 8, 9,
+             "p1_price_map", map_opts("latitude", "longitude", "zone", size="price")),
+        tile("Price detail by zone", "table", p1, 16, 4, 8, 9,
+             "p1_price_table", table_opts()),
+        tile("Price spread & extremes (congestion signal)", "multistat", p1, 0, 13, 24, 4,
+             "p1_spread", multistat_opts("metric", "value", slot_w=4)),
+        # Page 2 — Generation Mix & Renewables (zone = Zone1)
+        tile("Renewable share & headline generation (selected zone)", "multistat", p2, 0, 0, 24, 4,
+             "p2_res_multistat", multistat_opts("metric", "value", slot_w=4)),
+        tile("Current fuel mix (selected zone)", "pie", p2, 0, 4, 8, 11,
+             "p2_mix_donut", pie_opts("fuel", "MW")),
+        tile("Wind & solar — forecast vs actual (MW)", "column", p2, 8, 4, 8, 11,
+             "p2_windsolar", bar_opts("fuel", "MW", "MW", series=["series"], vtype_legend=True)),
+        tile("Generation by zone & fuel (MW)", "stackedcolumn", p2, 16, 4, 8, 11,
+             "p2_gen_by_zone", bar_opts("zone", "MW", "MW", series=["fuel"], vtype_legend=True)),
+        # Page 3 — System Balance & Cross-Border
+        tile("Net position by zone (import + / export −, MW)", "bar", p3, 0, 0, 8, 11,
+             "p3_netpos", bar_opts("zone", "Net position MW", "MW")),
+        tile("Actual total load by zone (MW)", "bar", p3, 8, 0, 8, 11,
+             "p3_load_bar", bar_opts("zone", "Load MW", "MW")),
+        tile("Top cross-border interconnector flows (MW)", "bar", p3, 16, 0, 8, 11,
+             "p3_top_flows", bar_opts("border", "Flow MW", "MW")),
+        tile("Cross-border flow matrix (from → to, MW)", "table", p3, 0, 11, 24, 8,
+             "p3_flow_matrix", table_opts()),
+    ]
+
+    parameters = [
+        {"kind": "duration", "id": p_time, "displayName": "Time range",
+         "description": "", "beginVariableName": "_startTime", "endVariableName": "_endTime",
+         "defaultValue": {"kind": "dynamic", "count": 1, "unit": "days"},
+         "showOnPages": {"kind": "all"}},
+        {"kind": "string", "id": p_zone1, "displayName": "Zone (Page 2)",
+         "description": "Bidding zone for the generation-mix deep dive.",
+         "variableName": zone1_var, "selectionType": "scalar",
+         "includeAllOption": False, "defaultValue": {"kind": "query-result"},
+         "dataSource": {"kind": "query",
+                        "columns": {"value": "value", "label": "label"},
+                        "queryRef": {"kind": "query", "queryId": qid("param_zone1")}},
+         "showOnPages": {"kind": "all"}},
+    ]
+
+    dashboard = {
+        "schema_version": 68,
+        "autoRefresh": {"enabled": True, "defaultInterval": "30s", "minInterval": "30s"},
+        "tiles": tiles,
+        "baseQueries": [],
+        "parameters": parameters,
+        "dataSources": [{
+            "kind": "kusto-trident", "id": DS_ID, "name": "entsoe",
+            "clusterUri": args.cluster, "database": args.db,
+            "workspace": "00000000-0000-0000-0000-000000000000",
+            "scopeId": "kusto-trident"}],
+        "pages": [
+            {"name": "Prices & Market", "id": p1},
+            {"name": "Generation Mix & Renewables", "id": p2},
+            {"name": "System Balance & Cross-Border", "id": p3},
+        ],
+        "queries": queries,
+    }
+
+    platform = {
+        "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+        "metadata": {"type": "KQLDashboard", "displayName": args.name,
+                     "description": DESCRIPTION},
+        "config": {"version": "2.0", "logicalId": "00000000-0000-0000-0000-000000000000"},
+    }
+
+    def b64(obj):
+        return base64.b64encode(json.dumps(obj).encode()).decode()
+
+    parts = [
+        {"path": "RealTimeDashboard.json", "payload": b64(dashboard), "payloadType": "InlineBase64"},
+        {"path": ".platform", "payload": b64(platform), "payloadType": "InlineBase64"},
+    ]
+
+    ft = tok("https://api.fabric.microsoft.com")
+    # find existing
+    st, _, body = api("GET", f"{FABRIC}/workspaces/{args.workspace}/items?type=KQLDashboard", ft)
+    existing = next((i for i in body.get("value", []) if i.get("displayName") == args.name), None)
+
+    if existing:
+        item_id = existing["id"]
+        print(f"Updating existing KQLDashboard {item_id} …")
+        st, hdr, body = api("POST",
+                            f"{FABRIC}/workspaces/{args.workspace}/items/{item_id}/updateDefinition",
+                            ft, {"definition": {"parts": parts}})
+        if st == 202:
+            poll_lro(hdr, ft)
+        elif st >= 300:
+            print("ERROR", st, json.dumps(body)); sys.exit(1)
+    else:
+        print("Creating KQLDashboard …")
+        st, hdr, body = api("POST", f"{FABRIC}/workspaces/{args.workspace}/items", ft,
+                            {"displayName": args.name, "type": "KQLDashboard",
+                             "description": DESCRIPTION,
+                             "definition": {"parts": parts}})
+        if st == 202:
+            res = poll_lro(hdr, ft)
+            item_id = (res or {}).get("id")
+        elif st in (200, 201):
+            item_id = body.get("id")
+        else:
+            print("ERROR", st, json.dumps(body)); sys.exit(1)
+
+    if not item_id:
+        # resolve by name
+        st, _, body = api("GET", f"{FABRIC}/workspaces/{args.workspace}/items?type=KQLDashboard", ft)
+        item_id = next((i["id"] for i in body.get("value", []) if i.get("displayName") == args.name), None)
+
+    url = f"https://app.fabric.microsoft.com/groups/{args.workspace}/kustodashboards/{item_id}"
+    print(f"\nOK  KQLDashboard ready")
+    print(f"    id : {item_id}")
+    print(f"    url: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/feeders/entsoe/fabric/build_map.py
+++ b/feeders/entsoe/fabric/build_map.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Create and wire the ENTSO-E Fabric Map item against the live `entsoe` KQL DB.
+
+Two Kusto-backed layers visualise the live European electricity market:
+
+  1. **Cross-border flows** (default-on) — one polyline per measured
+     interconnector flow (`ZoneFlowLines()`), drawn exporting-zone →
+     importing-zone, coloured by flow magnitude (light→dark blue) and
+     labelled with the MW figure.
+  2. **Zone day-ahead prices** (default-on) — one bubble per bidding zone
+     (`ZonePriceMarkers()`), coloured on a green→red price ramp and labelled
+     with the zone code and €/MWh.
+
+Both layers query helper functions applied to the live DB by
+`feeders/entsoe/fabric/helpers.kql`.
+
+Idempotent: re-running drops the two entsoe layers by name and re-creates
+them. Creates the Map item if it does not yet exist.
+
+Auth: uses `az account get-access-token` for the Fabric API (run `az login`).
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+FABRIC = "https://api.fabric.microsoft.com/v1"
+
+WORKSPACE = "c98acd97-4363-4296-8323-b6ab21e53903"
+KQL_DB_ID = "a08303ed-4148-4c4d-b0fd-7ad5eb882e68"
+MAP_NAME = "ENTSO-E Market Map"
+MAP_DESC = "Live European electricity market — cross-border physical flows and day-ahead bidding-zone prices (ENTSO-E Transparency Platform)."
+
+NAME_FLOWS = "entsoe cross-border flows"
+NAME_PRICES = "entsoe zone prices"
+LAYER_NAMES = {NAME_FLOWS, NAME_PRICES}
+
+# Bounded colour buckets so the map `match` expressions stay finite.
+# Cross-border flows use a dark, multi-hue magnitude ramp (blue = light load
+# -> purple -> red = heavy load) so direction-paired arrows differentiate
+# strongly against the grey basemap.
+FLOW_COLORS = ["#67001f", "#b2182b", "#762a83", "#225ea8", "#2b8cbe"]  # >=2500 / >=1200 / >=600 / >=200 / <200 MW
+PRICE_COLORS = ["#1a9641", "#a6d96a", "#ffffbf", "#fdae61", "#d7191c"]  # cheap→expensive
+
+
+def tok(resource: str) -> str:
+    out = subprocess.run(
+        ["az", "account", "get-access-token", "--resource", resource,
+         "--query", "accessToken", "-o", "tsv"],
+        capture_output=True, text=True, check=True, shell=True)
+    return out.stdout.strip()
+
+
+def api(method: str, url: str, token: str, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        resp = urllib.request.urlopen(req)
+        raw = resp.read().decode()
+        return resp.status, dict(resp.headers), (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        return e.code, dict(e.headers), (json.loads(raw) if raw else {"error": raw})
+
+
+def poll_lro(headers: dict, token: str):
+    loc = headers.get("Location")
+    if not loc:
+        return None
+    while True:
+        time.sleep(2)
+        _, _, body = api("GET", loc, token)
+        st = body.get("status")
+        if st in ("Succeeded", "Completed"):
+            _, _, res = api("GET", loc + "/result", token)
+            return res
+        if st in ("Failed", "Cancelled"):
+            raise RuntimeError(f"LRO failed: {json.dumps(body)[:400]}")
+
+
+# --- layer KQL --------------------------------------------------------------
+KQL_FLOWS = """ZoneFlowLines()
+| extend stroke_color = case(abs(quantity) >= 2500, '%s', abs(quantity) >= 1200, '%s', abs(quantity) >= 600, '%s', abs(quantity) >= 200, '%s', '%s')
+| project geometry, label, out_zone, in_zone, quantity, stroke_weight, stroke_color
+""" % (FLOW_COLORS[0], FLOW_COLORS[1], FLOW_COLORS[2], FLOW_COLORS[3], FLOW_COLORS[4])
+
+KQL_PRICES = """ZonePriceMarkers()
+| extend fill_color = case(price >= 150, '%s', price >= 120, '%s', price >= 90, '%s', price >= 60, '%s', '%s')
+| project geometry, label, zone, price, fill_color
+""" % (PRICE_COLORS[4], PRICE_COLORS[3], PRICE_COLORS[2], PRICE_COLORS[1], PRICE_COLORS[0])
+
+
+def _match_expr(get_col: str, colors: list[str]) -> list:
+    expr = ["match", ["get", get_col]]
+    for c in colors:
+        expr += [c, c]
+    expr.append("#888888")  # fallback
+    return expr
+
+
+def _custom_colors(colors: list[str]) -> dict:
+    return {c: c for c in colors}
+
+
+def flows_layer() -> dict:
+    return {
+        "name": NAME_FLOWS, "kql": KQL_FLOWS, "geometryColumnName": "geometry",
+        "filters": [],
+        "options": {
+            "type": "vector", "visible": True,
+            "lineOptions": {
+                "strokeWidth": 3, "strokeOpacity": 0.9,
+                "strokeColor": _match_expr("stroke_color", FLOW_COLORS),
+                "enableSeriesGroup": True, "seriesGroup": "stroke_color",
+                "customColors": _custom_colors(FLOW_COLORS),
+            },
+            "dataLabelKeys": ["label"],
+            "dataLabelOptions": {"enabled": True, "size": 11, "color": "#1a1a1a",
+                                  "textStrokeColor": "#FFFFFF", "textStrokeWidth": 2.5,
+                                  "allowOverlap": False},
+            "tooltipKeys": ["label", "out_zone", "in_zone", "quantity"],
+            "enablePopups": True,
+        },
+    }
+
+
+def prices_layer() -> dict:
+    return {
+        "name": NAME_PRICES, "kql": KQL_PRICES, "geometryColumnName": "geometry",
+        "filters": [],
+        "options": {
+            "type": "vector", "visible": True, "pointLayerType": "bubble",
+            "bubbleOptions": {
+                "color": _match_expr("fill_color", PRICE_COLORS),
+                "radius": 11, "strokeColor": "#FFFFFF", "strokeWidth": 2,
+                "opacity": 0.95, "enableSeriesGroup": True,
+                "seriesGroup": "fill_color", "customColors": _custom_colors(PRICE_COLORS),
+            },
+            "dataLabelKeys": ["label"],
+            "dataLabelOptions": {"enabled": True, "size": 13, "color": "#111111",
+                                  "textStrokeColor": "#FFFFFF", "textStrokeWidth": 2.5,
+                                  "allowOverlap": True},
+            "tooltipKeys": ["zone", "price"],
+            "enablePopups": True,
+        },
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", default=WORKSPACE)
+    ap.add_argument("--db", default=KQL_DB_ID)
+    ap.add_argument("--name", default=MAP_NAME)
+    args = ap.parse_args()
+
+    ft = tok("https://api.fabric.microsoft.com")
+
+    # find or create the Map item
+    _, _, body = api("GET", f"{FABRIC}/workspaces/{args.workspace}/items?type=Map", ft)
+    existing = next((i for i in body.get("value", []) if i.get("displayName") == args.name), None)
+    if existing:
+        map_id = existing["id"]
+        print(f"Reusing Map {map_id}")
+    else:
+        print("Creating Map item …")
+        st, hdr, b = api("POST", f"{FABRIC}/workspaces/{args.workspace}/items", ft,
+                         {"displayName": args.name, "type": "Map", "description": MAP_DESC})
+        if st == 202:
+            res = poll_lro(hdr, ft); map_id = (res or {}).get("id")
+        elif st in (200, 201):
+            map_id = b.get("id")
+        else:
+            print("ERROR creating map", st, json.dumps(b)); sys.exit(1)
+        if not map_id:
+            _, _, body = api("GET", f"{FABRIC}/workspaces/{args.workspace}/items?type=Map", ft)
+            map_id = next(i["id"] for i in body["value"] if i["displayName"] == args.name)
+        print(f"Created Map {map_id}")
+
+    # get current definition
+    st, hdr, _ = api("POST",
+                     f"{FABRIC}/workspaces/{args.workspace}/items/{map_id}/getDefinition", ft)
+    res = poll_lro(hdr, ft) if st == 202 else None
+    if res is None:
+        # non-LRO direct response path
+        st2, _, body2 = api("POST",
+                            f"{FABRIC}/workspaces/{args.workspace}/items/{map_id}/getDefinition", ft)
+        res = body2
+    parts = {p["path"]: p for p in res["definition"]["parts"]}
+
+    if "map.json" in parts:
+        mp = json.loads(base64.b64decode(parts["map.json"]["payload"]))
+    else:
+        mp = {"layerSources": [], "layerSettings": [], "dataSources": []}
+        parts["map.json"] = {"path": "map.json", "payload": "", "payloadType": "InlineBase64"}
+
+    # drop previously-wired entsoe layers (idempotent)
+    removed = set()
+    mp["layerSettings"] = [ls for ls in mp.get("layerSettings", [])
+                           if (ls.get("name") in LAYER_NAMES and removed.add(ls.get("sourceId")))
+                           is None and ls.get("name") not in LAYER_NAMES]
+    mp["layerSources"] = [s for s in mp.get("layerSources", []) if s["id"] not in removed]
+    for p in list(parts):
+        if p.startswith("queries/layerSource-"):
+            sid = p.split("layerSource-")[1].split(".kql")[0]
+            if sid in removed:
+                del parts[p]
+
+    # register KQL DB
+    if not any(d.get("itemId") == args.db for d in mp.get("dataSources", [])):
+        mp.setdefault("dataSources", []).append(
+            {"itemType": "KqlDatabase", "workspaceId": args.workspace, "itemId": args.db})
+
+    # basemap centred on Europe
+    bm = mp.setdefault("basemap", {})
+    o = bm.setdefault("options", {})
+    o.setdefault("style", "road_shaded_relief")
+    o.setdefault("center", [9.0, 50.2])
+    o.setdefault("zoom", 4.2)
+    o.setdefault("showLabels", True)
+    c = bm.setdefault("controls", {})
+    for k in ("zoom", "scale", "style", "compass"):
+        c.setdefault(k, True)
+
+    # wire layers (flows under prices)
+    for layer in (flows_layer(), prices_layer()):
+        src_id = str(uuid.uuid4())
+        mp.setdefault("layerSources", []).append({
+            "id": src_id, "name": layer["name"].replace(" ", "_") + "_kusto",
+            "type": "kusto", "options": {"cluster": False},
+            "itemId": args.db, "refreshIntervalMs": 60_000})
+        mp.setdefault("layerSettings", []).append({
+            "id": str(uuid.uuid4()), "name": layer["name"], "sourceId": src_id,
+            "geometryColumnName": layer["geometryColumnName"],
+            "filters": layer["filters"], "options": layer["options"]})
+        parts[f"queries/layerSource-{src_id}.kql"] = {
+            "path": f"queries/layerSource-{src_id}.kql",
+            "payload": base64.b64encode(layer["kql"].encode()).decode(),
+            "payloadType": "InlineBase64"}
+        print(f"  wired layer: {layer['name']}")
+
+    parts["map.json"]["payload"] = base64.b64encode(
+        json.dumps(mp, indent=2).encode()).decode()
+
+    st, hdr, b = api("POST",
+                     f"{FABRIC}/workspaces/{args.workspace}/items/{map_id}/updateDefinition",
+                     ft, {"definition": {"parts": list(parts.values())}})
+    if st == 202:
+        poll_lro(hdr, ft)
+    elif st >= 300:
+        print("ERROR updateDefinition", st, json.dumps(b)); sys.exit(1)
+
+    url = f"https://app.fabric.microsoft.com/groups/{args.workspace}/mapItems/{map_id}"
+    print(f"\nOK  Map ready\n    id : {map_id}\n    url: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/feeders/entsoe/fabric/build_map.py
+++ b/feeders/entsoe/fabric/build_map.py
@@ -42,12 +42,30 @@ NAME_FLOWS = "entsoe cross-border flows"
 NAME_PRICES = "entsoe zone prices"
 LAYER_NAMES = {NAME_FLOWS, NAME_PRICES}
 
-# Bounded colour buckets so the map `match` expressions stay finite.
+# Bounded, human-readable buckets so the map `match` expressions stay finite
+# AND the legend shows meaningful ranges instead of raw hex codes. Each band is
+# (lower_bound, label, colour) in ascending order; the lower bound drives the
+# KQL case(), the label drives the legend entry, and the colour keeps the
+# rendered geometry and the legend swatch in lockstep.
+#
 # Cross-border flows use a dark, multi-hue magnitude ramp (blue = light load
 # -> purple -> red = heavy load) so direction-paired arrows differentiate
 # strongly against the grey basemap.
-FLOW_COLORS = ["#67001f", "#b2182b", "#762a83", "#225ea8", "#2b8cbe"]  # >=2500 / >=1200 / >=600 / >=200 / <200 MW
-PRICE_COLORS = ["#1a9641", "#a6d96a", "#ffffbf", "#fdae61", "#d7191c"]  # cheap→expensive
+FLOW_BANDS = [
+    (0,    "< 200 MW",     "#2b8cbe"),
+    (200,  "200-600 MW",   "#225ea8"),
+    (600,  "600-1200 MW",  "#762a83"),
+    (1200, "1200-2500 MW", "#b2182b"),
+    (2500, ">= 2500 MW",   "#67001f"),
+]
+# Day-ahead bidding-zone prices, cheap (green) -> expensive (red).
+PRICE_BANDS = [
+    (0,   "< 60 EUR/MWh",     "#1a9641"),
+    (60,  "60-90 EUR/MWh",    "#a6d96a"),
+    (90,  "90-120 EUR/MWh",   "#ffffbf"),
+    (120, "120-150 EUR/MWh",  "#fdae61"),
+    (150, ">= 150 EUR/MWh",   "#d7191c"),
+]
 
 
 def tok(resource: str) -> str:
@@ -89,27 +107,37 @@ def poll_lro(headers: dict, token: str):
 
 
 # --- layer KQL --------------------------------------------------------------
+def _band_case(value_expr: str, bands: list[tuple[int, str, str]]) -> str:
+    # Build a KQL case() that maps a numeric column to its band LABEL (not its
+    # hex colour), evaluated high threshold first. Keeps the legend labels in
+    # lockstep with the band table.
+    clauses = [f"{value_expr} >= {lo}, '{label}'"
+               for lo, label, _ in reversed(bands) if lo > 0]
+    return "case(" + ", ".join(clauses) + f", '{bands[0][1]}')"
+
+
 KQL_FLOWS = """ZoneFlowLines()
-| extend stroke_color = case(abs(quantity) >= 2500, '%s', abs(quantity) >= 1200, '%s', abs(quantity) >= 600, '%s', abs(quantity) >= 200, '%s', '%s')
-| project geometry, label, out_zone, in_zone, quantity, stroke_weight, stroke_color
-""" % (FLOW_COLORS[0], FLOW_COLORS[1], FLOW_COLORS[2], FLOW_COLORS[3], FLOW_COLORS[4])
+| extend flow_band = %s
+| project geometry, label, out_zone, in_zone, quantity, stroke_weight, flow_band
+""" % _band_case("abs(quantity)", FLOW_BANDS)
 
 KQL_PRICES = """ZonePriceMarkers()
-| extend fill_color = case(price >= 150, '%s', price >= 120, '%s', price >= 90, '%s', price >= 60, '%s', '%s')
-| project geometry, label, zone, price, fill_color
-""" % (PRICE_COLORS[4], PRICE_COLORS[3], PRICE_COLORS[2], PRICE_COLORS[1], PRICE_COLORS[0])
+| extend price_band = %s
+| project geometry, label, zone, price, price_band
+""" % _band_case("price", PRICE_BANDS)
 
 
-def _match_expr(get_col: str, colors: list[str]) -> list:
+def _band_match_expr(get_col: str, bands: list[tuple[int, str, str]]) -> list:
+    # Map a labelled band column (e.g. "600-1200 MW") to its swatch colour.
     expr = ["match", ["get", get_col]]
-    for c in colors:
-        expr += [c, c]
+    for _, label, color in bands:
+        expr += [label, color]
     expr.append("#888888")  # fallback
     return expr
 
 
-def _custom_colors(colors: list[str]) -> dict:
-    return {c: c for c in colors}
+def _custom_colors(bands: list[tuple[int, str, str]]) -> dict:
+    return {label: color for _, label, color in bands}
 
 
 def flows_layer() -> dict:
@@ -119,10 +147,10 @@ def flows_layer() -> dict:
         "options": {
             "type": "vector", "visible": True,
             "lineOptions": {
-                "strokeWidth": 3, "strokeOpacity": 0.9,
-                "strokeColor": _match_expr("stroke_color", FLOW_COLORS),
-                "enableSeriesGroup": True, "seriesGroup": "stroke_color",
-                "customColors": _custom_colors(FLOW_COLORS),
+                "strokeWidth": ["get", "stroke_weight"], "strokeOpacity": 0.9,
+                "strokeColor": _band_match_expr("flow_band", FLOW_BANDS),
+                "enableSeriesGroup": True, "seriesGroup": "flow_band",
+                "customColors": _custom_colors(FLOW_BANDS),
             },
             "dataLabelKeys": ["label"],
             "dataLabelOptions": {"enabled": True, "size": 11, "color": "#1a1a1a",
@@ -141,10 +169,10 @@ def prices_layer() -> dict:
         "options": {
             "type": "vector", "visible": True, "pointLayerType": "bubble",
             "bubbleOptions": {
-                "color": _match_expr("fill_color", PRICE_COLORS),
+                "color": _band_match_expr("price_band", PRICE_BANDS),
                 "radius": 11, "strokeColor": "#FFFFFF", "strokeWidth": 2,
                 "opacity": 0.95, "enableSeriesGroup": True,
-                "seriesGroup": "fill_color", "customColors": _custom_colors(PRICE_COLORS),
+                "seriesGroup": "price_band", "customColors": _custom_colors(PRICE_BANDS),
             },
             "dataLabelKeys": ["label"],
             "dataLabelOptions": {"enabled": True, "size": 13, "color": "#111111",

--- a/feeders/entsoe/fabric/helpers.kql
+++ b/feeders/entsoe/fabric/helpers.kql
@@ -161,7 +161,9 @@
           pack_array(l_lon, ly),
           pack_array(t_lon, ty),
           pack_array(r_lon, ry)))
-    | extend stroke_weight = todouble(1.5 + abs(quantity) / 700.0)
+    // Arrow stem width scales with flow magnitude but is capped so heavy
+    // interconnectors (multi-GW) stay legible and do not blot out the map.
+    | extend stroke_weight = todouble(min_of(6.0, 1.5 + abs(quantity) / 700.0))
     | extend label = strcat(out_zone, "\u2192", in_zone, " ", tostring(round(abs(quantity), 0)))
     | project geometry, out_zone, in_zone, quantity, stroke_weight, label
 }

--- a/feeders/entsoe/fabric/helpers.kql
+++ b/feeders/entsoe/fabric/helpers.kql
@@ -1,0 +1,167 @@
+// ===========================================================================
+// ENTSO-E Fabric helper functions
+// ---------------------------------------------------------------------------
+// Shared KQL helpers consumed by the entsoe Real-Time Dashboard and the entsoe
+// Fabric Map. Apply to the `entsoe` KQL database (the one fed by the
+// entsoe eventstream). Idempotent: every function is .create-or-alter.
+//
+//   PsrType()          - ENTSO-E production-type code -> fuel label / renewable
+//                        flag / hex colour (B01..B20).
+//   EICZone()          - EIC area code -> bidding-zone label, country, centroid
+//                        lat/lon (for map markers and human-readable labels).
+//   PriceColor(price)  - scalar: day-ahead price (EUR/MWh) -> hex colour ramp.
+//   ZonePriceMarkers() - DayAheadPricesLatest joined to EICZone, projected to a
+//                        GeoJSON Point `geometry` column for the map symbol layer.
+//   ZoneFlowLines()    - CrossBorderPhysicalFlowsLatest joined to EICZone on both
+//                        endpoints, projected to a GeoJSON LineString `geometry`
+//                        column for the map flow layer (bidirectional pairs
+//                        netted to a single directed arrow).
+// ===========================================================================
+
+.create-or-alter function with (docstring="ENTSO-E production type (psrType) lookup: fuel label, renewable flag, hex colour.", folder="entsoe/reference") PsrType() {
+    datatable(code:string, fuel:string, isRenewable:bool, color:string)
+    [
+        "B01", "Biomass",                    true,  "#2E8B57",
+        "B02", "Fossil Brown coal/Lignite",  false, "#6B4423",
+        "B03", "Fossil Coal-derived gas",    false, "#5B4636",
+        "B04", "Fossil Gas",                 false, "#E66C37",
+        "B05", "Fossil Hard coal",           false, "#3F3A36",
+        "B06", "Fossil Oil",                 false, "#8B5A2B",
+        "B07", "Fossil Oil shale",           false, "#7A5230",
+        "B08", "Fossil Peat",                false, "#80664D",
+        "B09", "Geothermal",                 true,  "#B5651D",
+        "B10", "Hydro Pumped Storage",       false, "#17A2B8",
+        "B11", "Hydro Run-of-river",         true,  "#2E86C1",
+        "B12", "Hydro Water Reservoir",      true,  "#1F6FB2",
+        "B13", "Marine",                     true,  "#0E7C7B",
+        "B14", "Nuclear",                    false, "#A21CAF",
+        "B15", "Other renewable",            true,  "#88C057",
+        "B16", "Solar",                      true,  "#F4C20D",
+        "B17", "Waste",                      false, "#7D6608",
+        "B18", "Wind Offshore",              true,  "#15607A",
+        "B19", "Wind Onshore",               true,  "#4FB0E3",
+        "B20", "Other",                      false, "#8A8886",
+        "B25", "Energy storage",             false, "#9AA0A6"
+    ]
+}
+
+.create-or-alter function with (docstring="ENTSO-E EIC area code -> bidding-zone label, country, centroid lat/lon.", folder="entsoe/reference") EICZone() {
+    datatable(eic:string, zone:string, country:string, lat:real, lon:real)
+    [
+        // --- Central / Western continental ---
+        "10Y1001A1001A82H", "DE-LU", "DE/LU", 51.16, 10.45,
+        "10Y1001A1001A83F", "DE",    "DE",    51.16, 10.45,
+        "10YDE-AT-LU---Q",  "DE-AT-LU", "DE", 50.00, 11.00,
+        "10YFR-RTE------C", "FR",    "FR",    46.60,  2.40,
+        "10YNL----------L", "NL",    "NL",    52.20,  5.30,
+        "10YBE----------2", "BE",    "BE",    50.60,  4.60,
+        "10YAT-APG------L", "AT",    "AT",    47.60, 14.10,
+        "10YCH-SWISSGRIDZ", "CH",    "CH",    46.80,  8.20,
+        "10YCZ-CEPS-----N", "CZ",    "CZ",    49.80, 15.50,
+        "10YPL-AREA-----S", "PL",    "PL",    52.10, 19.40,
+        "10YSK-SEPS-----K", "SK",    "SK",    48.70, 19.50,
+        "10YHU-MAVIR----U", "HU",    "HU",    47.20, 19.40,
+        "10YSI-ELES-----O", "SI",    "SI",    46.15, 14.99,
+        // --- Iberia ---
+        "10YES-REE------0", "ES",    "ES",    40.30, -3.70,
+        "10YPT-REN------W", "PT",    "PT",    39.50, -8.00,
+        // --- Italy (north node for continental borders; south node for the GR link) ---
+        "10YIT-GRTN-----B", "IT",    "IT",    42.50, 12.50,
+        "10Y1001A1001A73I", "IT-N",  "IT",    45.40,  9.50,
+        "10Y1001A1001A699", "IT-BR", "IT",    40.45, 17.95,
+        "10Y1001A1001A66F", "IT-GR", "IT",    40.05, 18.15,
+        // --- British Isles ---
+        "10YGB----------A", "GB",    "GB",    52.80, -1.50,
+        "10Y1001A1001A59C", "IE-SEM","IE",    53.20, -7.80,
+        "10YIE-1001A00010", "IE",    "IE",    53.40, -7.90,
+        "10Y1001A1001A016", "NIE",   "GB",    54.60, -6.80,
+        // --- Nordic ---
+        "10YDK-1--------W", "DK1",   "DK",    56.20,  9.20,
+        "10YDK-2--------M", "DK2",   "DK",    55.50, 11.90,
+        "10YFI-1--------U", "FI",    "FI",    62.00, 25.70,
+        "10YNO-1--------2", "NO1",   "NO",    60.20,  9.80,
+        "10YNO-2--------T", "NO2",   "NO",    59.00,  7.50,
+        "10YNO-3--------J", "NO3",   "NO",    63.20, 10.60,
+        "10YNO-4--------9", "NO4",   "NO",    68.20, 16.50,
+        "10Y1001A1001A48H", "NO5",   "NO",    60.70,  6.40,
+        "10Y1001A1001A44P", "SE1",   "SE",    66.50, 19.80,
+        "10Y1001A1001A45N", "SE2",   "SE",    63.50, 16.50,
+        "10Y1001A1001A46L", "SE3",   "SE",    59.30, 16.00,
+        "10Y1001A1001A47J", "SE4",   "SE",    56.40, 13.60,
+        // --- Baltics ---
+        "10Y1001A1001A39I", "EE",    "EE",    58.70, 25.50,
+        "10YLV-1001A00074", "LV",    "LV",    56.90, 24.60,
+        "10YLT-1001A0008Q", "LT",    "LT",    55.20, 23.90,
+        // --- South-East Europe / Balkans ---
+        "10YGR-HTSO-----Y", "GR",    "GR",    39.50, 22.00,
+        "10YRO-TEL------P", "RO",    "RO",    45.90, 24.90,
+        "10YCA-BULGARIA-R", "BG",    "BG",    42.70, 25.30,
+        "10YCS-SERBIATSOV", "RS",    "RS",    44.00, 20.90,
+        "10YHR-HEP------M", "HR",    "HR",    45.50, 16.00,
+        "10YBA-JPCC-----D", "BA",    "BA",    44.00, 17.80,
+        "10YCS-CG-TSO---S", "ME",    "ME",    42.70, 19.30,
+        "10YMK-MEPSO----8", "MK",    "MK",    41.60, 21.70,
+        "10YAL-KESH-----5", "AL",    "AL",    41.00, 20.00,
+        "10Y1001C--00100H", "XK",    "XK",    42.60, 20.90,
+        // --- Eastern periphery ---
+        "10YTR-TEIAS----W", "TR",    "TR",    39.50, 33.00,
+        "10Y1001A1001A990", "MD",    "MD",    47.00, 28.50,
+        "10Y1001C--00003F", "UA",    "UA",    49.00, 27.00
+    ]
+}
+
+.create-or-alter function with (docstring="Day-ahead price (EUR/MWh) -> hex colour ramp (green cheap -> red expensive).", folder="entsoe/reference") PriceColor(price:real) {
+    case(
+        price < 0,    "#1A9850",
+        price < 40,   "#66BD63",
+        price < 70,   "#A6D96A",
+        price < 100,  "#FEE08B",
+        price < 130,  "#FDAE61",
+        price < 170,  "#F46D43",
+        "#D73027")
+}
+
+.create-or-alter function with (docstring="Day-ahead zone prices as GeoJSON Point markers for the Fabric Map symbol layer.", folder="entsoe/map") ZonePriceMarkers() {
+    ['eu.entsoe.transparency.DayAheadPricesLatest']
+    | join kind=inner (EICZone()) on $left.inDomain == $right.eic
+    | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(lon, lat))
+    | extend marker_color = PriceColor(price)
+    | extend label = strcat(zone, "  ", tostring(round(price, 1)), " EUR/MWh")
+    | project geometry, zone, country, price, unitName, marker_color, label
+}
+
+.create-or-alter function with (docstring="Cross-border physical flows as GeoJSON arrow LineStrings (exporter -> importer). Each directed flow is offset perpendicular to the border axis so the two directions of a border render as separate parallel arrows; the path carries an explicit arrowhead so direction is readable. Coordinates are cosine-corrected for longitude so arrows stay perpendicular on the map.", folder="entsoe/map") ZoneFlowLines() {
+    let off = 0.34;     // max perpendicular separation between the two directions (projected deg)
+    let t0  = 0.16;     // shaft start, fraction along the exporter->importer axis
+    let t1  = 0.80;     // arrow tip, fraction along the axis
+    ['eu.entsoe.transparency.CrossBorderPhysicalFlowsLatest']
+    | join kind=inner (EICZone() | project ineic=eic,  in_zone=zone,  in_lat=lat,  in_lon=lon)  on $left.inDomain  == $right.ineic
+    | join kind=inner (EICZone() | project outeic=eic, out_zone=zone, out_lat=lat, out_lon=lon) on $left.outDomain == $right.outeic
+    | where in_zone != out_zone and abs(quantity) > 0
+    // local equirectangular projection: scale longitude by cos(mean latitude)
+    | extend mlat = (in_lat + out_lat) / 2.0
+    | extend kx   = cos(mlat * pi() / 180.0)
+    | extend ogx  = out_lon * kx, igx = in_lon * kx
+    | extend vx   = igx - ogx, vy = in_lat - out_lat
+    | extend L    = sqrt(vx * vx + vy * vy)
+    | where L > 0
+    | extend ux = vx / L, uy = vy / L           // unit vector exporter->importer
+    | extend px = -uy,    py = ux               // left-hand perpendicular
+    | extend offe = todouble(min_of(off, 0.30 * L))  // shrink offset on short borders so arrows hug the axis
+    | extend hb = todouble(min_of(0.22, 0.08 * L))   // arrowhead length (compact)
+    | extend hw = hb * 0.5                            // arrowhead half-width
+    | extend sgx = ogx + ux * (L * t0) + px * offe, sy = out_lat + uy * (L * t0) + py * offe
+    | extend tgx = ogx + ux * (L * t1) + px * offe, ty = out_lat + uy * (L * t1) + py * offe
+    | extend lgx = tgx - ux * hb + px * hw, ly = ty - uy * hb + py * hw
+    | extend rgx = tgx - ux * hb - px * hw, ry = ty - uy * hb - py * hw
+    | extend s_lon = sgx / kx, t_lon = tgx / kx, l_lon = lgx / kx, r_lon = rgx / kx
+    | extend geometry = bag_pack("type", "LineString", "coordinates", pack_array(
+          pack_array(s_lon, sy),
+          pack_array(t_lon, ty),
+          pack_array(l_lon, ly),
+          pack_array(t_lon, ty),
+          pack_array(r_lon, ry)))
+    | extend stroke_weight = todouble(1.5 + abs(quantity) / 700.0)
+    | extend label = strcat(out_zone, "\u2192", in_zone, " ", tostring(round(abs(quantity), 0)))
+    | project geometry, out_zone, in_zone, quantity, stroke_weight, label
+}

--- a/feeders/entsoe/fabric/post-deploy.ps1
+++ b/feeders/entsoe/fabric/post-deploy.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+    ENTSO-E Fabric post-deploy hook: applies the shared KQL helper functions
+    to the live `entsoe` KQL database and (re)builds the Real-Time Dashboard
+    and the Map item against it.
+
+.DESCRIPTION
+    Run after the generic feeder deployment (which creates the `entsoe`
+    Eventhouse / KQL DB and applies `kql/entsoe.kql`). This hook then:
+
+      1. Applies `helpers.kql` — five reference/geometry helper functions
+         consumed by both the dashboard and the map:
+           PsrType()           B01..B25 production-type -> fuel/renewable/color
+           EICZone()           EIC code  -> zone/country/lat/lon
+           PriceColor(price)   €/MWh     -> hex on a green->red ramp
+           ZonePriceMarkers()  DayAheadPricesLatest -> GeoJSON price points
+           ZoneFlowLines()     CrossBorderPhysicalFlowsLatest -> GeoJSON lines
+      2. Runs `build_dashboard.py` — creates/updates the 3-page
+         `KQLDashboard` "ENTSO-E European Electricity Market".
+      3. Runs `build_map.py` — creates/updates the `Map` item
+         "ENTSO-E Market Map" with the flow-line and price-bubble layers.
+
+    All three steps are idempotent. Authentication uses the signed-in Azure
+    CLI context (`az login`) — Fabric API and Kusto management tokens are
+    acquired via `az account get-access-token`.
+
+.PARAMETER Context
+    Optional hashtable passed by the generic deployer. Consumed keys:
+        WorkspaceId, DatabaseId, EventhouseClusterUri, DatabaseName
+#>
+[CmdletBinding()]
+param(
+    [hashtable] $Context,
+    [string]    $WorkspaceId   = "c98acd97-4363-4296-8323-b6ab21e53903",
+    [string]    $KqlDatabaseId = "a08303ed-4148-4c4d-b0fd-7ad5eb882e68",
+    [string]    $KustoUri      = "https://trd-fssgb36e98qh3fk58u.z2.kusto.fabric.microsoft.com",
+    [string]    $KustoDatabase = "entsoe"
+)
+
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if ($Context) {
+    if ($Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
+    if ($Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
+    if ($Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
+    if ($Context.ContainsKey('DatabaseName'))         { $KustoDatabase = $Context.DatabaseName }
+}
+
+Write-Host "== ENTSO-E Fabric post-deploy ==" -ForegroundColor Cyan
+Write-Host "   workspace : $WorkspaceId"
+Write-Host "   kql db    : $KqlDatabaseId ($KustoDatabase)"
+Write-Host "   cluster   : $KustoUri"
+
+# ---------------------------------------------------------------------------
+# 1. Apply helpers.kql to the live database (one .create-or-alter per call).
+# ---------------------------------------------------------------------------
+Write-Host "`n[1/3] Applying helpers.kql ..." -ForegroundColor Yellow
+$kustoTok = az account get-access-token --resource $KustoUri --query accessToken -o tsv
+$mgmt = "$KustoUri/v1/rest/mgmt"
+$src  = Get-Content (Join-Path $here "helpers.kql") -Raw
+$cmds = [System.Text.RegularExpressions.Regex]::Split($src, "(?=\.create-or-alter function)") |
+        Where-Object { $_.Trim() -like '.create-or-alter*' }
+foreach ($c in $cmds) {
+    $name = ([regex]::Match($c, '\)\s*([A-Za-z_]+)\s*\(')).Groups[1].Value
+    $bodyFile = New-TemporaryFile
+    (@{ db = $KustoDatabase; csl = $c.Trim() } | ConvertTo-Json -Compress -Depth 20) |
+        Set-Content $bodyFile -Encoding utf8
+    try {
+        Invoke-RestMethod -Uri $mgmt -Method Post -InFile $bodyFile `
+            -Headers @{ Authorization = "Bearer $kustoTok"; 'Content-Type' = 'application/json; charset=utf-8' } | Out-Null
+        Write-Host "      applied $name"
+    } finally { Remove-Item $bodyFile -Force }
+}
+
+# ---------------------------------------------------------------------------
+# 2. + 3. Build/refresh the dashboard and the map.
+# ---------------------------------------------------------------------------
+Write-Host "`n[2/3] Building Real-Time Dashboard ..." -ForegroundColor Yellow
+python (Join-Path $here "build_dashboard.py") --workspace $WorkspaceId --db $KqlDatabaseId --cluster $KustoUri
+
+Write-Host "`n[3/3] Building Map ..." -ForegroundColor Yellow
+python (Join-Path $here "build_map.py") --workspace $WorkspaceId --db $KqlDatabaseId
+
+Write-Host "`nDone. Open the items from the Real-Time Open Data workspace." -ForegroundColor Green

--- a/tools/deploy-fabric/README.md
+++ b/tools/deploy-fabric/README.md
@@ -76,8 +76,14 @@ chooses to no-op should `exit 0` so the bootstrap remains green.
 If the hook throws, the deployment is treated as failed (re-run with
 `-SkipPostDeployHook` to bypass and re-run the hook manually later).
 
-Example: see [`pegelonline/fabric/post-deploy.ps1`](../../pegelonline/fabric/post-deploy.ps1)
-(wires a Fabric Map item and ingests static river-segment reference data).
+Examples:
+
+* [`pegelonline/fabric/post-deploy.ps1`](../../feeders/pegelonline/fabric/post-deploy.ps1)
+  — wires a Fabric Map item and ingests static river-segment reference data.
+* [`entsoe/fabric/post-deploy.ps1`](../../feeders/entsoe/fabric/post-deploy.ps1)
+  — applies the shared KQL helper functions and builds both a 3-page
+  Real-Time Dashboard and a cross-border-flow Map
+  (see [`feeders/entsoe/fabric/README.md`](../../feeders/entsoe/fabric/README.md)).
 
 ## Prerequisites
 


### PR DESCRIPTION
## What

Integrates the **ENTSO-E Real-Time Dashboard** and **Market Map** into the
generic Fabric deployment scripts so they are built/refreshed automatically
at the end of a deploy, via the existing `{source}/fabric/post-deploy.ps1`
hook convention that `deploy-fabric.ps1` and `deploy-feeder-notebook.ps1`
already auto-discover and invoke.

## New `feeders/entsoe/fabric/`

| File | Purpose |
| ---- | ------- |
| `post-deploy.ps1` | Hook auto-invoked by the deployers. Applies `helpers.kql` to the live `entsoe` KQL DB (one `.create-or-alter` per call), then runs `build_dashboard.py` and `build_map.py` with the workspace / KQL-db / cluster IDs from the deployer's `-Context`. Idempotent; standalone-runnable. |
| `build_dashboard.py` | Idempotent 3-page `KQLDashboard` *ENTSO-E European Electricity Market* — **Prices & Market**, **Generation Mix & Renewables**, **System Balance & Cross-Border**. Every tile binds to a real materialized view / helper + validated KQL. |
| `build_map.py` | Idempotent `Map` item *ENTSO-E Market Map*: directional cross-border physical-flow arrow layer (dark 5-bucket magnitude ramp + `OUT→IN MW` labels) and day-ahead price-bubble layer. |
| `helpers.kql` | `PsrType` / `EICZone` / `PriceColor` / `ZonePriceMarkers` / `ZoneFlowLines` reference + geometry functions shared by both items. |
| `README.md` | Mirrors the gold-standard `pegelonline/fabric` docs convention. |

## Supporting feeder fixes (make the live data the items render)

- **`acquisition.py`** — full ENTSO-E cross-border catalogue: **88 borders /
  176 directed pairs** (was ~17), plus request pacing + 429/503 backoff.
- **`xml_parser.py`** — correct Transparency-Platform URL building for
  day-ahead prices (`A44`: no `processType`, `out_Domain = in_Domain`) and
  the load family (`A65`/`A70` via `outBiddingZone_Domain`).
- **`entsoe_kafka/app.py`** — disable the idempotent producer on the
  connection-string path; Event Hubs / Fabric Event Stream reject it with
  `UNSUPPORTED_FOR_MESSAGE_FORMAT`.

## Docs

- `tools/deploy-fabric/README.md` now lists both per-source hook examples
  (`pegelonline` and `entsoe`).

## Validation

- `tools/validate-fabric-deployment.ps1 -FeederSlug entsoe` → **0 blockers /
  0 warnings** (hook detected & valid, catalog `notebook: true`).
- `feeders/entsoe` unit + integration tests → **45 passed**.
- Both items were deployed and verified live in the "Real-Time Open Data"
  workspace against the live `entsoe` KQL DB (dark flow palette + arrow
  labels confirmed by screenshot during development).

## Notes

The deployment-script *mechanism* (hook auto-discovery + `-Context`) already
existed; this PR adds the entsoe hook + build scripts that plug into it, so
no changes to the generic orchestrators were required beyond the README.
