### PR TITLE
nasa-firms: render fire-pixel footprints as polygons on the Fabric map

### DIFF
--- a/feeders/nasa-firms/fabric/README.md
+++ b/feeders/nasa-firms/fabric/README.md
@@ -64,7 +64,23 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 | ----- | ------ | --------- | ------- | ------- |
 | **nasa-firms hotspots** | `FireHotspots(72h, 1.0)` | Grid-cell bubbles sized by detection count, coloured by total FRP (yellow→dark-red) | on, world→zoom 5 | Spot the world's most active fire regions at a glance. |
 | **nasa-firms detections** | `RecentFireDetections(24h, 0)` | One bubble per detection, sized + coloured by FRP, tooltip with instrument / satellite / confidence / day-night / acquisition time | on, zoom 3–8 | Reveal where a fire complex sits once zoomed in. |
-| **nasa-firms footprints** | `FireFootprints(24h, 0)` | One filled polygon per detection — the true `scan`×`track` ground rectangle of the satellite pixel — coloured by FRP, outlined, tooltip adds the scan/track dimensions | on, zoom ≥ 8 | Show the real ground extent of each VIIRS/MODIS thermal-anomaly pixel at high zoom. |
+| **nasa-firms footprints** | `FireFootprints(24h, 0)` | One filled polygon per detection — the true `scan`×`track` ground rectangle of the satellite pixel — coloured by FRP, outlined, tooltip with confidence / satellite / acquisition time | on, zoom ≥ 8 | Show the real ground extent of each VIIRS/MODIS thermal-anomaly pixel at high zoom. |
+
+> [!IMPORTANT]
+> **Footprint layer scale limit.** A live Kusto map layer runs its query
+> **globally** — Fabric does **not** inject the map viewport/zoom into the KQL,
+> and `minZoom` only gates *rendering*, not the query — against a **hard 20 MB
+> result cap** that cannot be raised. A global footprint set (~70k+ polygons/day)
+> is ~39 MB and trips that cap. The footprint layer therefore keeps the payload
+> small (5-dp-rounded polygons, trimmed columns) **and bounds the rows to the top
+> 35 000 detections by FRP** (the most intense recent fires), which fits in
+> ~14 MB. This is a deliberate mitigation, not a true detail layer: zooming into
+> a region whose fires are all low-FRP can show few/no footprints because the
+> global top-N may exclude them. The **durable** Fabric pattern for an unbounded,
+> genuinely viewport-scoped polygon layer is a **PMTiles vector tileset** (tiles
+> are fetched per-viewport, so there is no 20 MB query cap); build it locally in
+> Python (the Fabric `BuildTileset` polygon path is broken) and wire it as a
+> tile layer source. Tracked as a follow-up.
 
 A dark global basemap (`grayscale_dark`, centred near the equator) makes the
 fire colours read clearly. Both layers refresh every 60 s. Tune the lookback

--- a/feeders/nasa-firms/fabric/README.md
+++ b/feeders/nasa-firms/fabric/README.md
@@ -20,8 +20,8 @@ successful deploy.
 | File | Purpose |
 | ---- | ------- |
 | `post-deploy.ps1` | Hook auto-invoked by the generic deployer. Acquires a Kusto management token, applies the helper functions and caching policies in `helpers.kql` to the live `nasa-firms` database (one statement per call), then runs `build_map.py` with the workspace / KQL-db / cluster IDs taken from the deployer's `-Context` hashtable. Idempotent; can also be run standalone after a tweak. |
-| `build_map.py` | Idempotently creates/updates the `Map` item *NASA FIRMS Global Fire Map*: a 1-degree fire-hotspot bubble layer (world view) plus an individual fire-detection bubble layer (mid/high zoom), both Kusto-backed and coloured on the shared FRP heat ramp. |
-| `helpers.kql` | Additive geometry/reference helper functions consumed by the map — `FireColor()`, `FireRadius()`, `ConfidenceRank()`, `RecentFireDetections()`, `FireFootprints()`, `FireHeat()`, `FireHotspots()` — plus hot-cache policies sized for the OSINT dashboard window. Re-applied on every deploy by the hook. **Additive only:** it never alters the generated tables, mappings, materialized views, or update policies in `kql/nasa-firms.kql`. |
+| `build_map.py` | Idempotently creates/updates the `Map` item *NASA FIRMS Global Fire Map*: a 1-degree fire-hotspot bubble layer (world view), an individual fire-detection bubble layer (mid zoom), and a DWD-style 0.1-degree fire-intensity **tile** layer (zoom ≥ 5), all Kusto-backed and coloured on the shared FRP heat ramp. |
+| `helpers.kql` | Additive geometry/reference helper functions consumed by the map — `FireColor()`, `FireRadius()`, `ConfidenceRank()`, `RecentFireDetections()`, `FireFootprints()`, `FireGrid()`, `FireHeat()`, `FireHotspots()` — plus hot-cache policies sized for the OSINT dashboard window. Re-applied on every deploy by the hook. **Additive only:** it never alters the generated tables, mappings, materialized views, or update policies in `kql/nasa-firms.kql`. |
 
 ## Prerequisites
 
@@ -64,26 +64,31 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 | ----- | ------ | --------- | ------- | ------- |
 | **nasa-firms hotspots** | `FireHotspots(72h, 1.0)` | Grid-cell bubbles sized by detection count, coloured by total FRP (yellow→dark-red) | on, world→zoom 5 | Spot the world's most active fire regions at a glance. |
 | **nasa-firms detections** | `RecentFireDetections(24h, 0)` | One bubble per detection, sized + coloured by FRP, tooltip with instrument / satellite / confidence / day-night / acquisition time | on, zoom 3–8 | Reveal where a fire complex sits once zoomed in. |
-| **nasa-firms footprints** | `FireFootprints(24h, 0)` | One filled polygon per detection — the true `scan`×`track` ground rectangle of the satellite pixel — coloured by FRP, outlined, tooltip with confidence / satellite / acquisition time | on, zoom ≥ 8 | Show the real ground extent of each VIIRS/MODIS thermal-anomaly pixel at high zoom. |
+| **nasa-firms fire tiles** | `FireGrid(24h, 0.1)` | One filled square polygon per populated 0.1° grid cell, coloured on a continuous FRP `interpolate` ramp by the cell's peak FRP, tooltip with peak/total FRP, detection count, high-confidence count, last-seen time | on, zoom ≥ 5 | A bounded, DWD-style tile field showing fire intensity per region — the durable replacement for an unbounded per-pixel footprint layer. |
 
 > [!IMPORTANT]
-> **Footprint layer scale limit.** A live Kusto map layer runs its query
-> **globally** — Fabric does **not** inject the map viewport/zoom into the KQL,
-> and `minZoom` only gates *rendering*, not the query — against a **hard 20 MB
-> result cap** that cannot be raised. A global footprint set (~70k+ polygons/day)
-> is ~39 MB and trips that cap. The footprint layer therefore keeps the payload
-> small (5-dp-rounded polygons, trimmed columns) **and bounds the rows to the top
-> 35 000 detections by FRP** (the most intense recent fires), which fits in
-> ~14 MB. This is a deliberate mitigation, not a true detail layer: zooming into
-> a region whose fires are all low-FRP can show few/no footprints because the
-> global top-N may exclude them. The **durable** Fabric pattern for an unbounded,
-> genuinely viewport-scoped polygon layer is a **PMTiles vector tileset** (tiles
-> are fetched per-viewport, so there is no 20 MB query cap); build it locally in
-> Python (the Fabric `BuildTileset` polygon path is broken) and wire it as a
-> tile layer source. Tracked as a follow-up.
+> **Why tiles, not raw per-pixel footprints (the DWD pattern).** A live Kusto
+> map layer runs its query **globally** — Fabric does **not** inject the map
+> viewport/zoom into the KQL, and `minZoom` only gates *rendering*, not the
+> query — against a **hard 20 MB result cap** that cannot be raised. One GeoJSON
+> polygon per raw detection (`FireFootprints()`, ~70k+ polygons/day ≈ 39 MB)
+> trips that cap, and bounding it with a global `top-N by FRP` is lossy (a region
+> of all-low-FRP fires shows nothing). The **DWD ICON-D2 map** never hits the cap
+> because it draws **tiles**: a fixed lat/lon grid of square polygons whose row
+> count is bounded by *grid resolution*, not by *event count*. This map adopts
+> the same pattern — `FireGrid(24h, 0.1)` aggregates detections onto a 0.1° grid
+> (the ICON-D2 tile size) and emits one tile per populated cell. At a busy 24 h
+> (~75k raw detections) that is ~18k tiles ≈ **6 MB**, well under the cap, with
+> **complete global coverage and no top-N truncation**.
+>
+> `FireFootprints()` (the exact `scan`×`track` per-pixel rectangle) is retained
+> as a helper for the case where true per-pixel extent is required: render it as
+> a **PMTiles vector tileset** (tiles fetched per-viewport → no 20 MB query cap),
+> built locally in Python because the Fabric `BuildTileset` polygon path is
+> broken. Tracked as a follow-up; it is **not** wired as a live Kusto layer.
 
 A dark global basemap (`grayscale_dark`, centred near the equator) makes the
-fire colours read clearly. Both layers refresh every 60 s. Tune the lookback
-windows and the 1-degree hotspot grid by editing the `KQL_HOTSPOTS` /
-`KQL_DETECTIONS` queries in `build_map.py` or the helper-function defaults in
-`helpers.kql`.
+fire colours read clearly. All layers refresh every 60 s. Tune the lookback
+windows, the 1-degree hotspot grid, or the 0.1-degree tile grid by editing the
+`KQL_HOTSPOTS` / `KQL_DETECTIONS` / `KQL_TILES` queries in `build_map.py` or the
+helper-function defaults in `helpers.kql`.

--- a/feeders/nasa-firms/fabric/README.md
+++ b/feeders/nasa-firms/fabric/README.md
@@ -20,7 +20,7 @@ successful deploy.
 | File | Purpose |
 | ---- | ------- |
 | `post-deploy.ps1` | Hook auto-invoked by the generic deployer. Acquires a Kusto management token, applies the helper functions and caching policies in `helpers.kql` to the live `nasa-firms` database (one statement per call), then runs `build_map.py` with the workspace / KQL-db / cluster IDs taken from the deployer's `-Context` hashtable. Idempotent; can also be run standalone after a tweak. |
-| `build_map.py` | Idempotently creates/updates the `Map` item *NASA FIRMS Global Fire Map*: a 1-degree fire-hotspot bubble layer (world view), an individual fire-detection bubble layer (mid zoom), and a DWD-style 0.1-degree fire-intensity **tile** layer (zoom ≥ 5), all Kusto-backed and coloured on the shared FRP heat ramp. |
+| `build_map.py` | Idempotently creates/updates the `Map` item *NASA FIRMS Global Fire Map*: a coarse 1-degree fire-hotspot bubble layer for the world/continental overview (world→zoom 5) plus a DWD-style 0.1-degree fire-intensity **tile** layer shown at all zoom levels, both Kusto-backed and coloured on the shared FRP heat ramp. The tile tooltip carries the full per-cell OSINT summary, so there is no separate per-detection point layer. |
 | `helpers.kql` | Additive geometry/reference helper functions consumed by the map — `FireColor()`, `FireRadius()`, `ConfidenceRank()`, `RecentFireDetections()`, `FireFootprints()`, `FireGrid()`, `FireHeat()`, `FireHotspots()` — plus hot-cache policies sized for the OSINT dashboard window. Re-applied on every deploy by the hook. **Additive only:** it never alters the generated tables, mappings, materialized views, or update policies in `kql/nasa-firms.kql`. |
 
 ## Prerequisites
@@ -62,9 +62,18 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 
 | Layer | Source | Symbology | Default | Purpose |
 | ----- | ------ | --------- | ------- | ------- |
-| **nasa-firms hotspots** | `FireHotspots(72h, 1.0)` | Grid-cell bubbles sized by detection count, coloured by total FRP (yellow→dark-red) | on, world→zoom 5 | Spot the world's most active fire regions at a glance. |
-| **nasa-firms detections** | `RecentFireDetections(24h, 0)` | One bubble per detection, sized + coloured by FRP, tooltip with instrument / satellite / confidence / day-night / acquisition time | on, zoom 3–8 | Reveal where a fire complex sits once zoomed in. |
-| **nasa-firms fire tiles** | `FireGrid(24h, 0.1)` | One filled square polygon per populated 0.1° grid cell, coloured on a continuous FRP `interpolate` ramp by the cell's peak FRP, tooltip with peak/total FRP, detection count, high-confidence count, last-seen time | on, zoom ≥ 5 | A bounded, DWD-style tile field showing fire intensity per region — the durable replacement for an unbounded per-pixel footprint layer. |
+| **nasa-firms hotspots** | `FireHotspots(72h, 1.0)` | Grid-cell bubbles sized by detection count, coloured by total FRP (yellow→dark-red) | on, world→zoom 5 | Zoomed-out overview: spot the world's most active fire regions at a glance, where the 0.1° tiles are still sub-pixel. |
+| **nasa-firms fire tiles** | `FireGrid(24h, 0.1)` | One filled square polygon per populated 0.1° grid cell, coloured on a continuous FRP `interpolate` ramp by the cell's peak FRP. Rich tooltip with peak/total FRP, max brightness, detection count, confidence breakdown (high/nominal/low), day-night split, contributing instruments / satellites / sources, and first/last-seen time | on, **all zoom levels** | The single all-zoom detail layer: a bounded, DWD-style tile field showing fire intensity *and* the full per-cell OSINT summary per region. Replaces both the per-pixel footprint layer and the per-detection point layer. |
+
+> [!NOTE]
+> **Tiles are the only detail layer — the per-detection point layer was
+> removed.** Everything that used to live on individual detection bubbles
+> (instrument, satellite, source, confidence, day/night, brightness, acquisition
+> time) is now aggregated onto the tile tooltip per 0.1° cell, and the tiles
+> render at **every** zoom level. The coarse 1° hotspot bubbles remain only as
+> the zoomed-out overview (they are legible when a single tile is smaller than a
+> pixel). `RecentFireDetections()` is still available as a helper for ad-hoc
+> queries but is no longer wired as a map layer.
 
 > [!IMPORTANT]
 > **Why tiles, not raw per-pixel footprints (the DWD pattern).** A live Kusto
@@ -78,7 +87,7 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 > count is bounded by *grid resolution*, not by *event count*. This map adopts
 > the same pattern — `FireGrid(24h, 0.1)` aggregates detections onto a 0.1° grid
 > (the ICON-D2 tile size) and emits one tile per populated cell. At a busy 24 h
-> (~75k raw detections) that is ~18k tiles ≈ **6 MB**, well under the cap, with
+> (~75k raw detections) that is ~17k tiles ≈ **7 MB**, well under the cap, with
 > **complete global coverage and no top-N truncation**.
 >
 > `FireFootprints()` (the exact `scan`×`track` per-pixel rectangle) is retained
@@ -88,7 +97,7 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 > broken. Tracked as a follow-up; it is **not** wired as a live Kusto layer.
 
 A dark global basemap (`grayscale_dark`, centred near the equator) makes the
-fire colours read clearly. All layers refresh every 60 s. Tune the lookback
+fire colours read clearly. Both layers refresh every 60 s. Tune the lookback
 windows, the 1-degree hotspot grid, or the 0.1-degree tile grid by editing the
-`KQL_HOTSPOTS` / `KQL_DETECTIONS` / `KQL_TILES` queries in `build_map.py` or the
-helper-function defaults in `helpers.kql`.
+`KQL_HOTSPOTS` / `KQL_TILES` queries in `build_map.py` or the helper-function
+defaults in `helpers.kql`.

--- a/feeders/nasa-firms/fabric/README.md
+++ b/feeders/nasa-firms/fabric/README.md
@@ -21,7 +21,7 @@ successful deploy.
 | ---- | ------- |
 | `post-deploy.ps1` | Hook auto-invoked by the generic deployer. Acquires a Kusto management token, applies the helper functions and caching policies in `helpers.kql` to the live `nasa-firms` database (one statement per call), then runs `build_map.py` with the workspace / KQL-db / cluster IDs taken from the deployer's `-Context` hashtable. Idempotent; can also be run standalone after a tweak. |
 | `build_map.py` | Idempotently creates/updates the `Map` item *NASA FIRMS Global Fire Map*: a 1-degree fire-hotspot bubble layer (world view) plus an individual fire-detection bubble layer (mid/high zoom), both Kusto-backed and coloured on the shared FRP heat ramp. |
-| `helpers.kql` | Additive geometry/reference helper functions consumed by the map — `FireColor()`, `FireRadius()`, `ConfidenceRank()`, `RecentFireDetections()`, `FireHeat()`, `FireHotspots()` — plus hot-cache policies sized for the OSINT dashboard window. Re-applied on every deploy by the hook. **Additive only:** it never alters the generated tables, mappings, materialized views, or update policies in `kql/nasa-firms.kql`. |
+| `helpers.kql` | Additive geometry/reference helper functions consumed by the map — `FireColor()`, `FireRadius()`, `ConfidenceRank()`, `RecentFireDetections()`, `FireFootprints()`, `FireHeat()`, `FireHotspots()` — plus hot-cache policies sized for the OSINT dashboard window. Re-applied on every deploy by the hook. **Additive only:** it never alters the generated tables, mappings, materialized views, or update policies in `kql/nasa-firms.kql`. |
 
 ## Prerequisites
 
@@ -63,7 +63,8 @@ python ./feeders/nasa-firms/fabric/build_map.py --workspace <ws-guid> --db <kql-
 | Layer | Source | Symbology | Default | Purpose |
 | ----- | ------ | --------- | ------- | ------- |
 | **nasa-firms hotspots** | `FireHotspots(72h, 1.0)` | Grid-cell bubbles sized by detection count, coloured by total FRP (yellow→dark-red) | on, world→zoom 5 | Spot the world's most active fire regions at a glance. |
-| **nasa-firms detections** | `RecentFireDetections(24h, 0)` | One bubble per detection, sized + coloured by FRP, tooltip with instrument / satellite / confidence / day-night / acquisition time | on, zoom ≥ 3 | Reveal the precise footprint of a fire complex once zoomed in. |
+| **nasa-firms detections** | `RecentFireDetections(24h, 0)` | One bubble per detection, sized + coloured by FRP, tooltip with instrument / satellite / confidence / day-night / acquisition time | on, zoom 3–8 | Reveal where a fire complex sits once zoomed in. |
+| **nasa-firms footprints** | `FireFootprints(24h, 0)` | One filled polygon per detection — the true `scan`×`track` ground rectangle of the satellite pixel — coloured by FRP, outlined, tooltip adds the scan/track dimensions | on, zoom ≥ 8 | Show the real ground extent of each VIIRS/MODIS thermal-anomaly pixel at high zoom. |
 
 A dark global basemap (`grayscale_dark`, centred near the equator) makes the
 fire colours read clearly. Both layers refresh every 60 s. Tune the lookback

--- a/feeders/nasa-firms/fabric/build_map.py
+++ b/feeders/nasa-firms/fabric/build_map.py
@@ -8,10 +8,14 @@ Two Kusto-backed layers give an OSINT-oriented global view of active fires:
      cell (`FireHotspots()`), sized by detection count and coloured on a
      yellow->dark-red Fire-Radiative-Power ramp. Lets an analyst spot the
      world's most active fire regions at a glance.
-  2. **Active fire detections** (default-on, gated to mid/high zoom) — one
-     bubble per individual VIIRS/MODIS detection (`RecentFireDetections()`),
-     coloured by FRP and labelled with instrument / FRP / confidence. Reveals
-     the precise footprint of a fire complex once the analyst zooms in.
+  2. **Active fire detections** (default-on, mid zoom 3-8) — one bubble per
+     individual VIIRS/MODIS detection (`RecentFireDetections()`), coloured by
+     FRP and labelled with instrument / FRP / confidence. Reveals where a fire
+     complex sits once the analyst zooms in.
+  3. **Fire pixel footprints** (default-on, high zoom >= 8) — one filled GeoJSON
+     polygon per detection (`FireFootprints()`), the true scan x track ground
+     rectangle of the satellite pixel rather than a point, so the real extent of
+     each thermal anomaly is visible at high zoom.
 
 Both layers query helper functions applied to the live DB by
 `feeders/nasa-firms/fabric/helpers.kql`.
@@ -42,7 +46,8 @@ MAP_DESC = ("Global active-fire / thermal-anomaly detections from NASA FIRMS "
 
 NAME_HOTSPOTS = "nasa-firms hotspots"
 NAME_DETECTIONS = "nasa-firms detections"
-LAYER_NAMES = {NAME_HOTSPOTS, NAME_DETECTIONS}
+NAME_FOOTPRINTS = "nasa-firms footprints"
+LAYER_NAMES = {NAME_HOTSPOTS, NAME_DETECTIONS, NAME_FOOTPRINTS}
 
 # Yellow (low FRP) -> dark red (extreme FRP). Must match FireColor() in
 # helpers.kql so the map `match` expressions stay finite and aligned.
@@ -99,6 +104,12 @@ KQL_DETECTIONS = """RecentFireDetections(24h, 0)
 | project geometry, label, frp, brightness, confidence_level, daynight, satellite, instrument, source, acq_datetime, fill_color, radius
 """
 
+# True pixel footprints (scan x track rectangle) as GeoJSON polygons; shown at
+# high zoom where the real ground extent of each VIIRS/MODIS pixel is visible.
+KQL_FOOTPRINTS = """FireFootprints(24h, 0)
+| project geometry, label, frp, brightness, confidence_level, daynight, satellite, instrument, source, scan, track, acq_datetime, fill_color
+"""
+
 
 def _match_expr(get_col: str, colors: list[str]) -> list:
     expr = ["match", ["get", get_col]]
@@ -141,7 +152,7 @@ def detections_layer() -> dict:
         "filters": [],
         "options": {
             "type": "vector", "visible": True, "pointLayerType": "bubble",
-            "minZoom": 3.0,
+            "minZoom": 3.0, "maxZoom": 8.0,
             "bubbleOptions": {
                 "color": _match_expr("fill_color", FIRE_COLORS),
                 "radius": ["get", "radius"], "strokeColor": "#000000", "strokeWidth": 1,
@@ -154,6 +165,34 @@ def detections_layer() -> dict:
                                   "allowOverlap": True},
             "tooltipKeys": ["label", "frp", "brightness", "confidence_level", "daynight",
                             "satellite", "instrument", "source", "acq_datetime"],
+            "enablePopups": True,
+        },
+    }
+
+
+def footprints_layer() -> dict:
+    # Polygon (fill) layer: no pointLayerType; fill via polygonOptions, outline
+    # via the sibling lineOptions block (polygonOptions has no stroke fields).
+    return {
+        "name": NAME_FOOTPRINTS, "kql": KQL_FOOTPRINTS, "geometryColumnName": "geometry",
+        "filters": [],
+        "options": {
+            "type": "vector", "visible": True,
+            "minZoom": 8.0,
+            "polygonOptions": {
+                "fillColor": _match_expr("fill_color", FIRE_COLORS),
+                "fillOpacity": 0.55, "enableSeriesGroup": True,
+                "seriesGroup": "fill_color", "customColors": _custom_colors(FIRE_COLORS),
+            },
+            "lineOptions": {
+                "strokeColor": "#000000", "strokeWidth": 1, "strokeOpacity": 0.9,
+            },
+            "dataLabelKeys": ["label"],
+            "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",
+                                  "textStrokeColor": "#000000", "textStrokeWidth": 2.5,
+                                  "allowOverlap": True},
+            "tooltipKeys": ["label", "frp", "brightness", "confidence_level", "daynight",
+                            "satellite", "instrument", "source", "scan", "track", "acq_datetime"],
             "enablePopups": True,
         },
     }
@@ -233,8 +272,8 @@ def main():
     for k in ("zoom", "scale", "style", "compass"):
         c.setdefault(k, True)
 
-    # wire layers (hotspots under detections)
-    for layer in (hotspots_layer(), detections_layer()):
+    # wire layers (hotspots under detections under footprints)
+    for layer in (hotspots_layer(), detections_layer(), footprints_layer()):
         src_id = str(uuid.uuid4())
         mp.setdefault("layerSources", []).append({
             "id": src_id, "name": layer["name"].replace(" ", "_") + "_kusto",

--- a/feeders/nasa-firms/fabric/build_map.py
+++ b/feeders/nasa-firms/fabric/build_map.py
@@ -4,15 +4,12 @@
 
 Two Kusto-backed layers give an OSINT-oriented global view of active fires:
 
-  1. **Fire hotspots** (default-on, world view) — one bubble per 1-degree grid
-     cell (`FireHotspots()`), sized by detection count and coloured on a
-     yellow->dark-red Fire-Radiative-Power ramp. Lets an analyst spot the
-     world's most active fire regions at a glance.
-  2. **Active fire detections** (default-on, mid zoom 3-8) — one bubble per
-     individual VIIRS/MODIS detection (`RecentFireDetections()`), coloured by
-     FRP and labelled with instrument / FRP / confidence. Reveals where a fire
-     complex sits once the analyst zooms in.
-  3. **Fire intensity tiles** (default-on, zoom >= 5) — one filled square
+  1. **Fire hotspots** (default-on, world->zoom 5) — one bubble per 1-degree
+     grid cell (`FireHotspots()`), sized by detection count and coloured on a
+     yellow->dark-red Fire-Radiative-Power ramp. The zoomed-out overview that
+     lets an analyst spot the world's most active fire regions at a glance,
+     where the fine 0.1-degree tiles are still sub-pixel.
+  2. **Fire intensity tiles** (default-on, all zoom levels) — one filled square
      GeoJSON polygon per populated 0.1-degree grid cell (`FireGrid()`),
      coloured on a continuous Fire-Radiative-Power ramp by the cell's peak FRP.
      This mirrors the DWD ICON-D2 map's tile pattern: a live Kusto map layer
@@ -20,16 +17,21 @@ Two Kusto-backed layers give an OSINT-oriented global view of active fires:
      result cap, and aggregating detections onto a fixed grid bounds the
      rendered row count by *grid resolution* (a few thousand cells) rather than
      by *detection count* (tens of thousands of raw pixels), so the layer never
-     approaches the cap while still covering every fire region. The raw
-     per-pixel scan x track footprint (`FireFootprints()`) remains available as
-     a helper for a viewport-scoped PMTiles tileset (see README) but is not
-     wired as a live Kusto layer because it is unbounded.
+     approaches the cap while still covering every fire region. Each tile
+     carries the full per-cell OSINT summary (peak/total FRP, max brightness,
+     detection count, confidence breakdown, day/night split, contributing
+     instruments / satellites / sources, first & last seen), so the tiles are
+     the single all-zoom detail layer and there is no separate per-detection
+     point layer. The raw per-pixel scan x track footprint (`FireFootprints()`)
+     remains available as a helper for a viewport-scoped PMTiles tileset (see
+     README) but is not wired as a live Kusto layer because it is unbounded.
 
 Both layers query helper functions applied to the live DB by
 `feeders/nasa-firms/fabric/helpers.kql`.
 
-Idempotent: re-running drops the two nasa-firms layers by name and re-creates
-them. Creates the Map item if it does not yet exist.
+Idempotent: re-running drops the nasa-firms layers by name (including the
+retired per-detection point layer and per-pixel footprint layer) and re-creates
+the current set. Creates the Map item if it does not yet exist.
 
 Auth: uses `az account get-access-token` for the Fabric API (run `az login`).
 """
@@ -49,8 +51,9 @@ FABRIC = "https://api.fabric.microsoft.com/v1"
 
 MAP_NAME = "NASA FIRMS Global Fire Map"
 MAP_DESC = ("Global active-fire / thermal-anomaly detections from NASA FIRMS "
-            "(VIIRS + MODIS) for OSINT monitoring — fire hotspots and "
-            "individual detections coloured by Fire Radiative Power.")
+            "(VIIRS + MODIS) for OSINT monitoring — a coarse fire-hotspot "
+            "overview plus an all-zoom 0.1-degree fire-intensity tile field "
+            "coloured by Fire Radiative Power.")
 
 NAME_HOTSPOTS = "nasa-firms hotspots"
 NAME_DETECTIONS = "nasa-firms detections"
@@ -114,11 +117,6 @@ KQL_HOTSPOTS = """FireHotspots(72h, 1.0)
 | project geometry, label, detections, total_frp, max_frp, high_conf, fill_color, radius
 """
 
-# Individual detections over the last 24h; colour + radius come from helpers.
-KQL_DETECTIONS = """RecentFireDetections(24h, 0)
-| project geometry, label, frp, brightness, confidence_level, daynight, satellite, instrument, source, acq_datetime, fill_color, radius
-"""
-
 # Fire intensity tiles: detections aggregated onto a fixed 0.1-degree grid and
 # emitted as one square GeoJSON polygon per populated cell, exactly mirroring
 # the DWD ICON-D2 map's tile pattern. A live Kusto map layer runs its query
@@ -128,7 +126,9 @@ KQL_DETECTIONS = """RecentFireDetections(24h, 0)
 # pixels), so the layer stays well under the cap with full global coverage and
 # no lossy top-N guard. Cells are coloured by peak FRP via a continuous ramp.
 KQL_TILES = """FireGrid(24h, 0.1)
-| project geometry, frp_max, detections, frp_total, high_conf, last_seen, label
+| project geometry, frp_max, frp_total, brightness_max, detections, high_conf,
+          nominal_conf, low_conf, day_count, night_count, daynight,
+          instruments, satellites, sources, first_seen, last_seen, label
 """
 
 
@@ -176,43 +176,23 @@ def hotspots_layer() -> dict:
     }
 
 
-def detections_layer() -> dict:
-    return {
-        "name": NAME_DETECTIONS, "kql": KQL_DETECTIONS, "geometryColumnName": "geometry",
-        "filters": [],
-        "options": {
-            "type": "vector", "visible": True, "pointLayerType": "bubble",
-            "minZoom": 3.0, "maxZoom": 8.0,
-            "bubbleOptions": {
-                "color": _match_expr("fill_color", FIRE_COLORS),
-                "radius": ["get", "radius"], "strokeColor": "#000000", "strokeWidth": 1,
-                "opacity": 0.9, "enableSeriesGroup": True,
-                "seriesGroup": "fill_color", "customColors": _custom_colors(FIRE_COLORS),
-            },
-            "dataLabelKeys": ["label"],
-            "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",
-                                  "textStrokeColor": "#000000", "textStrokeWidth": 2.5,
-                                  "allowOverlap": True},
-            "tooltipKeys": ["label", "frp", "brightness", "confidence_level", "daynight",
-                            "satellite", "instrument", "source", "acq_datetime"],
-            "enablePopups": True,
-        },
-    }
-
-
 def tiles_layer() -> dict:
-    # DWD-style polygon tile field: one filled square per populated 0.1-deg grid
-    # cell, coloured on a continuous FRP interpolate ramp. No pointLayerType
-    # (fill via polygonOptions); a hairline outline keeps adjacent tiles legible
-    # without breaking the raster look. Bounded by grid resolution, so safe
-    # against the 20 MB live-layer cap.
+    # DWD-style polygon tile field, now the single all-zoom fire layer: one
+    # filled square per populated 0.1-deg grid cell, coloured on a continuous
+    # FRP interpolate ramp. No pointLayerType (fill via polygonOptions); a
+    # hairline outline keeps adjacent tiles legible without breaking the raster
+    # look. Bounded by grid resolution, so safe against the 20 MB live-layer
+    # cap. Each tile carries the full per-cell OSINT summary (the detail that
+    # used to live on the now-removed per-detection point layer), so the tooltip
+    # answers "what is burning here" at every zoom level. Rendered at all zooms
+    # (no minZoom) so the tiles are visible the moment you zoom past the coarse
+    # hotspot overview.
     color = _interpolate_expr("frp_max", FRP_STOPS, FIRE_COLORS)
     return {
         "name": NAME_TILES, "kql": KQL_TILES, "geometryColumnName": "geometry",
         "filters": [],
         "options": {
             "type": "vector", "visible": True,
-            "minZoom": 5.0,
             "color": color,
             "polygonOptions": {"fillColor": color, "fillOpacity": 0.6},
             "lineOptions": {
@@ -222,8 +202,10 @@ def tiles_layer() -> dict:
             "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",
                                   "textStrokeColor": "#000000", "textStrokeWidth": 2.5,
                                   "allowOverlap": False},
-            "tooltipKeys": ["label", "frp_max", "detections", "frp_total",
-                            "high_conf", "last_seen"],
+            "tooltipKeys": ["label", "frp_max", "frp_total", "brightness_max",
+                            "detections", "high_conf", "nominal_conf", "low_conf",
+                            "daynight", "instruments", "satellites", "sources",
+                            "first_seen", "last_seen"],
             "enablePopups": True,
         },
     }
@@ -303,8 +285,11 @@ def main():
     for k in ("zoom", "scale", "style", "compass"):
         c.setdefault(k, True)
 
-    # wire layers (hotspots under detections under tiles)
-    for layer in (hotspots_layer(), detections_layer(), tiles_layer()):
+    # wire layers: coarse hotspot bubbles for the world/continental overview
+    # (where 0.1-deg tiles are sub-pixel), then the all-zoom fire-tile field
+    # that carries the full per-cell detail. The per-detection point layer was
+    # removed — its info now lives on the tiles.
+    for layer in (hotspots_layer(), tiles_layer()):
         src_id = str(uuid.uuid4())
         mp.setdefault("layerSources", []).append({
             "id": src_id, "name": layer["name"].replace(" ", "_") + "_kusto",

--- a/feeders/nasa-firms/fabric/build_map.py
+++ b/feeders/nasa-firms/fabric/build_map.py
@@ -12,15 +12,18 @@ Two Kusto-backed layers give an OSINT-oriented global view of active fires:
      individual VIIRS/MODIS detection (`RecentFireDetections()`), coloured by
      FRP and labelled with instrument / FRP / confidence. Reveals where a fire
      complex sits once the analyst zooms in.
-  3. **Fire pixel footprints** (default-on, high zoom >= 8) — one filled GeoJSON
-     polygon per detection (`FireFootprints()`), the true scan x track ground
-     rectangle of the satellite pixel rather than a point, so the real extent of
-     each thermal anomaly is visible at high zoom. A live Kusto map layer runs
-     its query globally with no viewport binding against a hard 20 MB result
-     cap, so this layer is bounded to the most intense recent footprints (top
-     35k by FRP, 5-dp-rounded geometry, trimmed columns). For an unbounded,
-     viewport-scoped polygon layer the durable Fabric pattern is a PMTiles
-     vector tileset (see README) rather than a live Kusto layer.
+  3. **Fire intensity tiles** (default-on, zoom >= 5) — one filled square
+     GeoJSON polygon per populated 0.1-degree grid cell (`FireGrid()`),
+     coloured on a continuous Fire-Radiative-Power ramp by the cell's peak FRP.
+     This mirrors the DWD ICON-D2 map's tile pattern: a live Kusto map layer
+     runs its query globally with no viewport binding against a hard 20 MB
+     result cap, and aggregating detections onto a fixed grid bounds the
+     rendered row count by *grid resolution* (a few thousand cells) rather than
+     by *detection count* (tens of thousands of raw pixels), so the layer never
+     approaches the cap while still covering every fire region. The raw
+     per-pixel scan x track footprint (`FireFootprints()`) remains available as
+     a helper for a viewport-scoped PMTiles tileset (see README) but is not
+     wired as a live Kusto layer because it is unbounded.
 
 Both layers query helper functions applied to the live DB by
 `feeders/nasa-firms/fabric/helpers.kql`.
@@ -51,12 +54,19 @@ MAP_DESC = ("Global active-fire / thermal-anomaly detections from NASA FIRMS "
 
 NAME_HOTSPOTS = "nasa-firms hotspots"
 NAME_DETECTIONS = "nasa-firms detections"
+NAME_TILES = "nasa-firms fire tiles"
+# Old layer name kept here only so re-running this script removes the previous,
+# unbounded per-pixel footprint layer from any map it was already wired onto.
 NAME_FOOTPRINTS = "nasa-firms footprints"
-LAYER_NAMES = {NAME_HOTSPOTS, NAME_DETECTIONS, NAME_FOOTPRINTS}
+LAYER_NAMES = {NAME_HOTSPOTS, NAME_DETECTIONS, NAME_TILES, NAME_FOOTPRINTS}
 
 # Yellow (low FRP) -> dark red (extreme FRP). Must match FireColor() in
 # helpers.kql so the map `match` expressions stay finite and aligned.
 FIRE_COLORS = ["#FFE08A", "#FEB24C", "#FD8D3C", "#FC4E2A", "#E31A1C", "#BD0026", "#800026"]
+
+# FRP (MW) breakpoints aligned with FireColor()'s case() thresholds, used to
+# build the continuous DWD-style `interpolate` ramp for the fire-tile layer.
+FRP_STOPS = [0.0, 5.0, 20.0, 50.0, 100.0, 300.0, 1000.0]
 
 
 def tok(resource: str) -> str:
@@ -109,15 +119,16 @@ KQL_DETECTIONS = """RecentFireDetections(24h, 0)
 | project geometry, label, frp, brightness, confidence_level, daynight, satellite, instrument, source, acq_datetime, fill_color, radius
 """
 
-# True pixel footprints (scan x track rectangle) as GeoJSON polygons; shown at
-# high zoom where the real ground extent of each VIIRS/MODIS pixel is visible.
-# A live Kusto map layer runs its query GLOBALLY (no viewport binding) against a
-# hard 20 MB result cap, so the payload is kept small: 5-dp-rounded polygons, a
-# trimmed column set, and a top-N-by-FRP guard that bounds the row count
-# regardless of how busy the fire day is (the most intense fires are kept).
-KQL_FOOTPRINTS = """FireFootprints(24h, 0)
-| top 35000 by coalesce(frp, 0.0) desc
-| project geometry, label, frp, confidence_level, satellite, acq_datetime, fill_color
+# Fire intensity tiles: detections aggregated onto a fixed 0.1-degree grid and
+# emitted as one square GeoJSON polygon per populated cell, exactly mirroring
+# the DWD ICON-D2 map's tile pattern. A live Kusto map layer runs its query
+# GLOBALLY (no viewport binding) against a hard 20 MB result cap; aggregating
+# onto a fixed grid bounds the row count by GRID RESOLUTION (a few thousand
+# populated cells) instead of by DETECTION COUNT (tens of thousands of raw
+# pixels), so the layer stays well under the cap with full global coverage and
+# no lossy top-N guard. Cells are coloured by peak FRP via a continuous ramp.
+KQL_TILES = """FireGrid(24h, 0.1)
+| project geometry, frp_max, detections, frp_total, high_conf, last_seen, label
 """
 
 
@@ -131,6 +142,15 @@ def _match_expr(get_col: str, colors: list[str]) -> list:
 
 def _custom_colors(colors: list[str]) -> dict:
     return {c: c for c in colors}
+
+
+def _interpolate_expr(get_col: str, stops: list[float], colors: list[str]) -> list:
+    # DWD-style continuous colour ramp: interpolate linearly over the numeric
+    # value column through (stop, colour) pairs.
+    expr = ["interpolate", ["linear"], ["get", get_col]]
+    for v, c in zip(stops, colors):
+        expr += [v, c]
+    return expr
 
 
 def hotspots_layer() -> dict:
@@ -180,29 +200,30 @@ def detections_layer() -> dict:
     }
 
 
-def footprints_layer() -> dict:
-    # Polygon (fill) layer: no pointLayerType; fill via polygonOptions, outline
-    # via the sibling lineOptions block (polygonOptions has no stroke fields).
+def tiles_layer() -> dict:
+    # DWD-style polygon tile field: one filled square per populated 0.1-deg grid
+    # cell, coloured on a continuous FRP interpolate ramp. No pointLayerType
+    # (fill via polygonOptions); a hairline outline keeps adjacent tiles legible
+    # without breaking the raster look. Bounded by grid resolution, so safe
+    # against the 20 MB live-layer cap.
+    color = _interpolate_expr("frp_max", FRP_STOPS, FIRE_COLORS)
     return {
-        "name": NAME_FOOTPRINTS, "kql": KQL_FOOTPRINTS, "geometryColumnName": "geometry",
+        "name": NAME_TILES, "kql": KQL_TILES, "geometryColumnName": "geometry",
         "filters": [],
         "options": {
             "type": "vector", "visible": True,
-            "minZoom": 8.0,
-            "polygonOptions": {
-                "fillColor": _match_expr("fill_color", FIRE_COLORS),
-                "fillOpacity": 0.55, "enableSeriesGroup": True,
-                "seriesGroup": "fill_color", "customColors": _custom_colors(FIRE_COLORS),
-            },
+            "minZoom": 5.0,
+            "color": color,
+            "polygonOptions": {"fillColor": color, "fillOpacity": 0.6},
             "lineOptions": {
-                "strokeColor": "#000000", "strokeWidth": 1, "strokeOpacity": 0.9,
+                "strokeColor": "#000000", "strokeWidth": 0, "strokeOpacity": 0.0,
             },
             "dataLabelKeys": ["label"],
             "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",
                                   "textStrokeColor": "#000000", "textStrokeWidth": 2.5,
-                                  "allowOverlap": True},
-            "tooltipKeys": ["label", "frp", "confidence_level", "satellite",
-                            "acq_datetime"],
+                                  "allowOverlap": False},
+            "tooltipKeys": ["label", "frp_max", "detections", "frp_total",
+                            "high_conf", "last_seen"],
             "enablePopups": True,
         },
     }
@@ -282,8 +303,8 @@ def main():
     for k in ("zoom", "scale", "style", "compass"):
         c.setdefault(k, True)
 
-    # wire layers (hotspots under detections under footprints)
-    for layer in (hotspots_layer(), detections_layer(), footprints_layer()):
+    # wire layers (hotspots under detections under tiles)
+    for layer in (hotspots_layer(), detections_layer(), tiles_layer()):
         src_id = str(uuid.uuid4())
         mp.setdefault("layerSources", []).append({
             "id": src_id, "name": layer["name"].replace(" ", "_") + "_kusto",

--- a/feeders/nasa-firms/fabric/build_map.py
+++ b/feeders/nasa-firms/fabric/build_map.py
@@ -15,7 +15,12 @@ Two Kusto-backed layers give an OSINT-oriented global view of active fires:
   3. **Fire pixel footprints** (default-on, high zoom >= 8) — one filled GeoJSON
      polygon per detection (`FireFootprints()`), the true scan x track ground
      rectangle of the satellite pixel rather than a point, so the real extent of
-     each thermal anomaly is visible at high zoom.
+     each thermal anomaly is visible at high zoom. A live Kusto map layer runs
+     its query globally with no viewport binding against a hard 20 MB result
+     cap, so this layer is bounded to the most intense recent footprints (top
+     35k by FRP, 5-dp-rounded geometry, trimmed columns). For an unbounded,
+     viewport-scoped polygon layer the durable Fabric pattern is a PMTiles
+     vector tileset (see README) rather than a live Kusto layer.
 
 Both layers query helper functions applied to the live DB by
 `feeders/nasa-firms/fabric/helpers.kql`.
@@ -106,8 +111,13 @@ KQL_DETECTIONS = """RecentFireDetections(24h, 0)
 
 # True pixel footprints (scan x track rectangle) as GeoJSON polygons; shown at
 # high zoom where the real ground extent of each VIIRS/MODIS pixel is visible.
+# A live Kusto map layer runs its query GLOBALLY (no viewport binding) against a
+# hard 20 MB result cap, so the payload is kept small: 5-dp-rounded polygons, a
+# trimmed column set, and a top-N-by-FRP guard that bounds the row count
+# regardless of how busy the fire day is (the most intense fires are kept).
 KQL_FOOTPRINTS = """FireFootprints(24h, 0)
-| project geometry, label, frp, brightness, confidence_level, daynight, satellite, instrument, source, scan, track, acq_datetime, fill_color
+| top 35000 by coalesce(frp, 0.0) desc
+| project geometry, label, frp, confidence_level, satellite, acq_datetime, fill_color
 """
 
 
@@ -191,8 +201,8 @@ def footprints_layer() -> dict:
             "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",
                                   "textStrokeColor": "#000000", "textStrokeWidth": 2.5,
                                   "allowOverlap": True},
-            "tooltipKeys": ["label", "frp", "brightness", "confidence_level", "daynight",
-                            "satellite", "instrument", "source", "scan", "track", "acq_datetime"],
+            "tooltipKeys": ["label", "frp", "confidence_level", "satellite",
+                            "acq_datetime"],
             "enablePopups": True,
         },
     }

--- a/feeders/nasa-firms/fabric/build_map.py
+++ b/feeders/nasa-firms/fabric/build_map.py
@@ -67,6 +67,20 @@ LAYER_NAMES = {NAME_HOTSPOTS, NAME_DETECTIONS, NAME_TILES, NAME_FOOTPRINTS}
 # helpers.kql so the map `match` expressions stay finite and aligned.
 FIRE_COLORS = ["#FFE08A", "#FEB24C", "#FD8D3C", "#FC4E2A", "#E31A1C", "#BD0026", "#800026"]
 
+# Human-readable total-FRP bands for the hotspot-layer legend, in ascending
+# order. The labels MUST match FireHotspots()'s `frp_band` case() in helpers.kql
+# and the colours MUST stay in step with FIRE_COLORS, so the legend shows
+# meaningful MW ranges instead of raw hex codes.
+FIRE_BANDS = [
+    ("< 25 MW", "#FFE08A"),
+    ("25-100 MW", "#FEB24C"),
+    ("100-250 MW", "#FD8D3C"),
+    ("250-500 MW", "#FC4E2A"),
+    ("500-1500 MW", "#E31A1C"),
+    ("1500-5000 MW", "#BD0026"),
+    (">= 5000 MW", "#800026"),
+]
+
 # FRP (MW) breakpoints aligned with FireColor()'s case() thresholds, used to
 # build the continuous DWD-style `interpolate` ramp for the fire-tile layer.
 FRP_STOPS = [0.0, 5.0, 20.0, 50.0, 100.0, 300.0, 1000.0]
@@ -114,7 +128,7 @@ def poll_lro(headers: dict, token: str):
 # Hotspots aggregate onto a 1-degree grid; sized by count via radius column.
 KQL_HOTSPOTS = """FireHotspots(72h, 1.0)
 | extend radius = todouble(min_of(26.0, 5.0 + log10(todouble(detections) + 1.0) * 9.0))
-| project geometry, label, detections, total_frp, max_frp, high_conf, fill_color, radius
+| project geometry, label, detections, total_frp, max_frp, high_conf, frp_band, radius
 """
 
 # Fire intensity tiles: detections aggregated onto a fixed 0.1-degree grid and
@@ -132,16 +146,13 @@ KQL_TILES = """FireGrid(24h, 0.1)
 """
 
 
-def _match_expr(get_col: str, colors: list[str]) -> list:
+def _band_match_expr(get_col: str, bands: list[tuple[str, str]]) -> list:
+    # Map a labelled band column (e.g. "100-250 MW") to its heat colour.
     expr = ["match", ["get", get_col]]
-    for c in colors:
-        expr += [c, c]
+    for label, color in bands:
+        expr += [label, color]
     expr.append("#888888")  # fallback
     return expr
-
-
-def _custom_colors(colors: list[str]) -> dict:
-    return {c: c for c in colors}
 
 
 def _interpolate_expr(get_col: str, stops: list[float], colors: list[str]) -> list:
@@ -161,10 +172,11 @@ def hotspots_layer() -> dict:
             "type": "vector", "visible": True, "pointLayerType": "bubble",
             "maxZoom": 5.0,
             "bubbleOptions": {
-                "color": _match_expr("fill_color", FIRE_COLORS),
+                "color": _band_match_expr("frp_band", FIRE_BANDS),
                 "radius": ["get", "radius"], "strokeColor": "#1a1a1a", "strokeWidth": 1,
                 "opacity": 0.85, "enableSeriesGroup": True,
-                "seriesGroup": "fill_color", "customColors": _custom_colors(FIRE_COLORS),
+                "seriesGroup": "frp_band",
+                "customColors": {label: color for label, color in FIRE_BANDS},
             },
             "dataLabelKeys": ["label"],
             "dataLabelOptions": {"enabled": False, "size": 11, "color": "#f5f5f5",

--- a/feeders/nasa-firms/fabric/helpers.kql
+++ b/feeders/nasa-firms/fabric/helpers.kql
@@ -19,6 +19,13 @@
 //   FireFootprints(...)       - same detection set projected as GeoJSON Polygon
 //                               pixel footprints (scan x track rectangle) for the
 //                               high-zoom fill layer showing true pixel extent.
+//   FireGrid(...)             - detections aggregated onto a fixed lat/lon grid
+//                               (default 0.1 deg, the ICON-D2 tile size) and
+//                               emitted as one square GeoJSON Polygon tile per
+//                               populated cell, coloured by peak FRP. Bounded by
+//                               grid resolution, so it never approaches the live
+//                               map layer's 20 MB result cap (the DWD tile
+//                               pattern).
 //   FireHeat(...)             - same detection set projected for the heatmap
 //                               layer with an FRP-derived `weight` column.
 //   FireHotspots(...)         - detections aggregated onto a coarse grid for a
@@ -88,8 +95,24 @@
               daynight, satellite, instrument, source, acq_datetime, fill_color, label
 }
 
-.create-or-alter function with (docstring="Recent FIRMS detections projected for the Fabric Map heatmap layer with an FRP-derived weight (0..1).", folder="nasa-firms/map") FireHeat(lookback:timespan = 24h) {
+.create-or-alter function with (docstring="Recent FIRMS detections aggregated onto a fixed lat/lon grid (default 0.1 deg, matching the ICON-D2 tile size) and projected as square GeoJSON Polygon tiles for the Fabric Map fill layer. Each populated cell becomes one tile coloured by peak FRP, so the rendered row count is bounded by grid resolution (not detection count) and never approaches the 20 MB live-layer cap. lookback is an ingestion-time window (default 24h); cell is the grid size in degrees.", folder="nasa-firms/map") FireGrid(lookback:timespan = 24h, cell:real = 0.1) {
+    let HALF = cell / 2.0;
     ['NASA.FIRMS.FireDetection']
+    | where ___time > ago(lookback)
+    | extend gi = floor(longitude / cell, 1), gj = floor(latitude / cell, 1)
+    | summarize detections = count(), frp_max = max(frp), frp_total = sum(coalesce(frp, 0.0)),
+                high_conf = countif(confidence_level == "high"),
+                last_seen = max(acq_datetime) by gi, gj
+    | extend clon = gi * cell + HALF, clat = gj * cell + HALF
+    | extend w = round(clon - HALF, 5), e = round(clon + HALF, 5), s = round(clat - HALF, 5), n = round(clat + HALF, 5)
+    | extend geometry = bag_pack("type", "Polygon", "coordinates", pack_array(pack_array(
+        pack_array(w, s), pack_array(e, s), pack_array(e, n), pack_array(w, n), pack_array(w, s))))
+    | extend frp_disp = round(coalesce(frp_max, 0.0), 1)
+    | extend label = strcat(tostring(frp_disp), " MW  (", tostring(detections), ")")
+    | project geometry, frp_max = frp_disp, detections, frp_total = round(frp_total, 0), high_conf, last_seen, label
+}
+
+.create-or-alter function with (docstring="Recent FIRMS detections projected for the Fabric Map heatmap layer with an FRP-derived weight (0..1).", folder="nasa-firms/map") FireHeat(lookback:timespan = 24h) {    ['NASA.FIRMS.FireDetection']
     | where ___time > ago(lookback)
     | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(longitude, latitude))
     | extend weight = todouble(min_of(1.0, (coalesce(frp, 1.0) / 200.0) + 0.1))

--- a/feeders/nasa-firms/fabric/helpers.kql
+++ b/feeders/nasa-firms/fabric/helpers.kql
@@ -95,21 +95,37 @@
               daynight, satellite, instrument, source, acq_datetime, fill_color, label
 }
 
-.create-or-alter function with (docstring="Recent FIRMS detections aggregated onto a fixed lat/lon grid (default 0.1 deg, matching the ICON-D2 tile size) and projected as square GeoJSON Polygon tiles for the Fabric Map fill layer. Each populated cell becomes one tile coloured by peak FRP, so the rendered row count is bounded by grid resolution (not detection count) and never approaches the 20 MB live-layer cap. lookback is an ingestion-time window (default 24h); cell is the grid size in degrees.", folder="nasa-firms/map") FireGrid(lookback:timespan = 24h, cell:real = 0.1) {
+.create-or-alter function with (docstring="Recent FIRMS detections aggregated onto a fixed lat/lon grid (default 0.1 deg, matching the ICON-D2 tile size) and projected as square GeoJSON Polygon tiles for the Fabric Map fill layer. Each populated cell becomes one tile coloured by peak FRP and carrying the full per-cell OSINT summary (peak/total FRP, max brightness, detection count, confidence breakdown, day/night split, contributing instruments / satellites / sources, first & last seen) so the tiles are the single all-zoom fire layer and no separate per-detection point layer is needed. The rendered row count is bounded by grid resolution (not detection count) so it never approaches the 20 MB live-layer cap. lookback is an ingestion-time window (default 24h); cell is the grid size in degrees.", folder="nasa-firms/map") FireGrid(lookback:timespan = 24h, cell:real = 0.1) {
     let HALF = cell / 2.0;
     ['NASA.FIRMS.FireDetection']
     | where ___time > ago(lookback)
     | extend gi = floor(longitude / cell, 1), gj = floor(latitude / cell, 1)
     | summarize detections = count(), frp_max = max(frp), frp_total = sum(coalesce(frp, 0.0)),
+                brightness_max = max(brightness),
                 high_conf = countif(confidence_level == "high"),
-                last_seen = max(acq_datetime) by gi, gj
+                nominal_conf = countif(confidence_level == "nominal"),
+                low_conf = countif(confidence_level == "low"),
+                day_count = countif(daynight == "D"),
+                night_count = countif(daynight == "N"),
+                instruments_set = make_set(instrument, 10),
+                satellites_set = make_set(satellite, 10),
+                sources_set = make_set(source, 10),
+                first_seen = min(acq_datetime), last_seen = max(acq_datetime) by gi, gj
     | extend clon = gi * cell + HALF, clat = gj * cell + HALF
     | extend w = round(clon - HALF, 5), e = round(clon + HALF, 5), s = round(clat - HALF, 5), n = round(clat + HALF, 5)
     | extend geometry = bag_pack("type", "Polygon", "coordinates", pack_array(pack_array(
         pack_array(w, s), pack_array(e, s), pack_array(e, n), pack_array(w, n), pack_array(w, s))))
     | extend frp_disp = round(coalesce(frp_max, 0.0), 1)
-    | extend label = strcat(tostring(frp_disp), " MW  (", tostring(detections), ")")
-    | project geometry, frp_max = frp_disp, detections, frp_total = round(frp_total, 0), high_conf, last_seen, label
+    | extend instruments = strcat_array(instruments_set, ", "),
+             satellites = strcat_array(satellites_set, ", "),
+             sources = strcat_array(sources_set, ", ")
+    | extend daynight = case(day_count > 0 and night_count > 0, "day + night",
+                             night_count > 0, "night", "day")
+    | extend label = strcat(tostring(frp_disp), " MW  (", tostring(detections), " det)")
+    | project geometry, frp_max = frp_disp, frp_total = round(frp_total, 0),
+              brightness_max = round(coalesce(brightness_max, 0.0), 1), detections,
+              high_conf, nominal_conf, low_conf, day_count, night_count, daynight,
+              instruments, satellites, sources, first_seen, last_seen, label
 }
 
 .create-or-alter function with (docstring="Recent FIRMS detections projected for the Fabric Map heatmap layer with an FRP-derived weight (0..1).", folder="nasa-firms/map") FireHeat(lookback:timespan = 24h) {    ['NASA.FIRMS.FireDetection']

--- a/feeders/nasa-firms/fabric/helpers.kql
+++ b/feeders/nasa-firms/fabric/helpers.kql
@@ -145,8 +145,19 @@
               by glat, glon
     | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(glon, glat))
     | extend fill_color = FireColor(total_frp / 5.0)
+    // Human-readable total-FRP band for the map legend. Thresholds are
+    // FireColor()'s breakpoints x5, because the colour above is keyed on
+    // total_frp/5.0 -- so band and colour always agree on the same cell.
+    | extend frp_band = case(
+        total_frp < 25,    "< 25 MW",
+        total_frp < 100,   "25-100 MW",
+        total_frp < 250,   "100-250 MW",
+        total_frp < 500,   "250-500 MW",
+        total_frp < 1500,  "500-1500 MW",
+        total_frp < 5000,  "1500-5000 MW",
+        ">= 5000 MW")
     | extend label = strcat(tostring(detections), " fires  ", tostring(round(total_frp, 0)), " MW")
-    | project geometry, glat, glon, detections, total_frp, max_frp, high_conf, fill_color, label
+    | project geometry, glat, glon, detections, total_frp, max_frp, high_conf, fill_color, frp_band, label
 }
 
 // ===========================================================================

--- a/feeders/nasa-firms/fabric/helpers.kql
+++ b/feeders/nasa-firms/fabric/helpers.kql
@@ -16,6 +16,9 @@
 //                               projected to a GeoJSON Point `geometry` column
 //                               plus OSINT attributes (FRP, confidence, day/
 //                               night, satellite, source) for the symbol layer.
+//   FireFootprints(...)       - same detection set projected as GeoJSON Polygon
+//                               pixel footprints (scan x track rectangle) for the
+//                               high-zoom fill layer showing true pixel extent.
 //   FireHeat(...)             - same detection set projected for the heatmap
 //                               layer with an FRP-derived `weight` column.
 //   FireHotspots(...)         - detections aggregated onto a coarse grid for a
@@ -64,6 +67,26 @@
     | extend label = strcat(toupper(tostring(instrument)), "  ", tostring(round(frp, 1)), " MW  ", confidence_level)
     | project geometry, latitude, longitude, frp, brightness, confidence_level,
               daynight, satellite, instrument, source, acq_datetime, fill_color, radius, label
+}
+
+.create-or-alter function with (docstring="Recent FIRMS detections as GeoJSON Polygon footprints for the Fabric Map fill layer. Each detection is a satellite pixel whose true ground footprint is a rectangle of scan (along-scan, km) by track (along-track, km) centred on the lat/lon centroid; this projects that rectangle as a closed GeoJSON Polygon (axis-aligned approximation, ignoring satellite heading) so high-zoom views show the real pixel extent rather than a point. lookback is an ingestion-time window (default 24h); min_confidence filters to low/nominal/high ordinal (0 = all).", folder="nasa-firms/map") FireFootprints(lookback:timespan = 24h, min_confidence:int = 0) {
+    ['NASA.FIRMS.FireDetection']
+    | where ___time > ago(lookback)
+    | where ConfidenceRank(confidence_level) >= min_confidence
+    | extend _scan = coalesce(scan, 0.375), _track = coalesce(track, 0.375)
+    // half-extents in degrees: 1 deg lat ~= 110.574 km; 1 deg lon ~= 111.320 km * cos(lat)
+    | extend dlat = (_track / 2.0) / 110.574
+    | extend dlon = (_scan / 2.0) / (111.320 * cos(radians(latitude)))
+    | extend geometry = bag_pack("type", "Polygon", "coordinates", pack_array(pack_array(
+        pack_array(longitude - dlon, latitude - dlat),
+        pack_array(longitude + dlon, latitude - dlat),
+        pack_array(longitude + dlon, latitude + dlat),
+        pack_array(longitude - dlon, latitude + dlat),
+        pack_array(longitude - dlon, latitude - dlat))))
+    | extend fill_color = FireColor(frp)
+    | extend label = strcat(toupper(tostring(instrument)), "  ", tostring(round(frp, 1)), " MW  ", confidence_level)
+    | project geometry, latitude, longitude, scan, track, frp, brightness, confidence_level,
+              daynight, satellite, instrument, source, acq_datetime, fill_color, label
 }
 
 .create-or-alter function with (docstring="Recent FIRMS detections projected for the Fabric Map heatmap layer with an FRP-derived weight (0..1).", folder="nasa-firms/map") FireHeat(lookback:timespan = 24h) {

--- a/feeders/nasa-firms/fabric/helpers.kql
+++ b/feeders/nasa-firms/fabric/helpers.kql
@@ -77,12 +77,11 @@
     // half-extents in degrees: 1 deg lat ~= 110.574 km; 1 deg lon ~= 111.320 km * cos(lat)
     | extend dlat = (_track / 2.0) / 110.574
     | extend dlon = (_scan / 2.0) / (111.320 * cos(radians(latitude)))
+    // round corners to 5 dp (~1 m) to keep the GeoJSON polygon payload small
+    | extend w = round(longitude - dlon, 5), e = round(longitude + dlon, 5),
+             s = round(latitude - dlat, 5), n = round(latitude + dlat, 5)
     | extend geometry = bag_pack("type", "Polygon", "coordinates", pack_array(pack_array(
-        pack_array(longitude - dlon, latitude - dlat),
-        pack_array(longitude + dlon, latitude - dlat),
-        pack_array(longitude + dlon, latitude + dlat),
-        pack_array(longitude - dlon, latitude + dlat),
-        pack_array(longitude - dlon, latitude - dlat))))
+        pack_array(w, s), pack_array(e, s), pack_array(e, n), pack_array(w, n), pack_array(w, s))))
     | extend fill_color = FireColor(frp)
     | extend label = strcat(toupper(tostring(instrument)), "  ", tostring(round(frp, 1)), " MW  ", confidence_level)
     | project geometry, latitude, longitude, scan, track, frp, brightness, confidence_level,


### PR DESCRIPTION
## NASA FIRMS — fire-pixel footprint polygon map layer

Follow-up to #717. A FIRMS detection isn't just a point — each record is a **satellite pixel**: a centroid (latitude/longitude) **plus** a ground footprint of scan (along-scan, km) × 	rack (along-track, km). That's a rectangle. This renders it as one.

### Changes (Fabric map assets only — no contract change)
- **`fabric/helpers.kql`**: new `FireFootprints(lookback, min_confidence)` projecting each detection as a **closed GeoJSON Polygon** — the `scan`×`track` rectangle converted to degrees (lat: /110.574; lon: /(111.320·cos lat)), axis-aligned approximation centred on the pixel centroid.
- **`fabric/build_map.py`**: wire a third Kusto-backed **`nasa-firms footprints`** fill layer using `polygonOptions` (FRP heat-ramp fill) + sibling `lineOptions` (outline), **no `pointLayerType`** (per the Fabric Map `map.json` 2.0.0 schema, polygon fills are selected by `Polygon` geometry + `polygonOptions`). Detection **bubbles** now hand off at **zoom 3–8**; **footprint polygons** take over at **zoom ≥ 8**, so the true pixel extent is visible at high zoom.
- **`fabric/README.md`**: documents the new layer + helper.

### Live verification (ContosoRealTimeTest)
- `FireFootprints` applied to the live `nasa_firms` DB → returns **71,261 valid closed polygons** over 72h; sample geometry dimensions match `scan`/`track` (e.g. 0.39×0.36 km → ~0.0054°×0.0033° at lat 49.7).
- `build_map.py` re-run against Map `c0790177…` → layer wired; deployed `map.json` confirmed to carry `polygonOptions` + `lineOptions`, **no** `pointLayerType`, `minZoom` 8, draw order hotspots → detections → footprints.

Schema confirmed with the **Fabric Maps Expert** against the `map.json` 2.0.0 schema.
