### PR TITLE
Migrate Fabric feeder notebooks to pure-Python kernel

### DIFF
--- a/feeders/australia-wildfires/notebook/australia-wildfires-feed.ipynb
+++ b/feeders/australia-wildfires/notebook/australia-wildfires-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/autobahn/notebook/autobahn-feed.ipynb
+++ b/feeders/autobahn/notebook/autobahn-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/aviationweather/notebook/aviationweather-feed.ipynb
+++ b/feeders/aviationweather/notebook/aviationweather-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/bafu-hydro/notebook/bafu-hydro-feed.ipynb
+++ b/feeders/bafu-hydro/notebook/bafu-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/bfs-odl/notebook/bfs-odl-feed.ipynb
+++ b/feeders/bfs-odl/notebook/bfs-odl-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/billetto/notebook/billetto-feed.ipynb
+++ b/feeders/billetto/notebook/billetto-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/bom-australia/notebook/bom-australia-feed.ipynb
+++ b/feeders/bom-australia/notebook/bom-australia-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/canada-aqhi/notebook/canada-aqhi-feed.ipynb
+++ b/feeders/canada-aqhi/notebook/canada-aqhi-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/canada-eccc-wateroffice/notebook/canada-eccc-wateroffice-feed.ipynb
+++ b/feeders/canada-eccc-wateroffice/notebook/canada-eccc-wateroffice-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/carbon-intensity/notebook/carbon-intensity-feed.ipynb
+++ b/feeders/carbon-intensity/notebook/carbon-intensity-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/cbp-border-wait/notebook/cbp-border-wait-feed.ipynb
+++ b/feeders/cbp-border-wait/notebook/cbp-border-wait-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/cdec-reservoirs/notebook/cdec-reservoirs-feed.ipynb
+++ b/feeders/cdec-reservoirs/notebook/cdec-reservoirs-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/chmi-hydro/notebook/chmi-hydro-feed.ipynb
+++ b/feeders/chmi-hydro/notebook/chmi-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/defra-aurn/notebook/defra-aurn-feed.ipynb
+++ b/feeders/defra-aurn/notebook/defra-aurn-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/dmi/notebook/dmi-feed.ipynb
+++ b/feeders/dmi/notebook/dmi-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/dwd-pollenflug/notebook/dwd-pollenflug-feed.ipynb
+++ b/feeders/dwd-pollenflug/notebook/dwd-pollenflug-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/dwd/notebook/dwd-feed.ipynb
+++ b/feeders/dwd/notebook/dwd-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/eaws-albina/notebook/eaws-albina-feed.ipynb
+++ b/feeders/eaws-albina/notebook/eaws-albina-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/elexon-bmrs/notebook/elexon-bmrs-feed.ipynb
+++ b/feeders/elexon-bmrs/notebook/elexon-bmrs-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/energidataservice-dk/notebook/energidataservice-dk-feed.ipynb
+++ b/feeders/energidataservice-dk/notebook/energidataservice-dk-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/energy-charts/notebook/energy-charts-feed.ipynb
+++ b/feeders/energy-charts/notebook/energy-charts-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/entsoe/notebook/entsoe-feed.ipynb
+++ b/feeders/entsoe/notebook/entsoe-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/entur-norway/notebook/entur-norway-feed.ipynb
+++ b/feeders/entur-norway/notebook/entur-norway-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/environment-canada/notebook/environment-canada-feed.ipynb
+++ b/feeders/environment-canada/notebook/environment-canada-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/epa-uv/notebook/epa-uv-feed.ipynb
+++ b/feeders/epa-uv/notebook/epa-uv-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/eurdep-radiation/notebook/eurdep-radiation-feed.ipynb
+++ b/feeders/eurdep-radiation/notebook/eurdep-radiation-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/fienta/notebook/fienta-feed.ipynb
+++ b/feeders/fienta/notebook/fienta-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/fmi-finland/notebook/fmi-finland-feed.ipynb
+++ b/feeders/fmi-finland/notebook/fmi-finland-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/french-road-traffic/notebook/french-road-traffic-feed.ipynb
+++ b/feeders/french-road-traffic/notebook/french-road-traffic-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/gdacs/notebook/gdacs-feed.ipynb
+++ b/feeders/gdacs/notebook/gdacs-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/geosphere-austria/notebook/geosphere-austria-feed.ipynb
+++ b/feeders/geosphere-austria/notebook/geosphere-austria-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/german-waters/notebook/german-waters-feed.ipynb
+++ b/feeders/german-waters/notebook/german-waters-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/gios-poland/notebook/gios-poland-feed.ipynb
+++ b/feeders/gios-poland/notebook/gios-poland-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/gracedb/notebook/gracedb-feed.ipynb
+++ b/feeders/gracedb/notebook/gracedb-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/gtfs/notebook/gtfs-feed.ipynb
+++ b/feeders/gtfs/notebook/gtfs-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/hko-hong-kong/notebook/hko-hong-kong-feed.ipynb
+++ b/feeders/hko-hong-kong/notebook/hko-hong-kong-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/hongkong-epd/notebook/hongkong-epd-feed.ipynb
+++ b/feeders/hongkong-epd/notebook/hongkong-epd-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/hubeau-hydrometrie/notebook/hubeau-hydrometrie-feed.ipynb
+++ b/feeders/hubeau-hydrometrie/notebook/hubeau-hydrometrie-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/imgw-hydro/notebook/imgw-hydro-feed.ipynb
+++ b/feeders/imgw-hydro/notebook/imgw-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/inpe-deter-brazil/notebook/inpe-deter-brazil-feed.ipynb
+++ b/feeders/inpe-deter-brazil/notebook/inpe-deter-brazil-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/irail/notebook/irail-feed.ipynb
+++ b/feeders/irail/notebook/irail-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/irceline-belgium/notebook/irceline-belgium-feed.ipynb
+++ b/feeders/irceline-belgium/notebook/irceline-belgium-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/ireland-opw-waterlevel/notebook/ireland-opw-waterlevel-feed.ipynb
+++ b/feeders/ireland-opw-waterlevel/notebook/ireland-opw-waterlevel-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/jma-bosai-amedas/notebook/jma-bosai-amedas-feed.ipynb
+++ b/feeders/jma-bosai-amedas/notebook/jma-bosai-amedas-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/jma-bosai-quake/notebook/jma-bosai-quake-feed.ipynb
+++ b/feeders/jma-bosai-quake/notebook/jma-bosai-quake-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/jma-bosai-volcano/notebook/jma-bosai-volcano-feed.ipynb
+++ b/feeders/jma-bosai-volcano/notebook/jma-bosai-volcano-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/jma-bosai-warning/notebook/jma-bosai-warning-feed.ipynb
+++ b/feeders/jma-bosai-warning/notebook/jma-bosai-warning-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/jma-japan/notebook/jma-japan-feed.ipynb
+++ b/feeders/jma-japan/notebook/jma-japan-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/king-county-marine/notebook/king-county-marine-feed.ipynb
+++ b/feeders/king-county-marine/notebook/king-county-marine-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/kmi-belgium/notebook/kmi-belgium-feed.ipynb
+++ b/feeders/kmi-belgium/notebook/kmi-belgium-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/laqn-london/notebook/laqn-london-feed.ipynb
+++ b/feeders/laqn-london/notebook/laqn-london-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/luchtmeetnet-nl/notebook/luchtmeetnet-nl-feed.ipynb
+++ b/feeders/luchtmeetnet-nl/notebook/luchtmeetnet-nl-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/madrid-traffic/notebook/madrid-traffic-feed.ipynb
+++ b/feeders/madrid-traffic/notebook/madrid-traffic-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nasa-firms/notebook/nasa-firms-feed.ipynb
+++ b/feeders/nasa-firms/notebook/nasa-firms-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/ndw-road-traffic/notebook/ndw-road-traffic-feed.ipynb
+++ b/feeders/ndw-road-traffic/notebook/ndw-road-traffic-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nepal-bipad-hydrology/notebook/nepal-bipad-hydrology-feed.ipynb
+++ b/feeders/nepal-bipad-hydrology/notebook/nepal-bipad-hydrology-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nextbus/notebook/nextbus-feed.ipynb
+++ b/feeders/nextbus/notebook/nextbus-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nifc-usa-wildfires/notebook/nifc-usa-wildfires-feed.ipynb
+++ b/feeders/nifc-usa-wildfires/notebook/nifc-usa-wildfires-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nina-bbk/notebook/nina-bbk-feed.ipynb
+++ b/feeders/nina-bbk/notebook/nina-bbk-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/noaa-goes/notebook/noaa-goes-feed.ipynb
+++ b/feeders/noaa-goes/notebook/noaa-goes-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/noaa-ndbc/notebook/noaa-ndbc-feed.ipynb
+++ b/feeders/noaa-ndbc/notebook/noaa-ndbc-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/noaa-nws/notebook/noaa-nws-feed.ipynb
+++ b/feeders/noaa-nws/notebook/noaa-nws-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/noaa-swpc-l1/notebook/noaa-swpc-l1-feed.ipynb
+++ b/feeders/noaa-swpc-l1/notebook/noaa-swpc-l1-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/noaa/notebook/noaa-feed.ipynb
+++ b/feeders/noaa/notebook/noaa-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nve-hydro/notebook/nve-hydro-feed.ipynb
+++ b/feeders/nve-hydro/notebook/nve-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nws-alerts/notebook/nws-alerts-feed.ipynb
+++ b/feeders/nws-alerts/notebook/nws-alerts-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/nws-forecasts/notebook/nws-forecasts-feed.ipynb
+++ b/feeders/nws-forecasts/notebook/nws-forecasts-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/paris-bicycle-counters/notebook/paris-bicycle-counters-feed.ipynb
+++ b/feeders/paris-bicycle-counters/notebook/paris-bicycle-counters-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/pegelonline/notebook/pegelonline-feed.ipynb
+++ b/feeders/pegelonline/notebook/pegelonline-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/ptwc-tsunami/notebook/ptwc-tsunami-feed.ipynb
+++ b/feeders/ptwc-tsunami/notebook/ptwc-tsunami-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/rws-waterwebservices/notebook/rws-waterwebservices-feed.ipynb
+++ b/feeders/rws-waterwebservices/notebook/rws-waterwebservices-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/seattle-911/notebook/seattle-911-feed.ipynb
+++ b/feeders/seattle-911/notebook/seattle-911-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/seattle-street-closures/notebook/seattle-street-closures-feed.ipynb
+++ b/feeders/seattle-street-closures/notebook/seattle-street-closures-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/sensor-community/notebook/sensor-community-feed.ipynb
+++ b/feeders/sensor-community/notebook/sensor-community-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/singapore-nea/notebook/singapore-nea-feed.ipynb
+++ b/feeders/singapore-nea/notebook/singapore-nea-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/smhi-hydro/notebook/smhi-hydro-feed.ipynb
+++ b/feeders/smhi-hydro/notebook/smhi-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/smhi-weather/notebook/smhi-weather-feed.ipynb
+++ b/feeders/smhi-weather/notebook/smhi-weather-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/snotel/notebook/snotel-feed.ipynb
+++ b/feeders/snotel/notebook/snotel-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/syke-hydro/notebook/syke-hydro-feed.ipynb
+++ b/feeders/syke-hydro/notebook/syke-hydro-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/tepco-denkiyoho/notebook/tepco-denkiyoho-feed.ipynb
+++ b/feeders/tepco-denkiyoho/notebook/tepco-denkiyoho-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/uba-airdata/notebook/uba-airdata-feed.ipynb
+++ b/feeders/uba-airdata/notebook/uba-airdata-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/uk-ea-flood-monitoring/notebook/uk-ea-flood-monitoring-feed.ipynb
+++ b/feeders/uk-ea-flood-monitoring/notebook/uk-ea-flood-monitoring-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/usgs-earthquakes/notebook/usgs-earthquakes-feed.ipynb
+++ b/feeders/usgs-earthquakes/notebook/usgs-earthquakes-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/usgs-geomag/notebook/usgs-geomag-feed.ipynb
+++ b/feeders/usgs-geomag/notebook/usgs-geomag-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/usgs-iv/notebook/usgs-iv-feed.ipynb
+++ b/feeders/usgs-iv/notebook/usgs-iv-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/usgs-nwis-wq/notebook/usgs-nwis-wq-feed.ipynb
+++ b/feeders/usgs-nwis-wq/notebook/usgs-nwis-wq-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/vatsim/notebook/vatsim-feed.ipynb
+++ b/feeders/vatsim/notebook/vatsim-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/wallonia-issep/notebook/wallonia-issep-feed.ipynb
+++ b/feeders/wallonia-issep/notebook/wallonia-issep-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/waterinfo-vmm/notebook/waterinfo-vmm-feed.ipynb
+++ b/feeders/waterinfo-vmm/notebook/waterinfo-vmm-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/wikimedia-osm-diffs/notebook/wikimedia-osm-diffs-feed.ipynb
+++ b/feeders/wikimedia-osm-diffs/notebook/wikimedia-osm-diffs-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/wsdot/notebook/wsdot-feed.ipynb
+++ b/feeders/wsdot/notebook/wsdot-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/feeders/xceed/notebook/xceed-feed.ipynb
+++ b/feeders/xceed/notebook/xceed-feed.ipynb
@@ -3,16 +3,16 @@
  "nbformat_minor": 5,
  "metadata": {
   "kernelspec": {
-   "name": "synapse_pyspark",
-   "display_name": "Synapse PySpark",
-   "language": "Python"
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
   },
   "language_info": {
    "name": "python"
   },
   "microsoft": {
    "language": "python",
-   "language_group": "synapse_pyspark",
+   "language_group": "jupyter_python",
    "ms_spell_check": {
     "ms_spell_check_language": "en"
    }

--- a/tools/deploy-fabric/deploy-feeder-notebook.ps1
+++ b/tools/deploy-fabric/deploy-feeder-notebook.ps1
@@ -638,6 +638,22 @@ $nb = $nbJson | ConvertFrom-Json
 
 if (-not $nb.metadata)              { $nb | Add-Member -NotePropertyName metadata     -NotePropertyValue ([pscustomobject]@{}) -Force }
 if (-not $nb.metadata.dependencies) { $nb.metadata | Add-Member -NotePropertyName dependencies -NotePropertyValue ([pscustomobject]@{}) -Force }
+
+# Force the pure-Python (jupyter_python) notebook kernel regardless of what the
+# committed .ipynb declares. Feeder notebooks are single-node Python pollers and
+# do no distributed Spark compute; the Python runtime is cheaper and faster to
+# start, and it still attaches the feeder Environment + custom wheels (verified
+# live on ContosoRealTimeTest). This is a safety net — the committed notebooks
+# are also stored with the Python kernel.
+$nb.metadata | Add-Member -NotePropertyName kernelspec -NotePropertyValue ([pscustomobject]@{
+    name         = 'python3.11'
+    display_name = 'Python 3.11'
+    language     = 'python'
+}) -Force
+$nb.metadata | Add-Member -NotePropertyName language_info -NotePropertyValue ([pscustomobject]@{ name = 'python' }) -Force
+if (-not $nb.metadata.microsoft) { $nb.metadata | Add-Member -NotePropertyName microsoft -NotePropertyValue ([pscustomobject]@{}) -Force }
+$nb.metadata.microsoft | Add-Member -NotePropertyName language       -NotePropertyValue 'python'         -Force
+$nb.metadata.microsoft | Add-Member -NotePropertyName language_group -NotePropertyValue 'jupyter_python' -Force
 $kqlBinding = @(
     [pscustomobject]@{
         name        = $db.displayName

--- a/tools/validate-fabric-deployment.ps1
+++ b/tools/validate-fabric-deployment.ps1
@@ -87,6 +87,16 @@ function Test-Notebook {
             $checks.Add((New-Check 'no-inline-installs' 'ok' 'No inline package installation magic found.'))
         }
 
+        $langGroup = $null
+        if ($notebook.metadata -and $notebook.metadata.microsoft) { $langGroup = $notebook.metadata.microsoft.language_group }
+        if ($langGroup -eq 'jupyter_python') {
+            $checks.Add((New-Check 'python-notebook-kernel' 'ok' 'Notebook uses the pure-Python (jupyter_python) kernel.'))
+        } elseif ($langGroup -eq 'synapse_pyspark') {
+            $checks.Add((New-Check 'python-notebook-kernel' 'blocker' 'Notebook uses the synapse_pyspark (Spark) kernel; feeder notebooks must use the pure-Python kernel (metadata.microsoft.language_group = "jupyter_python").'))
+        } else {
+            $checks.Add((New-Check 'python-notebook-kernel' 'warning' "Notebook metadata.microsoft.language_group is '$langGroup'; expected 'jupyter_python'."))
+        }
+
         if ($codeText -like '*/lakehouse/default/Files/feeder-state/*') {
             $checks.Add((New-Check 'onelake-feeder-state-log' 'ok' 'Notebook references /lakehouse/default/Files/feeder-state/.'))
         } elseif ($codeText -match '(/lakehouse/default/Files/|last-run\.log|LOG_PATH|STATE_FILE)') {


### PR DESCRIPTION
## What

Migrates all **92** committed Fabric feeder notebooks (`feeders/*/notebook/*-feed.ipynb`) from the Spark (`synapse_pyspark`) kernel to Fabric's pure-Python (`jupyter_python`) notebook kernel, and forces the Python kernel at deploy time so every deployment is Python regardless of the committed file.

## Why

Feeder notebooks are single-node Python pollers (requests / websocket → CloudEvents → Eventstream). They do **zero distributed Spark compute**, so the Spark kernel only added Capacity Unit cost and cold-start latency.

## Changes

- **92 notebooks**: `metadata.kernelspec` → `python3.11` and `metadata.microsoft.language_group` → `jupyter_python` (metadata-only; exactly 4 changed lines each).
- **`tools/deploy-fabric/deploy-feeder-notebook.ps1`**: forces the Python kernel metadata after parsing the committed `.ipynb` (belt-and-suspenders safety net).
- **`tools/validate-fabric-deployment.ps1`**: new `python-notebook-kernel` check — blocker on `synapse_pyspark`, ok on `jupyter_python`.

## Verification (live, ContosoRealTimeTest)

- A Python-kernel notebook still attaches the feeder **Environment + custom wheels**, uses `notebookutils` (`getToken`, `runtime.context`, `notebook.exit`), and writes to `/lakehouse/default/Files/...`.
- Ran **autobahn** end-to-end on the Python kernel → rows landed in **both** `_cloudevents_dispatch` **and** the typed update-policy tables (RoadEvent / WarningEvent / ChargingStation / ParkingLorry). Two-level KQL contract satisfied.
- `Update-EnvironmentSparkCompute` is intentionally kept — the Environment's library build/publish path is orthogonal to the notebook runtime kernel and the proven `feeder_env` was built that way.

## Static validation

`pwsh tools/validate-fabric-deployment.ps1` → **92 sources, 0 blockers, 0 warnings**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>