### PR TITLE
Regenerate stale pegelonline MQTT producer (xrcg 0.10.11)

### DIFF
--- a/feeders/pegelonline/pegelonline_mqtt_producer/README.md
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/README.md
@@ -149,13 +149,15 @@ make build
 
 ## Test```python
 
-de_wsv_pegelonline_mqtt_station_async:  Callable[[PartitionContext, EventData, CloudEvent, object], Awaitable[None]]
+de_wsv_pegelonline_mqtt_station_async:  Callable[[PartitionContext, EventData, CloudEvent, Station], Awaitable[None]]
 
 ```bash```
 
 make test
 
-```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.Station`:
+```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.Station`: A reference record for one federally administered
+German inland and coastal gauge published by Germany's Federal Waterways and Shipping Administration (WSV). It fires
+when the bridge publishes or refreshes the station catalog so consumers can interpret measurement events.
 
 
 The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
@@ -163,13 +165,13 @@ The assigned handler must be a coroutine (`async def`) that accepts the followin
 - `partition_context`: The partition context.
 - `event`: The event data.
 - `cloud_event`: The CloudEvent.
-- `data`: The event data of type `object`.
+- `data`: The event data of type `pegelonline_mqtt_producer_data.Station`.
 
 Example:
 
 ```python
 async def de_wsv_pegelonline_mqtt_station_event(partition_context: PartitionContext, event: EventData, cloud_event:
-CloudEvent, data: object) -> None:
+CloudEvent, data: Station) -> None:
     # Process the event data
     await partition_context.update_checkpoint(event)
 ```
@@ -191,14 +193,16 @@ make build
 
 ## Test```python
 
-de_wsv_pegelonline_mqtt_current_measurement_async:  Callable[[PartitionContext, EventData, CloudEvent, object],
-Awaitable[None]]
+de_wsv_pegelonline_mqtt_current_measurement_async:  Callable[[PartitionContext, EventData, CloudEvent,
+CurrentMeasurement], Awaitable[None]]
 
 ```bash```
 
 make test
 
-```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.CurrentMeasurement`:
+```Asynchronous handler hook for `de.wsv.pegelonline.mqtt.CurrentMeasurement`: A current measurement from Germany's
+Federal Waterways and Shipping Administration (WSV) for one monitoring site. It carries water level measurements for
+rivers, canals, and estuaries when the upstream feed reports a new or refreshed value.
 
 
 The assigned handler must be a coroutine (`async def`) that accepts the following parameters:
@@ -206,13 +210,13 @@ The assigned handler must be a coroutine (`async def`) that accepts the followin
 - `partition_context`: The partition context.
 - `event`: The event data.
 - `cloud_event`: The CloudEvent.
-- `data`: The event data of type `object`.
+- `data`: The event data of type `pegelonline_mqtt_producer_data.CurrentMeasurement`.
 
 Example:
 
 ```python
 async def de_wsv_pegelonline_mqtt_current_measurement_event(partition_context: PartitionContext, event: EventData,
-cloud_event: CloudEvent, data: object) -> None:
+cloud_event: CloudEvent, data: CurrentMeasurement) -> None:
     # Process the event data
     await partition_context.update_checkpoint(event)
 ```

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/__init__.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
+from .de import Water, Station, StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement
 
-__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]
+__all__ = ["Water", "Station", "StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement"]

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/__init__.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .wsv import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
+from .wsv import Water, Station, StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement
 
-__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]
+__all__ = ["Water", "Station", "StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement"]

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/__init__.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/__init__.py
@@ -1,3 +1,3 @@
-from .pegelonline import StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement, Water, Station
+from .pegelonline import Water, Station, StateMnwMhwEnum, StateNswHswEnum, TrendEnum, CurrentMeasurement
 
-__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]
+__all__ = ["Water", "Station", "StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement"]

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/__init__.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/__init__.py
@@ -1,8 +1,8 @@
+from .water import Water
+from .station import Station
 from .statemnwmhwenum import StateMnwMhwEnum
 from .statenswhswenum import StateNswHswEnum
 from .trendenum import TrendEnum
 from .currentmeasurement import CurrentMeasurement
-from .water import Water
-from .station import Station
 
-__all__ = ["StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement", "Water", "Station"]
+__all__ = ["Water", "Station", "StateMnwMhwEnum", "StateNswHswEnum", "TrendEnum", "CurrentMeasurement"]

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/currentmeasurement.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/currentmeasurement.py
@@ -12,11 +12,9 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-import avro.schema
-import avro.io
-from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
-from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
 from pegelonline_mqtt_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
 import datetime
 
 
@@ -34,10 +32,6 @@ class CurrentMeasurement:
         stateNswHsw (typing.Optional[StateNswHswEnum])
         trend (typing.Optional[TrendEnum])
     """
-    
-    AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.parse(
-        "{\"type\": \"record\", \"name\": \"CurrentMeasurement\", \"doc\": \"Latest 15-minute water-level reading for one WSV PegelOnline gauge. Sourced from `GET /stations/{uuid}/W/currentmeasurement.json` on the PegelOnline REST API v2. Carries only the W (water-level) timeseries; other timeseries (Q discharge, LT water temperature) are not emitted by this source.\", \"fields\": [{\"name\": \"station_id\", \"type\": \"string\", \"doc\": \"Stable UUID of the gauge this reading was taken at. References the `station_id` of the corresponding Station reference event. Used as the CloudEvents `subject` and the Kafka partition key so all readings for a given gauge land on the same partition / topic key.\"}, {\"name\": \"timestamp\", \"type\": {\"type\": \"string\", \"logicalType\": \"timestamp-millis\"}, \"doc\": \"Wall-clock time the upstream reading was taken, in ISO 8601 / RFC 3339 with an explicit UTC offset. PegelOnline publishes the value in Europe/Berlin local time, so the offset shifts between `+01:00` (CET) and `+02:00` (CEST) across the DST boundary \u2014 preserve the offset when storing. Sourced from the upstream `timestamp` field.\"}, {\"name\": \"value\", \"type\": \"double\", \"doc\": \"Water-level reading on the W (water-level) timeseries, in centimetres above the gauge's Pegelnullpunkt (PNP \u2014 a geodetically fixed datum specific to each gauge, see https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Typical operational range is 0\u20131500 cm; flood events at major Rhine gauges can exceed 1000 cm. Negative readings are valid at gauges whose normal pool is below PNP (e.g. tidal Elbe at low water). Unit: cm. [minimum: -1000, maximum: 2500]\"}, {\"name\": \"stateMnwMhw\", \"type\": [\"null\", \"string\"], \"doc\": \"Categorical classification of the current water level against the gauge's long-term mean low water (MNW) and mean high water (MHW) reference values, as computed by the upstream feed. Omitted by upstream when the gauge has no MNW/MHW reference series configured (treat absence as 'unknown').\", \"default\": null}, {\"name\": \"stateNswHsw\", \"type\": [\"null\", \"string\"], \"doc\": \"Categorical classification of the current water level against the highest navigable water level (HSW) reference for the reach, as computed by the upstream feed. Drives inland-shipping operational decisions (HSW = stop sign for commercial traffic). Note: upstream never emits 'low' on this series \u2014 HSW is an upper bound only. Omitted by upstream when the gauge has no HSW reference (treat absence as 'unknown').\", \"default\": null}, {\"name\": \"trend\", \"type\": [\"int\", \"null\"], \"doc\": \"Short-term trend of the water level relative to the previous reading, as classified by the upstream feed. First-class signal for flood-monitoring dashboards. Sourced from the upstream `trend` field; omitted when upstream cannot compute a trend (e.g. first reading after a gap).\", \"default\": null}]}"
-    )
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
@@ -59,37 +53,6 @@ class CurrentMeasurement:
             The dataclass representation of the dataclass.
         """
         return cls(**data)
-    @classmethod
-    def from_avro_dict(cls, data: dict) -> 'CurrentMeasurement':
-        """
-        Converts a dictionary from Avro deserialization to a dataclass instance.
-        Handles conversion of string representations back to Python types for
-        extended logical types.
-        
-        Args:
-            data: The dictionary from Avro deserialization.
-        
-        Returns:
-            The dataclass representation.
-        """
-        # Convert string values back to Python types for Avro string-based logical types
-        converted = data.copy()
-        if 'station_id' in converted and converted['station_id'] is not None:
-            value = converted['station_id']
-        if 'timestamp' in converted and converted['timestamp'] is not None:
-            value = converted['timestamp']
-            if isinstance(value, str):
-                converted['timestamp'] = datetime.datetime.fromisoformat(value)
-        if 'value' in converted and converted['value'] is not None:
-            value = converted['value']
-        if 'stateMnwMhw' in converted and converted['stateMnwMhw'] is not None:
-            value = converted['stateMnwMhw']
-        if 'stateNswHsw' in converted and converted['stateNswHsw'] is not None:
-            value = converted['stateNswHsw']
-        if 'trend' in converted and converted['trend'] is not None:
-            value = converted['trend']
-        
-        return cls(**converted)
 
     def to_serializer_dict(self) -> dict:
         """
@@ -113,26 +76,6 @@ class CurrentMeasurement:
             return k[:-1] if k.endswith('_') else k
         return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
 
-    def to_avro_dict(self) -> dict:
-        """
-        Converts the dataclass to a dictionary suitable for Avro serialization.
-        Handles conversion of Python types to Avro-compatible string representations
-        for extended logical types.
-
-        Returns:
-            The dictionary representation suitable for Avro serialization.
-        """
-        result = self.to_serializer_dict()
-        converted = result.copy()
-        
-        # Convert specific fields based on their source types
-        if 'timestamp' in converted and converted['timestamp'] is not None:
-            value = converted['timestamp']
-            if isinstance(value, datetime.datetime):
-                converted['timestamp'] = value.isoformat()
-        
-        return converted
-
     def to_byte_array(self, content_type_string: str) -> bytes:
         """
         Converts the dataclass to a byte array based on the content type string.
@@ -141,8 +84,6 @@ class CurrentMeasurement:
             content_type_string: The content type string to convert the dataclass to.
                 Supported content types:
                     'application/json': Encodes the data to JSON format.
-                    'avro/binary': Encodes the data to Avro binary format.
-                    'application/vnd.apache.avro+avro': Encodes the data to Avro binary format.
                 Supported content type extensions:
                     '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
 
@@ -154,13 +95,6 @@ class CurrentMeasurement:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-            # Convert to Avro binary format using the embedded schema
-            writer = avro.io.DatumWriter(self.AvroType)
-            with io.BytesIO() as stream:
-                encoder = avro.io.BinaryEncoder(stream)
-                writer.write(self.to_avro_dict(), encoder)
-                result = stream.getvalue()
         if base_content_type == 'application/json':
             #pylint: disable=no-member
             result = self.to_json()
@@ -190,8 +124,6 @@ class CurrentMeasurement:
             content_type_string: The content type string to convert the data to. 
                 Supported content types:
                     'application/json': Attempts to decode the data from JSON encoded format.
-                    'avro/binary': Attempts to decode the data from Avro binary format.
-                    'application/vnd.apache.avro+avro': Attempts to decode the data from Avro binary format.
                 Supported content type extensions:
                     '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
         Returns:
@@ -216,16 +148,6 @@ class CurrentMeasurement:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-            if isinstance(data, bytes):
-                # Decode from Avro binary format using the embedded schema
-                reader = avro.io.DatumReader(cls.AvroType)
-                with io.BytesIO(data) as stream:
-                    decoder = avro.io.BinaryDecoder(stream)
-                    _record = reader.read(decoder)
-                    return CurrentMeasurement.from_avro_dict(_record)
-            else:
-                raise NotImplementedError('Data is not of a supported type for Avro deserialization')
         if base_content_type == 'application/json':
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
@@ -244,9 +166,9 @@ class CurrentMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='mlsbcaufeieqnqnugtfe',
+            station_id='wkfurehpfqnswtovmxgf',
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            value=float(16.64115334335847),
+            value=float(70.61148318018796),
             stateMnwMhw=StateMnwMhwEnum.low,
             stateNswHsw=StateNswHswEnum.normal,
             trend=TrendEnum.VALUE_NEG_1

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/station.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/station.py
@@ -168,13 +168,13 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='kzdpykbcqqgzvelfnkki',
-            number='dumvaykuwuandljookao',
-            shortname='oniamautigdbzyktuquh',
-            longname='ongbqnrpnntlifcxftod',
-            km=float(48.90586839505602),
-            agency='jcpbfukajbutucymnrbu',
-            longitude=float(31.99545063211955),
-            latitude=float(28.4026986369164),
+            station_id='bivhvchptlwpjkptheew',
+            number='dcazyvzjvtuwhjmhsjlx',
+            shortname='hmdjcfhwhxvfbhnbqqhh',
+            longname='hbpzabotvbwsghpfdnft',
+            km=float(73.48493985389887),
+            agency='ykrwjsxeclkikuvguxra',
+            longitude=float(85.13182563335678),
+            latitude=float(75.13255396815651),
             water=None
         )

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/water.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/src/pegelonline_mqtt_producer_data/de/wsv/pegelonline/water.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-import avro.schema
-import avro.io
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -25,10 +23,6 @@ class Water:
         shortname (str)
         longname (str)
     """
-    
-    AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.parse(
-        "{\"type\": \"record\", \"name\": \"Water\", \"doc\": \"Federal waterway / water body the gauge measures, as returned in the nested `water` object of `GET /stations.json` on the PegelOnline REST API v2. Acts as the routing hierarchy for the MQTT Unified Namespace topology.\", \"fields\": [{\"name\": \"shortname\", \"type\": \"string\", \"doc\": \"Lowercase routing token for the waterway as published by WSV \u2014 e.g. 'rhein', 'elbe', 'donau', 'mosel'. Used (after ASCII-normalization for non-ASCII characters such as '\u00df' \u2192 'ss' or umlauts) as the `{water_shortname}` template variable on the MQTT topic and the AMQP application property. Sourced from the upstream `water.shortname` key. Maximum 40 characters.\"}, {\"name\": \"longname\", \"type\": \"string\", \"doc\": \"Canonical uppercase WSV name of the waterway (e.g. 'RHEIN', 'ELBE') as published in official German hydrology bulletins. Sourced from the upstream `water.longname` key. Maximum 255 characters.\"}]}"
-    )
     
     
     shortname: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="shortname"))
@@ -46,27 +40,6 @@ class Water:
             The dataclass representation of the dataclass.
         """
         return cls(**data)
-    @classmethod
-    def from_avro_dict(cls, data: dict) -> 'Water':
-        """
-        Converts a dictionary from Avro deserialization to a dataclass instance.
-        Handles conversion of string representations back to Python types for
-        extended logical types.
-        
-        Args:
-            data: The dictionary from Avro deserialization.
-        
-        Returns:
-            The dataclass representation.
-        """
-        # Convert string values back to Python types for Avro string-based logical types
-        converted = data.copy()
-        if 'shortname' in converted and converted['shortname'] is not None:
-            value = converted['shortname']
-        if 'longname' in converted and converted['longname'] is not None:
-            value = converted['longname']
-        
-        return cls(**converted)
 
     def to_serializer_dict(self) -> dict:
         """
@@ -90,22 +63,6 @@ class Water:
             return k[:-1] if k.endswith('_') else k
         return {_fix_key(k): _resolve_enum(v) for k, v in iter(data)}
 
-    def to_avro_dict(self) -> dict:
-        """
-        Converts the dataclass to a dictionary suitable for Avro serialization.
-        Handles conversion of Python types to Avro-compatible string representations
-        for extended logical types.
-
-        Returns:
-            The dictionary representation suitable for Avro serialization.
-        """
-        result = self.to_serializer_dict()
-        converted = result.copy()
-        
-        # Convert specific fields based on their source types
-        
-        return converted
-
     def to_byte_array(self, content_type_string: str) -> bytes:
         """
         Converts the dataclass to a byte array based on the content type string.
@@ -114,8 +71,6 @@ class Water:
             content_type_string: The content type string to convert the dataclass to.
                 Supported content types:
                     'application/json': Encodes the data to JSON format.
-                    'avro/binary': Encodes the data to Avro binary format.
-                    'application/vnd.apache.avro+avro': Encodes the data to Avro binary format.
                 Supported content type extensions:
                     '+gzip': Compresses the byte array using gzip, e.g. 'application/json+gzip'.
 
@@ -127,13 +82,6 @@ class Water:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-            # Convert to Avro binary format using the embedded schema
-            writer = avro.io.DatumWriter(self.AvroType)
-            with io.BytesIO() as stream:
-                encoder = avro.io.BinaryEncoder(stream)
-                writer.write(self.to_avro_dict(), encoder)
-                result = stream.getvalue()
         if base_content_type == 'application/json':
             #pylint: disable=no-member
             result = self.to_json()
@@ -163,8 +111,6 @@ class Water:
             content_type_string: The content type string to convert the data to. 
                 Supported content types:
                     'application/json': Attempts to decode the data from JSON encoded format.
-                    'avro/binary': Attempts to decode the data from Avro binary format.
-                    'application/vnd.apache.avro+avro': Attempts to decode the data from Avro binary format.
                 Supported content type extensions:
                     '+gzip': First decompresses the data using gzip, e.g. 'application/json+gzip'.
         Returns:
@@ -189,16 +135,6 @@ class Water:
         
         # Strip compression suffix for base type matching
         base_content_type = content_type.replace('+gzip', '')
-        if base_content_type in ['avro/binary', 'application/vnd.apache.avro+avro']:
-            if isinstance(data, bytes):
-                # Decode from Avro binary format using the embedded schema
-                reader = avro.io.DatumReader(cls.AvroType)
-                with io.BytesIO(data) as stream:
-                    decoder = avro.io.BinaryDecoder(stream)
-                    _record = reader.read(decoder)
-                    return Water.from_avro_dict(_record)
-            else:
-                raise NotImplementedError('Data is not of a supported type for Avro deserialization')
         if base_content_type == 'application/json':
             if isinstance(data, (bytes, str)):
                 data_str = data.decode('utf-8') if isinstance(data, bytes) else data
@@ -217,6 +153,6 @@ class Water:
             An instance of the dataclass.
         """
         return cls(
-            shortname='ahlkcubdjmzktrhmjfxm',
-            longname='yeeovcomgbpjhzqmuimw'
+            shortname='exuoeyzjedeeevuwrqjf',
+            longname='tbiguzmziqlrrgearhom'
         )

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_currentmeasurement.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_currentmeasurement.py
@@ -9,9 +9,9 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from pegelonline_mqtt_producer_data.de.wsv.pegelonline.currentmeasurement import CurrentMeasurement
-from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
-from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
 from pegelonline_mqtt_producer_data.de.wsv.pegelonline.trendenum import TrendEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statemnwmhwenum import StateMnwMhwEnum
+from pegelonline_mqtt_producer_data.de.wsv.pegelonline.statenswhswenum import StateNswHswEnum
 import datetime
 
 
@@ -32,9 +32,9 @@ class Test_CurrentMeasurement(unittest.TestCase):
         Create instance of CurrentMeasurement for testing
         """
         instance = CurrentMeasurement(
-            station_id='mlsbcaufeieqnqnugtfe',
+            station_id='wkfurehpfqnswtovmxgf',
             timestamp=datetime.datetime.now(datetime.timezone.utc),
-            value=float(16.64115334335847),
+            value=float(70.61148318018796),
             stateMnwMhw=StateMnwMhwEnum.low,
             stateNswHsw=StateNswHswEnum.normal,
             trend=TrendEnum.VALUE_NEG_1
@@ -46,7 +46,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'mlsbcaufeieqnqnugtfe'
+        test_value = 'wkfurehpfqnswtovmxgf'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -62,7 +62,7 @@ class Test_CurrentMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(16.64115334335847)
+        test_value = float(70.61148318018796)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -90,15 +90,6 @@ class Test_CurrentMeasurement(unittest.TestCase):
         self.instance.trend = test_value
         self.assertEqual(self.instance.trend, test_value)
     
-    def test_to_byte_array_avro(self):
-        """
-        Test to_byte_array method with avro media type
-        """
-        media_type = "application/vnd.apache.avro+avro"
-        bytes_data = self.instance.to_byte_array(media_type)
-        new_instance = CurrentMeasurement.from_data(bytes_data, media_type)
-        bytes_data2 = new_instance.to_byte_array(media_type)
-        self.assertEqual(bytes_data, bytes_data2)
     def test_to_byte_array_json(self):
         """
         Test to_byte_array method with json media type

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_station.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_station.py
@@ -29,14 +29,14 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='kzdpykbcqqgzvelfnkki',
-            number='dumvaykuwuandljookao',
-            shortname='oniamautigdbzyktuquh',
-            longname='ongbqnrpnntlifcxftod',
-            km=float(48.90586839505602),
-            agency='jcpbfukajbutucymnrbu',
-            longitude=float(31.99545063211955),
-            latitude=float(28.4026986369164),
+            station_id='bivhvchptlwpjkptheew',
+            number='dcazyvzjvtuwhjmhsjlx',
+            shortname='hmdjcfhwhxvfbhnbqqhh',
+            longname='hbpzabotvbwsghpfdnft',
+            km=float(73.48493985389887),
+            agency='ykrwjsxeclkikuvguxra',
+            longitude=float(85.13182563335678),
+            latitude=float(75.13255396815651),
             water=None
         )
         return instance
@@ -46,7 +46,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'kzdpykbcqqgzvelfnkki'
+        test_value = 'bivhvchptlwpjkptheew'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +54,7 @@ class Test_Station(unittest.TestCase):
         """
         Test number property
         """
-        test_value = 'dumvaykuwuandljookao'
+        test_value = 'dcazyvzjvtuwhjmhsjlx'
         self.instance.number = test_value
         self.assertEqual(self.instance.number, test_value)
     
@@ -62,7 +62,7 @@ class Test_Station(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'oniamautigdbzyktuquh'
+        test_value = 'hmdjcfhwhxvfbhnbqqhh'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -70,7 +70,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'ongbqnrpnntlifcxftod'
+        test_value = 'hbpzabotvbwsghpfdnft'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     
@@ -78,7 +78,7 @@ class Test_Station(unittest.TestCase):
         """
         Test km property
         """
-        test_value = float(48.90586839505602)
+        test_value = float(73.48493985389887)
         self.instance.km = test_value
         self.assertEqual(self.instance.km, test_value)
     
@@ -86,7 +86,7 @@ class Test_Station(unittest.TestCase):
         """
         Test agency property
         """
-        test_value = 'jcpbfukajbutucymnrbu'
+        test_value = 'ykrwjsxeclkikuvguxra'
         self.instance.agency = test_value
         self.assertEqual(self.instance.agency, test_value)
     
@@ -94,7 +94,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(31.99545063211955)
+        test_value = float(85.13182563335678)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -102,7 +102,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(28.4026986369164)
+        test_value = float(75.13255396815651)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_water.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_data/tests/test_water.py
@@ -28,8 +28,8 @@ class Test_Water(unittest.TestCase):
         Create instance of Water for testing
         """
         instance = Water(
-            shortname='ahlkcubdjmzktrhmjfxm',
-            longname='yeeovcomgbpjhzqmuimw'
+            shortname='exuoeyzjedeeevuwrqjf',
+            longname='tbiguzmziqlrrgearhom'
         )
         return instance
 
@@ -38,7 +38,7 @@ class Test_Water(unittest.TestCase):
         """
         Test shortname property
         """
-        test_value = 'ahlkcubdjmzktrhmjfxm'
+        test_value = 'exuoeyzjedeeevuwrqjf'
         self.instance.shortname = test_value
         self.assertEqual(self.instance.shortname, test_value)
     
@@ -46,19 +46,10 @@ class Test_Water(unittest.TestCase):
         """
         Test longname property
         """
-        test_value = 'yeeovcomgbpjhzqmuimw'
+        test_value = 'tbiguzmziqlrrgearhom'
         self.instance.longname = test_value
         self.assertEqual(self.instance.longname, test_value)
     
-    def test_to_byte_array_avro(self):
-        """
-        Test to_byte_array method with avro media type
-        """
-        media_type = "application/vnd.apache.avro+avro"
-        bytes_data = self.instance.to_byte_array(media_type)
-        new_instance = Water.from_data(bytes_data, media_type)
-        bytes_data2 = new_instance.to_byte_array(media_type)
-        self.assertEqual(bytes_data, bytes_data2)
     def test_to_byte_array_json(self):
         """
         Test to_byte_array method with json media type

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/src/pegelonline_mqtt_producer_mqtt_client/client.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/src/pegelonline_mqtt_producer_mqtt_client/client.py
@@ -4,6 +4,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
     # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
@@ -17,10 +18,57 @@ except Exception:  # pragma: no cover - paho < 2 fallback
 from cloudevents.conversion import to_binary, to_structured
 from cloudevents.http import CloudEvent
 import pegelonline_mqtt_producer_data
+from pegelonline_mqtt_producer_data import Station
+from pegelonline_mqtt_producer_data import CurrentMeasurement
 
 
 # URI template regex pattern
 _URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 
 
 def _topic_to_mqtt_wildcard(topic: str) -> str:
@@ -239,6 +287,10 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
         
         # Message handler callbacks (Dispatcher pattern)
         
+        self.de_wsv_pegelonline_mqtt_station_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, pegelonline_mqtt_producer_data.Station, Dict[str, str]], Awaitable[None]]] = None
+        
+        self.de_wsv_pegelonline_mqtt_current_measurement_async: Optional[Callable[[mqtt.MQTTMessage, CloudEvent, pegelonline_mqtt_producer_data.CurrentMeasurement, Dict[str, str]], Awaitable[None]]] = None
+        
         
         # Attach message callback
         self.client.on_message = self._on_message
@@ -281,6 +333,30 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
         """Dispatch CloudEvent to the appropriate handler based on type."""
         event_type = cloud_event['type']
         
+        
+        if event_type == "de.wsv.pegelonline.Station":
+            if self.de_wsv_pegelonline_mqtt_station_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = pegelonline_mqtt_producer_data.Station.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "de.wsv.pegelonline.mqtt.Station")
+                    await self.de_wsv_pegelonline_mqtt_station_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in de_wsv_pegelonline_mqtt_station handler: {e}")
+            return
+        
+        if event_type == "de.wsv.pegelonline.CurrentMeasurement":
+            if self.de_wsv_pegelonline_mqtt_current_measurement_async:
+                try:
+                    content_type = cloud_event.get_attributes().get('datacontenttype', 'application/json')
+                    # CloudEvent.data is now a dict or string, not bytes
+                    data = pegelonline_mqtt_producer_data.CurrentMeasurement.from_data(cloud_event.data, content_type)
+                    topic_params = self._extract_topic_params(mqtt_message.topic, "de.wsv.pegelonline.mqtt.CurrentMeasurement")
+                    await self.de_wsv_pegelonline_mqtt_current_measurement_async(mqtt_message, cloud_event, data, topic_params)
+                except Exception as e:
+                    print(f"Error in de_wsv_pegelonline_mqtt_current_measurement handler: {e}")
+            return
         
     
     async def subscribe(self, topics: Optional[typing.List[str]] = None, qos: int = 0):
@@ -325,4 +401,168 @@ class DeWsvPegelonlineMqttMqttClient(_ClientBase):
         self.client.disconnect()
 
     # Producer methods
+    
+    async def publish_de_wsv_pegelonline_mqtt_station(self,
+        feedurl: str,
+        station_id: str,
+        water_shortname: str,
+        data: pegelonline_mqtt_producer_data.Station,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'de.wsv.pegelonline.mqtt.Station' event to an MQTT topic.
+
+        Args:
+        
+            feedurl: URI template variable for 'feedurl'
+            station_id: URI template variable for 'station_id'
+            water_shortname: URI template variable for 'water_shortname'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/info"
+        _topic_template_values: Dict[str, str] = {
+            "feedurl": str(feedurl),
+            "station_id": str(station_id),
+            "water_shortname": str(water_shortname),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"de.wsv.pegelonline.Station",
+             "source":"{feedurl}".format(feedurl = feedurl),
+             "subject":"{station_id}".format(station_id = station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
+    
+    async def publish_de_wsv_pegelonline_mqtt_current_measurement(self,
+        feedurl: str,
+        station_id: str,
+        water_shortname: str,
+        data: pegelonline_mqtt_producer_data.CurrentMeasurement,
+        topic: Optional[str] = None,
+        qos: Optional[int] = None,
+        retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
+        content_type: str = "application/json") -> None:
+        """
+        Publish the 'de.wsv.pegelonline.mqtt.CurrentMeasurement' event to an MQTT topic.
+
+        Args:
+        
+            feedurl: URI template variable for 'feedurl'
+            station_id: URI template variable for 'station_id'
+            water_shortname: URI template variable for 'water_shortname'
+            data: The event data to be published.
+            topic: Optional topic override. If not provided, uses default topic 'hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level'
+                with URI template placeholders substituted from the keyword arguments.
+            qos: Optional MQTT QoS override. If not provided, uses the message default (1).
+            retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
+            content_type: The content type for the event data.
+        """
+        target_topic = topic if topic is not None else "hydro/de/wsv/pegelonline/{water_shortname}/{station_id}/water-level"
+        _topic_template_values: Dict[str, str] = {
+            "feedurl": str(feedurl),
+            "station_id": str(station_id),
+            "water_shortname": str(water_shortname),
+        }
+        if _topic_template_values:
+            target_topic = _apply_topic_template(target_topic, _topic_template_values)
+
+        attributes = {
+             "type":"de.wsv.pegelonline.CurrentMeasurement",
+             "source":"{feedurl}".format(feedurl = feedurl),
+             "subject":"{station_id}".format(station_id = station_id)
+        }
+        attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
+        byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
+        event = CloudEvent(attributes, byte_data)
+
+        _effective_qos = 1 if qos is None else qos
+        _effective_retain = True if retain is None else retain
+
+        publish_kwargs: Dict[str, typing.Any] = {
+            "qos": _effective_qos,
+            "retain": _effective_retain,
+        }
+
+        if self.content_mode == "structured":
+            _headers, body = to_structured(event)
+            payload = body
+        else:
+            headers, body = to_binary(event)
+            payload = body
+            mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
+            if mqtt5_props is not None:
+                publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
+
+        self.client.publish(target_topic, payload, **publish_kwargs)
+
     

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/tests/test_client.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 import pytest_asyncio
 import asyncio
+import datetime
 import time
 import paho.mqtt.client as mqtt
 from testcontainers.core.container import DockerContainer
@@ -15,6 +16,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../pegelonline_mqtt_producer_mqtt_client/src')))
 
 import pegelonline_mqtt_producer_data
+from pegelonline_mqtt_producer_data import Station
+from test_pegelonline_mqtt_producer_data_station import Test_Station
+from pegelonline_mqtt_producer_data import CurrentMeasurement
+from test_pegelonline_mqtt_producer_data_currentmeasurement import Test_CurrentMeasurement
 from pegelonline_mqtt_producer_mqtt_client import DeWsvPegelonlineMqttMqttClient
 
 @pytest_asyncio.fixture
@@ -38,5 +43,139 @@ async def mosquitto_broker():
         yield broker_host, broker_port
     finally:
         container.stop()
+
+
+
+@pytest.mark.asyncio
+async def test_de_wsv_pegelonline_mqtt_de_wsv_pegelonline_mqtt_station_py(mosquitto_broker):
+    """Test publishing and receiving de.wsv.pegelonline.mqtt.Station message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_Station.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = DeWsvPegelonlineMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = DeWsvPegelonlineMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_de_wsv_pegelonline_mqtt_station(mqtt_msg, cloud_event, data: pegelonline_mqtt_producer_data.Station, topic_params: dict):
+        """Handler for de.wsv.pegelonline.mqtt.Station messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "de.wsv.pegelonline.Station"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.de_wsv_pegelonline_mqtt_station_async = on_de_wsv_pegelonline_mqtt_station
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/de_wsv_pegelonline_mqtt/de_wsv_pegelonline_mqtt_station"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_de_wsv_pegelonline_mqtt_station(
+            topic=test_topic,
+            feedurl=f"test_feedurl_{i}",
+            station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
+
+
+
+@pytest.mark.asyncio
+async def test_de_wsv_pegelonline_mqtt_de_wsv_pegelonline_mqtt_current_measurement_py(mosquitto_broker):
+    """Test publishing and receiving de.wsv.pegelonline.mqtt.CurrentMeasurement message via MQTT."""
+    broker_host, broker_port = mosquitto_broker
+    # Create valid test data using the test helper
+    test_data = Test_CurrentMeasurement.create_instance()
+    
+    # Create subscriber client
+    subscriber_mqtt = mqtt.Client(client_id="test_subscriber")
+    loop = asyncio.get_running_loop()
+    subscriber_client = DeWsvPegelonlineMqttMqttClient(subscriber_mqtt, content_mode='structured', loop=loop)
+    
+    # Create publisher client
+    publisher_mqtt = mqtt.Client(client_id="test_publisher")
+    publisher_client = DeWsvPegelonlineMqttMqttClient(publisher_mqtt, content_mode='structured', loop=loop)
+    
+    # Track received messages (expecting 5)
+    received_data = []
+    received_event = asyncio.Event()
+    
+    async def on_de_wsv_pegelonline_mqtt_current_measurement(mqtt_msg, cloud_event, data: pegelonline_mqtt_producer_data.CurrentMeasurement, topic_params: dict):
+        """Handler for de.wsv.pegelonline.mqtt.CurrentMeasurement messages."""
+        received_data.append(data)
+        assert cloud_event['type'] == "de.wsv.pegelonline.CurrentMeasurement"
+        if len(received_data) >= 5:
+            received_event.set()
+    
+    # Register handler
+    subscriber_client.de_wsv_pegelonline_mqtt_current_measurement_async = on_de_wsv_pegelonline_mqtt_current_measurement
+    
+    # Connect both clients
+    await subscriber_client.connect(broker_host, broker_port)
+    await publisher_client.connect(broker_host, broker_port)
+    
+    # Subscribe to topic
+    test_topic = "test/de_wsv_pegelonline_mqtt/de_wsv_pegelonline_mqtt_current_measurement"
+    await subscriber_client.subscribe([test_topic])
+    
+    # Wait for subscription to be active
+    await asyncio.sleep(1)
+    
+    # Publish 5 messages to test message settlement and ordering
+    for i in range(5):
+        await publisher_client.publish_de_wsv_pegelonline_mqtt_current_measurement(
+            topic=test_topic,
+            feedurl=f"test_feedurl_{i}",
+            station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data=test_data,
+            content_type="application/json"
+        )
+    
+    # Wait for all 5 messages to be received (with timeout)
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Did not receive all 5 messages within timeout, got {len(received_data)}")
+    
+    # Verify all 5 messages received
+    assert len(received_data) == 5, f"Expected 5 messages, got {len(received_data)}"
+    
+    # Cleanup
+    await subscriber_client.disconnect()
+    await publisher_client.disconnect()
 
 

--- a/feeders/pegelonline/pegelonline_mqtt_producer/samples/sample.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/samples/sample.py
@@ -39,14 +39,18 @@ import signal
 from pegelonline_mqtt_producer_data import *
 from pegelonline_mqtt_producer_mqtt_client.client import DeWsvPegelonlineMqttProducer, DeWsvPegelonlineMqttDispatcher
 
-async def handle_de_wsv_pegelonline_mqtt_station(mqtt_msg,de_wsv_pegelonline_mqtt_station_data):
+async def handle_de_wsv_pegelonline_mqtt_station(mqtt_msg,cloud_event, de_wsv_pegelonline_mqtt_station_data):
     """ Handles the de.wsv.pegelonline.mqtt.Station message """
     print(f"Received de.wsv.pegelonline.mqtt.Station on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
     print(f"  Data: {de_wsv_pegelonline_mqtt_station_data}")
 
-async def handle_de_wsv_pegelonline_mqtt_current_measurement(mqtt_msg,de_wsv_pegelonline_mqtt_current_measurement_data):
+async def handle_de_wsv_pegelonline_mqtt_current_measurement(mqtt_msg,cloud_event, de_wsv_pegelonline_mqtt_current_measurement_data):
     """ Handles the de.wsv.pegelonline.mqtt.CurrentMeasurement message """
     print(f"Received de.wsv.pegelonline.mqtt.CurrentMeasurement on topic {mqtt_msg.topic}")
+    if cloud_event:
+        print(f"  CloudEvent ID: {cloud_event.id}, Source: {cloud_event.source}")
     print(f"  Data: {de_wsv_pegelonline_mqtt_current_measurement_data}")
 
 async def main(broker_host, broker_port, topic, username=None, password=None):


### PR DESCRIPTION
## What

Regenerate the **pegelonline MQTT producer** from the authoritative xreg manifest with the already-pinned **xrcg 0.10.11**. Pure regeneration — no manifest change, no hand-edits.

## Why (root cause of the `test` job failure)

The checked-in MQTT producer client on `main` was **truncated**:

`pegelonline_mqtt_producer_mqtt_client/.../client.py` ended at the `# Producer methods` marker with **all publish methods missing**. It had been generated by an older xrcg (`<=0.10.10`) whose `mqttclient` style emitted an empty producer-method section.

The `test` job runs pytest against the **checked-in** producer (it does not regenerate), so it failed with:

```
AttributeError: 'DeWsvPegelonlineMqttMqttClient' object has no attribute
'publish_de_wsv_pegelonline_mqtt_station'
```

xrcg **0.10.11** (already pinned in `tools/require-xrcg.ps1` on `main`) generates the complete client.

## Change

- `client.py` now contains `publish_de_wsv_pegelonline_mqtt_station` and `publish_de_wsv_pegelonline_mqtt_current_measurement` (+240 lines).
- Data classes drop the now-unused Avro serialization branch (`AvroType`, `to_avro_dict`, `avro/binary` content-type), **matching the Kafka producer output** which is already Avro-free. MQTT publishes JSON CloudEvents only — confirmed the app/tests never request `avro/binary`.

## Scope discipline

- **pegelonline MQTT producer only** (14 files, all under `pegelonline_mqtt_producer/`).
- Kafka and AMQP producers are complete on `main` and intentionally **untouched**.
- Does **not** bundle the broader fleet-wide producer regen drift present in the dirty working tree.

## Verification

Replicated the CI install (editable producer + app packages) in a clean venv and ran:

- `pytest tests/test_pegelonline_mqtt_app.py` → **2 passed** (the previously-failing CI test, incl. `test_mqtt_feed_publishes_station_and_measurement`).
- producer data unit tests → **26 passed**.
- full app suite minus e2e → **28 passed, 22 subtests**.

## Follow-up (not in this PR)

The same `<=0.10.10` `mqttclient` truncation likely affects **other** MQTT sources generated with the older xrcg. A fleet-wide MQTT producer regen sweep is warranted as a separate change.
