### PR TITLE
Add Fabric notebook feeder for meteoalarm

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -368,6 +368,7 @@
     "key": false,
     "desc": "Europe — 37 countries, severe weather warnings",
     "kql": true,
+    "notebook": true,
     "mqtt": true,
     "amqp": true
   },

--- a/feeders/meteoalarm/notebook/meteoalarm-feed.ipynb
+++ b/feeders/meteoalarm/notebook/meteoalarm-feed.ipynb
@@ -1,0 +1,225 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3.11",
+   "display_name": "Python 3.11",
+   "language": "python"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "jupyter_python",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "dependencies": {
+   "environment": {},
+   "kqlDatabases": [],
+   "lakehouse": {}
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Meteoalarm Feeder (Fabric Notebook)\n",
+    "\n",
+    "Polls the EUMETNET Meteoalarm API for severe weather warnings from 30+ European national meteorological services and emits CloudEvents to the bound Fabric Event Stream.\n",
+    "\n",
+    "**Runtime model**\n",
+    "- The `meteoalarm` package (with the generated producer sub-package) is pre-installed by the **attached Fabric Environment**. No `%pip install` is required at runtime.\n",
+    "- The Event Stream connection string is **looked up at runtime** via the Fabric REST API using the notebook's workspace identity (or user identity). The deploy script does not bake any secret into the notebook.\n",
+    "- The bridge runs `meteoalarm --once`, exits after one polling cycle, and persists dedupe state to a Lakehouse Files path so the next scheduled run only emits new warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python",
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# === PARAMETERS (overwritten by deploy-feeder-notebook.ps1) ===\n",
+    "EVENTSTREAM_NAME = \"meteoalarm-ingest\"      # Fabric Event Stream item name in this workspace\n",
+    "STATE_FILE       = \"/lakehouse/default/Files/feeder-state/meteoalarm/state.json\"\n",
+    "POLLING_INTERVAL = 300                       # seconds; only used if ONCE_MODE is False\n",
+    "ONCE_MODE        = True                      # True for scheduled execution\n",
+    "WORKSPACE_ID     = \"\"                        # filled in by deploy script (optional; falls back to runtime context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look up the Event Stream connection string\n",
+    "Uses `notebookutils.credentials.getToken('pbi')` (workspace identity when scheduled, user identity when run interactively) to call the Fabric REST + ES MWC APIs and retrieve the custom-endpoint `primaryConnectionString`. The token is short-lived and never persisted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, time, json\n",
+    "import requests\n",
+    "\n",
+    "FABRIC_API = 'https://api.fabric.microsoft.com/v1'\n",
+    "\n",
+    "def _get_pbi_token():\n",
+    "    try:\n",
+    "        import notebookutils  # noqa: F401\n",
+    "        return notebookutils.credentials.getToken('pbi')\n",
+    "    except Exception:\n",
+    "        from notebookutils import mssparkutils\n",
+    "        return mssparkutils.credentials.getToken('pbi')\n",
+    "\n",
+    "def _resolve_workspace_id(explicit: str) -> str:\n",
+    "    if explicit:\n",
+    "        return explicit\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        ctx = notebookutils.runtime.context\n",
+    "        return ctx['currentWorkspaceId']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    from notebookutils import mssparkutils\n",
+    "    ctx = json.loads(mssparkutils.runtime.context)\n",
+    "    return ctx['currentWorkspaceId']\n",
+    "\n",
+    "def lookup_es_connection_string(workspace_id: str, eventstream_name: str) -> str:\n",
+    "    \"\"\"Return the primary connection string for the named Event Stream's custom-endpoint source.\n",
+    "\n",
+    "    Uses the public Fabric Topology API (2 calls). Documented at\n",
+    "    https://learn.microsoft.com/en-us/rest/api/fabric/eventstream/topology/get-eventstream-source-connection\n",
+    "    \"\"\"\n",
+    "    headers = {'Authorization': f'Bearer {_get_pbi_token()}'}\n",
+    "\n",
+    "    es_list = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams', headers=headers, timeout=30)\n",
+    "    es_list.raise_for_status()\n",
+    "    es = next((x for x in es_list.json().get('value', []) if x['displayName'] == eventstream_name), None)\n",
+    "    if not es:\n",
+    "        raise RuntimeError(f\"Event Stream '{eventstream_name}' not found in workspace {workspace_id}.\")\n",
+    "\n",
+    "    topo = requests.get(f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/topology', headers=headers, timeout=30)\n",
+    "    topo.raise_for_status()\n",
+    "    src = next((s for s in topo.json().get('sources', []) if s.get('type') == 'CustomEndpoint'), None)\n",
+    "    if not src:\n",
+    "        raise RuntimeError(\"Event Stream has no CustomEndpoint source.\")\n",
+    "\n",
+    "    last_err = None\n",
+    "    for attempt in range(5):\n",
+    "        try:\n",
+    "            conn = requests.get(\n",
+    "                f'{FABRIC_API}/workspaces/{workspace_id}/eventstreams/{es[\"id\"]}/sources/{src[\"id\"]}/connection',\n",
+    "                headers=headers, timeout=30,\n",
+    "            )\n",
+    "            conn.raise_for_status()\n",
+    "            cs = conn.json().get('accessKeys', {}).get('primaryConnectionString')\n",
+    "            if cs:\n",
+    "                return cs\n",
+    "            last_err = 'empty primaryConnectionString'\n",
+    "        except Exception as e:\n",
+    "            last_err = str(e)\n",
+    "        time.sleep(min(15, 3 * (attempt + 1)))\n",
+    "    raise RuntimeError(f'Could not retrieve connection string after 5 attempts: {last_err}')\n",
+    "\n",
+    "ws_id = _resolve_workspace_id(WORKSPACE_ID)\n",
+    "cs = lookup_es_connection_string(ws_id, EVENTSTREAM_NAME)\n",
+    "print(f\"Workspace:        {ws_id}\")\n",
+    "print(f\"Event Stream:     {EVENTSTREAM_NAME}\")\n",
+    "print(f\"Connection ready: length={len(cs)}\")\n",
+    "os.environ['CONNECTION_STRING'] = cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare state and run one polling cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "language": "python"
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, pathlib, sys, traceback, datetime\n",
+    "\n",
+    "LOG_PATH = '/lakehouse/default/Files/feeder-state/meteoalarm/last-run.log'\n",
+    "pathlib.Path(LOG_PATH).parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def _log(msg):\n",
+    "    line = f'[{datetime.datetime.utcnow().isoformat()}Z] {msg}'\n",
+    "    print(line)\n",
+    "    with open(LOG_PATH, 'a', encoding='utf-8') as f:\n",
+    "        f.write(line + '\\n')\n",
+    "\n",
+    "with open(LOG_PATH, 'w', encoding='utf-8') as f:\n",
+    "    f.write('')\n",
+    "\n",
+    "try:\n",
+    "    _log('Starting feeder cycle')\n",
+    "    pathlib.Path(STATE_FILE).parent.mkdir(parents=True, exist_ok=True)\n",
+    "    os.environ['METEOALARM_STATE_FILE'] = STATE_FILE\n",
+    "    _log(f'CONNECTION_STRING present: {bool(os.environ.get(\"CONNECTION_STRING\"))}')\n",
+    "\n",
+    "    _log('Importing meteoalarm package from Fabric Environment...')\n",
+    "    from meteoalarm import meteoalarm as feeder\n",
+    "    _log(f'Imported feeder from: {feeder.__file__}')\n",
+    "\n",
+    "    argv_backup = sys.argv\n",
+    "    try:\n",
+    "        if ONCE_MODE:\n",
+    "            sys.argv = ['meteoalarm', '--once']\n",
+    "        else:\n",
+    "            sys.argv = ['meteoalarm', '--poll-interval', str(POLLING_INTERVAL)]\n",
+    "        _log(f'Running feeder.main() with argv={sys.argv}')\n",
+    "        import threading\n",
+    "        _err = []\n",
+    "        def _worker():\n",
+    "            try:\n",
+    "                feeder.main()\n",
+    "            except BaseException as e:\n",
+    "                _err.append(e)\n",
+    "        t = threading.Thread(target=_worker, daemon=True)\n",
+    "        t.start()\n",
+    "        t.join()\n",
+    "        if _err:\n",
+    "            raise _err[0]\n",
+    "    finally:\n",
+    "        sys.argv = argv_backup\n",
+    "    _log('Cycle complete.')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit('OK')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "except Exception as exc:\n",
+    "    tb = traceback.format_exc()\n",
+    "    _log(f'FAILED: {exc}\\n{tb}')\n",
+    "    try:\n",
+    "        import notebookutils\n",
+    "        notebookutils.notebook.exit(f'FAIL: {exc}')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    raise"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## Summary

\meteoalarm\ is a poll-based weather-warning source (EUMETNET Meteoalarm, 30+ European NMS) that already shipped Kafka/MQTT/AMQP containers and a \kql/meteoalarm.kql\ schema, but had **no Fabric notebook hosting option**. Per repo convention every poll-based source ships a Fabric notebook feeder.

## Changes
- **\eeders/meteoalarm/notebook/meteoalarm-feed.ipynb\** — new notebook, mirroring the canonical \pegelonline\ notebook:
  - Runtime Event Stream connection-string lookup via the public Fabric Topology API — **no baked secret, no \CONNECTION_STRING\ parameter**.
  - Runs \eeder.main()\ on a **worker thread** — no \^Gsyncio.run()\ (Fabric kernel owns the loop).
  - **OneLake** \last-run.log\ diagnostics + \
otebookutils.notebook.exit('FAIL: …')\ on the error path.
  - **No \%pip\/\%conda\ magic** — wheels come from the per-source Environment.
  - Cell 4 adapted to meteoalarm's flat CLI (no subcommand): injects \['meteoalarm','--once']\ (or \--poll-interval\ for continuous mode) and sets \METEOALARM_STATE_FILE\ (the env var the bridge actually reads) rather than the generic \STATE_FILE\.
- **\catalog.json\** — \
otebook: true\ for meteoalarm so the *Deploy to Fabric Notebook* button opts in.
- ghpages \^Gpp.js\ SOURCES entry mirrored in a separate \ghpages\ commit (\

---

## ✅ § 7a Fabric notebook deployment — live-deploy evidence

**Validator:** pwsh tools/validate-fabric-deployment.ps1 -FeederSlug meteoalarm → **11 PASS / 0 WARN / 0 BLOCK**.

**Live deploy + scheduled run + KQL data-flow** (canonical shared test workspace):

| Field | Value |
|---|---|
| Workspace | `ContosoRealTimeTest` (`99ffd706-9eb7-41e4-ab5e-fdf6b9bb2432`) |
| Notebook | `meteoalarm-feed` (`c0ecccca-b741-4a4f-b669-303082f63a3d`) |
| Immediate run id | `3a084194-9007-43ba-b25e-b749e792a40b` → **Completed** |
| Verified (UTC) | `2026-06-02T09:20:39Z` |
| Schedule | 15-min cadence created |
| Eventhouse / KQL DB | `meteoalarm` (`f986cdc4-7075-45ca-96f7-2a1523060010` / `fdb74706-1fa7-46b2-8403-0fea850a0e06`) |
| Eventstream | `meteoalarm-ingest` (`6ef7b6ac-229b-44fb-acc3-0a697ce1eecb`) |
| Environment (shared) | `feeder_env` (`98905461-cb31-42ef-b95c-c661d20a3f58`), republished state=Success |

**Two-level KQL data-flow gate (db `meteoalarm`):**

- `['_cloudevents_dispatch'] | count` → **9154** (raw landing) ✅
- `['WeatherWarning'] | count` → **9154** (typed, post update-policy) ✅

Both non-zero ⇒ ingest + update policy both fired.

**Orphan check:** workspace item list after run shows only the intended artifacts (Eventhouse, KQLDatabase, Eventstream, Notebook) plus the shared `feeder_env` / `feeder_state_lake`. No orphaned environments left by the Fabric env-delete bug.

_Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>_
