### PR TITLE
Fix Fabric post-deploy hook fallback

### DIFF
--- a/feeders/dwd/fabric/post-deploy.ps1
+++ b/feeders/dwd/fabric/post-deploy.ps1
@@ -63,13 +63,35 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$kustoDatabaseBound = $PSBoundParameters.ContainsKey('KustoDatabase')
+
+function Get-KustoAccessToken {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$KustoUri
+    )
+
+    $resources = @(
+        "https://kusto.kusto.windows.net",
+        $KustoUri
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($resource in $resources) {
+        $token = az account get-access-token --resource $resource --query accessToken -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($token)) {
+            return $token.Trim()
+        }
+    }
+
+    throw "Failed to acquire a Kusto access token for $KustoUri."
+}
 
 # Merge Context (hook invocation) with explicit params (standalone).
 if ($Context) {
     if (-not $WorkspaceId   -and $Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
     if (-not $KqlDatabaseId -and $Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
     if (-not $KustoUri      -and $Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
-    if (-not $KustoDatabase -and $Context.ContainsKey('DatabaseName'))         { $KustoDatabase = $Context.DatabaseName }
+    if (-not $kustoDatabaseBound -and $Context.ContainsKey('DatabaseName'))    { $KustoDatabase = $Context.DatabaseName }
 }
 
 if (-not $MapId) {
@@ -119,13 +141,8 @@ if (-not $env:FABRIC_TOKEN) {
         --query accessToken -o tsv)
 }
 if (-not $env:KUSTO_TOKEN) {
-    # The Kusto audience must be the specific cluster URI: the generic
-    # https://kusto.fabric.microsoft.com is not a registered AAD resource
-    # principal in some tenants (e.g. Microsoft corp).
     Write-Host "  [dwd post-deploy] Acquiring Kusto token via az CLI..."
-    $env:KUSTO_TOKEN = (az account get-access-token `
-        --resource $KustoUri `
-        --query accessToken -o tsv)
+    $env:KUSTO_TOKEN = Get-KustoAccessToken -KustoUri $KustoUri
 }
 
 $py = if ($env:PYTHON) { $env:PYTHON } else { "python" }

--- a/feeders/gtfs/fabric/post-deploy.ps1
+++ b/feeders/gtfs/fabric/post-deploy.ps1
@@ -90,13 +90,35 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$kustoDatabaseBound = $PSBoundParameters.ContainsKey('KustoDatabase')
+
+function Get-KustoAccessToken {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$KustoUri
+    )
+
+    $resources = @(
+        "https://kusto.kusto.windows.net",
+        $KustoUri
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($resource in $resources) {
+        $token = az account get-access-token --resource $resource --query accessToken -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($token)) {
+            return $token.Trim()
+        }
+    }
+
+    throw "Failed to acquire a Kusto access token for $KustoUri."
+}
 
 # Merge Context (hook invocation) with explicit params (standalone).
 if ($Context) {
     if (-not $WorkspaceId   -and $Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
     if (-not $KqlDatabaseId -and $Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
     if (-not $KustoUri      -and $Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
-    if (-not $KustoDatabase -and $Context.ContainsKey('DatabaseName'))         { $KustoDatabase = $Context.DatabaseName }
+    if (-not $kustoDatabaseBound -and $Context.ContainsKey('DatabaseName'))    { $KustoDatabase = $Context.DatabaseName }
 }
 
 if (-not $MapId) {
@@ -147,13 +169,8 @@ if (-not $env:FABRIC_TOKEN) {
         --query accessToken -o tsv)
 }
 if (-not $env:KUSTO_TOKEN) {
-    # The Kusto audience must be the specific cluster URI: the generic
-    # https://kusto.fabric.microsoft.com is not a registered AAD resource
-    # principal in some tenants (e.g. Microsoft corp).
     Write-Host "  [gtfs post-deploy] Acquiring Kusto token via az CLI..."
-    $env:KUSTO_TOKEN = (az account get-access-token `
-        --resource $KustoUri `
-        --query accessToken -o tsv)
+    $env:KUSTO_TOKEN = Get-KustoAccessToken -KustoUri $KustoUri
 }
 
 $py = if ($env:PYTHON) { $env:PYTHON }

--- a/feeders/nasa-firms/fabric/post-deploy.ps1
+++ b/feeders/nasa-firms/fabric/post-deploy.ps1
@@ -38,12 +38,37 @@ param(
 
 $ErrorActionPreference = "Stop"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$workspaceIdBound = $PSBoundParameters.ContainsKey('WorkspaceId')
+$kqlDatabaseIdBound = $PSBoundParameters.ContainsKey('KqlDatabaseId')
+$kustoUriBound = $PSBoundParameters.ContainsKey('KustoUri')
+$kustoDatabaseBound = $PSBoundParameters.ContainsKey('KustoDatabase')
+
+function Get-KustoAccessToken {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$KustoUri
+    )
+
+    $resources = @(
+        "https://kusto.kusto.windows.net",
+        $KustoUri
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($resource in $resources) {
+        $token = az account get-access-token --resource $resource --query accessToken -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($token)) {
+            return $token.Trim()
+        }
+    }
+
+    throw "Failed to acquire a Kusto access token for $KustoUri."
+}
 
 if ($Context) {
-    if ($Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
-    if ($Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
-    if ($Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
-    if ($Context.ContainsKey('DatabaseName'))         { $KustoDatabase = $Context.DatabaseName }
+    if (-not $workspaceIdBound -and $Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
+    if (-not $kqlDatabaseIdBound -and $Context.ContainsKey('DatabaseId'))         { $KqlDatabaseId = $Context.DatabaseId }
+    if (-not $kustoUriBound -and $Context.ContainsKey('EventhouseClusterUri'))    { $KustoUri      = $Context.EventhouseClusterUri }
+    if (-not $kustoDatabaseBound -and $Context.ContainsKey('DatabaseName'))    { $KustoDatabase = $Context.DatabaseName }
 }
 
 foreach ($pair in @{ WorkspaceId = $WorkspaceId; KqlDatabaseId = $KqlDatabaseId; KustoUri = $KustoUri }.GetEnumerator()) {
@@ -62,7 +87,10 @@ Write-Host "   cluster   : $KustoUri"
 #    top-level statement starts with '.' at column 0 (functions and policies).
 # ---------------------------------------------------------------------------
 Write-Host "`n[1/2] Applying helpers.kql ..." -ForegroundColor Yellow
-$kustoTok = az account get-access-token --resource $KustoUri --query accessToken -o tsv
+if (-not $env:KUSTO_TOKEN) {
+    $env:KUSTO_TOKEN = Get-KustoAccessToken -KustoUri $KustoUri
+}
+$kustoTok = $env:KUSTO_TOKEN
 $mgmt = "$KustoUri/v1/rest/mgmt"
 $src  = Get-Content (Join-Path $here "helpers.kql") -Raw
 $cmds = [System.Text.RegularExpressions.Regex]::Split($src, "(?m)(?=^\.(create-or-alter function|alter ))") |

--- a/feeders/pegelonline/fabric/post-deploy.ps1
+++ b/feeders/pegelonline/fabric/post-deploy.ps1
@@ -48,12 +48,34 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$kustoDatabaseBound = $PSBoundParameters.ContainsKey('KustoDatabase')
+
+function Get-KustoAccessToken {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$KustoUri
+    )
+
+    $resources = @(
+        "https://kusto.kusto.windows.net",
+        $KustoUri
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($resource in $resources) {
+        $token = az account get-access-token --resource $resource --query accessToken -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($token)) {
+            return $token.Trim()
+        }
+    }
+
+    throw "Failed to acquire a Kusto access token for $KustoUri."
+}
 
 if ($Context) {
     if (-not $WorkspaceId   -and $Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
     if (-not $KqlDatabaseId -and $Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
     if (-not $KustoUri      -and $Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
-    if (-not $KustoDatabase -and $Context.ContainsKey('DatabaseName'))         { $KustoDatabase = $Context.DatabaseName }
+    if (-not $kustoDatabaseBound -and $Context.ContainsKey('DatabaseName'))    { $KustoDatabase = $Context.DatabaseName }
 }
 
 if (-not $MapId) {
@@ -103,13 +125,8 @@ if (-not $env:FABRIC_TOKEN) {
         --query accessToken -o tsv)
 }
 if (-not $env:KUSTO_TOKEN) {
-    # The Kusto audience must be the specific cluster URI: the generic
-    # https://kusto.fabric.microsoft.com is not a registered AAD resource
-    # principal in some tenants (e.g. Microsoft corp).
     Write-Host "  [pegelonline post-deploy] Acquiring Kusto token via az CLI..."
-    $env:KUSTO_TOKEN = (az account get-access-token `
-        --resource $KustoUri `
-        --query accessToken -o tsv)
+    $env:KUSTO_TOKEN = Get-KustoAccessToken -KustoUri $KustoUri
 }
 
 $py = if ($env:PYTHON) { $env:PYTHON } else { "python" }

--- a/tools/deploy-fabric/deploy-fabric-notebook.ps1
+++ b/tools/deploy-fabric/deploy-fabric-notebook.ps1
@@ -166,6 +166,48 @@ function Invoke-FabricApi {
     return $null
 }
 
+function ConvertTo-GitHubContentsPath {
+    param([Parameter(Mandatory = $true)] [string]$Path)
+
+    return ((($Path -replace '\\', '/') -split '/') |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { [System.Uri]::EscapeDataString($_) }) -join '/'
+}
+
+function Expand-GitHubDirectoryToPath {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Repo,
+        [Parameter(Mandatory = $true)] [string]$Branch,
+        [Parameter(Mandatory = $true)] [string]$SourcePath,
+        [Parameter(Mandatory = $true)] [string]$DestinationPath,
+        [string]$RootPath = $SourcePath
+    )
+
+    $contentsPath = ConvertTo-GitHubContentsPath -Path $SourcePath
+    $url = "https://api.github.com/repos/$Repo/contents/$($contentsPath)?ref=$([System.Uri]::EscapeDataString($Branch))"
+    $headers = @{ "User-Agent" = "GitHubCopilotCLI/1.0" }
+
+    foreach ($item in (Invoke-RestMethod -Uri $url -Headers $headers -ErrorAction Stop)) {
+        if ($item.type -eq 'dir') {
+            Expand-GitHubDirectoryToPath -Repo $Repo -Branch $Branch -SourcePath $item.path -DestinationPath $DestinationPath -RootPath $RootPath
+            continue
+        }
+
+        if ($item.type -ne 'file' -or [string]::IsNullOrWhiteSpace($item.download_url)) {
+            continue
+        }
+
+        $relativePath = $item.path.Substring($RootPath.Length).TrimStart([char[]]@('/', '\'))
+        $targetPath = Join-Path $DestinationPath ($relativePath -replace '/', '\')
+        $targetDir = Split-Path -Parent $targetPath
+        if ($targetDir -and -not (Test-Path $targetDir)) {
+            New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        }
+
+        Invoke-WebRequest -Uri $item.download_url -OutFile $targetPath -UseBasicParsing -ErrorAction Stop | Out-Null
+    }
+}
+
 # ── Optional post-deploy hook (shared convention with deploy-fabric.ps1) ─
 # A source MAY ship a {Source}/fabric/post-deploy.ps1 to perform extra
 # Fabric wiring (Map layers, dashboards, environment seeding, …). The hook
@@ -187,13 +229,15 @@ function Invoke-SourcePostDeployHook {
         if (Test-Path $candidate) { $hookPath = $candidate; Write-Info "Post-deploy hook found locally: $hookPath" }
     } catch { }
     if (-not $hookPath) {
-        $hookUrl = "$RawBase/$rel"
         try {
-            $null = Invoke-WebRequest -Uri $hookUrl -Method Head -UseBasicParsing -ErrorAction Stop
-            $tmp = Join-Path $TempDir "post-deploy-$Source-$([Guid]::NewGuid().ToString('N')).ps1"
-            Invoke-WebRequest -Uri $hookUrl -OutFile $tmp -UseBasicParsing | Out-Null
-            $hookPath = $tmp
-            Write-Info "Post-deploy hook downloaded from $hookUrl"
+            $tmp = Join-Path $TempDir "post-deploy-$Source-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+            Expand-GitHubDirectoryToPath -Repo $Repo -Branch $Branch -SourcePath "feeders/$Source/fabric" -DestinationPath $tmp
+            $hookPath = Join-Path $tmp "post-deploy.ps1"
+            if (-not (Test-Path $hookPath)) {
+                throw "Downloaded hook bundle did not contain post-deploy.ps1."
+            }
+            Write-Info "Post-deploy hook bundle downloaded from $RawBase/feeders/$Source/fabric/"
         } catch {
             Write-Info "No post-deploy hook for '$Source' (looked for $rel) — skipping"
             return

--- a/tools/deploy-fabric/deploy-fabric.ps1
+++ b/tools/deploy-fabric/deploy-fabric.ps1
@@ -167,6 +167,48 @@ function Resolve-AzSubscriptionContext {
     }
 }
 
+function ConvertTo-GitHubContentsPath {
+    param([Parameter(Mandatory = $true)] [string]$Path)
+
+    return ((($Path -replace '\\', '/') -split '/') |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { [System.Uri]::EscapeDataString($_) }) -join '/'
+}
+
+function Expand-GitHubDirectoryToPath {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Repo,
+        [Parameter(Mandatory = $true)] [string]$Branch,
+        [Parameter(Mandatory = $true)] [string]$SourcePath,
+        [Parameter(Mandatory = $true)] [string]$DestinationPath,
+        [string]$RootPath = $SourcePath
+    )
+
+    $contentsPath = ConvertTo-GitHubContentsPath -Path $SourcePath
+    $url = "https://api.github.com/repos/$Repo/contents/$($contentsPath)?ref=$([System.Uri]::EscapeDataString($Branch))"
+    $headers = @{ "User-Agent" = "GitHubCopilotCLI/1.0" }
+
+    foreach ($item in (Invoke-RestMethod -Uri $url -Headers $headers -ErrorAction Stop)) {
+        if ($item.type -eq 'dir') {
+            Expand-GitHubDirectoryToPath -Repo $Repo -Branch $Branch -SourcePath $item.path -DestinationPath $DestinationPath -RootPath $RootPath
+            continue
+        }
+
+        if ($item.type -ne 'file' -or [string]::IsNullOrWhiteSpace($item.download_url)) {
+            continue
+        }
+
+        $relativePath = $item.path.Substring($RootPath.Length).TrimStart([char[]]@('/', '\'))
+        $targetPath = Join-Path $DestinationPath ($relativePath -replace '/', '\')
+        $targetDir = Split-Path -Parent $targetPath
+        if ($targetDir -and -not (Test-Path $targetDir)) {
+            New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        }
+
+        Invoke-WebRequest -Uri $item.download_url -OutFile $targetPath -UseBasicParsing -ErrorAction Stop | Out-Null
+    }
+}
+
 function Write-Step { param([string]$Step, [string]$Msg)
     Write-Host "`n[$Step] $Msg" -ForegroundColor Yellow
 }
@@ -384,13 +426,15 @@ function Invoke-SourcePostDeployHook {
         $hookPath = $localPath
         Write-Info "Post-deploy hook found locally: $hookPath"
     } else {
-        $hookUrl = "$RawBase/$rel"
         try {
-            $null = Invoke-WebRequest -Uri $hookUrl -Method Head -UseBasicParsing -ErrorAction Stop
-            $tmp = Join-Path $TempDir "post-deploy-$Source-$([Guid]::NewGuid().ToString('N')).ps1"
-            Invoke-WebRequest -Uri $hookUrl -OutFile $tmp -UseBasicParsing | Out-Null
-            $hookPath = $tmp
-            Write-Info "Post-deploy hook downloaded from $hookUrl"
+            $tmp = Join-Path $TempDir "post-deploy-$Source-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+            Expand-GitHubDirectoryToPath -Repo $Repo -Branch $Branch -SourcePath "feeders/$Source/fabric" -DestinationPath $tmp
+            $hookPath = Join-Path $tmp "post-deploy.ps1"
+            if (-not (Test-Path $hookPath)) {
+                throw "Downloaded hook bundle did not contain post-deploy.ps1."
+            }
+            Write-Info "Post-deploy hook bundle downloaded from $RawBase/feeders/$Source/fabric/"
         } catch {
             Write-Info "No post-deploy hook for '$Source' (looked for $rel) — skipping"
             return


### PR DESCRIPTION
## Summary
- fix Fabric post-deploy hooks to acquire Kusto tokens via the generic Kusto resource first, then cluster URI fallback
- download the full `feeders/<source>/fabric` bundle when a hook runs from raw GitHub/temp mode so sibling assets like `wire_icond2_map.py` and `river_geometries.kql` are present
- let deployer context override NASA hook env defaults unless the user explicitly bound the target parameters

## Validation
- ran `tools/deploy-fabric/deploy-feeder-notebook.ps1 -Source dwd -Workspace ContosoRealTimeTest -Eventhouse dwd -DatabaseName dwd -NoTriggerNow`
- reran the same deployment with scheduling enabled; notebook `dwd-feed` now has the 15-minute UTC schedule in `ContosoRealTimeTest`
- ran `deploy-fabric.ps1` from a raw temp copy against branch `fix-dwd-hook-fallback` and verified the hook bundle downloaded from GitHub and completed successfully
- parsed all modified PowerShell scripts successfully