### PR TITLE
fix: handle auto-created KQL database on Eventhouse creation (409 conflict)

### DIFF
--- a/tools/deploy-fabric/deploy-fabric.ps1
+++ b/tools/deploy-fabric/deploy-fabric.ps1
@@ -586,7 +586,10 @@ if ($existingDb) {
     $createResp = Invoke-WebRequest -Uri "$FabricApi/workspaces/$WorkspaceId/kqlDatabases" -Method POST `
         -Headers @{ Authorization="Bearer $accessToken"; "Content-Type"="application/json" } `
         -Body ($createBody | ConvertTo-Json -Depth 10 -Compress) -SkipHttpErrorCheck
-    if ($createResp.StatusCode -ge 400) {
+    if ($createResp.StatusCode -eq 409) {
+        # Eventhouse auto-creates a DB with the same name; wait for it to appear in the list
+        Write-Host "  Database '$DatabaseName' already exists (auto-created with Eventhouse); waiting for it to appear..." -ForegroundColor Yellow
+    } elseif ($createResp.StatusCode -ge 400) {
         throw "kqlDatabases POST returned $($createResp.StatusCode): $($createResp.Content)"
     }
     $opLoc = $createResp.Headers['Location'] | Select-Object -First 1

--- a/tools/deploy-fabric/deploy-feeder-notebook.ps1
+++ b/tools/deploy-fabric/deploy-feeder-notebook.ps1
@@ -525,8 +525,14 @@ $db = $dbList.value | Where-Object { $_.displayName -eq $DatabaseName } | Select
 if (-not $db) {
     Write-Host "  Creating KQL database '$DatabaseName'..." -ForegroundColor Yellow
     $dbProps = @{ databaseType = "ReadWrite"; parentEventhouseItemId = $eh.id; oneLakeCachingPeriod = "P36500D"; oneLakeStandardStoragePeriod = "P36500D" }
-    Invoke-FabricApi -Method POST -Url "$FabricApi/workspaces/$WorkspaceId/kqlDatabases" -Body @{ displayName = $DatabaseName; creationPayload = $dbProps } | Out-Null
-    for ($i = 0; $i -lt 12 -and -not $db; $i++) {
+    try {
+        Invoke-FabricApi -Method POST -Url "$FabricApi/workspaces/$WorkspaceId/kqlDatabases" -Body @{ displayName = $DatabaseName; creationPayload = $dbProps } | Out-Null
+    } catch {
+        if ($_.Exception.Message -match 'ItemDisplayNameAlreadyInUse|409') {
+            Write-Host "  Database '$DatabaseName' already exists (auto-created with Eventhouse); waiting for it to appear..." -ForegroundColor Yellow
+        } else { throw }
+    }
+    for ($i = 0; $i -lt 24 -and -not $db; $i++) {
         Start-Sleep -Seconds 5
         $dbList = Invoke-FabricApi -Method GET -Url "$FabricApi/workspaces/$WorkspaceId/kqlDatabases"
         $db = $dbList.value | Where-Object { $_.displayName -eq $DatabaseName } | Select-Object -First 1


### PR DESCRIPTION
When a Fabric Eventhouse is created, it auto-creates a KQL database with the same display name. The deploy scripts now catch the 409 conflict and wait for the auto-created database to appear in the API list instead of failing.

Tested: successfully deployed DWD to 'Real-Time Open Data' workspace with this fix.