### PR TITLE
Use consistent, descriptive User-Agent across all feeders

### DIFF
--- a/feeders/aisstream/aisstream/ws_source.py
+++ b/feeders/aisstream/aisstream/ws_source.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 from typing import Any, Callable, Dict, List, Optional
 
@@ -10,6 +11,13 @@ import websockets.sync.client as ws_client
 logger = logging.getLogger(__name__)
 
 AISSTREAM_WS_URL = "wss://stream.aisstream.io/v0/stream"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-aisstream/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class WebSocketSource:
@@ -53,7 +61,7 @@ class WebSocketSource:
                 logger.info("Connecting to %s ...", self.url)
                 conn = ws_client.connect(
                     self.url,
-                    additional_headers={"User-Agent": "aisstream-bridge/1.0"},
+                    additional_headers={"User-Agent": USER_AGENT},
                     open_timeout=30,
                     close_timeout=10,
                 )

--- a/feeders/aisstream/aisstream_amqp/aisstream_amqp/app.py
+++ b/feeders/aisstream/aisstream_amqp/aisstream_amqp/app.py
@@ -59,6 +59,14 @@ from .enrichment import (
 logger = logging.getLogger("aisstream_mqtt")
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-aisstream/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 POSITION_REPORT_TYPES = {
     "PositionReport",
     "StandardClassBPositionReport",
@@ -274,7 +282,11 @@ class AisStreamMqttBridge:
         max_retry_delay = 60
         while True:
             try:
-                async with websockets.connect(self.ws_url, max_size=2 ** 22) as ws:
+                async with websockets.connect(
+                    self.ws_url,
+                    additional_headers={"User-Agent": USER_AGENT},
+                    max_size=2 ** 22,
+                ) as ws:
                     await ws.send(subscription)
                     logger.info("Connected to AISstream WS at %s", self.ws_url)
                     retry_delay = 1

--- a/feeders/aisstream/aisstream_mqtt/aisstream_mqtt/app.py
+++ b/feeders/aisstream/aisstream_mqtt/aisstream_mqtt/app.py
@@ -62,6 +62,14 @@ from aisstream_mqtt.enrichment import (
 logger = logging.getLogger("aisstream_mqtt")
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-aisstream/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 POSITION_REPORT_TYPES = {
     "PositionReport",
     "StandardClassBPositionReport",
@@ -277,7 +285,11 @@ class AisStreamMqttBridge:
         max_retry_delay = 60
         while True:
             try:
-                async with websockets.connect(self.ws_url, max_size=2 ** 22) as ws:
+                async with websockets.connect(
+                    self.ws_url,
+                    additional_headers={"User-Agent": USER_AGENT},
+                    max_size=2 ** 22,
+                ) as ws:
                     await ws.send(subscription)
                     logger.info("Connected to AISstream WS at %s", self.ws_url)
                     retry_delay = 1

--- a/feeders/aisstream/fabric/wire_aisstream_map.py
+++ b/feeders/aisstream/fabric/wire_aisstream_map.py
@@ -30,6 +30,15 @@ from typing import Any, Optional
 import requests
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-aisstream/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
+
 def _get_token(env_name: str, scope: str | list[str]) -> str:
     token = os.environ.get(env_name)
     if token:
@@ -58,6 +67,7 @@ def _session(token: str) -> requests.Session:
     session = requests.Session()
     session.headers["Authorization"] = f"Bearer {token}"
     session.headers["Content-Type"] = "application/json"
+    session.headers["User-Agent"] = USER_AGENT
     return session
 
 

--- a/feeders/australia-wildfires/australia_wildfires/australia_wildfires.py
+++ b/feeders/australia-wildfires/australia_wildfires/australia_wildfires.py
@@ -23,6 +23,14 @@ NSW_RFS_URL = "https://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
 VIC_EMERGENCY_URL = "https://www.emergency.vic.gov.au/public/osom-geojson.json"
 QLD_FIRE_URL = "https://publiccontent-gis-psba-qld-gov-au.s3.amazonaws.com/content/Feeds/BushfireCurrentIncidents/bushfireAlert.json"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-australia-wildfires/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Regex to parse key-value pairs from the NSW RFS HTML description field
 NSW_DESC_PATTERN = re.compile(
     r"(?:ALERT LEVEL|LOCATION|COUNCIL AREA|STATUS|TYPE|FIRE|SIZE|RESPONSIBLE AGENCY|UPDATED)\s*:\s*([^<]+?)(?:<br\s*/?>|$)",
@@ -131,7 +139,7 @@ class AustraliaWildfiresAPI:
     def __init__(self, polling_interval: int = 300):
         self.polling_interval = polling_interval
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": "real-time-sources-australia-wildfires-bridge/1.0"})
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_nsw_incidents(self) -> list[FireIncident]:
         """Fetch and parse fire incidents from NSW Rural Fire Service."""

--- a/feeders/autobahn/autobahn/autobahn.py
+++ b/feeders/autobahn/autobahn/autobahn.py
@@ -25,6 +25,14 @@ DEFAULT_REQUEST_CONCURRENCY = 16
 DEFAULT_STATE_FILE = os.path.expanduser("~/.autobahn_state.json")
 SELECTION_SENTINEL = "*"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-autobahn/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 RESOURCE_RESPONSE_KEYS: dict[str, str] = {
     "roadworks": "roadworks",
     "warning": "warning",
@@ -551,7 +559,7 @@ class AutobahnPoller:
 
     headers = {
         "Accept": "application/json",
-        "User-Agent": "(real-time-sources, clemensv@microsoft.com)",
+        "User-Agent": USER_AGENT,
     }
 
     def __init__(
@@ -754,7 +762,7 @@ class AutobahnPoller:
 
     async def poll_and_send(self, once: bool = False) -> None:
         timeout = aiohttp.ClientTimeout(total=60)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(timeout=timeout, headers={"User-Agent": USER_AGENT}) as session:
             while True:
                 cycle_started = datetime.now(timezone.utc)
                 changes = await self.poll_once(session, cycle_started)
@@ -776,7 +784,7 @@ class AutobahnPoller:
 
 async def run_list_roads() -> None:
     timeout = aiohttp.ClientTimeout(total=30)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with aiohttp.ClientSession(timeout=timeout, headers={"User-Agent": USER_AGENT}) as session:
         poller = AutobahnPoller()
         for road_id in await poller.fetch_roads(session):
             print(road_id)

--- a/feeders/autobahn/autobahn_mqtt/autobahn_mqtt/app.py
+++ b/feeders/autobahn/autobahn_mqtt/autobahn_mqtt/app.py
@@ -36,6 +36,14 @@ from autobahn_mqtt_producer_mqtt_client.client import DEAutobahnMqttMqttClient
 
 logger = logging.getLogger("autobahn_mqtt")
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-autobahn/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 STABLE_RETAINED_FAMILIES = {
     "weight_limit_35_restriction",
     "webcam",
@@ -186,7 +194,7 @@ class AutobahnMqttBridge:
 
     async def poll_and_publish(self, once: bool = False) -> None:
         timeout = aiohttp.ClientTimeout(total=60)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(timeout=timeout, headers={"User-Agent": USER_AGENT}) as session:
             while True:
                 cycle_started = datetime.now(timezone.utc)
                 changes = await self.poll_once(session, cycle_started)

--- a/feeders/aviationweather/aviationweather/aviationweather.py
+++ b/feeders/aviationweather/aviationweather/aviationweather.py
@@ -24,6 +24,14 @@ METAR_POLL_INTERVAL = 60
 SIGMET_POLL_INTERVAL = 120
 STATION_REFRESH_HOURS = 24
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-aviationweather/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 class AviationWeatherPoller:
     """
@@ -107,7 +115,7 @@ class AviationWeatherPoller:
         """
         try:
             url = f"{API_BASE}/metar?ids={station_ids}&format=json"
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, list):
@@ -130,7 +138,7 @@ class AviationWeatherPoller:
         """
         try:
             url = f"{API_BASE}/stationinfo?ids={station_ids}&format=json"
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, list):
@@ -150,7 +158,7 @@ class AviationWeatherPoller:
         """
         try:
             url = f"{API_BASE}/airsigmet?format=json"
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, list):
@@ -170,7 +178,7 @@ class AviationWeatherPoller:
         """
         try:
             url = f"{API_BASE}/isigmet?format=json"
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, list):

--- a/feeders/bafu-hydro/bafu_hydro/bafu_hydro.py
+++ b/feeders/bafu-hydro/bafu_hydro/bafu_hydro.py
@@ -19,6 +19,14 @@ logger = logging.getLogger(__name__)
 EXISTENZ_BASE_URL = "https://api.existenz.ch/apiv1/hydro"
 BAFU_SOURCE = "https://www.hydrodaten.admin.ch"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bafu-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 PAR_HEIGHT = "height"
 PAR_FLOW = "flow"
 PAR_TEMPERATURE = "temperature"
@@ -31,6 +39,7 @@ class BAFUHydroAPI:
         self.base_url = base_url
         self.session = requests.Session()
         self.session.headers['Accept'] = 'application/json'
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_locations(self) -> dict:
         """Fetch all station locations. Returns dict of station_id -> details."""

--- a/feeders/bfs-odl/bfs_odl/bfs_odl.py
+++ b/feeders/bfs-odl/bfs_odl/bfs_odl.py
@@ -23,6 +23,14 @@ else:
 WFS_BASE = "https://www.imis.bfs.de/ogc/opendata/ows"
 FEED_URL = "https://odlinfo.bfs.de"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bfs-odl/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # WFS parameters for the ODL layers
 WFS_PARAMS_BASE = {
     "service": "WFS",
@@ -69,6 +77,7 @@ class BfsOdlAPI:
 
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_stations(self) -> List[Dict[str, Any]]:
         """Fetch all station metadata from the odlinfo_sitelist layer."""

--- a/feeders/billetto/billetto/billetto.py
+++ b/feeders/billetto/billetto/billetto.py
@@ -36,6 +36,13 @@ DEFAULT_PAGE_SIZE = 100
 DEFAULT_POLLING_INTERVAL = 300  # seconds
 DEFAULT_TOPIC = "billetto-events"
 MIN_RATE_LIMIT_COOLDOWN_SECONDS = 60.0
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-billetto/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 FILTER_ENV_VARS = {
     "postal_code": "BILLETTO_POSTAL_CODE",
     "macroregion": "BILLETTO_MACROREGION",
@@ -54,6 +61,7 @@ def _make_session(api_keypair: str) -> requests.Session:
     session.headers.update({
         "Api-Keypair": api_keypair,
         "Accept": "application/json",
+        "User-Agent": USER_AGENT,
     })
     retry = Retry(
         total=5,

--- a/feeders/blitzortung/blitzortung/blitzortung.py
+++ b/feeders/blitzortung/blitzortung/blitzortung.py
@@ -29,10 +29,14 @@ DEFAULT_BBOX = (90.0, 180.0, -90.0, -180.0)
 DEFAULT_TOPIC = "blitzortung"
 DEFAULT_SOURCE_MASK = 4
 DEFAULT_STATE_FILE = os.path.expanduser("~/.blitzortung_state.json")
-DEFAULT_USER_AGENT = (
-    "real-time-sources-blitzortung/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-blitzortung/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
+DEFAULT_USER_AGENT = USER_AGENT
 
 
 if sys.gettrace() is not None:

--- a/feeders/blitzortung/blitzortung_amqp/blitzortung_amqp/app.py
+++ b/feeders/blitzortung/blitzortung_amqp/blitzortung_amqp/app.py
@@ -108,10 +108,14 @@ DEFAULT_WS_URLS = (
     "wss://live2.lightningmaps.org:443/",
 )
 DEFAULT_BBOX = (90.0, 180.0, -90.0, -180.0)
-DEFAULT_USER_AGENT = (
-    "real-time-sources-blitzortung-mqtt/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-blitzortung/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
+DEFAULT_USER_AGENT = USER_AGENT
 
 
 def _iso_from_ms(ts_ms: Any) -> str:

--- a/feeders/bluesky/bluesky/bluesky.py
+++ b/feeders/bluesky/bluesky/bluesky.py
@@ -17,6 +17,14 @@ from confluent_kafka import Producer
 from bluesky_producer_kafka_producer.producer import BlueskyFirehoseEventProducer
 from bluesky_producer_data import Post, Like, Repost, Follow, Block, Profile
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Logging setup
 if sys.gettrace() is not None:
     logging.basicConfig(level=logging.DEBUG)
@@ -531,7 +539,7 @@ class BlueskyFirehose:
 
         while True:
             try:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
                     async with session.ws_connect(url) as ws:
                         logging.info("Connected to firehose")
                         retry_delay = 1  # Reset on successful connection

--- a/feeders/bluesky/bluesky_amqp/bluesky_amqp/app.py
+++ b/feeders/bluesky/bluesky_amqp/bluesky_amqp/app.py
@@ -32,6 +32,14 @@ import aiohttp
 from bluesky_amqp_producer_data import Block, Follow, Like, Post, Profile, Repost
 from bluesky_amqp_producer_amqp_producer.producer import BlueskyFirehoseAmqpProducer
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 logger = logging.getLogger("bluesky_amqp")
 
 
@@ -318,7 +326,7 @@ class BlueskyMqttBridge:
         url = self.firehose_url
         while True:
             try:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
                     async with session.ws_connect(url) as ws:
                         logger.info("Connected to Bluesky firehose at %s", url)
                         retry_delay = 1

--- a/feeders/bluesky/bluesky_mqtt/bluesky_mqtt/app.py
+++ b/feeders/bluesky/bluesky_mqtt/bluesky_mqtt/app.py
@@ -34,6 +34,14 @@ from paho.mqtt.client import CallbackAPIVersion, MQTTv5
 from bluesky_mqtt_producer_data import Block, Follow, Like, Post, Profile, Repost
 from bluesky_mqtt_producer_mqtt_client.client import BlueskyFirehoseMqttMqttClient
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 logger = logging.getLogger("bluesky_mqtt")
 
 
@@ -220,7 +228,7 @@ class BlueskyMqttBridge:
         url = self.firehose_url
         while True:
             try:
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
                     async with session.ws_connect(url) as ws:
                         logger.info("Connected to Bluesky firehose at %s", url)
                         retry_delay = 1

--- a/feeders/bluesky/botfinder/botfinder/acquire.py
+++ b/feeders/bluesky/botfinder/botfinder/acquire.py
@@ -10,6 +10,7 @@ through it, all later scoring, clustering, and dossier steps.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -19,6 +20,14 @@ import pandas as pd
 from .config import Config
 from .kusto import execute_query
 
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 @dataclass
 class AcquiredData:
@@ -127,6 +136,7 @@ def _resolve_target_did(config: Config) -> str:
         r = httpx.get(
             "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle",
             params={"handle": handle},
+            headers={"User-Agent": USER_AGENT},
         )
         r.raise_for_status()
         return r.json()["did"]

--- a/feeders/bluesky/botfinder/botfinder/bluesky_api.py
+++ b/feeders/bluesky/botfinder/botfinder/bluesky_api.py
@@ -7,6 +7,7 @@ XRPC endpoints into typed dataclasses that downstream scoring, cluster, and
 cross-follow stages can consume without parsing raw JSON repeatedly.
 """
 
+import os
 import httpx
 import asyncio
 from dataclasses import dataclass, field
@@ -14,6 +15,14 @@ from datetime import datetime
 
 
 XRPC_BASE = "https://public.api.bsky.app/xrpc"
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 @dataclass
@@ -348,7 +357,7 @@ async def enrich_suspects(
     bsky = BlueskyClient(concurrency=concurrency)
     results: dict[str, dict] = {}
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(timeout=30.0, headers={"User-Agent": USER_AGENT}) as client:
         # Batch-resolve profiles (25 per request)
         all_profiles: dict[str, BlueskyProfile] = {}
         for i in range(0, len(dids), 25):

--- a/feeders/bluesky/botfinder/botfinder/cluster.py
+++ b/feeders/bluesky/botfinder/botfinder/cluster.py
@@ -12,6 +12,7 @@ surrounding the anchor.
 from __future__ import annotations
 
 import asyncio
+import os
 from ._async import run_async
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -24,6 +25,14 @@ import pandas as pd
 import plotly.graph_objects as go
 
 from .bluesky_api import BlueskyClient
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from .pipeline import AnalysisResult
@@ -71,7 +80,7 @@ async def _fetch_follows_for_suspects(
     """
     bsky = BlueskyClient(concurrency=concurrency)
     results: dict[str, list[str]] = {}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(timeout=30.0, headers={"User-Agent": USER_AGENT}) as client:
         sem = asyncio.Semaphore(concurrency)
 
         async def _get_one(did: str):
@@ -100,7 +109,7 @@ async def _resolve_handles(dids: list[str], concurrency: int = 25) -> dict[str, 
     """
     bsky = BlueskyClient(concurrency=concurrency)
     handles: dict[str, str] = {}
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(timeout=30.0, headers={"User-Agent": USER_AGENT}) as client:
         for i in range(0, len(dids), 25):
             batch = dids[i: i + 25]
             try:

--- a/feeders/bluesky/botfinder/botfinder/cross_follow.py
+++ b/feeders/bluesky/botfinder/botfinder/cross_follow.py
@@ -11,6 +11,7 @@ behavior.
 from __future__ import annotations
 
 import asyncio
+import os
 from ._async import run_async
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -20,6 +21,14 @@ import pandas as pd
 
 from .bluesky_api import BlueskyClient
 from .kusto import execute_query
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from .pipeline import AnalysisResult
@@ -79,7 +88,7 @@ async def _measure_via_api(
     client_obj = BlueskyClient(concurrency=concurrency, timeout=30.0)
     results = []
 
-    async with httpx.AsyncClient(timeout=30.0) as http_client:
+    async with httpx.AsyncClient(timeout=30.0, headers={"User-Agent": USER_AGENT}) as http_client:
         for _, row in sample.iterrows():
             did = row["did"]
             handle = row.get("handle", "")

--- a/feeders/bluesky/botfinder/botfinder/pipeline.py
+++ b/feeders/bluesky/botfinder/botfinder/pipeline.py
@@ -10,6 +10,7 @@ exposes a scoring-only entry point and a full reporting entry point.
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 from dataclasses import dataclass, field
 from typing import Any
@@ -26,6 +27,14 @@ from .bluesky_api import (
     enrich_suspects_sync,
 )
 from .config import Config
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bluesky/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 from .scoring import (
     BotScore,
     _is_random_handle,
@@ -106,7 +115,7 @@ def _fetch_all_followers_via_api(
     async def _fetch():
         """Run the async follower crawl used by the synchronous pipeline wrapper."""
         bsky = BlueskyClient(concurrency=concurrency)
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, headers={"User-Agent": USER_AGENT}) as client:
             return await bsky.get_followers(client, target_handle, limit=max_followers)
     from ._async import run_async
     return run_async(_fetch())

--- a/feeders/bom-australia/bom_australia/bom_australia.py
+++ b/feeders/bom-australia/bom_australia/bom_australia.py
@@ -87,6 +87,14 @@ WARNING_TITLE_PATTERN = re.compile(
 )
 WARNING_FEED_STATE_PATTERN = re.compile(r"warnings_(?P<state>[a-z]+)\.xml$", re.IGNORECASE)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-bom-australia/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 class BOMAustraliaAPI:
     """Client for the BOM weather observation JSON feeds."""
@@ -97,9 +105,7 @@ class BOMAustraliaAPI:
         self.fetch_workers = max(1, fetch_workers)
         self.session = requests.Session()
         # BOM copyright/etiquette page asks bots to identify themselves.
-        self.session.headers.update({
-            "User-Agent": "real-time-sources-bom-bridge/1.0 (+https://github.com/clemensv/real-time-sources)"
-        })
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def discover_stations(self, state_filter: typing.Optional[str] = None) -> list[tuple[str, int]]:
         """Discover active BOM observing stations.

--- a/feeders/canada-aqhi/canada_aqhi/canada_aqhi.py
+++ b/feeders/canada-aqhi/canada_aqhi/canada_aqhi.py
@@ -31,6 +31,14 @@ else:
 
 LOGGER = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-canada-aqhi/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 AQHI_BASE_URL = "https://dd.weather.gc.ca/today/air_quality/aqhi"
 COMMUNITY_GEOJSON_URL = (
     "https://collaboration.cmc.ec.gc.ca/cmc/cmos/public_doc/msc-data/aqhi/aqhi_community.geojson"
@@ -168,7 +176,7 @@ def canonicalize_feed_url(feed_url: str | None) -> str | None:
 def create_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/canada-aqhi/tests/test_canada_aqhi_unit.py
+++ b/feeders/canada-aqhi/tests/test_canada_aqhi_unit.py
@@ -103,7 +103,7 @@ class TestConnectionStringParsing:
         session = create_retrying_session()
         https_adapter = session.get_adapter("https://dd.weather.gc.ca")
 
-        assert session.headers["User-Agent"] == "GitHub-Copilot-CLI/1.0"
+        assert session.headers["User-Agent"].startswith("real-time-sources-canada-aqhi/")
         assert https_adapter.max_retries.total == 3
         assert https_adapter.max_retries.backoff_factor == 1
 

--- a/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice/canada_eccc_wateroffice.py
+++ b/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice/canada_eccc_wateroffice.py
@@ -25,6 +25,14 @@ from canada_eccc_wateroffice_producer_data import Observation
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-canada-eccc-wateroffice/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 ECCC_STATIONS_URL = "https://api.weather.gc.ca/collections/hydrometric-stations/items"
 ECCC_REALTIME_URL = "https://api.weather.gc.ca/collections/hydrometric-realtime/items"
 
@@ -35,6 +43,7 @@ STATION_REFRESH_INTERVAL = 86400    # 24 hours
 def _make_session() -> requests.Session:
     """Create a requests session with retry handling for transient failures."""
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         backoff_factor=0.5,

--- a/feeders/carbon-intensity/carbon_intensity/carbon_intensity.py
+++ b/feeders/carbon-intensity/carbon_intensity/carbon_intensity.py
@@ -26,6 +26,13 @@ from carbon_intensity_producer_kafka_producer.producer import (
 API_BASE = "https://api.carbonintensity.org.uk"
 POLL_INTERVAL_SECONDS = 1800  # 30 minutes
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-carbon-intensity/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 FUEL_TYPES = [
     "biomass", "coal", "imports", "gas", "nuclear",
@@ -177,7 +184,7 @@ class CarbonIntensityPoller:
     def fetch_intensity() -> Optional[Dict]:
         """GET /intensity — current national carbon intensity."""
         try:
-            resp = requests.get(f"{API_BASE}/intensity", timeout=30)
+            resp = requests.get(f"{API_BASE}/intensity", headers={"User-Agent": USER_AGENT}, timeout=30)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -188,7 +195,7 @@ class CarbonIntensityPoller:
     def fetch_generation() -> Optional[Dict]:
         """GET /generation — current national generation mix."""
         try:
-            resp = requests.get(f"{API_BASE}/generation", timeout=30)
+            resp = requests.get(f"{API_BASE}/generation", headers={"User-Agent": USER_AGENT}, timeout=30)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:
@@ -199,7 +206,7 @@ class CarbonIntensityPoller:
     def fetch_regional() -> Optional[Dict]:
         """GET /regional — all 17 DNO regions."""
         try:
-            resp = requests.get(f"{API_BASE}/regional", timeout=30)
+            resp = requests.get(f"{API_BASE}/regional", headers={"User-Agent": USER_AGENT}, timeout=30)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:

--- a/feeders/carbon-intensity/tests/test_carbon_intensity_unit.py
+++ b/feeders/carbon-intensity/tests/test_carbon_intensity_unit.py
@@ -18,6 +18,7 @@ from carbon_intensity.carbon_intensity import (
     FUEL_TYPES,
     API_BASE,
     POLL_INTERVAL_SECONDS,
+    USER_AGENT,
 )
 
 
@@ -456,7 +457,9 @@ class TestFetchMethods:
         mock_get.return_value.raise_for_status = Mock()
         result = CarbonIntensityPoller.fetch_intensity()
         assert result == SAMPLE_INTENSITY_RESPONSE
-        mock_get.assert_called_once_with(f"{API_BASE}/intensity", timeout=30)
+        mock_get.assert_called_once_with(
+            f"{API_BASE}/intensity", headers={"User-Agent": USER_AGENT}, timeout=30
+        )
 
     @patch('carbon_intensity.carbon_intensity.requests.get')
     def test_fetch_intensity_failure(self, mock_get):

--- a/feeders/cbp-border-wait/cbp_border_wait/cbp_border_wait.py
+++ b/feeders/cbp-border-wait/cbp_border_wait/cbp_border_wait.py
@@ -24,6 +24,14 @@ if sys.gettrace() is not None:
 else:
     logging.basicConfig(level=logging.INFO)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-cbp-border-wait/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 API_URL = "https://bwt.cbp.gov/api/bwtnew"
 
 
@@ -147,6 +155,7 @@ class CbpBorderWaitAPI:
     def __init__(self, api_url: str = API_URL):
         self.api_url = api_url
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_ports(self) -> List[Dict[str, Any]]:
         """Fetch all port data from the CBP API.

--- a/feeders/cdec-reservoirs/cdec_reservoirs/cdec_reservoirs.py
+++ b/feeders/cdec-reservoirs/cdec_reservoirs/cdec_reservoirs.py
@@ -28,6 +28,14 @@ else:
 # CDEC always reports in PST (UTC-8), never PDT
 PST = timezone(timedelta(hours=-8))
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-cdec-reservoirs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 BASE_URL = "https://cdec.water.ca.gov/dynamicapp/req/JSONDataServlet"
 
 # Default major California reservoir stations
@@ -81,6 +89,7 @@ class CdecReservoirsAPI:
         self.sensors = sensors
         self.dur_code = dur_code
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def build_url(self, start_date: str, end_date: str) -> str:
         """Build the CDEC JSON Data Servlet URL.

--- a/feeders/chmi-hydro/chmi_hydro/chmi_hydro.py
+++ b/feeders/chmi-hydro/chmi_hydro/chmi_hydro.py
@@ -17,6 +17,14 @@ from chmi_hydro_producer_data import WaterLevelObservation
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-chmi-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 CHMI_BASE_URL = "https://opendata.chmi.cz/hydrology/now"
 CHMI_METADATA_URL = f"{CHMI_BASE_URL}/metadata/meta1.json"
 CHMI_DATA_URL = f"{CHMI_BASE_URL}/data"
@@ -33,6 +41,7 @@ class CHMIHydroAPI:
         self.data_url = f"{base_url}/data"
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
         self._station_metadata: typing.Optional[typing.List[typing.List]] = None
         self._station_header: typing.Optional[typing.List[str]] = None
 

--- a/feeders/defra-aurn/defra_aurn/defra_aurn.py
+++ b/feeders/defra-aurn/defra_aurn/defra_aurn.py
@@ -24,6 +24,14 @@ from defra_aurn_producer_kafka_producer.producer import (
 
 LOGGER = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-defra-aurn/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 BASE_URL = "https://uk-air.defra.gov.uk/sos-ukair/api/v1"
 DEFAULT_POLLING_INTERVAL = 3600
 DEFAULT_PAGE_LIMIT = 1000
@@ -115,7 +123,7 @@ def _is_truthy(value: str | None, default: bool = True) -> bool:
 def create_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/defra-aurn/tests/test_defra_aurn_unit.py
+++ b/feeders/defra-aurn/tests/test_defra_aurn_unit.py
@@ -83,7 +83,7 @@ class TestDefraAURNAPIInitialization:
         session = create_retrying_session()
         https_adapter = session.get_adapter("https://uk-air.defra.gov.uk")
 
-        assert session.headers["User-Agent"] == "GitHub-Copilot-CLI/1.0"
+        assert session.headers["User-Agent"].startswith("real-time-sources-defra-aurn/")
         assert https_adapter.max_retries.total == 3
         assert https_adapter.max_retries.backoff_factor == 1
 

--- a/feeders/digitraffic-maritime/digitraffic_maritime/bridge.py
+++ b/feeders/digitraffic-maritime/digitraffic_maritime/bridge.py
@@ -35,6 +35,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-maritime/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Map MQTT topic type to (data class, send method name)
 _MESSAGE_MAP: Dict[str, tuple] = {
     "location": (VesselLocation, "send_fi_digitraffic_marine_ais_vessel_location"),
@@ -159,7 +167,7 @@ class DigitrafficPortCallPoller:
         self._state_file = state_file
         self._poll_interval = poll_interval
         self._session = session or requests.Session()
-        self._session.headers.update({"User-Agent": "real-time-sources-digitraffic-maritime/1.0"})
+        self._session.headers["User-Agent"] = USER_AGENT
 
     @classmethod
     def _empty_state(cls) -> Dict[str, Dict[str, str]]:

--- a/feeders/digitraffic-maritime/digitraffic_maritime/mqtt_source.py
+++ b/feeders/digitraffic-maritime/digitraffic_maritime/mqtt_source.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import time
 import uuid
 from typing import Any, Callable, Dict, Optional
@@ -9,6 +10,14 @@ from typing import Any, Callable, Dict, Optional
 import paho.mqtt.client as mqtt
 
 logger = logging.getLogger(__name__)
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-maritime/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 DIGITRAFFIC_MQTT_HOST = "meri.digitraffic.fi"
 DIGITRAFFIC_MQTT_PORT = 443
@@ -127,6 +136,7 @@ class MQTTSource:
         client.on_disconnect = on_disconnect
         client.on_message = on_message
 
+        client.ws_set_options(headers={"User-Agent": USER_AGENT})
         client.tls_set()
         logger.info("Connecting to %s:%d ...", self.host, self.port)
         client.connect(self.host, self.port)

--- a/feeders/digitraffic-road/digitraffic_road/bridge.py
+++ b/feeders/digitraffic-road/digitraffic_road/bridge.py
@@ -36,6 +36,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-road/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Maps MQTT situation type values to producer send methods
 _SITUATION_TYPE_SENDERS = {
     "TRAFFIC_ANNOUNCEMENT": "send_fi_digitraffic_road_messages_traffic_announcement",
@@ -103,7 +111,7 @@ def fetch_and_emit_tms_stations(
     stations_producer: "FiDigitrafficRoadStationsEventProducer",
 ) -> int:
     """Fetch all TMS stations from the REST API and emit as reference events. Returns count."""
-    resp = requests.get(_TMS_STATIONS_URL, timeout=60)
+    resp = requests.get(_TMS_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
     resp.raise_for_status()
     features = resp.json().get("features", [])
     count = 0
@@ -126,7 +134,7 @@ def fetch_and_emit_weather_stations(
     stations_producer: "FiDigitrafficRoadStationsEventProducer",
 ) -> int:
     """Fetch all weather stations from the REST API and emit as reference events. Returns count."""
-    resp = requests.get(_WEATHER_STATIONS_URL, timeout=60)
+    resp = requests.get(_WEATHER_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
     resp.raise_for_status()
     features = resp.json().get("features", [])
     count = 0
@@ -149,7 +157,7 @@ def fetch_and_emit_maintenance_tasks(
     tasks_producer: "FiDigitrafficRoadMaintenanceTasksEventProducer",
 ) -> int:
     """Fetch all maintenance task types from the REST API and emit as reference events. Returns count."""
-    resp = requests.get(_MAINTENANCE_TASKS_URL, timeout=30)
+    resp = requests.get(_MAINTENANCE_TASKS_URL, headers={"User-Agent": USER_AGENT}, timeout=30)
     resp.raise_for_status()
     tasks = resp.json()
     count = 0

--- a/feeders/digitraffic-road/digitraffic_road/mqtt_source.py
+++ b/feeders/digitraffic-road/digitraffic_road/mqtt_source.py
@@ -4,6 +4,7 @@ import base64
 import gzip
 import json
 import logging
+import os
 import time
 import uuid
 from typing import Any, Callable, Dict, Optional, Set
@@ -11,6 +12,14 @@ from typing import Any, Callable, Dict, Optional, Set
 import paho.mqtt.client as mqtt
 
 logger = logging.getLogger(__name__)
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-road/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 DIGITRAFFIC_MQTT_HOST = "tie.digitraffic.fi"
 DIGITRAFFIC_MQTT_PORT = 443
@@ -151,6 +160,7 @@ class MQTTSource:
         client.on_disconnect = on_disconnect
         client.on_message = on_message
 
+        client.ws_set_options(headers={"User-Agent": USER_AGENT})
         client.tls_set()
         logger.info("Connecting to %s:%d ...", self.host, self.port)
         client.connect(self.host, self.port)

--- a/feeders/digitraffic-road/digitraffic_road_amqp/digitraffic_road_amqp/app.py
+++ b/feeders/digitraffic-road/digitraffic_road_amqp/digitraffic_road_amqp/app.py
@@ -29,6 +29,14 @@ from digitraffic_road_amqp_producer_amqp_producer.producer import FiDigitrafficR
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-road/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 DIGITRAFFIC_MQTT_HOST = "tie.digitraffic.fi"
 DIGITRAFFIC_MQTT_PORT = 443
 
@@ -148,6 +156,7 @@ class MQTTSource:
         client.on_disconnect = on_disconnect
         client.on_message = on_message
 
+        client.ws_set_options(headers={"User-Agent": USER_AGENT})
         client.tls_set()
         logger.info("Connecting to %s:%d ...", self.host, self.port)
         client.connect(self.host, self.port)
@@ -625,7 +634,7 @@ class DigitrafficRoadAmqpBridge:
         )
 
     def _emit_reference_data(self) -> None:
-        tms_response = requests.get(_TMS_STATIONS_URL, timeout=60)
+        tms_response = requests.get(_TMS_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
         tms_response.raise_for_status()
         for feature in tms_response.json().get("features", []):
             flat = _flatten_station(feature)
@@ -634,7 +643,7 @@ class DigitrafficRoadAmqpBridge:
                 _station_id=str(flat["station_id"]),
             )
 
-        weather_response = requests.get(_WEATHER_STATIONS_URL, timeout=60)
+        weather_response = requests.get(_WEATHER_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
         weather_response.raise_for_status()
         for feature in weather_response.json().get("features", []):
             flat = _flatten_station(feature)
@@ -643,7 +652,7 @@ class DigitrafficRoadAmqpBridge:
                 _station_id=str(flat["station_id"]),
             )
 
-        tasks_response = requests.get(_MAINTENANCE_TASKS_URL, timeout=30)
+        tasks_response = requests.get(_MAINTENANCE_TASKS_URL, headers={"User-Agent": USER_AGENT}, timeout=30)
         tasks_response.raise_for_status()
         for task in tasks_response.json():
             flat = {

--- a/feeders/digitraffic-road/digitraffic_road_mqtt/digitraffic_road_mqtt/app.py
+++ b/feeders/digitraffic-road/digitraffic_road_mqtt/digitraffic_road_mqtt/app.py
@@ -33,6 +33,14 @@ from digitraffic_road_mqtt_producer_mqtt_client.client import FiDigitrafficRoadM
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-digitraffic-road/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 DIGITRAFFIC_MQTT_HOST = "tie.digitraffic.fi"
 DIGITRAFFIC_MQTT_PORT = 443
 
@@ -171,6 +179,7 @@ class MQTTSource:
         client.on_disconnect = on_disconnect
         client.on_message = on_message
 
+        client.ws_set_options(headers={"User-Agent": USER_AGENT})
         client.tls_set()
         logger.info("Connecting to %s:%d ...", self.host, self.port)
         client.connect(self.host, self.port)
@@ -633,7 +642,7 @@ class DigitrafficRoadMqttBridge:
         await self._client.publish_fi_digitraffic_road_mqtt_maintenance_tracking(domain="state-roads", data=maintenance)
 
     async def _emit_reference_data(self) -> None:
-        tms_response = requests.get(_TMS_STATIONS_URL, timeout=60)
+        tms_response = requests.get(_TMS_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
         tms_response.raise_for_status()
         for feature in tms_response.json().get("features", []):
             flat = _flatten_station(feature)
@@ -644,7 +653,7 @@ class DigitrafficRoadMqttBridge:
                 retain=True,
             )
 
-        weather_response = requests.get(_WEATHER_STATIONS_URL, timeout=60)
+        weather_response = requests.get(_WEATHER_STATIONS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
         weather_response.raise_for_status()
         for feature in weather_response.json().get("features", []):
             flat = _flatten_station(feature)
@@ -655,7 +664,7 @@ class DigitrafficRoadMqttBridge:
                 retain=True,
             )
 
-        tasks_response = requests.get(_MAINTENANCE_TASKS_URL, timeout=30)
+        tasks_response = requests.get(_MAINTENANCE_TASKS_URL, headers={"User-Agent": USER_AGENT}, timeout=30)
         tasks_response.raise_for_status()
         for task in tasks_response.json():
             flat = {

--- a/feeders/dmi/dmi_core/dmi_core/acquisition.py
+++ b/feeders/dmi/dmi_core/dmi_core/acquisition.py
@@ -16,6 +16,7 @@ Reference:
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 import requests
@@ -30,6 +31,14 @@ LIGHTNING_FEED_ROOT = "https://dmigw.govcloud.dk/v2/lightningdata"
 _DEFAULT_PAGE_LIMIT = 1000
 
 logger = logging.getLogger(__name__)
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-dmi/1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class _DmiBaseAPI:
@@ -49,6 +58,7 @@ class _DmiBaseAPI:
             )
         self._api_key = api_key
         self._session = session or requests.Session()
+        self._session.headers["User-Agent"] = USER_AGENT
         self._request_timeout = request_timeout
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:

--- a/feeders/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
+++ b/feeders/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
@@ -27,6 +27,14 @@ POLLEN_NAME_MAP = {
     "Ambrosia": "ragweed",
 }
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-dwd-pollenflug/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 FORECAST_API_URL = "https://opendata.dwd.de/climate_environment/health/alerts/s31fg.json"
 POLL_INTERVAL_SECONDS = 3600  # 1 hour
 
@@ -135,7 +143,7 @@ class DWDPollenflugPoller:
     def fetch_data() -> Optional[dict]:
         """Fetch the DWD pollen forecast JSON."""
         try:
-            response = requests.get(FORECAST_API_URL, timeout=60)
+            response = requests.get(FORECAST_API_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             return response.json()
         except Exception as err:

--- a/feeders/dwd/dwd/util/http_client.py
+++ b/feeders/dwd/dwd/util/http_client.py
@@ -2,6 +2,7 @@
 
 import io
 import logging
+import os
 import re
 import zipfile
 from dataclasses import dataclass
@@ -11,6 +12,14 @@ from typing import Dict, List, Optional
 import requests
 
 logger = logging.getLogger(__name__)
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-dwd/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # Apache/nginx directory listing pattern: <a href="filename">filename</a>  date  size
 _DIR_ENTRY_RE = re.compile(
@@ -57,7 +66,7 @@ class DWDHttpClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "dwd-bridge/1.0 (https://github.com/clemensv/real-time-sources)"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._etags: Dict[str, str] = {}
 
     def list_directory(self, path: str) -> List[DirEntry]:

--- a/feeders/eaws-albina/eaws_albina/eaws_albina.py
+++ b/feeders/eaws-albina/eaws_albina/eaws_albina.py
@@ -41,6 +41,14 @@ def topic_segment(value: Optional[str]) -> str:
     return value
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-eaws-albina/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 DEFAULT_REGIONS = ["AT-07", "IT-32-BZ", "IT-32-TN", "AT-02"]
 DEFAULT_LANG = "en"
 BASE_URL = "https://avalanche.report/albina_files"
@@ -102,7 +110,7 @@ class AlbinaPoller:
     def fetch_bulletin(url: str, timeout: int = 30) -> Optional[dict]:
         """Fetch a single CAAMLv6 JSON bulletin. Returns None on 404 or error."""
         try:
-            response = requests.get(url, timeout=timeout)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=timeout)
             if response.status_code == 404:
                 return None
             response.raise_for_status()

--- a/feeders/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
+++ b/feeders/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
@@ -18,6 +18,14 @@ from elexon_bmrs_producer_data import GenerationMix, DemandOutturn
 from elexon_bmrs_producer_kafka_producer.producer import UKCoElexonBMRSEventProducer
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-elexon-bmrs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Mapping from BMRS fuelType strings to GenerationMix field names
 FUEL_TYPE_FIELD_MAP = {
     "BIOMASS": "biomass_mw",
@@ -199,7 +207,12 @@ class ElexonBMRSPoller:
             Parsed JSON list, or None on failure.
         """
         try:
-            response = requests.get(self.GENERATION_URL, params={"format": "json"}, timeout=30)
+            response = requests.get(
+                self.GENERATION_URL,
+                params={"format": "json"},
+                headers={"User-Agent": USER_AGENT},
+                timeout=30,
+            )
             response.raise_for_status()
             return response.json()
         except Exception as e:
@@ -214,7 +227,12 @@ class ElexonBMRSPoller:
             Parsed JSON dict, or None on failure.
         """
         try:
-            response = requests.get(self.DEMAND_URL, params={"format": "json"}, timeout=30)
+            response = requests.get(
+                self.DEMAND_URL,
+                params={"format": "json"},
+                headers={"User-Agent": USER_AGENT},
+                timeout=30,
+            )
             response.raise_for_status()
             return response.json()
         except Exception as e:

--- a/feeders/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
+++ b/feeders/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
@@ -16,6 +16,14 @@ import requests
 from energidataservice_dk_producer_data import PowerSystemSnapshot, SpotPrice
 from energidataservice_dk_producer_kafka_producer.producer import DkEnerginetEnergidataserviceEventProducer
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-energidataservice-dk/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 POWER_SYSTEM_URL = "https://api.energidataservice.dk/dataset/PowerSystemRightNow"
 SPOT_PRICES_URL = "https://api.energidataservice.dk/dataset/ElspotPrices"
 
@@ -170,7 +178,7 @@ class EnergiDataServicePoller:
         """Fetch raw records from the PowerSystemRightNow endpoint."""
         url = build_power_system_url(limit)
         try:
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data.get("records", [])
@@ -182,7 +190,7 @@ class EnergiDataServicePoller:
         """Fetch raw records from the ElspotPrices endpoint."""
         url = build_spot_prices_url(limit)
         try:
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data.get("records", [])

--- a/feeders/energidataservice-dk/tests/test_energidataservice_dk_unit.py
+++ b/feeders/energidataservice-dk/tests/test_energidataservice_dk_unit.py
@@ -691,7 +691,8 @@ class TestPollAndSend:
         mock_event_producer_class.return_value = mock_event_producer
         mock_event_producer.producer = Mock()
 
-        def side_effect(url, timeout=30):
+        def side_effect(url, headers=None, timeout=30):
+            assert headers["User-Agent"].startswith("real-time-sources-energidataservice-dk/")
             resp = Mock()
             resp.raise_for_status = Mock()
             if "PowerSystemRightNow" in url:
@@ -737,7 +738,8 @@ class TestPollAndSend:
         with open(temp_state_file, 'w', encoding='utf-8') as f:
             json.dump(state_data, f)
 
-        def side_effect(url, timeout=30):
+        def side_effect(url, headers=None, timeout=30):
+            assert headers["User-Agent"].startswith("real-time-sources-energidataservice-dk/")
             resp = Mock()
             resp.raise_for_status = Mock()
             if "PowerSystemRightNow" in url:

--- a/feeders/energy-charts/energy_charts/energy_charts.py
+++ b/feeders/energy-charts/energy_charts/energy_charts.py
@@ -18,6 +18,14 @@ import requests
 from energy_charts_producer_data import PublicPower, SpotPrice, GridSignal
 from energy_charts_producer_kafka_producer.producer import InfoEnergyChartsEventProducer
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-energy-charts/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Map API production type names to schema field names
 PRODUCTION_TYPE_MAP = {
     "Hydro pumped storage consumption": "hydro_pumped_storage_consumption_mw",
@@ -74,7 +82,7 @@ class EnergyChartsPoller:
         self.kafka_topic = kafka_topic
         self.last_polled_file = last_polled_file
         self.session = requests.Session()
-        self.session.headers.update({"Accept": "application/json"})
+        self.session.headers.update({"Accept": "application/json", "User-Agent": USER_AGENT})
 
         from confluent_kafka import Producer
         kafka_producer = Producer(kafka_config)

--- a/feeders/entsoe/entsoe/entsoe.py
+++ b/feeders/entsoe/entsoe/entsoe.py
@@ -35,6 +35,14 @@ from entsoe.delta_state import load_state, save_state, get_last_polled, set_last
 
 logger = logging.getLogger("entsoe")
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-entsoe/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 BASE_URL = "https://web-api.tp.entsoe.eu/api"
 
 DEFAULT_DOMAINS = [
@@ -132,7 +140,7 @@ class EntsoePoller:
                             domain, period_start, period_end,
                             out_domain=out_domain)
         try:
-            response = requests.get(url, timeout=60)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
             if response.status_code == 400:
                 # ENTSO-E returns 400 for "no data" scenarios
                 logger.debug("No data for %s/%s (%s - %s)",

--- a/feeders/entsoe/entsoe_core/entsoe_core/acquisition.py
+++ b/feeders/entsoe/entsoe_core/entsoe_core/acquisition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Protocol, Tuple
@@ -13,6 +14,14 @@ from .delta_state import get_last_polled, load_state, save_state, set_last_polle
 from .xml_parser import TimeSeriesPoint, build_api_url, parse_entsoe_xml
 
 logger = logging.getLogger("entsoe")
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-entsoe/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 BASE_URL = "https://web-api.tp.entsoe.eu/api"
 
@@ -100,7 +109,7 @@ class EntsoeAPI:
               out_domain: Optional[str] = None) -> Optional[str]:
         url = build_api_url(self.base_url, self.security_token, document_type, domain, period_start, period_end, out_domain=out_domain)
         try:
-            response = requests.get(url, timeout=60)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
             if response.status_code == 400:
                 logger.debug("No data for %s/%s", document_type, domain)
                 return None

--- a/feeders/entur-norway/entur_norway/entur_norway.py
+++ b/feeders/entur-norway/entur_norway/entur_norway.py
@@ -34,6 +34,14 @@ if sys.gettrace() is not None:
 else:
     logging.basicConfig(level=logging.INFO)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-entur-norway/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 SIRI_NS = 'http://www.siri.org.uk/siri'
 NS = {'s': SIRI_NS}
 
@@ -150,7 +158,7 @@ class EnturNorwayBridge:
 
     def _create_session(self) -> requests.Session:
         session = requests.Session()
-        session.headers.update({'ET-Client-Name': self.CLIENT_NAME})
+        session.headers.update({'ET-Client-Name': self.CLIENT_NAME, 'User-Agent': USER_AGENT})
         retry = Retry(
             total=3,
             connect=3,

--- a/feeders/environment-canada/environment_canada/environment_canada.py
+++ b/feeders/environment-canada/environment_canada/environment_canada.py
@@ -16,6 +16,14 @@ from environment_canada_producer_data import Station, WeatherObservation
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-environment-canada/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 EC_API_BASE = "https://api.weather.gc.ca/collections"
 SWOB_STATIONS_URL = f"{EC_API_BASE}/swob-stations/items"
 SWOB_REALTIME_URL = f"{EC_API_BASE}/swob-realtime/items"
@@ -33,6 +41,7 @@ class ECWeatherAPI:
         self.station_limit = station_limit
         self.obs_limit = obs_limit
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_stations(self) -> list[dict]:
         """Fetch station metadata from swob-stations collection."""

--- a/feeders/epa-uv/epa_uv/epa_uv.py
+++ b/feeders/epa-uv/epa_uv/epa_uv.py
@@ -19,6 +19,14 @@ from epa_uv_producer_kafka_producer.producer import USEPAUVIndexEventProducer
 
 LOGGER = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-epa-uv/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 HOURLY_URL = "https://data.epa.gov/dmapservice/getEnvirofactsUVHOURLY/CITY/{city}/STATE/{state}/JSON"
 DAILY_URL = "https://data.epa.gov/dmapservice/getEnvirofactsUVDAILY/CITY/{city}/STATE/{state}/JSON"
 DEFAULT_POLL_INTERVAL_SECONDS = 21600
@@ -131,7 +139,7 @@ class EPAUVBridge:
         self.locations = locations
         self.state_file = state_file
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+        self.session.headers["User-Agent"] = USER_AGENT
         state = _load_state(state_file)
         self.hourly_order = [str(value) for value in state.get("seen_hourly_ids", [])][-MAX_SEEN_IDS:]
         self.daily_order = [str(value) for value in state.get("seen_daily_ids", [])][-MAX_SEEN_IDS:]

--- a/feeders/eurdep-radiation/eurdep_radiation/eurdep_radiation.py
+++ b/feeders/eurdep-radiation/eurdep_radiation/eurdep_radiation.py
@@ -28,6 +28,14 @@ else:
 WFS_BASE = "https://www.imis.bfs.de/ogc/opendata/ows"
 FEED_URL = "https://www.imis.bfs.de/ogc/opendata/ows"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-eurdep-radiation/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 WFS_PARAMS_BASE = {
     "service": "WFS",
     "version": "2.0.0",
@@ -66,6 +74,7 @@ class EurdepAPI:
 
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_all_features(self) -> List[Dict[str, Any]]:
         """Fetch all EURDEP features with WFS pagination."""

--- a/feeders/fienta/fienta/fienta.py
+++ b/feeders/fienta/fienta/fienta.py
@@ -28,6 +28,14 @@ FILTER_ENV_VARS = {
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 LOGGER = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-fienta/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _optional_string(value: object) -> Optional[str]:
     """Normalize optional string-like values."""
@@ -108,7 +116,7 @@ def fetch_events(page: int = 1, api_filters: Optional[Dict[str, str]] = None) ->
     """
     try:
         params: Dict[str, object] = {"page": page, **(api_filters or {})}
-        response = requests.get(FIENTA_API_URL, params=params, timeout=60)
+        response = requests.get(FIENTA_API_URL, params=params, headers={"User-Agent": USER_AGENT}, timeout=60)
         response.raise_for_status()
         data = response.json()
 

--- a/feeders/fmi-finland/fmi_finland/fmi_finland.py
+++ b/feeders/fmi-finland/fmi_finland/fmi_finland.py
@@ -22,6 +22,14 @@ from fmi_finland_producer_kafka_producer.producer import FiFmiOpendataAirquality
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-fmi-finland/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 FMI_WFS_URL = "https://opendata.fmi.fi/wfs"
 STATIONS_STORED_QUERY = "fmi::ef::stations"
 OBSERVATIONS_STORED_QUERY = "urban::observations::airquality::hourly::simple"
@@ -120,7 +128,7 @@ class FMIAirQualityAPI:
 def create_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/fmi-finland/tests/test_fmi_finland_unit.py
+++ b/feeders/fmi-finland/tests/test_fmi_finland_unit.py
@@ -105,7 +105,7 @@ class TestHttpResilience:
         session = create_retrying_session()
         https_adapter = session.get_adapter("https://opendata.fmi.fi/wfs")
 
-        assert session.headers["User-Agent"] == "GitHub-Copilot-CLI/1.0"
+        assert session.headers["User-Agent"].startswith("real-time-sources-fmi-finland/")
         assert https_adapter.max_retries.total == 3
         assert https_adapter.max_retries.backoff_factor == 1
 

--- a/feeders/french-road-traffic/french_road_traffic/french_road_traffic.py
+++ b/feeders/french-road-traffic/french_road_traffic/french_road_traffic.py
@@ -34,6 +34,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-french-road-traffic/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # DATEX II XML namespace
 DATEX2_NS = "http://datex2.eu/schema/2/2_0"
 XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
@@ -373,6 +381,7 @@ def run_bridge(
     flow_producer = FrGouvTransportBisonFuteTrafficFlowEventProducer(producer, topic_flow)
     event_producer = FrGouvTransportBisonFuteRoadEventEventProducer(producer, topic_events)
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
 
     logger.info(
         "Starting French Road Traffic bridge — flow topic=%s, events topic=%s, interval=%ds",

--- a/feeders/gdacs/gdacs/gdacs.py
+++ b/feeders/gdacs/gdacs/gdacs.py
@@ -27,6 +27,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-gdacs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 GDACS_RSS_URL = "https://www.gdacs.org/xml/rss.xml"
 
 NAMESPACES = {
@@ -248,7 +256,7 @@ class GDACSPoller:
 
     async def fetch_feed(self) -> str:
         """Download the GDACS RSS feed XML."""
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}, timeout=aiohttp.ClientTimeout(total=60)) as session:
             async with session.get(GDACS_RSS_URL) as response:
                 response.raise_for_status()
                 return await response.text()

--- a/feeders/geosphere-austria/geosphere_austria/geosphere_austria.py
+++ b/feeders/geosphere-austria/geosphere_austria/geosphere_austria.py
@@ -20,6 +20,14 @@ from geosphere_austria_producer_kafka_producer.producer import AtGeosphereTawesE
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-geosphere-austria/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 METADATA_URL = "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min/metadata"
 OBSERVATIONS_URL = "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min"
 OBSERVATION_PARAMS = "TL,RF,RR,DD,FF,P,SO,GLOW"
@@ -72,7 +80,7 @@ def parse_connection_string(connection_string: str) -> typing.Tuple[typing.Dict[
 def create_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/geosphere-austria/tests/test_geosphere_austria_unit.py
+++ b/feeders/geosphere-austria/tests/test_geosphere_austria_unit.py
@@ -163,7 +163,7 @@ class TestParseConnectionString:
         session = create_retrying_session()
         https_adapter = session.get_adapter("https://dataset.api.hub.geosphere.at")
 
-        assert session.headers["User-Agent"] == "GitHub-Copilot-CLI/1.0"
+        assert session.headers["User-Agent"].startswith("real-time-sources-geosphere-austria/")
         assert https_adapter.max_retries.total == 3
         assert https_adapter.max_retries.backoff_factor == 1
 

--- a/feeders/german-waters/german_waters/providers/bayern_gkd.py
+++ b/feeders/german-waters/german_waters/providers/bayern_gkd.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class BayernGKDProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._ws_cache: Optional[List[Dict[str, Any]]] = None
         self._q_cache: Optional[List[Dict[str, Any]]] = None
 

--- a/feeders/german-waters/german_waters/providers/bb_lfu.py
+++ b/feeders/german-waters/german_waters/providers/bb_lfu.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,7 @@ class BrandenburgProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, str]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/be_senumvk.py
+++ b/feeders/german-waters/german_waters/providers/be_senumvk.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +96,7 @@ class BerlinProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/bw_hvz.py
+++ b/feeders/german-waters/german_waters/providers/bw_hvz.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +101,7 @@ class BadenWuerttembergProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[List[Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/he_hlnug.py
+++ b/feeders/german-waters/german_waters/providers/he_hlnug.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class HessenHLNUGProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._w_cache: Optional[List[Dict[str, Any]]] = None
         self._q_cache: Optional[List[Dict[str, Any]]] = None
 

--- a/feeders/german-waters/german_waters/providers/mv_lung.py
+++ b/feeders/german-waters/german_waters/providers/mv_lung.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class MecklenburgVorpommernProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/nds_nlwkn.py
+++ b/feeders/german-waters/german_waters/providers/nds_nlwkn.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class NiedersachsenProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/nrw_hygon.py
+++ b/feeders/german-waters/german_waters/providers/nrw_hygon.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class NRWHygonProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/sa_lhw.py
+++ b/feeders/german-waters/german_waters/providers/sa_lhw.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ class SachsenAnhaltProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/sh_lkn.py
+++ b/feeders/german-waters/german_waters/providers/sh_lkn.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class SchleswigHolsteinProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/sn_lfulg.py
+++ b/feeders/german-waters/german_waters/providers/sn_lfulg.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class SachsenLfULGProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
 
     @property

--- a/feeders/german-waters/german_waters/providers/th_tlubn.py
+++ b/feeders/german-waters/german_waters/providers/th_tlubn.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Any
 import requests
 
 from german_waters.providers import BaseProvider, StationData, ObservationData
+from german_waters.user_agent import USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class ThueringenProvider(BaseProvider):
 
     def __init__(self) -> None:
         self._session = requests.Session()
-        self._session.headers["User-Agent"] = "german-waters-bridge/1.0"
+        self._session.headers["User-Agent"] = USER_AGENT
         self._cache: Optional[List[Dict[str, Any]]] = None
         self._name_cache: Dict[str, Dict[str, str]] = {}
 

--- a/feeders/german-waters/german_waters/user_agent.py
+++ b/feeders/german-waters/german_waters/user_agent.py
@@ -1,0 +1,11 @@
+"""Shared outbound HTTP identity for German Waters providers."""
+
+import os
+
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-german-waters/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)

--- a/feeders/gios-poland/gios_poland/gios_poland.py
+++ b/feeders/gios-poland/gios_poland/gios_poland.py
@@ -24,6 +24,15 @@ from gios_poland_producer_kafka_producer.producer import (
 )
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-gios-poland/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
+
 # Polish-to-English field mappings for each API endpoint
 STATION_FIELD_MAP = {
     "Identyfikator stacji": "station_id",
@@ -323,7 +332,8 @@ class GIOSPolandPoller:
             List of Station dataclass instances.
         """
         try:
-            response = requests.get(f"{self.BASE_URL}/station/findAll", timeout=60)
+            response = requests.get(
+                f"{self.BASE_URL}/station/findAll", headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             data = response.json()
             raw_stations = data.get("Lista stacji pomiarowych", [])
@@ -351,7 +361,7 @@ class GIOSPolandPoller:
         """
         try:
             response = requests.get(
-                f"{self.BASE_URL}/station/sensors/{station_id}", timeout=60)
+                f"{self.BASE_URL}/station/sensors/{station_id}", headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             data = response.json()
             raw_sensors = data.get("Lista stanowisk pomiarowych dla podanej stacji", [])
@@ -379,7 +389,7 @@ class GIOSPolandPoller:
         """
         try:
             response = requests.get(
-                f"{self.BASE_URL}/data/getData/{sensor_id}", timeout=60)
+                f"{self.BASE_URL}/data/getData/{sensor_id}", headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             data = response.json()
             raw_measurements = data.get("Lista danych pomiarowych", [])
@@ -402,7 +412,7 @@ class GIOSPolandPoller:
         """
         try:
             response = requests.get(
-                f"{self.BASE_URL}/aqindex/getIndex/{station_id}", timeout=60)
+                f"{self.BASE_URL}/aqindex/getIndex/{station_id}", headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             data = response.json()
             return data.get("AqIndex")

--- a/feeders/gracedb/gracedb/gracedb.py
+++ b/feeders/gracedb/gracedb/gracedb.py
@@ -27,6 +27,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-gracedb/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 BASE_API_URL = "https://gracedb.ligo.org/api/superevents/"
 DEFAULT_POLL_COUNT = 25
 DEFAULT_CATEGORIES = "Production,MDC"
@@ -58,7 +66,7 @@ class GraceDBPoller:
     async def fetch_superevents(self, count: Optional[int] = None) -> List[Dict[str, Any]]:
         """Fetch superevents from the GraceDB public API."""
         url = f"{BASE_API_URL}?format=json&count={count or self.poll_count}"
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}, timeout=aiohttp.ClientTimeout(total=30)) as session:
             try:
                 async with session.get(url) as response:
                     response.raise_for_status()

--- a/feeders/gtfs/gtfs_rt_bridge/src/gtfs_rt_bridge/gtfs_cli.py
+++ b/feeders/gtfs/gtfs_rt_bridge/src/gtfs_rt_bridge/gtfs_cli.py
@@ -109,6 +109,14 @@ else:
     logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-gtfs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def fetch_schedule_file(gtfs_url: str, mdb_source_id: str, gtfs_headers: List[List[str]], etag: str, cache_dir: str | None) -> Tuple[str, str]:
     """
     Fetches the latest schedule file from the schedule URL if the file does not exist in the cache.
@@ -136,7 +144,7 @@ def fetch_schedule_file(gtfs_url: str, mdb_source_id: str, gtfs_headers: List[Li
 
     if etag and os.path.exists(schedule_file_path):
         request_headers["If-None-Match"] = etag
-    response = requests.get(gtfs_url, headers={**request_headers,  "User-Agent": "gtfs-rt-cli/0.1"}, timeout=300, stream=True)
+    response = requests.get(gtfs_url, headers={**request_headers, "User-Agent": USER_AGENT}, timeout=300, stream=True)
     if response.status_code == 304:
         return etag, schedule_file_path
     etag = response.headers.get("ETag")
@@ -227,7 +235,7 @@ def poll_and_submit_realtime_feed(agency_id: str, producer_client: GeneralTransi
             headers[header[0]] = header[1]
 
     # Make a request to the GTFS Realtime API to get the feed data for the specified scope
-    response = requests.get(feed_url, headers={**headers, "User-Agent": "gtfs-rt-cli/0.1"}, timeout=10)
+    response = requests.get(feed_url, headers={**headers, "User-Agent": USER_AGENT}, timeout=10)
     response.raise_for_status()
 
     # Parse the Protocol Buffer message and submit each feed info to the Event Hub
@@ -1099,7 +1107,7 @@ async def print_feed_items(feed_url: str, mdb_source_id: str, gtfs_rt_headers: L
             headers[header[0]] = header[1]
 
     # Make a request to the GTFS Realtime API to get the vehicle locations for the specified route
-    response = requests.get(feed_url, headers={**headers, "User-Agent": "gtfs-rt-cli/0.1"}, timeout=10)
+    response = requests.get(feed_url, headers={**headers, "User-Agent": USER_AGENT}, timeout=10)
     response.raise_for_status()
 
     # Parse the Protocol Buffer message and submit each vehicle location to the Event Hub

--- a/feeders/gtfs/tests/test_gtfs_bridge_integration.py
+++ b/feeders/gtfs/tests/test_gtfs_bridge_integration.py
@@ -88,7 +88,7 @@ class TestScheduleFileFetching:
             assert 'Authorization' in headers
             assert headers['Authorization'] == 'Bearer token123'
             assert headers['X-Custom'] == 'value'
-            assert headers['User-Agent'] == 'gtfs-rt-cli/0.1'
+            assert headers['User-Agent'].startswith('real-time-sources-gtfs/')
 
     def test_fetch_schedule_file_timeout_raises_error(self, tmp_path):
         """Test that request timeout is handled"""

--- a/feeders/hko-hong-kong/hko_hong_kong/hko_hong_kong.py
+++ b/feeders/hko-hong-kong/hko_hong_kong/hko_hong_kong.py
@@ -17,6 +17,14 @@ from hko_hong_kong_producer_data import Station, WeatherObservation
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-hko-hong-kong/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 HKO_API_URL = "https://data.weather.gov.hk/weatherAPI/opendata/weather.php"
 
 
@@ -36,6 +44,7 @@ class HKOWeatherAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_current_weather(self) -> dict:
         """Fetch the rhrread (Regional Weather in Hong Kong) endpoint."""

--- a/feeders/hongkong-epd/hongkong_epd/hongkong_epd.py
+++ b/feeders/hongkong-epd/hongkong_epd/hongkong_epd.py
@@ -18,6 +18,14 @@ from hongkong_epd_producer_kafka_producer.producer import HKGovEPDAQHIEventProdu
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-hongkong-epd/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 AQHI_FEED_URL = "https://www.aqhi.gov.hk/epd/ddata/html/out/24aqhi_Eng.xml"
 
 STATION_COORDS = {
@@ -85,6 +93,7 @@ class HKEPDAQHIAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_feed_xml(self) -> str:
         """Fetch the full 24-hour AQHI XML feed."""

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
@@ -24,6 +24,15 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-hubeau-hydrometrie/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
+
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
     try:
@@ -60,6 +69,7 @@ class HubEauHydrometrieAPI:
 
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def list_stations(self) -> List[Dict[str, Any]]:
         """Fetch all monitoring stations with pagination."""

--- a/feeders/imgw-hydro/imgw_hydro/imgw_hydro.py
+++ b/feeders/imgw-hydro/imgw_hydro/imgw_hydro.py
@@ -17,6 +17,14 @@ from imgw_hydro_producer_data import WaterLevelObservation
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-imgw-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 IMGW_BASE_URL = "https://danepubliczne.imgw.pl/api/data/hydro"
 
 class IMGWHydroAPI:
@@ -26,6 +34,7 @@ class IMGWHydroAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_all_data(self) -> typing.List[dict]:
         """Fetch all hydrological station data from the IMGW API."""

--- a/feeders/inpe-deter-brazil/inpe_deter_brazil/inpe_deter_brazil.py
+++ b/feeders/inpe-deter-brazil/inpe_deter_brazil/inpe_deter_brazil.py
@@ -32,6 +32,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-inpe-deter-brazil/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 WFS_ENDPOINTS = {
     "amazon": {
         "base_url": "http://terrabrasilis.dpi.inpe.br/geoserver/deter-amz/ows",
@@ -173,7 +181,10 @@ class INPEDeterPoller:
         all_features: List[Dict[str, Any]] = []
         start_index = 0
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=60),
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
             while True:
                 url = build_wfs_url(biome, cql_filter=cql_filter,
                                     count=self.page_size, start_index=start_index)

--- a/feeders/irail/irail/irail.py
+++ b/feeders/irail/irail/irail.py
@@ -32,8 +32,16 @@ FEED_URL = "https://api.irail.be"
 REQUEST_DELAY = 0.35  # slightly over 1/3 sec to stay within limits
 DEFAULT_HTTP_RETRY_TOTAL = 3
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-irail/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
-def create_retrying_session(user_agent: str) -> requests.Session:
+
+def create_retrying_session(user_agent: str = USER_AGENT) -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
     session.headers.update({
@@ -59,7 +67,7 @@ def create_retrying_session(user_agent: str) -> requests.Session:
 class IRailAPI:
     """Client for the iRail REST API."""
 
-    def __init__(self, user_agent: str = "real-time-sources/1.0 (github.com/clemensv/real-time-sources)"):
+    def __init__(self, user_agent: str = USER_AGENT):
         self.session = create_retrying_session(user_agent)
 
     def fetch_stations(self) -> List[Dict[str, Any]]:

--- a/feeders/irail/tests/test_irail.py
+++ b/feeders/irail/tests/test_irail.py
@@ -5,7 +5,7 @@ import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-from irail.irail import IRailAPI, _parse_connection_string, create_retrying_session
+from irail.irail import IRailAPI, USER_AGENT, _parse_connection_string, create_retrying_session
 
 
 # --- Sample API responses ---
@@ -603,11 +603,11 @@ class TestFetchStations(unittest.TestCase):
     """Test API fetch methods with mocking."""
 
     def test_create_retrying_session(self):
-        session = create_retrying_session("test-agent")
+        session = create_retrying_session()
         https_adapter = session.get_adapter("https://api.irail.be")
 
         self.assertEqual(session.headers["Accept"], "application/json")
-        self.assertEqual(session.headers["User-Agent"], "test-agent")
+        self.assertEqual(session.headers["User-Agent"], USER_AGENT)
         self.assertEqual(https_adapter.max_retries.total, 3)
         self.assertEqual(https_adapter.max_retries.backoff_factor, 1)
 

--- a/feeders/irceline-belgium/irceline_belgium/irceline_belgium.py
+++ b/feeders/irceline-belgium/irceline_belgium/irceline_belgium.py
@@ -28,6 +28,14 @@ else:
 
 LOGGER = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-irceline-belgium/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _load_state(state_file: str) -> Dict[str, int]:
     """Load persisted per-timeseries dedup state from disk."""
@@ -83,6 +91,7 @@ class IrcelineBelgiumAPI:
         self.reference_refresh_interval = reference_refresh_interval
         self.session = session or requests.Session()
         self.session.headers.setdefault("Accept", "application/json")
+        self.session.headers["User-Agent"] = USER_AGENT
 
     @staticmethod
     def parse_connection_string(connection_string: str) -> Tuple[Dict[str, str], Optional[str]]:

--- a/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
+++ b/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
@@ -22,6 +22,14 @@ else:
 
 FEED_URL = "https://waterlevel.ie/geojson/latest/"
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-ireland-opw-waterlevel/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
@@ -129,6 +137,7 @@ def parse_connection_string(connection_string: str) -> Dict[str, str]:
 
 def fetch_geojson(session: requests.Session, url: str = FEED_URL) -> List[Dict[str, Any]]:
     """Fetch GeoJSON from waterlevel.ie and return the list of features."""
+    session.headers["User-Agent"] = USER_AGENT
     response = session.get(url, timeout=30)
     response.raise_for_status()
     data = response.json()
@@ -205,6 +214,7 @@ def feed(kafka_config: dict, kafka_topic: str, polling_interval: int,
     """Main polling loop: emit stations then poll readings."""
     seen_keys: Set[str] = set(_load_state(state_file).get("seen_keys", []))
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     kafka_producer = Producer(kafka_config)
     producer_client = IeGovOpwWaterlevelEventProducer(kafka_producer, kafka_topic)
 
@@ -307,6 +317,7 @@ def main() -> None:
 
     if args.command == 'list':
         session = requests.Session()
+        session.headers["User-Agent"] = USER_AGENT
         features = fetch_geojson(session)
         stations = extract_stations(features)
         for ref, info in sorted(stations.items()):

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
@@ -49,6 +49,14 @@ POINT_DETAIL_FIELDS = [
 
 logging.basicConfig(level=logging.DEBUG if sys.gettrace() else logging.INFO)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-jma-bosai-amedas/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _load_state(state_file: str) -> dict:
     try:
@@ -72,6 +80,7 @@ def _save_state(state_file: str, data: dict) -> None:
 
 def create_retrying_session() -> requests.Session:
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         connect=3,
@@ -85,7 +94,6 @@ def create_retrying_session() -> requests.Session:
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
-    session.headers.update({"User-Agent": "real-time-sources-jma-bosai-amedas/0.1"})
     return session
 
 

--- a/feeders/jma-bosai-quake/jma_bosai_quake/jma_bosai_quake.py
+++ b/feeders/jma-bosai-quake/jma_bosai_quake/jma_bosai_quake.py
@@ -39,6 +39,14 @@ _JST = timezone(timedelta(hours=9))
 
 logging.basicConfig(level=logging.DEBUG if sys.gettrace() else logging.INFO)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-jma-bosai-quake/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 _ISO6709_RE = re.compile(r"^([+-]\d+(?:\.\d+)?)([+-]\d+(?:\.\d+)?)([+-]\d+(?:\.\d+)?)/$")
 _INFO_TYPE_MAP = {"発表": "ISSUED", "訂正": "CORRECTED", "取消": "CANCELLED"}
 _NO_TSUNAMI_MARKERS = (
@@ -75,6 +83,7 @@ _PREFECTURE_NAMES = set(_PREFECTURE_BY_CODE.values())
 def create_retry_session() -> requests.Session:
     """Create a requests session with bounded retries for public HTTP polling."""
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         connect=3,

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano/jma_bosai_volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano/jma_bosai_volcano.py
@@ -30,6 +30,11 @@ VOLCANO_LIST_URL = "https://www.jma.go.jp/bosai/volcano/const/volcano_list.json"
 DEFAULT_TOPIC = "jma-bosai-volcano"
 DEFAULT_STATE_FILE = "./state/jma-bosai-volcano.json"
 TARGET_VOLCANO_INFO = "噴火警報・予報（対象火山）"
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-jma-bosai-volcano/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -68,6 +73,7 @@ ERUPTION_TYPE_MAP = {
 
 def make_retrying_session() -> requests.Session:
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         connect=3,

--- a/feeders/jma-bosai-warning/jma_bosai_warning/jma_bosai_warning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning/jma_bosai_warning.py
@@ -28,6 +28,11 @@ TSUNAMI_LIST_URL = "https://www.jma.go.jp/bosai/tsunami/data/list.json"
 TSUNAMI_DETAIL_BASE = "https://www.jma.go.jp/bosai/tsunami/data/"
 STATE_CAP = 5000
 OFFICE_AREA_CODE = None
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-jma-bosai-warning/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 WARNING_CODE_DESCRIPTIONS: dict[str, tuple[str, str]] = {
     "03": ("大雨", "Heavy rain"), "04": ("洪水", "Flood"), "05": ("暴風", "Storm"),
@@ -62,6 +67,7 @@ def make_retrying_session() -> requests.Session:
     retry = Retry(total=3, connect=3, read=3, status=3, backoff_factor=0.5, status_forcelist=(429, 500, 502, 503, 504), allowed_methods=("GET",))
     adapter = HTTPAdapter(max_retries=retry)
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return session

--- a/feeders/jma-japan/jma_japan/jma_japan.py
+++ b/feeders/jma-japan/jma_japan/jma_japan.py
@@ -22,6 +22,11 @@ from jma_japan_producer_kafka_producer.producer import (
 
 
 ATOM_NS = "{http://www.w3.org/2005/Atom}"
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-jma-japan/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class JMABulletinPoller:
@@ -31,7 +36,7 @@ class JMABulletinPoller:
     REGULAR_FEED_URL = "https://www.data.jma.go.jp/developer/xml/feed/regular.xml"
     EXTRA_FEED_URL = "https://www.data.jma.go.jp/developer/xml/feed/extra.xml"
     HEADERS = {
-        "User-Agent": "(real-time-sources, clemensv@microsoft.com)",
+        "User-Agent": USER_AGENT,
         "Accept": "application/xml"
     }
     POLL_INTERVAL_SECONDS = 60

--- a/feeders/jma-japan/tests/test_jma_japan_unit.py
+++ b/feeders/jma-japan/tests/test_jma_japan_unit.py
@@ -639,4 +639,4 @@ class TestFeedConstants:
         assert JMABulletinPoller.POLL_INTERVAL_SECONDS == 60
 
     def test_user_agent_header(self):
-        assert "real-time-sources" in JMABulletinPoller.HEADERS["User-Agent"]
+        assert JMABulletinPoller.HEADERS["User-Agent"].startswith("real-time-sources-jma-japan/")

--- a/feeders/king-county-marine/king_county_marine/king_county_marine.py
+++ b/feeders/king-county-marine/king_county_marine/king_county_marine.py
@@ -33,6 +33,11 @@ HTTP_TIMEOUT = (15, 60)
 HTTP_RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
 HTTP_RETRY_TOTAL = 5
 HTTP_RETRY_BACKOFF_FACTOR = 2.0
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-king-county-marine/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def parse_connection_string(connection_string: str) -> Dict[str, str]:
@@ -145,7 +150,7 @@ def create_retrying_session() -> requests.Session:
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     return session
 
 

--- a/feeders/king-county-marine/tests/test_king_county_marine_unit.py
+++ b/feeders/king-county-marine/tests/test_king_county_marine_unit.py
@@ -48,7 +48,7 @@ class TestHelpers:
         session = create_retrying_session()
         https_adapter = session.get_adapter("https://data.kingcounty.gov")
 
-        assert session.headers["User-Agent"] == "GitHub-Copilot-CLI/1.0"
+        assert session.headers["User-Agent"].startswith("real-time-sources-king-county-marine/")
         assert https_adapter.max_retries.total == 5
         assert https_adapter.max_retries.backoff_factor == 2.0
 

--- a/feeders/kmi-belgium/kmi_belgium/kmi_belgium.py
+++ b/feeders/kmi-belgium/kmi_belgium/kmi_belgium.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 KMI_AWS_WFS_URL = "https://opendata.meteo.be/service/aws/ows"
 FEATURE_TYPE = "aws:aws_10min"
 LATEST_FETCH_COUNT = 200
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-kmi-belgium/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 OBSERVATION_FIELDS = (
     "precip_quantity",
     "temp_dry_shelter_avg",
@@ -48,6 +53,7 @@ class KMIBelgiumAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_observations(self, last_timestamp: str | None = None, count: int | None = None) -> list[dict[str, Any]]:
         """Fetch aws:aws_10min observations as GeoJSON features."""

--- a/feeders/laqn-london/laqn_london/laqn_london.py
+++ b/feeders/laqn-london/laqn_london/laqn_london.py
@@ -25,6 +25,11 @@ BASE_URL = "http://api.erg.ic.ac.uk/AirQuality/"
 SITES_PATH = "Information/MonitoringSites/GroupName=All/Json"
 SPECIES_PATH = "Information/Species/Json"
 DAILY_INDEX_PATH = "Daily/MonitoringIndex/Latest/GroupName=London/Json"
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-laqn-london/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 if sys.gettrace() is not None:
     logging.basicConfig(level=logging.DEBUG)
@@ -95,6 +100,7 @@ class LAQNLondonAPI:
     def __init__(self, base_url: str = BASE_URL):
         self.base_url = base_url.rstrip("/") + "/"
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def _get_json(self, path: str) -> Dict[str, Any]:
         # Per-request 15s timeout: the LAQN API usually responds in <1s, and

--- a/feeders/luchtmeetnet-nl/luchtmeetnet_nl/luchtmeetnet_nl.py
+++ b/feeders/luchtmeetnet-nl/luchtmeetnet_nl/luchtmeetnet_nl.py
@@ -21,6 +21,11 @@ from luchtmeetnet_nl_producer_kafka_producer.producer import (
 
 
 LOGGER = logging.getLogger(__name__)
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-luchtmeetnet-nl/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _load_state(state_file: str) -> dict[str, str]:
@@ -68,6 +73,7 @@ class LuchtmeetnetAPI:
     def __init__(self, base_url: str = "https://api.luchtmeetnet.nl/open_api", session: requests.Session | None = None):
         self.base_url = base_url.rstrip("/")
         self.session = session or requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def _request_json(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         response = self.session.get(f"{self.base_url}{path}", params=params, timeout=30)

--- a/feeders/madrid-traffic/madrid_traffic/madrid_traffic.py
+++ b/feeders/madrid-traffic/madrid_traffic/madrid_traffic.py
@@ -21,6 +21,11 @@ from madrid_traffic_producer_kafka_producer.producer import EsMadridInformoEvent
 PM_XML_URL = "https://informo.madrid.es/informo/tmadrid/pm.xml"
 POLL_INTERVAL_SECONDS = 300
 REFERENCE_REFRESH_SECONDS = 3600
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-madrid-traffic/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def parse_european_float(value: str) -> Optional[float]:
@@ -216,7 +221,7 @@ class MadridTrafficPoller:
             Raw XML text, or None on failure.
         """
         try:
-            response = requests.get(PM_XML_URL, timeout=60)
+            response = requests.get(PM_XML_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             return response.text
         except Exception as err:

--- a/feeders/meteoalarm/meteoalarm/meteoalarm.py
+++ b/feeders/meteoalarm/meteoalarm/meteoalarm.py
@@ -22,6 +22,11 @@ else:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 logger = logging.getLogger(__name__)
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-meteoalarm/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 BASE_URL = "https://feeds.meteoalarm.org/api/v1/warnings/feeds-{country}"
 
@@ -223,7 +228,10 @@ class MeteoalarmPoller:
             count_new = 0
             count_updated = 0
 
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"User-Agent": USER_AGENT},
+            ) as session:
                 for country in self.countries:
                     try:
                         raw_warnings = await self.fetch_country(session, country)

--- a/feeders/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/app.py
+++ b/feeders/meteoalarm/meteoalarm_amqp/meteoalarm_amqp/app.py
@@ -91,6 +91,11 @@ from meteoalarm_amqp_producer_data import CategoryEnum, CertaintyEnum, MsgTypeen
 from meteoalarm_amqp_producer_amqp_producer.producer import MeteoalarmWarningsAmqpProducer
 
 logger = logging.getLogger(__name__)
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-meteoalarm/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _sample_warning() -> WeatherWarning:
@@ -104,7 +109,10 @@ def _send(producer: MeteoalarmWarningsAmqpProducer, warning) -> None:
 async def _poll_once(poller: MeteoalarmPoller, producer: MeteoalarmWarningsAmqpProducer) -> int:
     state = poller.load_state()
     count = 0
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=60),
+        headers={"User-Agent": USER_AGENT},
+    ) as session:
         for country in poller.countries:
             raw_warnings = await poller.fetch_country(session, country)
             for item in raw_warnings:

--- a/feeders/meteoalarm/meteoalarm_mqtt/meteoalarm_mqtt/app.py
+++ b/feeders/meteoalarm/meteoalarm_mqtt/meteoalarm_mqtt/app.py
@@ -18,6 +18,11 @@ from meteoalarm.meteoalarm import DEFAULT_COUNTRIES, DEFAULT_POLL_INTERVAL, DEFA
 from meteoalarm_mqtt_producer_mqtt_client.client import MeteoalarmWarningsMqttMqttClient
 
 logger = logging.getLogger(__name__)
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-meteoalarm/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _topic_segment(value: Optional[str]) -> str:
@@ -31,7 +36,10 @@ async def _poll_once(poller: MeteoalarmPoller, mqtt_client: MeteoalarmWarningsMq
     state = poller.load_state()
     count_new = 0
     count_updated = 0
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=60),
+        headers={"User-Agent": USER_AGENT},
+    ) as session:
         for country in poller.countries:
             raw_warnings = await poller.fetch_country(session, country)
             for item in raw_warnings:

--- a/feeders/nasa-firms/nasa_firms/nasa_firms.py
+++ b/feeders/nasa-firms/nasa_firms/nasa_firms.py
@@ -53,6 +53,11 @@ FIRMS_BASE = "https://firms.modaps.eosdis.nasa.gov/"
 API_BASE = FIRMS_BASE + "api/"
 # CloudEvents `source` attribute value for every emitted event.
 SOURCE_URI = API_BASE + "area/"
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nasa-firms/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # Global near-real-time sources suited to worldwide OSINT monitoring.
 DEFAULT_SOURCES = [
@@ -307,7 +312,10 @@ class FirmsPoller:
 
         while True:
             start = datetime.now(timezone.utc)
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120)) as session:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=120),
+                headers={"User-Agent": USER_AGENT},
+            ) as session:
                 # Reference data first, refreshed roughly once per hour.
                 if not availability_sent or start.minute < self.poll_minutes:
                     await self._send_availability(session)
@@ -372,7 +380,10 @@ class FirmsPoller:
 
 async def run_recent_detections(map_key: str, sources: List[str], area: str, day_range: int) -> None:
     poller = FirmsPoller(map_key=map_key, sources=sources, area=area, day_range=day_range)
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120)) as session:
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=120),
+        headers={"User-Agent": USER_AGENT},
+    ) as session:
         for source in poller.sources:
             detections = await poller.fetch_detections(session, source)
             print(f"{source}: {len(detections)} detections")

--- a/feeders/ndw-road-traffic/ndw_road_traffic/ndw_road_traffic.py
+++ b/feeders/ndw-road-traffic/ndw_road_traffic/ndw_road_traffic.py
@@ -85,6 +85,13 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-ndw-road-traffic/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # ---------------------------------------------------------------------------
 # HTTP helpers
@@ -92,6 +99,7 @@ logger = logging.getLogger(__name__)
 
 def _make_session() -> requests.Session:
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         backoff_factor=1.0,

--- a/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology/nepal_bipad_hydrology.py
+++ b/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology/nepal_bipad_hydrology.py
@@ -23,6 +23,14 @@ else:
 BIPAD_API_BASE = "https://bipadportal.gov.np/api/v1"
 DEFAULT_PAGE_SIZE = 100
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nepal-bipad-hydrology/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
@@ -53,6 +61,7 @@ class NepalBipadHydrologyAPI:
         self.base_url = base_url.rstrip('/')
         self.page_size = page_size
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_all_stations(self) -> List[Dict[str, Any]]:
         """Fetch all river stations by paginating until the results array is empty.

--- a/feeders/nextbus/nextbus/nextbus.py
+++ b/feeders/nextbus/nextbus/nextbus.py
@@ -10,12 +10,19 @@ from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_json
 
 NEXTBUS_BASE_URL = "https://retro.umoiq.com/service/publicXMLFeed"   
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nextbus/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 backoff_time: float = 0
 poll_interval: float = 10
 
 def print_route_predictions(agency_tag, route_tag):
     # Make a request to the NextBus API to get the predictions for the specified route
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "predictions", "a": agency_tag, "r": route_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "predictions", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -30,7 +37,7 @@ def print_route_predictions(agency_tag, route_tag):
 
 def print_stops(agency_tag, route_tag):
     # Make a request to the NextBus API to get the configuration for the specified route
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
 
@@ -43,7 +50,7 @@ def print_stops(agency_tag, route_tag):
         
 def print_agencies():
     # Make a request to the NextBus API to get the list of agencies
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "agencyList"})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "agencyList"}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
 
@@ -54,7 +61,7 @@ def print_agencies():
 
 def print_routes(agency_tag):
     # Make a request to the NextBus API to get the list of routes for the specified agency
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -86,7 +93,7 @@ def element_to_dict(element):
 route_checksums = {}
 def poll_and_submit_route_config(producer_client: EventHubProducerClient, agency_tag: str):
     # Make a request to the NextBus API to get the list of routes for the specified agency
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -99,10 +106,10 @@ def poll_and_submit_route_config(producer_client: EventHubProducerClient, agency
         # slow down the request rate
         time.sleep(backoff_time)        
         
-        response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag})
+        response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
         if response.status_code == 404:
             # API is flaky, try again
-            response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag})
+            response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeConfig", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
             if response.status_code == 404:
                 print(f"404 for {agency_tag}/{route_tag}")
                 continue
@@ -138,7 +145,7 @@ schedule_checksums = {}
 
 def poll_and_submit_schedule(producer_client: EventHubProducerClient, agency_tag: str):
     # Make a request to the NextBus API to get the list of routes for the specified agency
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -150,7 +157,7 @@ def poll_and_submit_schedule(producer_client: EventHubProducerClient, agency_tag
         route_tag = route.get("tag")
         # slow down the request rate
         time.sleep(backoff_time)        
-        response = requests.get(NEXTBUS_BASE_URL, params={"command": "schedule", "a": agency_tag, "r": route_tag})
+        response = requests.get(NEXTBUS_BASE_URL, params={"command": "schedule", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
         if response.status_code == 404:
             print(f"404 for {agency_tag}/{route_tag}")
             continue
@@ -183,7 +190,7 @@ def poll_and_submit_schedule(producer_client: EventHubProducerClient, agency_tag
 messages_checksums = {}
 def poll_and_submit_messages(producer_client : EventHubProducerClient, agency_tag : str):
     # Make a request to the NextBus API to get the list of routes for the specified agency
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "routeList", "a": agency_tag}, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -195,7 +202,7 @@ def poll_and_submit_messages(producer_client : EventHubProducerClient, agency_ta
         route_tag = route.get("tag")
         # slow down the request rate
         time.sleep(backoff_time)        
-        response = requests.get(NEXTBUS_BASE_URL, params={"command": "messages", "a": agency_tag, "r": route_tag})
+        response = requests.get(NEXTBUS_BASE_URL, params={"command": "messages", "a": agency_tag, "r": route_tag}, headers={"User-Agent": USER_AGENT})
         if response.status_code == 404:
             print(f"404 for {agency_tag}/{route_tag}")
             continue
@@ -238,7 +245,7 @@ def poll_and_submit_vehicle_locations(producer_client: EventHubProducerClient, a
         params["t"] = int(last_time)
 
     
-    response = requests.get(NEXTBUS_BASE_URL, params=params)
+    response = requests.get(NEXTBUS_BASE_URL, params=params, headers={"User-Agent": USER_AGENT})
     if response.status_code == 404:
         return
     
@@ -340,7 +347,7 @@ def feed(feed_connection_string: str, feed_event_hub_name: str, reference_connec
 
 def print_vehicle_locations(agency, route):
     # Make a request to the NextBus API to get the vehicle locations for the specified route
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "vehicleLocations", "a" : agency, "r": route})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "vehicleLocations", "a" : agency, "r": route}, headers={"User-Agent": USER_AGENT})
     response.raise_for_status()
 
     # Parse the XML response and print the vehicle locations for the route
@@ -351,7 +358,7 @@ def print_vehicle_locations(agency, route):
 def print_predictions(agency_tag, stop_id, route_tag):
  
     # Make a request to the NextBus API to get the predictions for the specified stop
-    response = requests.get(NEXTBUS_BASE_URL, params={"command": "predictions", "a": agency_tag, "s": stop_id, "r": route_tag})
+    response = requests.get(NEXTBUS_BASE_URL, params={"command": "predictions", "a": agency_tag, "s": stop_id, "r": route_tag}, headers={"User-Agent": USER_AGENT})
     response.raise_for_status()
 
     # Parse the XML response and print the predictions for the stop

--- a/feeders/nifc-usa-wildfires/nifc_usa_wildfires/nifc_usa_wildfires.py
+++ b/feeders/nifc-usa-wildfires/nifc_usa_wildfires/nifc_usa_wildfires.py
@@ -29,6 +29,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nifc-usa-wildfires/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 BASE_URL = "https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer/0/query"
 SOURCE_URI = "https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer/0"
 MAX_RECORD_COUNT = 2000
@@ -90,7 +98,7 @@ class NIFCWildfirePoller:
         """Fetch wildfire incidents from the ArcGIS Feature Service, paging through all results."""
         all_features: List[Dict[str, Any]] = []
         offset = 0
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers={"User-Agent": USER_AGENT}) as session:
             while True:
                 url = build_query_url(where_clause, offset)
                 try:

--- a/feeders/nina-bbk/nina_bbk/nina_bbk.py
+++ b/feeders/nina-bbk/nina_bbk/nina_bbk.py
@@ -21,6 +21,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nina-bbk/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 MAP_DATA_URL = "https://warnung.bund.de/api31/{provider}/mapData.json"
 DETAIL_URL = "https://warnung.bund.de/api31/warnings/{warning_id}.json"
 
@@ -258,7 +266,7 @@ class NINABBKPoller:
 
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=60),
-                headers={"User-Agent": "nina-bbk-bridge/1.0"}
+                headers={"User-Agent": USER_AGENT}
             ) as session:
                 for provider in self.providers:
                     try:

--- a/feeders/nina-bbk/nina_bbk_mqtt/nina_bbk_mqtt/app.py
+++ b/feeders/nina-bbk/nina_bbk_mqtt/nina_bbk_mqtt/app.py
@@ -19,6 +19,13 @@ from nina_bbk_mqtt_producer_mqtt_client.client import NINAWarningsMqttMqttClient
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nina-bbk/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 def _topic_segment(value: Optional[str]) -> str:
     text = (value or "unknown").strip() or "unknown"
@@ -31,7 +38,7 @@ async def _poll_once(poller: NINABBKPoller, mqtt_client: NINAWarningsMqttMqttCli
     state = poller.load_state()
     count_new = 0
     count_updated = 0
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers={"User-Agent": "nina-bbk-mqtt-bridge/1.0"}) as session:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers={"User-Agent": USER_AGENT}) as session:
         for provider in poller.providers:
             stubs = await poller.fetch_map_data(session, provider)
             for stub in stubs:

--- a/feeders/noaa-goes/noaa_goes/noaa_goes.py
+++ b/feeders/noaa-goes/noaa_goes/noaa_goes.py
@@ -30,6 +30,13 @@ from noaa_goes_producer_kafka_producer.producer import (
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-noaa-goes/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 class SWPCPoller:
     """
@@ -80,7 +87,7 @@ class SWPCPoller:
 
     def _get_json(self, url: str) -> Optional[list]:
         try:
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data if isinstance(data, list) else [data] if isinstance(data, dict) else []
@@ -100,10 +107,10 @@ class SWPCPoller:
 
     def poll_solar_wind(self) -> List[dict]:
         try:
-            speed_response = requests.get(self.SOLAR_WIND_SPEED_URL, timeout=30)
+            speed_response = requests.get(self.SOLAR_WIND_SPEED_URL, headers={"User-Agent": USER_AGENT}, timeout=30)
             speed_response.raise_for_status()
             speed_data = speed_response.json()
-            mag_response = requests.get(self.SOLAR_WIND_MAG_FIELD_URL, timeout=30)
+            mag_response = requests.get(self.SOLAR_WIND_MAG_FIELD_URL, headers={"User-Agent": USER_AGENT}, timeout=30)
             mag_response.raise_for_status()
             mag_data = mag_response.json()
             if isinstance(speed_data, list) and speed_data:

--- a/feeders/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
+++ b/feeders/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
@@ -26,6 +26,14 @@ from noaa_ndbc_producer_data import BuoySupplementalMeasurement
 from noaa_ndbc_producer_kafka_producer.producer import MicrosoftOpenDataUSNOAANDBCEventProducer
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-noaa-ndbc/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def parse_float(value: str) -> Optional[float]:
     """
     Parse a float value from NDBC text data.
@@ -315,7 +323,7 @@ class NDBCBuoyPoller:
             Dict mapping family extensions to station ID lists.
         """
         try:
-            response = requests.get(self.REALTIME2_INDEX_URL, timeout=60)
+            response = requests.get(self.REALTIME2_INDEX_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             return self.parse_realtime2_file_index(response.text)
         except Exception as err:
@@ -334,7 +342,7 @@ class NDBCBuoyPoller:
             Raw file text, or None on failure.
         """
         try:
-            response = requests.get(f"{self.REALTIME2_INDEX_URL}{station_id}.{extension}", timeout=60)
+            response = requests.get(f"{self.REALTIME2_INDEX_URL}{station_id}.{extension}", headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             return response.text
         except Exception as err:
@@ -683,7 +691,7 @@ class NDBCBuoyPoller:
             List of BuoyStation dataclass instances.
         """
         try:
-            response = requests.get(self.STATION_TABLE_URL, timeout=60)
+            response = requests.get(self.STATION_TABLE_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
         except Exception as err:
             print(f"Error fetching NDBC station table: {err}")
@@ -853,7 +861,7 @@ class NDBCBuoyPoller:
             List of BuoyObservation dataclass instances.
         """
         try:
-            response = requests.get(self.LATEST_OBS_URL, timeout=60)
+            response = requests.get(self.LATEST_OBS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             return self.parse_observations(response.text)
         except Exception as err:

--- a/feeders/noaa-ndbc/tests/test_noaa_ndbc_unit.py
+++ b/feeders/noaa-ndbc/tests/test_noaa_ndbc_unit.py
@@ -17,7 +17,7 @@ from noaa_ndbc_producer_data import BuoyOceanographicObservation
 from noaa_ndbc_producer_data import BuoySolarRadiationObservation
 from noaa_ndbc_producer_data import BuoyStation
 from noaa_ndbc_producer_data import BuoySupplementalMeasurement
-from noaa_ndbc.noaa_ndbc import NDBCBuoyPoller, parse_connection_string, parse_float
+from noaa_ndbc.noaa_ndbc import NDBCBuoyPoller, USER_AGENT, parse_connection_string, parse_float
 
 
 SAMPLE_STATION_TABLE_TEXT = """\
@@ -530,7 +530,7 @@ class TestNDBCBuoyPoller:
 
         observations = poller.poll_observations()
         assert len(observations) == 3
-        mock_get.assert_called_once_with(NDBCBuoyPoller.LATEST_OBS_URL, timeout=60)
+        mock_get.assert_called_once_with(NDBCBuoyPoller.LATEST_OBS_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
 
     @patch('noaa_ndbc.noaa_ndbc.requests.get')
     @patch('noaa_ndbc.noaa_ndbc.MicrosoftOpenDataUSNOAANDBCEventProducer')

--- a/feeders/noaa-nws/noaa_nws/noaa_nws.py
+++ b/feeders/noaa-nws/noaa_nws/noaa_nws.py
@@ -22,6 +22,14 @@ from noaa_nws_producer_kafka_producer.producer import (
 )
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-noaa-nws/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 class NWSAlertPoller:
     """
     Polls the NWS Weather Alerts API and sends alerts to Kafka as CloudEvents.
@@ -30,7 +38,7 @@ class NWSAlertPoller:
     ZONES_URL = "https://api.weather.gov/zones?type=forecast"
     STATIONS_URL = "https://api.weather.gov/stations"
     HEADERS = {
-        "User-Agent": "(real-time-sources, clemensv@microsoft.com)",
+        "User-Agent": USER_AGENT,
         "Accept": "application/geo+json"
     }
     POLL_INTERVAL_SECONDS = 60

--- a/feeders/noaa-nws/tests/test_noaa_nws_e2e.py
+++ b/feeders/noaa-nws/tests/test_noaa_nws_e2e.py
@@ -13,7 +13,7 @@ import requests
 NWS_ALERTS_URL = "https://api.weather.gov/alerts/active"
 NWS_ZONES_URL = "https://api.weather.gov/zones?type=forecast&limit=10"
 NWS_HEADERS = {
-    "User-Agent": "(real-time-sources-test, clemensv@microsoft.com)",
+    "User-Agent": "real-time-sources-noaa-nws/0.1.0 (+https://github.com/clemensv/real-time-sources; clemensv@microsoft.com)",
     "Accept": "application/geo+json"
 }
 

--- a/feeders/noaa-swpc-l1/noaa_swpc_l1_core/noaa_swpc_l1_core/acquisition.py
+++ b/feeders/noaa-swpc-l1/noaa_swpc_l1_core/noaa_swpc_l1_core/acquisition.py
@@ -20,6 +20,7 @@ Upstream shape (verbatim, live-confirmed):
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable, List, Optional
@@ -47,6 +48,13 @@ EXPECTED_COLUMNS = [
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-noaa-swpc-l1/1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 @dataclass(frozen=True)
 class PropagatedSolarWindRow:
@@ -141,6 +149,9 @@ class SwpcL1API:
         feed_url: str = FEED_URL,
     ) -> None:
         self._session = session or requests.Session()
+        if not hasattr(self._session, "headers"):
+            self._session.headers = {}
+        self._session.headers["User-Agent"] = USER_AGENT
         self._request_timeout = request_timeout
         self._feed_url = feed_url
 

--- a/feeders/noaa/noaa/noaa.py
+++ b/feeders/noaa/noaa/noaa.py
@@ -30,6 +30,14 @@ from noaa_producer_data import QualityLevel
 from noaa_producer_kafka_producer.producer import MicrosoftOpenDataUSNOAAEventProducer
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-noaa/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 class NOAADataPoller:
     """
     Class to poll NOAA data and send it to a Kafka topic.
@@ -84,7 +92,7 @@ class NOAADataPoller:
         """
         url = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json"
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=10)
             response.raise_for_status()
             stations_data = response.json()
             raw_stations = stations_data.get('stations', [])
@@ -157,7 +165,7 @@ class NOAADataPoller:
         else:
             data_key = "data"
         try:
-            response = requests.get(product_url, timeout=10)
+            response = requests.get(product_url, headers={"User-Agent": USER_AGENT}, timeout=10)
             response.raise_for_status()
             if data_key is None:
                 data = response.json().get("current_predictions", {}).get("cp", [])

--- a/feeders/noaa/tests/test_noaa_unit.py
+++ b/feeders/noaa/tests/test_noaa_unit.py
@@ -6,7 +6,7 @@ Tests core functionality without external dependencies
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime, timezone
-from noaa.noaa import NOAADataPoller
+from noaa.noaa import NOAADataPoller, USER_AGENT
 from noaa_producer_data.microsoft.opendata.us.noaa.station import Station
 
 
@@ -147,6 +147,7 @@ class TestNOAADataPoller:
             assert len(poller.stations) == 2
             mock_get.assert_called_with(
                 "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json",
+                headers={"User-Agent": USER_AGENT},
                 timeout=10
             )
 

--- a/feeders/nve-hydro/nve_hydro/nve_hydro.py
+++ b/feeders/nve-hydro/nve_hydro/nve_hydro.py
@@ -18,6 +18,13 @@ from nve_hydro_producer_kafka_producer.producer import NONVEHydrologyEventProduc
 logger = logging.getLogger(__name__)
 
 NVE_BASE_URL = "https://hydapi.nve.no/api/v1"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nve-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 PARAM_STAGE = 1000       # Water level / Vannstand (m)
 PARAM_DISCHARGE = 1001   # Discharge / Vannføring (m³/s)
@@ -31,6 +38,7 @@ class NVEHydroAPI:
     def __init__(self, api_key: str, base_url: str = NVE_BASE_URL):
         self.base_url = base_url
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
         self.session.headers['X-API-Key'] = api_key
         self.session.headers['Accept'] = 'application/json'
 

--- a/feeders/nws-alerts/nws_alerts/nws_alerts.py
+++ b/feeders/nws-alerts/nws_alerts/nws_alerts.py
@@ -23,7 +23,13 @@ else:
 logger = logging.getLogger(__name__)
 
 NWS_API_URL = "https://api.weather.gov/alerts/active"
-USER_AGENT = "(real-time-sources, https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nws-alerts/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 DEFAULT_POLL_INTERVAL = 60
 DEFAULT_STATE_FILE = os.path.expanduser("~/.nws_alerts_state.json")
@@ -194,8 +200,8 @@ class NWSAlertsPoller:
     async def fetch_alerts(self) -> List[dict]:
         """Fetch active alerts from the NWS API."""
         headers = {"User-Agent": USER_AGENT, "Accept": "application/geo+json"}
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
-            async with session.get(NWS_API_URL, headers=headers) as response:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+            async with session.get(NWS_API_URL) as response:
                 response.raise_for_status()
                 data = await response.json(content_type=None)
                 return data.get("features", [])

--- a/feeders/nws-forecasts/nws_forecasts/nws_forecasts.py
+++ b/feeders/nws-forecasts/nws_forecasts/nws_forecasts.py
@@ -41,8 +41,15 @@ MARINE_FORECAST_URL = "https://tgftp.nws.noaa.gov/data/forecasts/marine/coastal/
 DEFAULT_POLL_INTERVAL_SECONDS = 900
 DEFAULT_REFERENCE_REFRESH_SECONDS = 21600
 DEFAULT_STATE_FILE = "/mnt/fileshare/nws_forecasts_state.json"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-nws-forecasts/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 HEADERS = {
-    "User-Agent": "(real-time-sources, clemensv@microsoft.com)",
+    "User-Agent": USER_AGENT,
     "Accept": "application/geo+json",
 }
 MARINE_PERIOD_RE = re.compile(r"^\.(?P<name>[A-Z0-9 /]+)\.\.\.(?P<body>.*)$")

--- a/feeders/nws-forecasts/tests/test_nws_forecasts_e2e.py
+++ b/feeders/nws-forecasts/tests/test_nws_forecasts_e2e.py
@@ -5,7 +5,7 @@ import requests
 
 
 HEADERS = {
-    "User-Agent": "(real-time-sources-test, clemensv@microsoft.com)",
+    "User-Agent": "real-time-sources-nws-forecasts/0.1.0 (+https://github.com/clemensv/real-time-sources; clemensv@microsoft.com)",
     "Accept": "application/geo+json",
 }
 

--- a/feeders/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
+++ b/feeders/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
@@ -22,6 +22,13 @@ from paris_bicycle_counters_producer_kafka_producer.producer import FRParisOpenD
 
 COUNTER_DATA_URL = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/comptage-velo-donnees-compteurs/records"
 COUNTER_LOCATIONS_URL = "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/comptage-velo-compteurs/records"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-paris-bicycle-counters/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def ce_datetime(value: datetime) -> str:
@@ -100,7 +107,7 @@ class ParisBicycleCounterPoller:
         limit = 100
         while True:
             params = {"limit": limit, "offset": offset}
-            response = requests.get(COUNTER_LOCATIONS_URL, params=params, timeout=30)
+            response = requests.get(COUNTER_LOCATIONS_URL, params=params, headers={"User-Agent": USER_AGENT}, timeout=30)
             response.raise_for_status()
             data = response.json()
             results = data.get("results", [])
@@ -152,7 +159,7 @@ class ParisBicycleCounterPoller:
                 where_clause = f"date >= '{since.strftime('%Y-%m-%dT%H:%M:%S')}'"
                 params["where"] = where_clause
             try:
-                response = requests.get(COUNTER_DATA_URL, params=params, timeout=30)
+                response = requests.get(COUNTER_DATA_URL, params=params, headers={"User-Agent": USER_AGENT}, timeout=30)
                 response.raise_for_status()
             except requests.HTTPError as e:
                 # 400 typically means we have hit the API's 10000-row paging

--- a/feeders/pegelonline/pegelonline_core/pegelonline_core/acquisition.py
+++ b/feeders/pegelonline/pegelonline_core/pegelonline_core/acquisition.py
@@ -12,12 +12,20 @@ bookkeeping.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 import requests
 
 
 FEED_URL_ROOT = "https://www.pegelonline.wsv.de/webservices/rest-api/v2"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-pegelonline/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class PegelOnlineAPI:
@@ -25,6 +33,7 @@ class PegelOnlineAPI:
 
     def __init__(self, session: Optional[requests.Session] = None, request_timeout: float = 10.0) -> None:
         self._session = session or requests.Session()
+        self._session.headers["User-Agent"] = USER_AGENT
         self._request_timeout = request_timeout
         # URLs that returned non-200/304 are sidelined for the lifetime of the process.
         self.skip_urls: List[str] = []

--- a/feeders/ptwc-tsunami/ptwc_tsunami/ptwc_tsunami.py
+++ b/feeders/ptwc-tsunami/ptwc_tsunami/ptwc_tsunami.py
@@ -37,6 +37,13 @@ NS = {
 DEFAULT_POLL_INTERVAL = 300
 DEFAULT_STATE_FILE = os.path.expanduser("~/.ptwc_tsunami_state.json")
 DEFAULT_TOPIC = "ptwc-tsunami"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-ptwc-tsunami/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 FEED_BASINS = {
     "PAAQ": "alaska",
@@ -228,7 +235,7 @@ class PTWCTsunamiPoller:
 
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=60),
-                headers={"User-Agent": "ptwc-tsunami-bridge/1.0"}
+                headers={"User-Agent": USER_AGENT}
             ) as session:
                 for feed_name in self.feeds:
                     root = await self.fetch_feed(session, feed_name)

--- a/feeders/ptwc-tsunami/ptwc_tsunami_mqtt/ptwc_tsunami_mqtt/app.py
+++ b/feeders/ptwc-tsunami/ptwc_tsunami_mqtt/ptwc_tsunami_mqtt/app.py
@@ -19,6 +19,14 @@ from ptwc_tsunami_mqtt_producer_mqtt_client.client import PTWCBulletinsMqttMqttC
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-ptwc-tsunami/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _topic_segment(value: Optional[str]) -> str:
     text = (value or "unknown").strip() or "unknown"
@@ -31,7 +39,7 @@ async def _poll_once(poller: PTWCTsunamiPoller, mqtt_client: PTWCBulletinsMqttMq
     state = poller.load_state()
     count_new = 0
     count_updated = 0
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers={"User-Agent": "ptwc-tsunami-mqtt-bridge/1.0"}) as session:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), headers={"User-Agent": USER_AGENT}) as session:
         for feed_name in poller.feeds:
             root = await poller.fetch_feed(session, feed_name)
             if root is None:

--- a/feeders/rss/rssbridge/rssbridge.py
+++ b/feeders/rss/rssbridge/rssbridge.py
@@ -46,7 +46,13 @@ STATE_FILE = os.path.join(USER_DIR, ".rss-grabber.json")
 FEEDSTORE_FILE = os.path.join(USER_DIR, ".rss-grabber-feedstore.xml")
 __version__ = "1.0.0"
 
-USER_AGENT = f"Event Stream RSS Agent {__version__}"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-rss/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def topic_token(value: str, fallback: str = "unknown") -> str:
@@ -431,7 +437,7 @@ def process_feed(feed_url: str, state: dict, producer_instance: MicrosoftOpenDat
             }
             return
 
-        feed = feedparser.parse(response.content)
+        feed = feedparser.parse(response.content, agent=USER_AGENT)
         # Check for redirection
         actual_url = response.url
 
@@ -658,7 +664,7 @@ async def run():
 
         for url in args.urls:
             if url.endswith(".opml"):
-                opml_content = requests.get(url, timeout=10).content
+                opml_content = requests.get(url, headers={'User-Agent': USER_AGENT}, timeout=10).content
                 opml_tree = listparser.parse(opml_content)
                 feed_urls.extend([outline.url for outline in opml_tree.feeds])
             else:

--- a/feeders/rss/tests/test_rssbridge_e2e.py
+++ b/feeders/rss/tests/test_rssbridge_e2e.py
@@ -23,6 +23,7 @@ from rssbridge.rssbridge import (
     save_feedstore,
     extract_feed_urls_from_webpage,
     parse_connection_string,
+    USER_AGENT,
 )
 
 
@@ -36,7 +37,7 @@ class TestRealFeedParsing:
         feed_url = "https://www.w3.org/blog/news/feed/"
         
         try:
-            parsed = feedparser.parse(feed_url)
+            parsed = feedparser.parse(feed_url, agent=USER_AGENT)
             
             # Verify feed was successfully parsed
             assert parsed is not None
@@ -62,7 +63,7 @@ class TestRealFeedParsing:
         feed_url = "https://datatracker.ietf.org/feed/group/httpbis/"
         
         try:
-            parsed = feedparser.parse(feed_url)
+            parsed = feedparser.parse(feed_url, agent=USER_AGENT)
             
             # Verify feed was successfully parsed
             assert parsed is not None

--- a/feeders/rws-waterwebservices/rws_waterwebservices/rws_waterwebservices.py
+++ b/feeders/rws-waterwebservices/rws_waterwebservices/rws_waterwebservices.py
@@ -24,6 +24,14 @@ if sys.gettrace() is not None:
 else:
     logging.basicConfig(level=logging.INFO)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-rws-waterwebservices/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
@@ -65,7 +73,7 @@ class RWSWaterwebservicesAPI:
 
     def __init__(self):
         self.session = requests.Session()
-        self.session.headers.update({"Content-Type": "application/json"})
+        self.session.headers.update({"Content-Type": "application/json", "User-Agent": USER_AGENT})
 
     BATCH_SIZE = 100  # Max locations per observations request
 

--- a/feeders/rws-waterwebservices/tests/test_rws_waterwebservices_e2e.py
+++ b/feeders/rws-waterwebservices/tests/test_rws_waterwebservices_e2e.py
@@ -7,7 +7,10 @@ import requests
 RWS_BASE_URL = "https://ddapi20-waterwebservices.rijkswaterstaat.nl"
 CATALOG_ENDPOINT = "/METADATASERVICES/OphalenCatalogus"
 LATEST_ENDPOINT = "/ONLINEWAARNEMINGENSERVICES/OphalenLaatsteWaarnemingen"
-HEADERS = {"Content-Type": "application/json"}
+HEADERS = {
+    "Content-Type": "application/json",
+    "User-Agent": "real-time-sources-rws-waterwebservices/0.1.0 (+https://github.com/clemensv/real-time-sources; clemensv@microsoft.com)",
+}
 
 
 class TestRWSRealEndpoints:

--- a/feeders/seattle-911/seattle_911/seattle_911.py
+++ b/feeders/seattle-911/seattle_911/seattle_911.py
@@ -31,12 +31,19 @@ DEFAULT_CONNECT_TIMEOUT_SECONDS = 10
 DEFAULT_READ_TIMEOUT_SECONDS = 120
 DEFAULT_KAFKA_FLUSH_TIMEOUT_SECONDS = 30
 DEFAULT_HTTP_RETRY_TOTAL = 3
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-seattle-911/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _build_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/seattle-street-closures/seattle_street_closures/seattle_street_closures.py
+++ b/feeders/seattle-street-closures/seattle_street_closures/seattle_street_closures.py
@@ -28,12 +28,19 @@ DEFAULT_CONNECT_TIMEOUT_SECONDS = 10
 DEFAULT_READ_TIMEOUT_SECONDS = 120
 DEFAULT_KAFKA_FLUSH_TIMEOUT_SECONDS = 30
 DEFAULT_HTTP_RETRY_TOTAL = 3
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-seattle-street-closures/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _build_retrying_session() -> requests.Session:
     """Create an HTTP session with bounded retries for transient upstream failures."""
     session = requests.Session()
-    session.headers.update({"User-Agent": "GitHub-Copilot-CLI/1.0"})
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=DEFAULT_HTTP_RETRY_TOTAL,
         connect=DEFAULT_HTTP_RETRY_TOTAL,

--- a/feeders/sensor-community/sensor_community/sensor_community.py
+++ b/feeders/sensor-community/sensor_community/sensor_community.py
@@ -28,6 +28,13 @@ else:
 DEFAULT_SENSOR_TYPES = "SDS011,BME280,SPS30,DHT22,PMS5003,SHT31,BMP280"
 STATE_FILE_DEFAULT = os.path.expanduser("~/.sensor_community_state.json")
 API_BASE_URL = "https://data.sensor.community/airrohr/v1"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-sensor-community/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 MEASUREMENT_FIELD_MAP = {
     "P1": "pm10_ug_m3",
     "P2": "pm2_5_ug_m3",
@@ -135,6 +142,7 @@ class SensorCommunityAPI:
         session: requests.Session | None = None,
     ) -> None:
         self.session = session or requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
         self.sensor_types = self.normalize_sensor_types(sensor_types or DEFAULT_SENSOR_TYPES)
         self.countries = self.normalize_countries(countries or os.getenv("COUNTRIES", ""))
         self.state_file = state_file

--- a/feeders/singapore-nea/singapore_nea/air_quality.py
+++ b/feeders/singapore-nea/singapore_nea/air_quality.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 import logging
+import os
 
 import requests
 
@@ -11,6 +12,13 @@ from singapore_nea_producer_kafka_producer.producer import SGGovNEAAirQualityEve
 logger = logging.getLogger(__name__)
 
 NEA_AIR_QUALITY_BASE_URL = "https://api.data.gov.sg/v1/environment"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-singapore-nea/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class NEAAirQualityAPI:
@@ -20,6 +28,7 @@ class NEAAirQualityAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def _get_endpoint(self, endpoint: str) -> dict:
         response = self.session.get(f"{self.base_url}/{endpoint}", timeout=30)

--- a/feeders/singapore-nea/singapore_nea/singapore_nea.py
+++ b/feeders/singapore-nea/singapore_nea/singapore_nea.py
@@ -27,6 +27,13 @@ from singapore_nea.air_quality import (
 logger = logging.getLogger(__name__)
 
 NEA_BASE_URL = "https://api.data.gov.sg/v1/environment"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-singapore-nea/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 AIR_QUALITY_REFERENCE_REFRESH_INTERVAL = 24 * 60 * 60
 
 ENDPOINTS = ["air-temperature", "rainfall", "relative-humidity", "wind-speed", "wind-direction"]
@@ -47,6 +54,7 @@ class NEAWeatherAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_endpoint(self, endpoint: str) -> dict:
         """Fetch a single environment endpoint."""

--- a/feeders/smhi-hydro/smhi_hydro/smhi_hydro.py
+++ b/feeders/smhi-hydro/smhi_hydro/smhi_hydro.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 SMHI_BASE_URL = "https://opendata-download-hydroobs.smhi.se/api/version/1.0"
 SMHI_BULK_DISCHARGE_URL = f"{SMHI_BASE_URL}/parameter/2/station-set/all/period/latest-hour/data.json"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-smhi-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 class SMHIHydroAPI:
@@ -29,6 +36,7 @@ class SMHIHydroAPI:
         self.bulk_discharge_url = f"{base_url}/parameter/2/station-set/all/period/latest-hour/data.json"
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_bulk_discharge_data(self) -> dict:
         """Fetch bulk discharge data for all stations from the latest-hour endpoint."""

--- a/feeders/smhi-weather/smhi_weather/smhi_weather.py
+++ b/feeders/smhi-weather/smhi_weather/smhi_weather.py
@@ -17,6 +17,13 @@ from smhi_weather_producer_data import Station, WeatherObservation
 logger = logging.getLogger(__name__)
 
 SMHI_BASE_URL = "https://opendata-download-metobs.smhi.se/api/version/1.0"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-smhi-weather/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # SMHI parameter IDs for hourly weather observations
 PARAM_AIR_TEMP = 1        # Lufttemperatur, momentanvärde, 1 gång/tim
@@ -50,6 +57,7 @@ class SMHIWeatherAPI:
         self.base_url = base_url
         self.polling_interval = polling_interval
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def get_stations_for_parameter(self, parameter_id: int) -> list[dict]:
         """Fetch the station list for a given parameter."""

--- a/feeders/snotel/snotel/snotel.py
+++ b/feeders/snotel/snotel/snotel.py
@@ -29,6 +29,13 @@ else:
 logger = logging.getLogger(__name__)
 
 REPORT_GENERATOR_BASE = "https://wcc.sc.egov.usda.gov/reportGenerator/view_csv"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-snotel/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # Representative set of SNOTEL stations across western US states
 DEFAULT_STATION_TRIPLETS = [
@@ -310,7 +317,7 @@ class SnotelPoller:
             requests.RequestException: On HTTP failure.
         """
         url = build_station_csv_url(station_triplet)
-        response = requests.get(url, timeout=60)
+        response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
         response.raise_for_status()
         return response.text
 

--- a/feeders/syke-hydro/syke_hydro/syke_hydro.py
+++ b/feeders/syke-hydro/syke_hydro/syke_hydro.py
@@ -17,6 +17,13 @@ from syke_hydro_producer_kafka_producer.producer import FISYKEHydrologyEventProd
 logger = logging.getLogger(__name__)
 
 SYKE_BASE_URL = "https://rajapinnat.ymparisto.fi/api/Hydrologiarajapinta/1.1/odata"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-syke-hydro/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 MAX_ODATA_TOP = 5000
 
@@ -74,6 +81,7 @@ class SYKEHydroAPI:
         self.base_url = base_url
         self.session = requests.Session()
         self.session.headers['Accept'] = 'application/json'
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def _odata_get_all(self, entity: str, params: dict = None) -> list:
         """Fetch all records from an OData endpoint, handling pagination."""

--- a/feeders/tepco-denkiyoho/tepco_denkiyoho/tepco_denkiyoho.py
+++ b/feeders/tepco-denkiyoho/tepco_denkiyoho/tepco_denkiyoho.py
@@ -24,6 +24,13 @@ from tepco_denkiyoho_producer_data import DemandActual, DemandForecast, PeakDema
 from tepco_denkiyoho_producer_kafka_producer.producer import JPTEPCODenkiyohoKafkaEventProducer
 
 DAILY_CSV_URL = "https://www.tepco.co.jp/forecast/html/images/juyo-d1-j.csv"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-tepco-denkiyoho/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 DEFAULT_TOPIC = "tepco-denkiyoho"
 DEFAULT_STATE_FILE = "./state/tepco-denkiyoho.json"
 JST = timezone(timedelta(hours=9))
@@ -159,6 +166,7 @@ class DenkiyohoState:
 
 def create_retrying_session() -> requests.Session:
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=5,
         connect=3,
@@ -464,6 +472,7 @@ class TepcoDenkiyohoAPI:
     def __init__(self, url: str = DAILY_CSV_URL, session: requests.Session | None = None):
         self.url = url
         self.session = session or create_retrying_session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_daily_csv(self) -> bytes:
         response = self.session.get(self.url, timeout=30)

--- a/feeders/tfl-road-traffic/tfl_road_traffic/tfl_road_traffic.py
+++ b/feeders/tfl-road-traffic/tfl_road_traffic/tfl_road_traffic.py
@@ -70,6 +70,13 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-tfl-road-traffic/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 TFL_ROAD_URL = "https://api.tfl.gov.uk/Road"
 TFL_STATUS_URL = "https://api.tfl.gov.uk/Road/all/Status"
 TFL_DISRUPTION_URL = "https://api.tfl.gov.uk/Road/all/Disruption"
@@ -78,6 +85,7 @@ TFL_DISRUPTION_URL = "https://api.tfl.gov.uk/Road/all/Disruption"
 def _make_session() -> requests.Session:
     """Create a requests session with bounded retry logic for transient upstream failures."""
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         backoff_factor=1.5,
@@ -342,6 +350,7 @@ class TflRoadTrafficPoller:
         self.polling_interval = polling_interval
         self.reference_refresh_interval = reference_refresh_interval
         self.session = session or _make_session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
         self._kafka_producer = KafkaProducer(kafka_config)
         self.corridors_producer = UkGovTflRoadCorridorsEventProducer(

--- a/feeders/ticketmaster/ticketmaster/ticketmaster.py
+++ b/feeders/ticketmaster/ticketmaster/ticketmaster.py
@@ -40,6 +40,13 @@ else:
 logger = logging.getLogger(__name__)
 
 DISCOVERY_API_BASE = "https://app.ticketmaster.com/discovery/v2"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-ticketmaster/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def _load_state(state_file: str) -> Dict[str, str]:
@@ -100,6 +107,7 @@ EVENT_FILTER_ENV_VARS = {
 def _make_session() -> requests.Session:
     """Create a requests session with bounded retry policy for transient failures."""
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=5,
         backoff_factor=1.0,

--- a/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare/tokyo_docomo_bikeshare.py
+++ b/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare/tokyo_docomo_bikeshare.py
@@ -30,6 +30,13 @@ from tokyo_docomo_bikeshare_producer_kafka_producer.producer import (
 
 GBFS_AUTODISCOVERY_URL = "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json"
 SYSTEM_ID = "docomo-cycle-tokyo"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-tokyo-docomo-bikeshare/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 # Re-fetch reference data every hour
 REFERENCE_REFRESH_INTERVAL_SECONDS = 3600
@@ -41,6 +48,7 @@ DEFAULT_POLL_INTERVAL_SECONDS = 60
 def _make_session() -> requests.Session:
     """Create a requests Session with bounded retry handling for transient failures."""
     session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     retry = Retry(
         total=3,
         backoff_factor=1.5,

--- a/feeders/uba-airdata/uba_airdata/uba_airdata.py
+++ b/feeders/uba-airdata/uba_airdata/uba_airdata.py
@@ -22,6 +22,14 @@ from uba_airdata_producer_kafka_producer.producer import (
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-uba-airdata/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 UBA_API_BASE = "https://www.umweltbundesamt.de/api/air_data/v3"
 BERLIN_TZ = ZoneInfo("Europe/Berlin")
 
@@ -84,6 +92,7 @@ class UBAAirDataAPI:
         self.polling_interval = polling_interval
         self.scope_id = scope_id
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def parse_connection_string(self, connection_string: str) -> dict[str, str]:
         """Parse Event Hubs, Fabric, or plain Kafka style connection strings."""

--- a/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring/uk_ea_flood_monitoring.py
+++ b/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring/uk_ea_flood_monitoring.py
@@ -23,6 +23,14 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-uk-ea-flood-monitoring/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
     try:
@@ -58,6 +66,7 @@ class EAFloodMonitoringAPI:
 
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
         self.measure_to_station: Dict[str, str] = {}
 
     def list_stations(self) -> List[Dict[str, Any]]:

--- a/feeders/usgs-earthquakes/usgs_earthquakes/usgs_earthquakes.py
+++ b/feeders/usgs-earthquakes/usgs_earthquakes/usgs_earthquakes.py
@@ -27,6 +27,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-usgs-earthquakes/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Available feed URLs by time period and minimum magnitude
 FEED_URLS = {
     "all_hour": "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson",
@@ -105,7 +113,10 @@ class USGSEarthquakePoller:
             logger.error("Unknown feed: %s. Available feeds: %s", self.feed, ', '.join(FEED_URLS.keys()))
             return []
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
             try:
                 async with session.get(url) as response:
                     response.raise_for_status()

--- a/feeders/usgs-geomag/tests/test_usgs_geomag_unit.py
+++ b/feeders/usgs-geomag/tests/test_usgs_geomag_unit.py
@@ -10,7 +10,7 @@ import tempfile
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime, timezone
 from usgs_geomag_producer_data import Observatory, MagneticFieldReading
-from usgs_geomag.usgs_geomag import USGSGeomagPoller, parse_connection_string
+from usgs_geomag.usgs_geomag import USGSGeomagPoller, USER_AGENT, parse_connection_string
 
 
 SAMPLE_OBSERVATORIES_GEOJSON = {
@@ -666,4 +666,7 @@ class TestUrlConstruction:
 
         USGSGeomagPoller.fetch_observatories()
         mock_get.assert_called_once_with(
-            "https://geomag.usgs.gov/ws/observatories/", timeout=60)
+            "https://geomag.usgs.gov/ws/observatories/",
+            headers={"User-Agent": USER_AGENT},
+            timeout=60,
+        )

--- a/feeders/usgs-geomag/usgs_geomag/usgs_geomag.py
+++ b/feeders/usgs-geomag/usgs_geomag/usgs_geomag.py
@@ -29,6 +29,14 @@ POLL_INTERVAL_SECONDS = 300
 REFERENCE_REFRESH_HOURS = 12
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-usgs-geomag/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 class USGSGeomagPoller:
     """
     Polls the USGS Geomagnetism web-service for 1-minute variation data
@@ -75,7 +83,7 @@ class USGSGeomagPoller:
             List of observatory feature dicts from the API.
         """
         try:
-            response = requests.get(OBSERVATORIES_URL, timeout=60)
+            response = requests.get(OBSERVATORIES_URL, headers={"User-Agent": USER_AGENT}, timeout=60)
             response.raise_for_status()
             data = response.json()
             return data.get("features", [])
@@ -128,7 +136,7 @@ class USGSGeomagPoller:
             "endtime": end_time,
         }
         try:
-            response = requests.get(DATA_URL, params=params, timeout=120)
+            response = requests.get(DATA_URL, params=params, headers={"User-Agent": USER_AGENT}, timeout=120)
             response.raise_for_status()
             return response.json()
         except Exception as err:

--- a/feeders/usgs-iv/usgs_iv/usgs_iv.py
+++ b/feeders/usgs-iv/usgs_iv/usgs_iv.py
@@ -57,6 +57,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-usgs-iv/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 state_codes = [
     'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC',
     'FL', 'GA', 'GU', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA',
@@ -160,7 +168,10 @@ class USGSDataPoller:
 
         url = f'https://waterservices.usgs.gov/nwis/iv/?stateCd={state_code}&format=rdb&modifiedSince=PT2H'
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
             try:
                 async with session.get(url) as response:
                     response.raise_for_status()
@@ -530,7 +541,10 @@ class USGSDataPoller:
     async def get_sites_in_state(self, state_code: str) -> AsyncIterator[Site]:
         """Get all sites in a state."""
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
             url = f'https://waterservices.usgs.gov/nwis/site/?format=rdb&stateCd={state_code}&siteOutput=expanded'
             try:
                 async with session.get(url) as response:

--- a/feeders/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
@@ -38,6 +38,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-usgs-nwis-wq/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 # Water quality parameter codes
 WQ_PARAMETER_CODES = {
     "00010": "Water Temperature",
@@ -252,7 +260,10 @@ class USGSWaterQualityPoller:
 
     async def fetch_json(self, url: str) -> Optional[dict]:
         """Fetch JSON from the USGS API."""
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=60),
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
             try:
                 async with asyncio.timeout(60):
                     async with session.get(url) as response:

--- a/feeders/vatsim/vatsim/vatsim.py
+++ b/feeders/vatsim/vatsim/vatsim.py
@@ -29,6 +29,14 @@ else:
 VATSIM_DATA_URL = "https://data.vatsim.net/v3/vatsim-data.json"
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-vatsim/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def _parse_iso(value: str) -> datetime.datetime:
     """Parse an ISO-8601 timestamp tolerating 'Z' suffix and >6-digit fractional seconds.
 
@@ -98,6 +106,7 @@ class VatsimBridge:
 
     def __init__(self, session: Optional[requests.Session] = None):
         self.session = session or requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def fetch_data(self) -> Dict[str, Any]:
         """Fetch the current VATSIM data snapshot."""

--- a/feeders/wallonia-issep/wallonia_issep/wallonia_issep.py
+++ b/feeders/wallonia-issep/wallonia_issep/wallonia_issep.py
@@ -28,6 +28,14 @@ else:
 LOGGER = logging.getLogger(__name__)
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wallonia-issep/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def _load_state(state_file: str) -> Dict[str, str]:
     """Load persisted per-configuration dedup state from disk."""
     try:
@@ -100,6 +108,7 @@ class WalloniaISsePAPI:
         self.page_limit = page_limit
         self.reference_refresh_interval = reference_refresh_interval
         self.session = session or requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
         self.session.headers.setdefault("Accept", "application/json")
 
     @staticmethod

--- a/feeders/waterinfo-vmm/waterinfo_vmm/waterinfo_vmm.py
+++ b/feeders/waterinfo-vmm/waterinfo_vmm/waterinfo_vmm.py
@@ -24,6 +24,14 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-waterinfo-vmm/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
+
 def _load_state(state_file: str) -> dict:
     """Load persisted dedup state from a JSON file."""
     try:
@@ -66,6 +74,7 @@ class WaterinfoVMMAPI:
 
     def __init__(self):
         self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
 
     def _kiwis_request(self, extra_params: Dict[str, str]) -> Any:
         """Make a request to the KIWIS API."""

--- a/feeders/wikimedia-eventstreams/wikimedia_eventstreams/wikimedia_eventstreams.py
+++ b/feeders/wikimedia-eventstreams/wikimedia_eventstreams/wikimedia_eventstreams.py
@@ -27,11 +27,13 @@ from wikimedia_eventstreams_producer_kafka_producer.producer import (
 STREAM_URL = "https://stream.wikimedia.org/v2/stream/recentchange"
 DEFAULT_TOPIC = "wikimedia-eventstreams"
 DEFAULT_STATE_FILE = os.path.expanduser("~/.wikimedia_eventstreams_state.json")
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-eventstreams/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+DEFAULT_USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-eventstreams/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
-
 
 if sys.gettrace() is not None:
     logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(message)s")

--- a/feeders/wikimedia-eventstreams/wikimedia_eventstreams_amqp/wikimedia_eventstreams_amqp/app.py
+++ b/feeders/wikimedia-eventstreams/wikimedia_eventstreams_amqp/wikimedia_eventstreams_amqp/app.py
@@ -37,11 +37,13 @@ logger = logging.getLogger("wikimedia_eventstreams_amqp")
 
 
 STREAM_URL = "https://stream.wikimedia.org/v2/stream/recentchange"
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-eventstreams-amqp/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+DEFAULT_USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-eventstreams/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
-
 
 # MediaWiki canonical namespace numbers -> kebab-case bucket. Anything
 # not listed here is bucketed as ``ns-<n>`` so the axis remains stable.

--- a/feeders/wikimedia-eventstreams/wikimedia_eventstreams_mqtt/wikimedia_eventstreams_mqtt/app.py
+++ b/feeders/wikimedia-eventstreams/wikimedia_eventstreams_mqtt/wikimedia_eventstreams_mqtt/app.py
@@ -41,11 +41,13 @@ logger = logging.getLogger("wikimedia_eventstreams_mqtt")
 
 
 STREAM_URL = "https://stream.wikimedia.org/v2/stream/recentchange"
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-eventstreams-mqtt/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+DEFAULT_USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-eventstreams/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
-
 
 # MediaWiki canonical namespace numbers -> kebab-case bucket. Anything
 # not listed here is bucketed as ``ns-<n>`` so the axis remains stable.

--- a/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
+++ b/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs/wikimedia_osm_diffs.py
@@ -29,10 +29,14 @@ STATE_URL = "https://planet.openstreetmap.org/replication/minute/state.txt"
 DIFF_BASE_URL = "https://planet.openstreetmap.org/replication/minute"
 DEFAULT_TOPIC = "wikimedia-osm-diffs"
 DEFAULT_STATE_FILE = os.path.expanduser("~/.wikimedia_osm_diffs_state.json")
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-osm-diffs/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-osm-diffs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
+DEFAULT_USER_AGENT = USER_AGENT
 
 if sys.gettrace() is not None:
     logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(message)s")

--- a/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_amqp/wikimedia_osm_diffs_amqp/app.py
+++ b/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_amqp/wikimedia_osm_diffs_amqp/app.py
@@ -46,10 +46,14 @@ logger = logging.getLogger("wikimedia_osm_diffs_amqp")
 
 STATE_URL = "https://planet.openstreetmap.org/replication/minute/state.txt"
 DIFF_BASE_URL = "https://planet.openstreetmap.org/replication/minute"
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-osm-diffs-amqp/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-osm-diffs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
+DEFAULT_USER_AGENT = USER_AGENT
 DEFAULT_STATE_FILE = os.path.expanduser("~/.wikimedia_osm_diffs_amqp_state.json")
 
 

--- a/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
+++ b/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
@@ -50,10 +50,14 @@ logger = logging.getLogger("wikimedia_osm_diffs_mqtt")
 
 STATE_URL = "https://planet.openstreetmap.org/replication/minute/state.txt"
 DIFF_BASE_URL = "https://planet.openstreetmap.org/replication/minute"
-DEFAULT_USER_AGENT = (
-    "real-time-sources-wikimedia-osm-diffs-mqtt/0.1 "
-    "(https://github.com/clemensv/real-time-sources)"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wikimedia-osm-diffs/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
+DEFAULT_USER_AGENT = USER_AGENT
 DEFAULT_STATE_FILE = os.path.expanduser("~/.wikimedia_osm_diffs_mqtt_state.json")
 
 

--- a/feeders/wsdot/wsdot/wsdot.py
+++ b/feeders/wsdot/wsdot/wsdot.py
@@ -98,6 +98,13 @@ else:
 TRAVELER_BASE = "https://www.wsdot.wa.gov/Traffic/api"
 FERRIES_BASE = "https://www.wsdot.wa.gov/ferries/api/vessels/rest"
 FEED_URL = "https://www.wsdot.wa.gov/Traffic/api"
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-wsdot/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 _WCF_DATE_RE = re.compile(r"/Date\((-?\d+)([+-]\d{4})?\)/")
 
@@ -147,7 +154,7 @@ class WSDOTApi:
         self.session = requests.Session()
         self.session.headers.update({
             "Accept": "application/json",
-            "User-Agent": "real-time-sources/1.0 (github.com/clemensv/real-time-sources)",
+            "User-Agent": USER_AGENT,
         })
 
     def _traveler_get(self, service: str, method: str) -> Any:

--- a/feeders/xceed/xceed/xceed.py
+++ b/feeders/xceed/xceed/xceed.py
@@ -31,6 +31,13 @@ DEFAULT_POLL_INTERVAL = 300
 DEFAULT_EVENT_REFRESH_INTERVAL = 3600
 DEFAULT_EVENT_WINDOW_SIZE = 250
 DEFAULT_EVENT_PAGE_SIZE = 100
+# Outbound HTTP identity. Operators can override the entire string with the
+# USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
+USER_AGENT = os.environ.get("USER_AGENT") or (
+    "real-time-sources-xceed/0.1.0 "
+    "(+https://github.com/clemensv/real-time-sources; "
+    + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
+)
 
 
 def create_retrying_session(user_agent: str) -> requests.Session:
@@ -61,7 +68,7 @@ class XceedAPI:
 
     def __init__(
         self,
-        user_agent: str = "real-time-sources/1.0 (github.com/clemensv/real-time-sources)",
+        user_agent: str = USER_AGENT,
         event_window_size: int = DEFAULT_EVENT_WINDOW_SIZE,
         event_page_size: int = DEFAULT_EVENT_PAGE_SIZE,
     ):


### PR DESCRIPTION
## Consistent, descriptive User-Agent across all feeders

Replaces the four competing User-Agent styles — and the many feeders that sent **no** UA at all (falling back to python-requests/x.y, which NWS / Wikimedia / OSM actively block) — with a single canonical, operator-overridable string:

```
real-time-sources-<slug>/<version> (+https://github.com/clemensv/real-time-sources; <contact>)
```

### What changed
- Every HTTP-making feeder runtime package now defines a USER_AGENT constant.
- Overridable via the USER_AGENT env var (full string) or USER_AGENT_CONTACT (contact token only; default clemensv@microsoft.com).
- Applied to every outbound call site per transport: requests.Session / inline requests.get, aiohttp.ClientSession, websockets.connect / WebSocketApp, feedparser.parse, urllib.
- New shared module feeders/german-waters/german_waters/user_agent.py imported by all 12 german-waters providers.
- Generated *_producer/ code is **untouched**; old-UA test assertions updated.

### Scope
- **158 files** changed (157 feeder modules + 1 new shared module).
- No _producer/, build/, or dist/ artifacts included.
- Out of scope: kystverket-ais, mode-s (raw TCP, no HTTP).

### Verification
- Fleet-wide py_compile over all 158 committed Python files: **0 failures**.
- Spot-checked the three HTTP styles (entsoe inline requests.get, aisstream websocket additional_headers, feedparser agent=).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
