### PR TITLE
Fix wsdot enum assertion test drift (#709)

### DIFF
--- a/feeders/wsdot/tests/test_wsdot.py
+++ b/feeders/wsdot/tests/test_wsdot.py
@@ -295,7 +295,7 @@ class TestDataClassSerialization:
         json_str = reading.to_json()
         restored = reading.from_json(json_str)
         assert restored.flow_data_id == reading.flow_data_id
-        assert restored.flow_reading == reading.flow_reading
+        assert restored.flow_reading.value == reading.flow_reading
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The WSDOT generated producer now deserializes `flow_reading` as the typed enum `FlowReadingenum` (`FlowReadingenum.WideOpen`) while the parsed test fixture still carries the upstream-normalized string value (`"WideOpen"`).

## What changed

Updated the stale round-trip unit-test assertion to compare the generated enum member's `.value` to the original normalized string. The bridge/runtime and generated producer are unchanged.

## Validation

- `python -m pytest feeders\wsdot\tests -q -p no:cacheprovider --no-cov` -> `69 passed in 0.65s`
- Code-review check on the changed test: no blockers.

## Feeder release checklist scope

- Transport scope: Kafka/MQTT/AMQP support unchanged; this is test-only.
- Change scope: stale unit-test assertion only; no contract, schema, runtime, env-var, deploy-template, generated-code, Docker, KQL, Fabric, or documentation changes.
- Source-local unit tests pass: `69 passed in 0.65s`.
- Other feeder release checklist items: N/A for this PR because no feeder behavior or delivery artifact changed.

Closes #709
