### PR TITLE
Fix wallonia-issep unit test failures (#705)

### DIFF
--- a/feeders/wallonia-issep/tests/test_wallonia_issep_unit.py
+++ b/feeders/wallonia-issep/tests/test_wallonia_issep_unit.py
@@ -216,6 +216,7 @@ def test_normalize_observation_full_record():
     api = WalloniaISsePAPI()
     obs = api.normalize_observation(SAMPLE_RECORD)
     assert obs.configuration_id == "10412"
+    assert obs.province == "unknown"
     assert obs.moment == "2026-04-08T20:21:04+02:00"
     assert obs.co == 16
     assert obs.no == 7
@@ -262,6 +263,7 @@ def test_normalize_observation_null_fields():
     }
     obs = api.normalize_observation(minimal_record)
     assert obs.configuration_id == "99999"
+    assert obs.province == "unknown"
     assert obs.moment == "2026-04-08T10:00:00+02:00"
     assert obs.co is None
     assert obs.no is None
@@ -291,6 +293,13 @@ def test_normalize_observation_config_id_as_string():
 
 
 @pytest.mark.unit
+def test_normalize_observation_preserves_province_when_present():
+    api = WalloniaISsePAPI()
+    obs = api.normalize_observation({**SAMPLE_RECORD, "province": "hainaut"})
+    assert obs.province == "hainaut"
+
+
+@pytest.mark.unit
 def test_normalize_observation_zero_humidity():
     """Zero humidity is valid, not None."""
     api = WalloniaISsePAPI()
@@ -310,6 +319,7 @@ def test_observation_serialization_roundtrip():
     obs = api.normalize_observation(SAMPLE_RECORD)
     serialized = obs.to_serializer_dict()
     assert serialized["configuration_id"] == "10412"
+    assert serialized["province"] == "unknown"
     assert serialized["moment"] == "2026-04-08T20:21:04+02:00"
     assert serialized["no2"] == -1
     assert serialized["pm25"] == 1.957
@@ -329,6 +339,7 @@ def test_observation_json_roundtrip():
     from wallonia_issep_producer_data import Observation
     restored = Observation.from_json(json_str)  # type: ignore[attr-defined]
     assert restored.configuration_id == "10412"
+    assert restored.province == "unknown"
     assert restored.no2 == -1
     assert restored.ppbno == 2.711
 
@@ -338,9 +349,10 @@ def test_sensor_configuration_serialization():
     from wallonia_issep_producer_data import SensorConfiguration
     config = SensorConfiguration(configuration_id="10412")
     serialized = config.to_serializer_dict()
-    assert serialized == {"configuration_id": "10412"}
+    assert serialized == {"configuration_id": "10412", "province": "unknown"}
     restored = SensorConfiguration.from_serializer_dict(serialized)
     assert restored.configuration_id == "10412"
+    assert restored.province == "unknown"
 
 
 @pytest.mark.unit
@@ -361,6 +373,7 @@ def test_observation_byte_array_roundtrip():
     restored = Observation.from_data(byte_arr, "application/json")
     assert restored is not None
     assert restored.configuration_id == "10412"
+    assert restored.province == "unknown"
     assert restored.no2 == -1
 
 
@@ -372,6 +385,7 @@ def test_observation_null_fields_in_json():
     obs = api.normalize_observation(minimal)
     json_str = obs.to_json()  # type: ignore[attr-defined]
     parsed = json.loads(json_str)
+    assert parsed["province"] == "unknown"
     assert parsed["co"] is None
     assert parsed["pm10"] is None
     assert parsed["vbat"] is None
@@ -393,6 +407,17 @@ def test_extract_configurations():
     assert len(configs) == 2
     ids = {c.configuration_id for c in configs}
     assert ids == {"10412", "10296"}
+    assert {c.province for c in configs} == {"unknown"}
+
+
+@pytest.mark.unit
+def test_extract_configurations_preserves_province():
+    records = [
+        {"id_configuration": 10412, "moment": "2026-04-08T20:21:04+02:00", "province": "hainaut"},
+    ]
+    configs = WalloniaISsePAPI.extract_configurations(records)
+    assert configs[0].configuration_id == "10412"
+    assert configs[0].province == "hainaut"
 
 
 @pytest.mark.unit

--- a/feeders/wallonia-issep/wallonia_issep/wallonia_issep.py
+++ b/feeders/wallonia-issep/wallonia_issep/wallonia_issep.py
@@ -85,6 +85,12 @@ def _safe_float(value: Any) -> Optional[float]:
         return None
 
 
+def _province_from_record(record: Dict[str, Any]) -> str:
+    """Return the Walloon province slug when present, otherwise the contract sentinel."""
+    province = record.get("province")
+    return str(province).strip() if province else "unknown"
+
+
 class WalloniaISsePAPI:
     """Poll the Wallonia ISSeP Opendatasoft API and emit CloudEvents."""
 
@@ -177,9 +183,11 @@ class WalloniaISsePAPI:
         """Normalize one upstream Opendatasoft record into an Observation."""
         config_id = str(record.get("id_configuration", ""))
         moment = str(record.get("moment", ""))
+        province = _province_from_record(record)
 
         return Observation(
             configuration_id=config_id,
+            province=province,
             moment=moment,
             co=_safe_int(record.get("co")),
             no=_safe_int(record.get("no")),
@@ -232,7 +240,9 @@ class WalloniaISsePAPI:
             config_id = str(record.get("id_configuration", ""))
             if config_id and config_id not in seen:
                 seen.add(config_id)
-                configs.append(SensorConfiguration(configuration_id=config_id))
+                configs.append(
+                    SensorConfiguration(configuration_id=config_id, province=_province_from_record(record))
+                )
         return configs
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes Wallonia ISSeP unit-test drift after the `province` contract enrichment.

## Root cause and fix

- `Observation` now requires `province`, but `wallonia_issep.py::normalize_observation` only mapped `id_configuration` and `moment`. The live Opendatasoft dataset metadata/records expose `id_configuration`, `moment`, and measurement fields, but no `province` field. Because the xreg/EVENTS contract explicitly allows the `"unknown"` sentinel when location is not mapped, the bridge now derives `province` from an upstream `province` field when present and otherwise uses `"unknown"`.
- `SensorConfiguration(configuration_id="10412")` was not resolving the configuration id to `"unknown"`; the generated dataclass correctly serialized the required `province` default as `"unknown"` alongside `configuration_id`. The stale test expected the pre-enrichment payload shape, so the test now asserts both fields. Reference extraction also passes through a real province when supplied and otherwise emits the contract sentinel.

## Validation

- `python -m pytest feeders\wallonia-issep\tests -q -p no:cacheprovider --no-cov`
- Result: 53 passed

Closes #705
