### PR TITLE
Fix usgs-nwis-wq test import path (#703)

### DIFF
--- a/feeders/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq/usgs_nwis_wq.py
@@ -23,8 +23,8 @@ from typing import Dict, List, Optional, Tuple, Any, Set
 from confluent_kafka import Producer
 
 # pylint: disable=import-error, line-too-long
-from usgs_nwis_wq_producer_data.usgs_nwis_wq_producer_data.monitoringsite import MonitoringSite
-from usgs_nwis_wq_producer_data.usgs_nwis_wq_producer_data.waterqualityreading import WaterQualityReading
+from usgs_nwis_wq_producer_data.monitoringsite import MonitoringSite
+from usgs_nwis_wq_producer_data.waterqualityreading import WaterQualityReading
 from usgs_nwis_wq_producer_kafka_producer.producer import (
     USGSWaterQualitySitesEventProducer,
     USGSWaterQualityReadingsEventProducer,
@@ -164,6 +164,13 @@ class USGSWaterQualityPoller:
             latitude = geo.get("latitude")
             longitude = geo.get("longitude")
 
+            # Extract variable info
+            var_codes = variable.get("variableCode", [])
+            parameter_code = var_codes[0].get("value", "") if var_codes else ""
+            parameter_name = html.unescape(variable.get("variableDescription", variable.get("variableName", "")))
+            unit_code = variable.get("unit", {}).get("unitCode", "")
+            no_data_value = variable.get("noDataValue", USGSWaterQualityPoller.NO_DATA_VALUE)
+
             # Extract site properties
             site_type = None
             state_code = None
@@ -194,15 +201,10 @@ class USGSWaterQualityPoller:
                     state_code=state_code,
                     county_code=county_code,
                     huc_code=huc_code,
+                    state=None,
+                    parameter_code=parameter_code or None,
                 )
                 sites_list.append(site)
-
-            # Extract variable info
-            var_codes = variable.get("variableCode", [])
-            parameter_code = var_codes[0].get("value", "") if var_codes else ""
-            parameter_name = html.unescape(variable.get("variableDescription", variable.get("variableName", "")))
-            unit_code = variable.get("unit", {}).get("unitCode", "")
-            no_data_value = variable.get("noDataValue", USGSWaterQualityPoller.NO_DATA_VALUE)
 
             # Extract timezone info
             tz_info = source_info.get("timeZoneInfo", {})
@@ -253,6 +255,7 @@ class USGSWaterQualityPoller:
                         unit=unit_code,
                         qualifier=qualifier,
                         date_time=dt_utc.isoformat(),
+                        state=None,
                     )
                     readings_list.append(reading)
 


### PR DESCRIPTION
## Root cause

The bridge imported generated data classes from a doubled package path:
`usgs_nwis_wq_producer_data.usgs_nwis_wq_producer_data.monitoringsite`.
The generated package layout exposes these modules directly as
`usgs_nwis_wq_producer_data.monitoringsite` and
`usgs_nwis_wq_producer_data.waterqualityreading`.

## What changed

- Corrected the bridge imports to match the generated package layout.
- Updated `MonitoringSite` and `WaterQualityReading` construction to provide the required generated dataclass fields after collection succeeded.
- Did not hand-edit generated producer code.

## Validation

- Smoke import: `python -c "import usgs_nwis_wq.usgs_nwis_wq; from usgs_nwis_wq_producer_data.monitoringsite import MonitoringSite"` passed.
- `python -m pytest feeders\usgs-nwis-wq\tests -q -p no:cacheprovider --no-cov` → 59 passed in 5.37s.

## Release checklist scope

- Change scope: runtime/test-drift fix only; no contract, schema, generated producer, Docker, ARM, Fabric, or documentation changes.
- Transport scope: existing Kafka bridge unchanged; MQTT/AMQP artifacts not modified.
- Source-local unit tests pass: 59 passed.

Closes #703
