### PR TITLE
Fix waterinfo-vmm test drift (#706)

### DIFF
--- a/feeders/waterinfo-vmm/tests/test_waterinfo_vmm_container.py
+++ b/feeders/waterinfo-vmm/tests/test_waterinfo_vmm_container.py
@@ -65,7 +65,7 @@ class TestWaterinfoContainerIntegration:
                 unit_name="meter",
                 parameter_name="H",
             )
-            waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_water_level_reading(reading)
+            waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_water_level_reading(reading.station_no, reading)
 
             # Send a mock station
             station = Station(
@@ -79,7 +79,7 @@ class TestWaterinfoContainerIntegration:
                 ts_id="306367042",
                 ts_unitname="meter",
             )
-            waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_station(station)
+            waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_station(station.station_no, station)
 
             # Consume and verify
             consumer = _create_consumer(bootstrap_servers)
@@ -136,7 +136,7 @@ class TestWaterinfoLiveContainerIntegration:
                     ts_id="",
                     ts_unitname="",
                 )
-                waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_station(station, flush_producer=False)
+                waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_station(station.station_no, station, flush_producer=False)
             producer.flush()
 
             consumer = _create_consumer(bootstrap_servers)
@@ -177,7 +177,7 @@ class TestWaterinfoLiveContainerIntegration:
                     unit_name=entry.get("ts_unitname", "meter"),
                     parameter_name=entry.get("stationparameter_name", "H"),
                 )
-                waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_water_level_reading(reading, flush_producer=False)
+                waterinfo_producer.send_be_vlaanderen_waterinfo_vmm_water_level_reading(reading.station_no, reading, flush_producer=False)
                 sent_count += 1
             producer.flush()
 


### PR DESCRIPTION
## Root cause
The generated waterinfo-vmm Kafka producer signatures now require the subject/key placeholder argument (`station_no`) before the event `data` object. The container tests still called the old data-only signature.

## What changed
Updated the waterinfo-vmm container tests to pass `station.station_no` / `reading.station_no` before the corresponding data objects, matching the bridge call sites and generated producer signature.

## Validation
`python -m pytest feeders\waterinfo-vmm\tests -q -p no:cacheprovider --no-cov`

Result: 35 passed, 5 warnings.

Closes #706
