### PR TITLE
Fix snotel unit test drift (#692)

### DIFF
--- a/feeders/snotel/snotel/snotel.py
+++ b/feeders/snotel/snotel/snotel.py
@@ -215,9 +215,14 @@ def parse_observation_row(station_triplet: str, row: List[str]) -> Optional[Snow
     prec = parse_float(row[2]) if len(row) > 2 else None
     tobs = parse_float(row[3]) if len(row) > 3 else None
     snwd = parse_float(row[4]) if len(row) > 4 else None
+    state = STATION_METADATA.get(station_triplet, {}).get("state")
+    if state is None:
+        parts = station_triplet.split(":")
+        state = parts[1] if len(parts) > 1 else ""
 
     return SnowObservation(
         station_triplet=station_triplet,
+        state=state,
         date_time=dt,
         snow_water_equivalent=swe,
         snow_depth=snwd,

--- a/feeders/snotel/tests/test_snotel_unit.py
+++ b/feeders/snotel/tests/test_snotel_unit.py
@@ -181,6 +181,7 @@ class TestParseObservationRow:
         obs = parse_observation_row("838:CO:SNTL", row)
         assert obs is not None
         assert obs.station_triplet == "838:CO:SNTL"
+        assert obs.state == "CO"
         assert obs.snow_water_equivalent == 9.0
         assert obs.precipitation == 16.40
         assert obs.air_temperature == 36.3
@@ -579,6 +580,7 @@ class TestDataClasses:
         dt = datetime(2026, 4, 8, 0, 0, tzinfo=timezone.utc)
         obs = SnowObservation(
             station_triplet="838:CO:SNTL",
+            state="CO",
             date_time=dt,
             snow_water_equivalent=9.0,
             snow_depth=26.0,
@@ -586,6 +588,7 @@ class TestDataClasses:
             air_temperature=36.3,
         )
         assert obs.station_triplet == "838:CO:SNTL"
+        assert obs.state == "CO"
         assert obs.snow_water_equivalent == 9.0
         assert obs.date_time == dt
 
@@ -593,6 +596,7 @@ class TestDataClasses:
         dt = datetime(2026, 4, 8, 0, 0, tzinfo=timezone.utc)
         obs = SnowObservation(
             station_triplet="838:CO:SNTL",
+            state="CO",
             date_time=dt,
             snow_water_equivalent=None,
             snow_depth=None,
@@ -608,6 +612,7 @@ class TestDataClasses:
         dt = datetime(2026, 4, 8, 0, 0, tzinfo=timezone.utc)
         obs = SnowObservation(
             station_triplet="838:CO:SNTL",
+            state="CO",
             date_time=dt,
             snow_water_equivalent=9.0,
             snow_depth=26.0,
@@ -622,6 +627,7 @@ class TestDataClasses:
         dt = datetime(2026, 4, 8, 0, 0, tzinfo=timezone.utc)
         obs = SnowObservation(
             station_triplet="838:CO:SNTL",
+            state="CO",
             date_time=dt,
             snow_water_equivalent=9.0,
             snow_depth=26.0,


### PR DESCRIPTION
## Root cause
The enriched SNOTEL producer contract now requires `SnowObservation.state`, but the bridge row parser and direct unit-test fixtures still constructed observations without that field.

## Tests vs bridge changes
Fixed the bridge where production parsing was genuinely missing the required `state`: observations now use station metadata, with triplet-derived state as fallback. Updated stale unit fixtures/assertions to pass and verify realistic state value `CO`.

## Validation
- `python -m pytest feeders\snotel\tests -q -p no:cacheprovider --no-cov` → 64 passed
- Code-review specialist: no blockers for changed test/bridge files

Closes #692
