### PR TITLE
docs(container): clear ARM/CONTAINER.md drift for wallonia-issep, wikimedia-eventstreams, xceed

### DIFF
--- a/feeders/wallonia-issep/CONTAINER.md
+++ b/feeders/wallonia-issep/CONTAINER.md
@@ -119,6 +119,29 @@ docker run --rm `
 - Re-emits reference data every 24 hours to keep downstream state temporally consistent
 - Continues past per-record errors and retries on the next cycle
 
+## Image contract
+
+All three images share the same operational contract:
+
+| Aspect | Value |
+| --- | --- |
+| Base image | `python:3.10-slim` |
+| Default entry point | `python -m wallonia_issep_{kafka,mqtt,amqp} feed` (the Kafka image runs `python -m wallonia_issep feed`) |
+| Default user | root (no `USER` directive) |
+| Exposed ports | none — the feeder is an outbound publisher only |
+| Health check | none defined; treat process liveness as health |
+| Signals | terminates cleanly on `SIGTERM`; the polling loop flushes producers before exit |
+| Persistent state | `STATE_FILE` (default `~/.wallonia_issep_state.json`, or `~/.wallonia_issep_mqtt_state.json` for the MQTT image). **Mount a volume** to keep dedupe state across restarts. |
+| Image tags | `:latest` tracks the default branch; immutable tags `:v<MAJOR>.<MINOR>.<PATCH>` and `:sha-<git-sha>` are published per release. |
+
+| Image | Transport | Base Dockerfile | State share required |
+| --- | --- | --- | --- |
+| `real-time-sources-wallonia-issep:latest` | Kafka / Event Hubs | `Dockerfile` | yes (`STATE_FILE`) |
+| `real-time-sources-wallonia-issep-mqtt:latest` | MQTT 5 / UNS | `Dockerfile.mqtt` | yes (`STATE_FILE`) |
+| `real-time-sources-wallonia-issep-amqp:latest` | AMQP 1.0 | `Dockerfile.amqp` | yes (`STATE_FILE`) |
+
+Pull and inspect available tags at <https://github.com/clemensv/real-time-sources/pkgs/container/real-time-sources-wallonia-issep-kafka>.
+
 ## Deploying into Azure Container Instances
 
 You can deploy this bridge directly to Azure Container Instances. Two deployment

--- a/feeders/wikimedia-eventstreams/CONTAINER.md
+++ b/feeders/wikimedia-eventstreams/CONTAINER.md
@@ -89,6 +89,7 @@ docker run --rm   -e AMQP_BROKER_URL="amqp://<user>:<password>@<broker>:5672/wik
 | `KAFKA_TOPIC` | Core configuration for this image variant. |
 | `WIKIMEDIA_EVENTSTREAMS_USER_AGENT` | Core configuration for this image variant. |
 | `WIKIMEDIA_EVENTSTREAMS_STATE_FILE` | Core configuration for this image variant. |
+| `WIKIMEDIA_EVENTSTREAMS_FLUSH_INTERVAL` | Number of recentchange events to buffer before flushing the producer (default `250`). Lower values reduce end-to-end latency; higher values improve throughput. |
 | `WIKIMEDIA_EVENTSTREAMS_DEDUPE_SIZE` | Core configuration for this image variant. |
 | `WIKIMEDIA_EVENTSTREAMS_MAX_RETRY_DELAY` | Core configuration for this image variant. |
 

--- a/feeders/xceed/CONTAINER.md
+++ b/feeders/xceed/CONTAINER.md
@@ -91,6 +91,7 @@ docker run --rm   -e AMQP_BROKER_URL="amqp://<user>:<password>@<broker>:5672/xce
 | `EVENT_REFRESH_INTERVAL` | Core configuration for this image variant. |
 | `EVENT_WINDOW_SIZE` | Core configuration for this image variant. |
 | `EVENT_PAGE_SIZE` | Core configuration for this image variant. |
+| `XCEED_STATE_FILE` | Container path for persistent feeder state. Set by the `azure-template*.json` deployments to `/mnt/bridge-state/xceed_state.json` on the mounted Azure Files share so state survives container restarts. |
 
 ### MQTT image (`ghcr.io/clemensv/real-time-sources-xceed-mqtt:latest`)
 


### PR DESCRIPTION
## Summary

Clears the CONTAINER.md ↔ ARM template documentation-drift warnings flagged by the feeder-release-checklist ARM static auditor (`tools/validate-arm-templates.ps1`) for three feeders. Doc-only changes; no code, schema, or generated-template edits.

| Feeder | Warning cleared | Fix |
|---|---|---|
| wallonia-issep | `missing-image-contract` | Added the gold-standard **Image contract** table (mirrors `pegelonline`) |
| wikimedia-eventstreams | `container-md-drift` (FLUSH_INTERVAL) | Documented `WIKIMEDIA_EVENTSTREAMS_FLUSH_INTERVAL` in the Kafka env-var table |
| xceed | `container-md-drift` (STATE_FILE) | Documented `XCEED_STATE_FILE` deployment-provided state mount path |

## Verification

`pwsh tools/validate-arm-templates.ps1 -FeederSlug <slug>` for each feeder — the targeted `container-md-drift` / `missing-image-contract` warnings are now **gone**; all three remain `Blockers: 0`.

## Out of scope (generator-level, deferred)

- **`stub-description: eventHubSku`** — appears fleet-wide on every feeder shipping an Event Hubs template; a generator template issue, not per-feeder doc drift.
- **wikimedia-eventstreams `env-var-missing`** — the eventhub/kafka ARM templates do not expose several tuning env vars (`STATE_FILE`, `FLUSH_INTERVAL`, `DEDUPE_SIZE`, `MAX_RETRY_DELAY`, `USER_AGENT`, `MAX_EVENTS`, `MOCK`, `URL`). These are WARNINGs (non-blocking); fixing them means regenerating ARM templates, which belongs in a generator-level change, not a doc PR.

## Note on related audit findings

The `missing-file` ERRORs for `xreg`/`kql` in the wallonia-issep and wikimedia-eventstreams audit issues are **false positives**: the audit looks for hyphenated filenames (`wallonia-issep.xreg.json`) but the actual files use underscores (`wallonia_issep.xreg.json`). Same pattern as the rss false positive.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
