### PR TITLE
Fix arm-stub-description: sync eventHubSku/queueName descriptions fleet-wide

### DIFF
--- a/feeders/nve-hydro/azure-template-with-eventhub.json
+++ b/feeders/nve-hydro/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives nve-hydro CloudEvents."
       }
     },
     "location": {

--- a/feeders/nve-hydro/azure-template-with-servicebus.json
+++ b/feeders/nve-hydro/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default nve-hydro)."
       }
     },
     "imageName": {

--- a/feeders/nve-hydro/infra/azure-template-amqp.json
+++ b/feeders/nve-hydro/infra/azure-template-amqp.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default nve-hydro)."
       }
     },
     "imageName": {

--- a/feeders/pegelonline/azure-template-with-eventhub.json
+++ b/feeders/pegelonline/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives pegelonline CloudEvents."
       }
     },
     "location": {

--- a/feeders/rss/azure-template-with-eventhub.json
+++ b/feeders/rss/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives rss CloudEvents."
       }
     },
     "location": {

--- a/feeders/rws-waterwebservices/azure-template-with-eventhub.json
+++ b/feeders/rws-waterwebservices/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives rws-waterwebservices CloudEvents."
       }
     },
     "location": {

--- a/feeders/rws-waterwebservices/azure-template-with-servicebus.json
+++ b/feeders/rws-waterwebservices/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default rws-waterwebservices)."
       }
     },
     "imageName": {

--- a/feeders/rws-waterwebservices/infra/azure-template-amqp.json
+++ b/feeders/rws-waterwebservices/infra/azure-template-amqp.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default rws-waterwebservices)."
       }
     },
     "imageName": {

--- a/feeders/snotel/azure-template-with-eventhub.json
+++ b/feeders/snotel/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives snotel CloudEvents."
       }
     },
     "location": {

--- a/feeders/snotel/azure-template-with-servicebus.json
+++ b/feeders/snotel/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default snotel)."
       }
     },
     "imageName": {

--- a/feeders/syke-hydro/azure-template-with-eventhub.json
+++ b/feeders/syke-hydro/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives syke-hydro CloudEvents."
       }
     },
     "location": {

--- a/feeders/syke-hydro/azure-template-with-servicebus.json
+++ b/feeders/syke-hydro/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default syke-hydro)."
       }
     },
     "imageName": {

--- a/feeders/ticketmaster/azure-template-with-eventhub.json
+++ b/feeders/ticketmaster/azure-template-with-eventhub.json
@@ -40,7 +40,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives ticketmaster CloudEvents."
       },
       "type": "string",
       "defaultValue": "Standard"

--- a/feeders/usgs-nwis-wq/azure-template-with-eventhub.json
+++ b/feeders/usgs-nwis-wq/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives usgs-nwis-wq CloudEvents."
       }
     },
     "location": {

--- a/feeders/usgs-nwis-wq/azure-template-with-servicebus.json
+++ b/feeders/usgs-nwis-wq/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default usgs-nwis-wq)."
       }
     },
     "imageName": {

--- a/feeders/wallonia-issep/azure-template-with-eventhub.json
+++ b/feeders/wallonia-issep/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives wallonia-issep CloudEvents."
       }
     },
     "location": {

--- a/feeders/waterinfo-vmm/azure-template-with-eventhub.json
+++ b/feeders/waterinfo-vmm/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives waterinfo-vmm CloudEvents."
       }
     },
     "location": {

--- a/feeders/waterinfo-vmm/azure-template-with-servicebus.json
+++ b/feeders/waterinfo-vmm/azure-template-with-servicebus.json
@@ -38,7 +38,7 @@
       "minLength": 1,
       "maxLength": 50,
       "metadata": {
-        "description": "AMQP node/address name."
+        "description": "AMQP node (queue / topic) name (default waterinfo-vmm)."
       }
     },
     "imageName": {

--- a/feeders/wikimedia-eventstreams/azure-template-with-eventhub.json
+++ b/feeders/wikimedia-eventstreams/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives wikimedia-eventstreams CloudEvents."
       }
     },
     "location": {

--- a/feeders/wikimedia-osm-diffs/azure-template-with-eventhub.json
+++ b/feeders/wikimedia-osm-diffs/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives wikimedia-osm-diffs CloudEvents."
       }
     },
     "location": {

--- a/feeders/wsdot/azure-template-with-eventhub.json
+++ b/feeders/wsdot/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives wsdot CloudEvents."
       }
     },
     "location": {

--- a/feeders/xceed/azure-template-with-eventhub.json
+++ b/feeders/xceed/azure-template-with-eventhub.json
@@ -22,7 +22,7 @@
         "Standard"
       ],
       "metadata": {
-        "description": "Event Hub namespace SKU."
+        "description": "Event Hubs namespace SKU for the broker that receives xceed CloudEvents."
       }
     },
     "location": {

--- a/tools/generate-arm-templates.py
+++ b/tools/generate-arm-templates.py
@@ -48,6 +48,9 @@ IMAGE_SUFFIXES = {
 }
 
 FRAMEWORK_ENV_NAMES = {"LOG_LEVEL", "PYTHONUNBUFFERED"}
+# Infra parameters whose authoritative description lives in the variant
+# reference template (not CONTAINER.md). Synced to every feeder on regen.
+INFRA_REFERENCE_PARAMS = ("eventHubSku", "queueName")
 GENERIC_DESCRIPTION_PATTERNS = (
     re.compile(r"^[A-Z0-9_]+ configuration value\.?$", re.IGNORECASE),
     re.compile(r"^Core configuration for this image variant\.?$", re.IGNORECASE),
@@ -536,9 +539,11 @@ def refresh_existing_template_descriptions(
     generated_targets: set[Path],
     staged_writes: dict[Path, dict[str, Any]],
     filters: set[str] | None,
+    references: dict[str, dict[str, Any]] | None = None,
 ) -> int:
     updated = 0
     source_cache: dict[str, dict[str, tuple[str, str]]] = {}
+    references = references or {}
     for path in (repo_root / "feeders").glob("**/azure-template*.json"):
         if path in generated_targets:
             continue
@@ -574,6 +579,29 @@ def refresh_existing_template_descriptions(
                     metadata["description"] = description
                     changed = True
                     DESCRIPTION_SOURCE_COUNTS[source] += 1
+        # Infrastructure parameters (eventHubSku, queueName) are not driven by
+        # CONTAINER.md env-var descriptions; their authoritative description
+        # lives in the variant reference template. Sync this whitelist so
+        # reference-level description fixes propagate to every feeder on
+        # regeneration. Scoped to known-stub infra params to avoid clobbering
+        # richer per-param descriptions that already exist downstream.
+        try:
+            variant = variant_from_template(path.name)
+        except ValueError:
+            variant = None
+        ref_params = references.get(variant, {}).get("parameters", {}) if variant else {}
+        for param_name in INFRA_REFERENCE_PARAMS:
+            if param_name not in parameters or param_name not in ref_params:
+                continue
+            ref_desc = ref_params[param_name].get("metadata", {}).get("description")
+            if not ref_desc:
+                continue
+            description = recursively_replace_aisstream(ref_desc, slug)
+            metadata = parameters[param_name].setdefault("metadata", {})
+            if metadata.get("description") != description:
+                metadata["description"] = description
+                changed = True
+                DESCRIPTION_SOURCE_COUNTS["reference"] += 1
         if changed:
             staged_writes[path] = template
             updated += 1
@@ -635,7 +663,7 @@ def main() -> int:
 
     existing_updated = 0
     if not args.dry_run:
-        existing_updated = refresh_existing_template_descriptions(repo_root, generated_targets, staged_writes, filters)
+        existing_updated = refresh_existing_template_descriptions(repo_root, generated_targets, staged_writes, filters, references)
 
     generated_count = len(generated_targets)
     written = commit_staged_writes(repo_root, staged_writes, args.dry_run)


### PR DESCRIPTION
## Summary

Clears the fleet-wide `arm-stub-description` warning flagged by the audit
issues (#678–#710) for the two infrastructure ARM parameters `eventHubSku`
and `queueName`.

The ARM static auditor (`tools/validate-arm-templates.ps1`,
`Test-StubDescription`) treats any `metadata.description` shorter than 25
characters as a stub. Across the fleet these two infra params were stale
stubs:

- `eventHubSku` → `"Event Hub namespace SKU."` (24 chars)
- `queueName` → `"AMQP node/address name."` (23 chars)

### Root cause

`refresh_existing_template_descriptions()` in
`tools/generate-arm-templates.py` only synced **env-var-driven** parameter
descriptions (sourced from `CONTAINER.md`). It never synced **infra**
parameters whose authoritative description lives in the canonical
**aisstream** variant reference templates, so reference-level description
improvements never propagated to already-generated feeders.

### Fix

- **Generator:** add `INFRA_REFERENCE_PARAMS = ("eventHubSku", "queueName")`
  and a second sync pass that resolves each existing template's variant,
  looks up the slug-substituted reference description, and applies it. The
  variant reference is now authoritative for these two params, so future
  regenerations keep them non-stub. Scoped to exactly these two params to
  avoid clobbering richer per-param descriptions (e.g. `mqttTopicRoot`,
  `imageName`) and to avoid leaking the pre-existing `serviceBusSku`
  reference typo.
- **Templates:** apply the same slug-substituted description to the 22
  affected templates **in place** (description-only, no reformatting),
  matching the generator output exactly.

### Verification

- `pwsh tools/validate-arm-templates.ps1` → `stub-description` warnings for
  `eventHubSku`/`queueName` are **zero** fleet-wide.
- `pwsh tools/validate-arm-templates.ps1 -FeederSlug nve-hydro` →
  `Blockers: 0  Warnings: 0  PASS`.
- `python tools/generate-arm-templates.py --filter nve-hydro` produces **no
  net diff** on the fixed lines — generator output and the in-place edits
  are consistent.
- Diff is strictly description-only: every changed template is `1 insertion
  / 1 deletion`.

### Scope

23 files: `tools/generate-arm-templates.py` + 22 `azure-template-*.json`
(eventhub / servicebus / amqp variants). Description-only; no resource,
parameter-shape, or env-wiring changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
