### PR TITLE
fix(xreg): JsonStructure schema spec-compliance for updated json-structure SDK

### DIFF
--- a/feeders/carbon-intensity/xreg/carbon_intensity.xreg.json
+++ b/feeders/carbon-intensity/xreg/carbon_intensity.xreg.json
@@ -253,7 +253,7 @@
             "1": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$id": "uk.org.carbonintensity.Intensity",
+                "$id": "https://api.carbonintensity.org.uk/schemas/Intensity",
                 "type": "object",
                 "description": "National half-hourly carbon intensity for the Great Britain electricity grid, published by National Grid ESO. Contains the forecast and actual carbon dioxide emission intensity in grams of CO2 per kilowatt-hour, along with a qualitative index band.",
                 "properties": {
@@ -317,7 +317,7 @@
             "1": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$id": "uk.org.carbonintensity.GenerationMix",
+                "$id": "https://api.carbonintensity.org.uk/schemas/GenerationMix",
                 "type": "object",
                 "description": "National half-hourly electricity generation fuel mix for Great Britain, published by National Grid ESO. Each field represents the percentage contribution of a specific fuel type to total generation during the settlement period.",
                 "properties": {
@@ -438,7 +438,7 @@
             "1": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$id": "uk.org.carbonintensity.RegionalIntensity",
+                "$id": "https://api.carbonintensity.org.uk/schemas/RegionalIntensity",
                 "type": "object",
                 "description": "Half-hourly carbon intensity and generation mix for one of the 17 GB Distribution Network Operator (DNO) regions, published by National Grid ESO. Each record covers a specific DNO region identified by its numeric region ID.",
                 "properties": {

--- a/feeders/eaws-albina/xreg/eaws_albina.xreg.json
+++ b/feeders/eaws-albina/xreg/eaws_albina.xreg.json
@@ -179,6 +179,7 @@
               "format": "JsonStructure/draft-02",
               "schema": {
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://static.avalanche.report/schemas/AvalancheBulletin",
                 "type": "object",
                 "name": "AvalancheBulletin",
                 "required": [
@@ -310,6 +311,7 @@
               "format": "JsonStructure/draft-02",
               "schema": {
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "$id": "https://static.avalanche.report/schemas/AvalancheRegion",
                 "type": "object",
                 "name": "AvalancheRegion",
                 "description": "Reference event describing an EAWS region (or super-region) that the bridge is configured to observe. Emitted at bridge startup and whenever the configured region set changes. Acts as the catalog backbone for downstream consumers, ensuring the regional context is available even outside the avalanche season when no bulletins are being published.",

--- a/feeders/rss/xreg/feeds.xreg.json
+++ b/feeders/rss/xreg/feeds.xreg.json
@@ -292,7 +292,9 @@
                             "contributors": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemAuthor"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemAuthor"
+                                }
                               },
                               "default": null,
                               "description": "A list of contributors to the source feed."
@@ -315,7 +317,9 @@
                             "links": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/Link"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/Link"
+                                }
                               },
                               "default": null,
                               "description": "A collection of links related to the source feed."
@@ -455,7 +459,9 @@
                             "content": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemContent"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemContent"
+                                }
                               },
                               "default": null,
                               "description": "The content of the feed item, potentially including multiple formats."
@@ -463,7 +469,9 @@
                             "enclosures": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemEnclosure"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemEnclosure"
+                                }
                               },
                               "default": null,
                               "description": "Media attachments associated with the feed item."
@@ -510,7 +518,9 @@
                             "contributors": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemAuthor"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/FeedItemAuthor"
+                                }
                               },
                               "default": null,
                               "description": "A list of individuals who contributed to the feed item."
@@ -518,7 +528,9 @@
                             "links": {
                               "type": "array",
                               "items": {
-                                "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/Link"
+                                "type": {
+                                  "$ref": "#/definitions/Microsoft/OpenData/RssFeeds/Link"
+                                }
                               },
                               "default": null,
                               "description": "A collection of links related to the feed item."

--- a/feeders/usgs-nwis-wq/xreg/usgs_nwis_wq.xreg.json
+++ b/feeders/usgs-nwis-wq/xreg/usgs_nwis_wq.xreg.json
@@ -254,7 +254,7 @@
             "1.0": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$id": "gov.usgs.waterservices.wq.MonitoringSite",
+                "$id": "https://waterservices.usgs.gov/schemas/wq/MonitoringSite",
                 "type": "object",
                 "name": "MonitoringSite",
                 "description": "USGS water quality monitoring site. Describes a physical surface-water or groundwater monitoring location equipped with continuous water quality sensors. Site metadata is extracted from the WaterML 2.0 JSON response sourceInfo block returned by the USGS Instantaneous Values Service.",
@@ -325,7 +325,7 @@
             "1.0": {
               "format": "JsonStructure/draft-02",
               "schema": {
-                "$id": "gov.usgs.waterservices.wq.WaterQualityReading",
+                "$id": "https://waterservices.usgs.gov/schemas/wq/WaterQualityReading",
                 "type": "object",
                 "name": "WaterQualityReading",
                 "description": "A single water quality observation from a USGS continuous monitoring sensor. The USGS Instantaneous Values Service returns time series of sensor readings in WaterML 2.0 JSON format. Each reading represents one measurement at a specific date_time for one parameter at one site.",


### PR DESCRIPTION
## Summary

The json-structure SDK was updated, tightening its schema-core validator. Running
the updated validator across all **105** feeder xreg manifests surfaced **13 genuine
JSON Structure spec violations in 4 feeders**. This PR fixes them. No false positives
were worked around — every fix brings a real schema into spec compliance.

| Feeder | Count | Rule violated | Fix |
|---|---|---|---|
| carbon-intensity | 3 | `$id` must be an absolute URI | `uk.org.carbonintensity.{Intensity,GenerationMix,RegionalIntensity}` → `https://api.carbonintensity.org.uk/schemas/{...}` |
| usgs-nwis-wq | 2 | `$id` must be an absolute URI | `gov.usgs.waterservices.wq.{MonitoringSite,WaterQualityReading}` → `https://waterservices.usgs.gov/schemas/wq/{...}` |
| eaws-albina | 2 | root schema must declare `$id` | added `https://static.avalanche.report/schemas/{AvalancheBulletin,AvalancheRegion}` |
| rss | 6 | a `$ref` must appear under a `type` keyword | bare array `items: {"$ref": …}` → `items: {"type": {"$ref": …}}` |

## What is deliberately unchanged

- **Dotted xreg registry keys, CloudEvents `type` values, and `dataschemauri`
  pointers stay dotted.** In an xreg manifest the schema is registered under a
  dotted registry key that is independent of the JSON Structure `$id` inside the
  schema body. The validator only checks the internal `$id`, so only the literal
  `"$id"` lines were touched. Registry keys, `type` metadata values, subjects, and
  Kafka keys are all unchanged — **no contract/identity semantics change**.
- **The Avro schemagroups are untouched.** These rules are JsonStructure-specific.

## Codegen impact — verified neutral, producers intentionally not regenerated

These changes do **not** alter generated producer output:

- `$id` is schema metadata; avrotize/xrcg dataclass generation keys off `name`, not `$id`.
- The rss `$ref`-in-`type` wrapping resolves to the **same** referenced type.

I verified this empirically: regenerated the rss Kafka producer from the **original**
manifest and from the **fixed** manifest (both with the pinned **xrcg 0.10.11**) and
diffed the two outputs. The only differences are non-deterministic generation noise
(random sample values, random sample array lengths, import ordering); **all dataclass
field definitions and types are identical**.

Regenerating the checked-in producers would instead introduce a large **xrcg version
drift** diff (the committed producers predate 0.10.11) unrelated to this fix, so they
are intentionally left as-is to keep the PR surgical. A fleet-wide producer
regeneration to 0.10.11 is a separate concern.

## Validation evidence

```
Scanning 105 xreg manifests with json-structure SDK...
No schema-core ERRORS across the fleet.
TOTAL: 0 errors, 0 warnings across 105 manifests
```

(Before this PR: 13 errors across the 4 feeders above.)

`git diff --stat`:
```
 feeders/carbon-intensity/xreg/carbon_intensity.xreg.json |  6 +++---
 feeders/eaws-albina/xreg/eaws_albina.xreg.json           |  2 ++
 feeders/rss/xreg/feeds.xreg.json                         | 24 +++++++++++++------
 feeders/usgs-nwis-wq/xreg/usgs_nwis_wq.xreg.json         |  4 ++--
```

## Mandatory expert review (contract-touching change)

Per repo policy, contract changes require sign-off from **xRegistry Expert**,
**JSON Structure Expert**, and **Avro Schema Expert**. These are mechanical
spec-compliance fixes that the updated SDK now enforces; reviewer verdicts will be
recorded here before merge. The changes do not alter keys, subjects, identity shapes,
event types, or the Avro schemagroups.
