### PR TITLE
ci(docker-e2e): shard build/flow matrices to dodge 256-job cap (#774)

### DIFF
--- a/.github/workflows/_docker-build-shard.yml
+++ b/.github/workflows/_docker-build-shard.yml
@@ -1,0 +1,36 @@
+name: _docker-build-shard
+
+# Reusable workflow: builds + import-checks one shard of the Docker E2E build
+# matrix. Called once per shard by test-docker-e2e.yml so the combined matrix
+# can exceed GitHub Actions' 256-job-per-matrix limit. An empty shard (the
+# `{include: []}` shape) skips via the job-level `if` guard.
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: JSON matrix ({include:[...]}) for this build shard.
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Docker Build & Import
+    if: ${{ inputs.matrix != '' && fromJson(inputs.matrix).include[0] != null }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix: ${{ fromJson(inputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: |
+          docker build -t test-${{ matrix.image || matrix.module }} -f ./${{ matrix.dir }}/${{ matrix.file || 'Dockerfile' }} ./${{ matrix.dir }}
+
+      - name: Verify module imports
+        run: |
+          docker run --rm test-${{ matrix.image || matrix.module }} \
+            python -c "import ${{ matrix.module }}; print('OK')"

--- a/.github/workflows/_docker-flow-shard.yml
+++ b/.github/workflows/_docker-flow-shard.yml
@@ -1,0 +1,49 @@
+name: _docker-flow-shard
+
+# Reusable workflow: runs the Kafka flow E2E tests for one shard of the Docker
+# E2E flow matrix. Called once per shard by test-docker-e2e.yml so the combined
+# matrix can exceed GitHub Actions' 256-job-per-matrix limit. An empty shard
+# (the `{include: []}` shape) skips via the job-level `if` guard.
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: JSON matrix ({include:[...]}) for this flow shard.
+        required: true
+        type: string
+    secrets:
+      WSDOT_ACCESS_CODE:
+        required: false
+
+jobs:
+  flow:
+    name: Docker Kafka Flow
+    if: ${{ inputs.matrix != '' && fromJson(inputs.matrix).include[0] != null }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix: ${{ fromJson(inputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install test dependencies
+        run: pip install -r tests/docker_e2e/requirements.txt
+
+      - name: Run Kafka flow test
+        run: |
+          pytest tests/docker_e2e/${{ matrix.test_file || 'test_docker_kafka_flow.py' }} \
+            -v --timeout=600 \
+            -k "${{ matrix.test_class }}" \
+            --tb=long
+        timeout-minutes: 10
+        env:
+          WSDOT_ACCESS_CODE: ${{ secrets.WSDOT_ACCESS_CODE }}

--- a/.github/workflows/test-docker-e2e.yml
+++ b/.github/workflows/test-docker-e2e.yml
@@ -21,8 +21,14 @@ jobs:
     name: Discover affected feeders
     runs-on: ubuntu-latest
     outputs:
-      build_matrix: ${{ steps.compute.outputs.build_matrix }}
-      flow_matrix: ${{ steps.compute.outputs.flow_matrix }}
+      build_matrix_0: ${{ steps.compute.outputs.build_matrix_0 }}
+      build_matrix_1: ${{ steps.compute.outputs.build_matrix_1 }}
+      build_matrix_2: ${{ steps.compute.outputs.build_matrix_2 }}
+      build_matrix_3: ${{ steps.compute.outputs.build_matrix_3 }}
+      flow_matrix_0: ${{ steps.compute.outputs.flow_matrix_0 }}
+      flow_matrix_1: ${{ steps.compute.outputs.flow_matrix_1 }}
+      flow_matrix_2: ${{ steps.compute.outputs.flow_matrix_2 }}
+      flow_matrix_3: ${{ steps.compute.outputs.flow_matrix_3 }}
       full_run: ${{ steps.compute.outputs.full_run }}
       reason: ${{ steps.compute.outputs.reason }}
     steps:
@@ -62,55 +68,24 @@ jobs:
         run: python tests/docker_e2e/discover_matrix.py
 
   docker-build:
-    name: Docker Build & Import
+    name: Build shard ${{ matrix.shard }}
     needs: discover
-    if: ${{ needs.discover.outputs.build_matrix != '' && fromJson(needs.discover.outputs.build_matrix).include[0] != null }}
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix: ${{ fromJson(needs.discover.outputs.build_matrix) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Build Docker image
-        run: |
-          docker build -t test-${{ matrix.image || matrix.module }} -f ./${{ matrix.dir }}/${{ matrix.file || 'Dockerfile' }} ./${{ matrix.dir }}
-
-      - name: Verify module imports
-        run: |
-          docker run --rm test-${{ matrix.image || matrix.module }} \
-            python -c "import ${{ matrix.module }}; print('OK')"
+      matrix:
+        shard: [0, 1, 2, 3]
+    uses: ./.github/workflows/_docker-build-shard.yml
+    with:
+      matrix: ${{ needs.discover.outputs[format('build_matrix_{0}', matrix.shard)] }}
 
   docker-kafka-flow:
-    name: Docker Kafka Flow
-    needs: [discover, docker-build]
-    if: ${{ always() && needs.docker-build.result != 'failure' && needs.discover.outputs.flow_matrix != '' && fromJson(needs.discover.outputs.flow_matrix).include[0] != null }}
-    runs-on: ubuntu-latest
+    name: Flow shard ${{ matrix.shard }}
+    needs: discover
     strategy:
       fail-fast: false
-      max-parallel: 20
-      matrix: ${{ fromJson(needs.discover.outputs.flow_matrix) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Install test dependencies
-        run: pip install -r tests/docker_e2e/requirements.txt
-
-      - name: Run Kafka flow test
-        run: |
-          pytest tests/docker_e2e/${{ matrix.test_file || 'test_docker_kafka_flow.py' }} \
-            -v --timeout=600 \
-            -k "${{ matrix.test_class }}" \
-            --tb=long
-        timeout-minutes: 10
-        env:
-          WSDOT_ACCESS_CODE: ${{ secrets.WSDOT_ACCESS_CODE }}
+      matrix:
+        shard: [0, 1, 2, 3]
+    uses: ./.github/workflows/_docker-flow-shard.yml
+    with:
+      matrix: ${{ needs.discover.outputs[format('flow_matrix_{0}', matrix.shard)] }}
+    secrets: inherit

--- a/tests/docker_e2e/discover_matrix.py
+++ b/tests/docker_e2e/discover_matrix.py
@@ -8,10 +8,12 @@ Inputs (env):
   HEAD_SHA      : head SHA (optional; defaults to HEAD).
 
 Outputs (GITHUB_OUTPUT):
-  build_matrix  : JSON object {include: [...]}
-  flow_matrix   : JSON object {include: [...]}
-  full_run      : "true" or "false"
-  reason        : short human-readable reason.
+  build_matrix    : JSON object {include: [...]} (full, legacy/debug)
+  flow_matrix     : JSON object {include: [...]} (full, legacy/debug)
+  build_matrix_<n>: JSON object {include: [...]} per shard (0..SHARD_COUNT-1)
+  flow_matrix_<n> : JSON object {include: [...]} per shard (0..SHARD_COUNT-1)
+  full_run        : "true" or "false"
+  reason          : short human-readable reason.
 
 Logic:
   - If event is workflow_dispatch/schedule, or any changed file matches an
@@ -37,6 +39,17 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 MATRIX_PATH = ROOT / "tests" / "docker_e2e" / "matrix.json"
+
+# GitHub Actions hard-limits a single matrix to 256 jobs. The full feeder
+# matrix (build + flow) has outgrown that, so on a force_full run the matrix
+# can no longer instantiate as one strategy. We therefore split each section
+# into a fixed number of shards and emit one matrix output per shard
+# (build_matrix_0..N-1 / flow_matrix_0..N-1); the workflow fans these out to
+# parallel reusable-workflow calls. Entries fill shards sequentially up to
+# SHARD_CAP so that scoped (few-feeder) runs stay compact in shard 0 and only
+# spill into later shards when the full matrix runs.
+SHARD_COUNT = 4
+SHARD_CAP = 250  # < 256 GitHub limit, leaves headroom inside each shard
 
 # Anything under these paths invalidates per-feeder scoping and forces full
 # run UNLESS the change is purely additive (handled per-file below).
@@ -272,6 +285,26 @@ def _load_changed_files() -> list[str]:
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
+def shard_entries(entries: list) -> list[list]:
+    """Split entries into SHARD_COUNT shards, filling sequentially up to
+    SHARD_CAP per shard so scoped runs stay in shard 0. Raises if the total
+    exceeds the total capacity (SHARD_COUNT * SHARD_CAP), which signals that
+    SHARD_COUNT must be increased (and matching jobs added to the workflow)."""
+    shards: list[list] = [[] for _ in range(SHARD_COUNT)]
+    for i, entry in enumerate(entries):
+        idx = i // SHARD_CAP
+        if idx >= SHARD_COUNT:
+            raise SystemExit(
+                f"[discover] matrix section has {len(entries)} entries, "
+                f"exceeding capacity {SHARD_COUNT * SHARD_CAP} "
+                f"(SHARD_COUNT={SHARD_COUNT} x SHARD_CAP={SHARD_CAP}). "
+                f"Increase SHARD_COUNT and add matching shard jobs to "
+                f"test-docker-e2e.yml."
+            )
+        shards[idx].append(entry)
+    return shards
+
+
 def main() -> int:
     matrix = json.loads(MATRIX_PATH.read_text())
     event = os.environ.get("EVENT_NAME", "")
@@ -330,8 +363,14 @@ def main() -> int:
 
     emit("full_run", "true" if force_full else "false")
     emit("reason", reason)
+    # Legacy single-matrix outputs (kept for debugging / external consumers).
     emit("build_matrix", json.dumps({"include": build}))
     emit("flow_matrix", json.dumps({"include": flow}))
+    # Sharded outputs consumed by the workflow (build_matrix_<n> / flow_matrix_<n>).
+    for n, chunk in enumerate(shard_entries(build)):
+        emit(f"build_matrix_{n}", json.dumps({"include": chunk}))
+    for n, chunk in enumerate(shard_entries(flow)):
+        emit(f"flow_matrix_{n}", json.dumps({"include": chunk}))
 
     print(f"[discover] full_run={force_full} reason={reason}", file=sys.stderr)
     print(


### PR DESCRIPTION
## Summary

Fixes **#774**. The full feeder Docker E2E matrix has outgrown GitHub Actions'
hard limit of **256 jobs per matrix** (currently build=315 / flow=338). On a
`force_full` run the matrix strategy could no longer instantiate, so the
`docker-build` job failed to start and `docker-kafka-flow` was skipped — the
E2E gate effectively never ran on full-matrix runs.

## What changed

- **`tests/docker_e2e/discover_matrix.py`** — in addition to the legacy
  `build_matrix` / `flow_matrix` outputs (kept for debugging), now emits
  per-shard outputs `build_matrix_0..3` / `flow_matrix_0..3`.
  `SHARD_COUNT=4`, `SHARD_CAP=250` (< 256, with headroom). Entries fill shards
  **sequentially** so scoped (few-feeder) runs stay compact in shard 0 and only
  spill into later shards on a full run. `shard_entries()` raises an actionable
  `SystemExit` if the total ever exceeds `SHARD_COUNT * SHARD_CAP` (= 1000).
- **`.github/workflows/_docker-build-shard.yml`** (new) — reusable workflow that
  builds + import-checks one build shard; empty shards skip via an
  `include[0] != null` guard.
- **`.github/workflows/_docker-flow-shard.yml`** (new) — reusable workflow that
  runs the Kafka flow tests for one flow shard; same empty-shard guard;
  `WSDOT_ACCESS_CODE` passed through as a non-required secret.
- **`.github/workflows/test-docker-e2e.yml`** — `discover` now exposes the 8
  sharded outputs; `docker-build` and `docker-kafka-flow` become 4-way
  (`shard: [0,1,2,3]`) `uses:` fan-outs into the reusable workflows via
  `needs.discover.outputs[format('build_matrix_{0}', matrix.shard)]`. The flow
  job now depends only on `discover` (the flow test rebuilds its own image via
  the pytest fixture, so the old cross-job `needs: docker-build` gate was
  redundant).

## Validation (local)

Ran `discover_matrix.py` with `force_full` and asserted:

```
build full=315  shards=[250,65,0,0]  sum=315  max=250
flow  full=338  shards=[250,88,0,0]  sum=338  max=250
OK: shard unions == full lists, every shard < 256
```

All three workflow YAMLs parse (`yaml.safe_load`). The matrixed reusable-workflow
`uses:` + `format()` output indexing is valid Actions expression syntax and is
exercised by this PR's own CI run.

## Reviewer notes

- If branch-protection required-status-check names reference the old
  `Docker Build & Import` / `Docker Kafka Flow` job names directly, they may
  need updating to the reusable-workflow check names — a repo-admin follow-up.
- This is **orthogonal** to the scoped-run zero-jobs bug (`top_dir()` returns the
  bare feeder name while `matrix.dir` is `feeders/<name>`), which is filed and
  fixed separately to keep one issue per PR.

Closes #774.
