### PR TITLE
ci(docker-e2e): fix scoped runs selecting zero feeder jobs (#777)

### DIFF
--- a/tests/docker_e2e/discover_matrix.py
+++ b/tests/docker_e2e/discover_matrix.py
@@ -69,7 +69,11 @@ def is_additive_candidate(path: str) -> bool:
 def top_dir(path: str) -> str:
     parts = path.split("/")
     if len(parts) >= 2 and parts[0] == "feeders":
-        return parts[1]
+        # matrix.json entries use dir="feeders/<name>" (since feeders were
+        # moved under feeders/), so we must return the same prefixed form for
+        # the scoped filter `m["dir"] in touched_dirs` to match. Returning the
+        # bare name silently scoped every feeder change to zero jobs.
+        return f"feeders/{parts[1]}"
     return parts[0]
 
 

--- a/tests/docker_e2e/test_discover_matrix.py
+++ b/tests/docker_e2e/test_discover_matrix.py
@@ -1,0 +1,96 @@
+"""Regression tests for tests/docker_e2e/discover_matrix.py scoping.
+
+Guards against the prefix-mismatch bug where ``top_dir`` returned the bare
+feeder name (``aisstream``) while ``matrix.json`` entries use the prefixed
+form (``feeders/aisstream``), causing every scoped feeder change to select
+zero build/flow jobs and silently pass the Docker E2E gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+MODULE_PATH = HERE / "discover_matrix.py"
+MATRIX_PATH = HERE / "matrix.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("discover_matrix", MODULE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dm = _load_module()
+
+
+def _parse_github_output(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    vals: dict[str, str] = {}
+    multi = re.compile(r"^(\w+)<<EOF_MATRIX_OUT\n(.*?)\nEOF_MATRIX_OUT$", re.S | re.M)
+    for m in multi.finditer(text):
+        vals[m.group(1)] = m.group(2)
+    for line in text.splitlines():
+        if "<<" in line or line.startswith("EOF_MATRIX_OUT"):
+            continue
+        if "=" in line and not line.startswith("{"):
+            k, _, v = line.partition("=")
+            vals.setdefault(k, v)
+    return vals
+
+
+def test_top_dir_returns_feeders_prefixed_name():
+    # matrix.json dir entries are "feeders/<name>"; top_dir must match.
+    assert dm.top_dir("feeders/aisstream/aisstream/aisstream.py") == "feeders/aisstream"
+    assert dm.top_dir("feeders/dwd/Dockerfile") == "feeders/dwd"
+    # Non-feeder paths are returned as their first segment.
+    assert dm.top_dir("tools/ci/foo.py") == "tools"
+
+
+def test_top_dir_matches_matrix_dir_format():
+    matrix = json.loads(MATRIX_PATH.read_text())
+    sample = matrix["build"][0]["dir"]  # e.g. "feeders/aisstream"
+    feeder = sample.split("/", 1)[1]
+    assert dm.top_dir(f"{sample}/{feeder}/{feeder}.py") == sample
+
+
+def test_scoped_change_selects_that_feeders_jobs(tmp_path, monkeypatch):
+    matrix = json.loads(MATRIX_PATH.read_text())
+    target = matrix["build"][0]["dir"]  # "feeders/<name>"
+    feeder = target.split("/", 1)[1]
+    changed = f"{target}/{feeder}/{feeder}.py"
+
+    out = tmp_path / "gh_output"
+    out.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("EVENT_NAME", "push")
+    monkeypatch.setenv("CHANGED_FILES", changed)
+    monkeypatch.delenv("CHANGED_FILES_PATH", raising=False)
+
+    assert dm.main() == 0
+
+    vals = _parse_github_output(out)
+    assert vals["full_run"] == "false"
+    build = json.loads(vals["build_matrix"])["include"]
+    flow = json.loads(vals["flow_matrix"])["include"]
+
+    expected_build = [m for m in matrix["build"] if m["dir"] == target]
+    expected_flow = [m for m in matrix["flow"] if m["dir"] == target]
+
+    assert build == expected_build
+    assert flow == expected_flow
+    # The whole point: a real feeder change must select at least one job.
+    assert build, "scoped feeder change selected zero build jobs"
+    assert all(m["dir"] == target for m in build)
+    assert all(m["dir"] == target for m in flow)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Fixes the Docker E2E discovery bug where **feeder-only PRs scope to zero
build/flow jobs** and silently pass the gate.

`tests/docker_e2e/matrix.json` entries use `dir = "feeders/<name>"` (since
the feeders were moved under `feeders/`), but `top_dir()` in
`discover_matrix.py` returned the **bare** feeder name (`<name>`). The
scoped selector `m["dir"] in touched_dirs` therefore never matched any
`top_dir`-derived entry, so a PR that only touches a feeder selected **0
build / 0 flow** jobs and reported green without running any E2E.

This was observed live in a recent feeder PR run:

```
scoped to 0 build / 0 flow job(s): carbon-intensity, eaws-albina, rss, usgs-nwis-wq
```

## Fix

- `top_dir()` now returns `feeders/<name>` for `feeders/*` paths — the same
  form used by `matrix.json` `dir` and by the additive-infra scoping
  helpers (which already matched, masking the bug).
- Adds `tests/docker_e2e/test_discover_matrix.py`: unit-tests `top_dir`
  format and an integration test that sets `CHANGED_FILES` to a real
  feeder file and asserts the run scopes to exactly that feeder's build +
  flow entries (and selects at least one job).

## Validation

`python -m pytest tests/docker_e2e/test_discover_matrix.py -v` → 3 passed.

Orthogonal to #776 (matrix 256-job cap sharding).

Closes #777.
