### PR TITLE
Fix DWD measured-field nullability + precipitation_indicator int type (#775)

### DIFF
--- a/feeders/dwd/EVENTS.md
+++ b/feeders/dwd/EVENTS.md
@@ -141,10 +141,10 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`pressure_station_level`** (null or double, optional): Reference details for a station, monitoring site, or reporting area in the DWD Weather source.
-- **`air_temperature_2m`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`air_temperature_5cm`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`relative_humidity`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`dew_point_temperature`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_2m`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_5cm`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`relative_humidity`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`dew_point_temperature`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 
@@ -195,8 +195,8 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`precipitation_height`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`precipitation_indicator`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`precipitation_height`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`precipitation_indicator`** (null or int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 
@@ -244,8 +244,8 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`wind_speed`** (double, optional): Wind speed reported by the station.
-- **`wind_direction`** (double, optional): Wind direction reported by the station.
+- **`wind_speed`** (null or double, optional): Wind speed reported by the station.
+- **`wind_direction`** (null or double, optional): Wind direction reported by the station.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 
@@ -293,10 +293,10 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`global_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`sunshine_duration`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`diffuse_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`longwave_radiation`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`global_radiation`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`sunshine_duration`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`diffuse_radiation`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`longwave_radiation`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 
@@ -397,9 +397,9 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`wind_speed_maximum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`wind_speed_minimum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`wind_direction_at_maximum`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_speed_maximum`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_speed_minimum`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`wind_direction_at_maximum`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 
@@ -448,8 +448,8 @@ Each event identifies the real-world resource with `{station_id}`. `{station_id}
 - **`station_id`** (string, required): Stable identifier assigned by the upstream provider for the station or monitoring site.
 - **`timestamp`** (string, required): Time when the provider recorded or published the value.
 - **`quality_level`** (int32, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`air_temperature_maximum_2m`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
-- **`air_temperature_minimum_5cm`** (double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_maximum_2m`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
+- **`air_temperature_minimum_5cm`** (null or double, optional): Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source.
 - **`state`** (null or string, optional): Normalized routing field 'state' added for MQTT/AMQP subscriber filtering.
 #### Example payload
 

--- a/feeders/dwd/dwd/parsers/csv_parser.py
+++ b/feeders/dwd/dwd/parsers/csv_parser.py
@@ -148,6 +148,15 @@ def map_row(row: Dict[str, Any], category: str) -> Dict[str, Any]:
 
     for dwd_col, semantic_name in col_map.items():
         if dwd_col in row:
-            result[semantic_name] = row[dwd_col]
+            value = row[dwd_col]
+            # RWS_IND_10 is a categorical precipitation-type code (0 = none,
+            # 1/3/6/7/8 = type); the generic float parser yields e.g. 0.0, but
+            # the contract declares it int32, so coerce non-null values to int.
+            if semantic_name == "precipitation_indicator" and value is not None:
+                try:
+                    value = int(float(value))
+                except (ValueError, TypeError):
+                    pass
+            result[semantic_name] = value
 
     return result

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_amqp_producer/src/dwd_amqp_producer_amqp_producer/producer.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_amqp_producer/src/dwd_amqp_producer_amqp_producer/producer.py
@@ -14,15 +14,62 @@ import sys
 import typing
 import uuid
 import json
+import re
 import threading
 import queue
 import concurrent.futures
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
 from proton import Message, symbol
+from proton.reactor import AtMostOnce
 from proton.utils import BlockingConnection
 from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_binary, to_structured
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 
 # --- Azure CBS support (azure_cbs_target=servicebus) ---
 # Two CBS auth modes are supported:
@@ -496,9 +543,7 @@ class DEDWDCDCAmqpProducer:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
 
     def _init_reactor(self):
         """Start the proton reactor thread and block until CBS handshake completes.
@@ -561,6 +606,32 @@ class DEDWDCDCAmqpProducer:
         fut: "concurrent.futures.Future" = concurrent.futures.Future()
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
+            self._connection.wait(
+                lambda: (
+                    self._sender.link.queued == 0 and
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -631,6 +702,7 @@ class DEDWDCDCAmqpProducer:
         data: StationMetadata,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.StationMetadata` message
@@ -639,6 +711,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (StationMetadata): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -651,6 +724,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -703,12 +777,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_station_metadata_batch(self,
         data_array: typing.List[StationMetadata],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.StationMetadata` messages
@@ -716,6 +791,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[StationMetadata]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -723,6 +799,7 @@ class DEDWDCDCAmqpProducer:
             self.send_station_metadata(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -731,6 +808,7 @@ class DEDWDCDCAmqpProducer:
         data: AirTemperature10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.AirTemperature10Min` message
@@ -739,6 +817,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (AirTemperature10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -751,6 +830,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -803,12 +883,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_air_temperature10_min_batch(self,
         data_array: typing.List[AirTemperature10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.AirTemperature10Min` messages
@@ -816,6 +897,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[AirTemperature10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -823,6 +905,7 @@ class DEDWDCDCAmqpProducer:
             self.send_air_temperature10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -831,6 +914,7 @@ class DEDWDCDCAmqpProducer:
         data: Precipitation10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.Precipitation10Min` message
@@ -839,6 +923,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (Precipitation10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -851,6 +936,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -903,12 +989,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_precipitation10_min_batch(self,
         data_array: typing.List[Precipitation10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.Precipitation10Min` messages
@@ -916,6 +1003,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[Precipitation10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -923,6 +1011,7 @@ class DEDWDCDCAmqpProducer:
             self.send_precipitation10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -931,6 +1020,7 @@ class DEDWDCDCAmqpProducer:
         data: Wind10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.Wind10Min` message
@@ -939,6 +1029,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (Wind10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -951,6 +1042,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1003,12 +1095,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_wind10_min_batch(self,
         data_array: typing.List[Wind10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.Wind10Min` messages
@@ -1016,6 +1109,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[Wind10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -1023,6 +1117,7 @@ class DEDWDCDCAmqpProducer:
             self.send_wind10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -1031,6 +1126,7 @@ class DEDWDCDCAmqpProducer:
         data: Solar10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.Solar10Min` message
@@ -1039,6 +1135,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (Solar10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -1051,6 +1148,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1103,12 +1201,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_solar10_min_batch(self,
         data_array: typing.List[Solar10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.Solar10Min` messages
@@ -1116,6 +1215,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[Solar10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -1123,6 +1223,7 @@ class DEDWDCDCAmqpProducer:
             self.send_solar10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -1131,6 +1232,7 @@ class DEDWDCDCAmqpProducer:
         data: HourlyObservation,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.HourlyObservation` message
@@ -1139,6 +1241,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (HourlyObservation): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -1151,6 +1254,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1203,12 +1307,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_hourly_observation_batch(self,
         data_array: typing.List[HourlyObservation],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.HourlyObservation` messages
@@ -1216,6 +1321,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[HourlyObservation]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -1223,6 +1329,7 @@ class DEDWDCDCAmqpProducer:
             self.send_hourly_observation(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -1231,6 +1338,7 @@ class DEDWDCDCAmqpProducer:
         data: ExtremeWind10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.ExtremeWind10Min` message
@@ -1239,6 +1347,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (ExtremeWind10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -1251,6 +1360,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1303,12 +1413,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_extreme_wind10_min_batch(self,
         data_array: typing.List[ExtremeWind10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.ExtremeWind10Min` messages
@@ -1316,6 +1427,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[ExtremeWind10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -1323,6 +1435,7 @@ class DEDWDCDCAmqpProducer:
             self.send_extreme_wind10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -1331,6 +1444,7 @@ class DEDWDCDCAmqpProducer:
         data: ExtremeTemperature10Min,
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.CDC.amqp.ExtremeTemperature10Min` message
@@ -1339,6 +1453,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             _station_id (str): Value for placeholder station_id in attribute subject
             _state (str): Value for AMQP protocol option placeholder state
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (ExtremeTemperature10Min): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -1351,6 +1466,7 @@ class DEDWDCDCAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1403,12 +1519,13 @@ class DEDWDCDCAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_extreme_temperature10_min_batch(self,
         data_array: typing.List[ExtremeTemperature10Min],
         _station_id: str,
         _state: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.CDC.amqp.ExtremeTemperature10Min` messages
@@ -1416,6 +1533,7 @@ class DEDWDCDCAmqpProducer:
         Args:
             data_array (typing.List[ExtremeTemperature10Min]): Array of message data objects
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             _state (str): Value for AMQP protocol option placeholder state
             content_type (str): The content type of the message data
         """
@@ -1423,6 +1541,7 @@ class DEDWDCDCAmqpProducer:
             self.send_extreme_temperature10_min(
                 data=data,
                 _station_id=_station_id,
+                _time=_time,
                 _state=_state,
                 content_type=content_type)
     
@@ -1543,9 +1662,7 @@ class DEDWDWeatherAmqpProducer:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
 
     def _init_reactor(self):
         """Start the proton reactor thread and block until CBS handshake completes.
@@ -1608,6 +1725,32 @@ class DEDWDWeatherAmqpProducer:
         fut: "concurrent.futures.Future" = concurrent.futures.Future()
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
+            self._connection.wait(
+                lambda: (
+                    self._sender.link.queued == 0 and
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -1679,6 +1822,7 @@ class DEDWDWeatherAmqpProducer:
         _state: str,
         _severity: str,
         _identifier: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.Weather.amqp.Alert` message
@@ -1688,6 +1832,7 @@ class DEDWDWeatherAmqpProducer:
             _state (str): Value for placeholder state in attribute subject
             _severity (str): Value for placeholder severity in attribute subject
             _identifier (str): Value for placeholder identifier in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (Alert): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -1700,6 +1845,7 @@ class DEDWDWeatherAmqpProducer:
             "subject":
             "{state}/{severity}/{identifier}".format(state=_state, severity=_severity, identifier=_identifier),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -1751,13 +1897,14 @@ class DEDWDWeatherAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_alert_batch(self,
         data_array: typing.List[Alert],
         _state: str,
         _severity: str,
         _identifier: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.Weather.amqp.Alert` messages
@@ -1767,6 +1914,7 @@ class DEDWDWeatherAmqpProducer:
             _state (str): Value for placeholder state in attribute subject
             _severity (str): Value for placeholder severity in attribute subject
             _identifier (str): Value for placeholder identifier in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
@@ -1775,6 +1923,7 @@ class DEDWDWeatherAmqpProducer:
                 _state=_state,
                 _severity=_severity,
                 _identifier=_identifier,
+                _time=_time,
                 content_type=content_type)
     
     
@@ -1894,9 +2043,7 @@ class DEDWDRadarAmqpProducer:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
 
     def _init_reactor(self):
         """Start the proton reactor thread and block until CBS handshake completes.
@@ -1959,6 +2106,32 @@ class DEDWDRadarAmqpProducer:
         fut: "concurrent.futures.Future" = concurrent.futures.Future()
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
+            self._connection.wait(
+                lambda: (
+                    self._sender.link.queued == 0 and
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -2028,6 +2201,7 @@ class DEDWDRadarAmqpProducer:
     def send_radar_product_catalog(self,
         data: RadarProductCatalog,
         _kind: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.Radar.amqp.RadarProductCatalog` message
@@ -2035,6 +2209,7 @@ class DEDWDRadarAmqpProducer:
         
         Args:
             _kind (str): Value for placeholder kind in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (RadarProductCatalog): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -2047,6 +2222,7 @@ class DEDWDRadarAmqpProducer:
             "subject":
             "{kind}".format(kind=_kind),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -2098,11 +2274,12 @@ class DEDWDRadarAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_radar_product_catalog_batch(self,
         data_array: typing.List[RadarProductCatalog],
         _kind: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.Radar.amqp.RadarProductCatalog` messages
@@ -2110,12 +2287,14 @@ class DEDWDRadarAmqpProducer:
         Args:
             data_array (typing.List[RadarProductCatalog]): Array of message data objects
             _kind (str): Value for placeholder kind in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
             self.send_radar_product_catalog(
                 data=data,
                 _kind=_kind,
+                _time=_time,
                 content_type=content_type)
     
     
@@ -2123,6 +2302,7 @@ class DEDWDRadarAmqpProducer:
         data: RadarFileProduct,
         _product_type: str,
         _file_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.Radar.amqp.RadarFileProduct` message
@@ -2131,6 +2311,7 @@ class DEDWDRadarAmqpProducer:
         Args:
             _product_type (str): Value for placeholder product_type in attribute subject
             _file_id (str): Value for placeholder file_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (RadarFileProduct): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -2143,6 +2324,7 @@ class DEDWDRadarAmqpProducer:
             "subject":
             "{product_type}/{file_id}".format(product_type=_product_type, file_id=_file_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -2194,12 +2376,13 @@ class DEDWDRadarAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_radar_file_product_batch(self,
         data_array: typing.List[RadarFileProduct],
         _product_type: str,
         _file_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.Radar.amqp.RadarFileProduct` messages
@@ -2208,6 +2391,7 @@ class DEDWDRadarAmqpProducer:
             data_array (typing.List[RadarFileProduct]): Array of message data objects
             _product_type (str): Value for placeholder product_type in attribute subject
             _file_id (str): Value for placeholder file_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
@@ -2215,6 +2399,7 @@ class DEDWDRadarAmqpProducer:
                 data=data,
                 _product_type=_product_type,
                 _file_id=_file_id,
+                _time=_time,
                 content_type=content_type)
     
     
@@ -2334,9 +2519,7 @@ class DEDWDForecastAmqpProducer:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
 
     def _init_reactor(self):
         """Start the proton reactor thread and block until CBS handshake completes.
@@ -2399,6 +2582,32 @@ class DEDWDForecastAmqpProducer:
         fut: "concurrent.futures.Future" = concurrent.futures.Future()
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
+            self._connection.wait(
+                lambda: (
+                    self._sender.link.queued == 0 and
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -2468,6 +2677,7 @@ class DEDWDForecastAmqpProducer:
     def send_forecast_model_catalog(self,
         data: ForecastModelCatalog,
         _kind: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.Forecast.amqp.ForecastModelCatalog` message
@@ -2475,6 +2685,7 @@ class DEDWDForecastAmqpProducer:
         
         Args:
             _kind (str): Value for placeholder kind in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (ForecastModelCatalog): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -2487,6 +2698,7 @@ class DEDWDForecastAmqpProducer:
             "subject":
             "{kind}".format(kind=_kind),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -2538,11 +2750,12 @@ class DEDWDForecastAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_forecast_model_catalog_batch(self,
         data_array: typing.List[ForecastModelCatalog],
         _kind: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.Forecast.amqp.ForecastModelCatalog` messages
@@ -2550,12 +2763,14 @@ class DEDWDForecastAmqpProducer:
         Args:
             data_array (typing.List[ForecastModelCatalog]): Array of message data objects
             _kind (str): Value for placeholder kind in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
             self.send_forecast_model_catalog(
                 data=data,
                 _kind=_kind,
+                _time=_time,
                 content_type=content_type)
     
     
@@ -2563,6 +2778,7 @@ class DEDWDForecastAmqpProducer:
         data: IconD2ForecastFile,
         _variable: str,
         _file_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `DE.DWD.Forecast.amqp.IconD2ForecastFile` message
@@ -2571,6 +2787,7 @@ class DEDWDForecastAmqpProducer:
         Args:
             _variable (str): Value for placeholder variable in attribute subject
             _file_id (str): Value for placeholder file_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (IconD2ForecastFile): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -2583,6 +2800,7 @@ class DEDWDForecastAmqpProducer:
             "subject":
             "{variable}/{file_id}".format(variable=_variable, file_id=_file_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -2634,12 +2852,13 @@ class DEDWDForecastAmqpProducer:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_icon_d2_forecast_file_batch(self,
         data_array: typing.List[IconD2ForecastFile],
         _variable: str,
         _file_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `DE.DWD.Forecast.amqp.IconD2ForecastFile` messages
@@ -2648,6 +2867,7 @@ class DEDWDForecastAmqpProducer:
             data_array (typing.List[IconD2ForecastFile]): Array of message data objects
             _variable (str): Value for placeholder variable in attribute subject
             _file_id (str): Value for placeholder file_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
@@ -2655,6 +2875,7 @@ class DEDWDForecastAmqpProducer:
                 data=data,
                 _variable=_variable,
                 _file_id=_file_id,
+                _time=_time,
                 content_type=content_type)
     
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_amqp_producer/tests/test_producer.py
@@ -5,6 +5,7 @@
 Tests for dwd_amqp_producer_amqp_producer
 """
 import base64
+import datetime
 import json
 import os
 import sys
@@ -17,7 +18,7 @@ from urllib.parse import quote_plus
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
-from proton import symbol
+from proton import Message, symbol
 from proton.utils import BlockingConnection
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../dwd_amqp_producer_data/src')))
@@ -256,6 +257,45 @@ class TestDEDWDCDCAmqpProducer:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__(DEDWDCDCAmqpProducer)
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     def test_send_station_metadata(self, artemis_container):
         """Send and receive a StationMetadata message via ActiveMQ Artemis."""
@@ -283,6 +323,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -315,6 +356,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_station_metadata_single_fresh_connection(self, artemis_container):
+        """Send exactly one StationMetadata message on a fresh producer connection."""
+        payload = Test_StationMetadata.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_station_metadata(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.StationMetadata'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_air_temperature10_min(self, artemis_container):
         """Send and receive a AirTemperature10Min message via ActiveMQ Artemis."""
@@ -342,6 +415,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -374,6 +448,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_air_temperature10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one AirTemperature10Min message on a fresh producer connection."""
+        payload = Test_AirTemperature10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_air_temperature10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.AirTemperature10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_precipitation10_min(self, artemis_container):
         """Send and receive a Precipitation10Min message via ActiveMQ Artemis."""
@@ -401,6 +507,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -433,6 +540,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_precipitation10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one Precipitation10Min message on a fresh producer connection."""
+        payload = Test_Precipitation10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_precipitation10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.Precipitation10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_wind10_min(self, artemis_container):
         """Send and receive a Wind10Min message via ActiveMQ Artemis."""
@@ -460,6 +599,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -492,6 +632,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_wind10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one Wind10Min message on a fresh producer connection."""
+        payload = Test_Wind10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_wind10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.Wind10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_solar10_min(self, artemis_container):
         """Send and receive a Solar10Min message via ActiveMQ Artemis."""
@@ -519,6 +691,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -551,6 +724,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_solar10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one Solar10Min message on a fresh producer connection."""
+        payload = Test_Solar10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_solar10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.Solar10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_hourly_observation(self, artemis_container):
         """Send and receive a HourlyObservation message via ActiveMQ Artemis."""
@@ -578,6 +783,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -610,6 +816,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_hourly_observation_single_fresh_connection(self, artemis_container):
+        """Send exactly one HourlyObservation message on a fresh producer connection."""
+        payload = Test_HourlyObservation.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_hourly_observation(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.HourlyObservation'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_extreme_wind10_min(self, artemis_container):
         """Send and receive a ExtremeWind10Min message via ActiveMQ Artemis."""
@@ -637,6 +875,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -669,6 +908,38 @@ class TestDEDWDCDCAmqpProducer:
                 assert properties.get('state') == "{state}".format(state="value")
         finally:
             producer.close()
+
+    def test_send_extreme_wind10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one ExtremeWind10Min message on a fresh producer connection."""
+        payload = Test_ExtremeWind10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_extreme_wind10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.ExtremeWind10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
     
     def test_send_extreme_temperature10_min(self, artemis_container):
         """Send and receive a ExtremeTemperature10Min message via ActiveMQ Artemis."""
@@ -696,6 +967,7 @@ class TestDEDWDCDCAmqpProducer:
                     data=payload,
                     _station_id="value",
                     _state="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -729,6 +1001,38 @@ class TestDEDWDCDCAmqpProducer:
         finally:
             producer.close()
 
+    def test_send_extreme_temperature10_min_single_fresh_connection(self, artemis_container):
+        """Send exactly one ExtremeTemperature10Min message on a fresh producer connection."""
+        payload = Test_ExtremeTemperature10Min.create_instance()
+
+        producer = DEDWDCDCAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_extreme_temperature10_min(
+                data=payload,
+                _station_id="value",
+                _state="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.CDC.amqp.ExtremeTemperature10Min'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
+        assert properties.get('state') == "{state}".format(state="value")
+
 
 
 class TestDEDWDWeatherAmqpProducer:
@@ -749,6 +1053,45 @@ class TestDEDWDWeatherAmqpProducer:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__(DEDWDWeatherAmqpProducer)
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     def test_send_alert(self, artemis_container):
         """Send and receive a Alert message via ActiveMQ Artemis."""
@@ -777,6 +1120,7 @@ class TestDEDWDWeatherAmqpProducer:
                     _state="value",
                     _severity="value",
                     _identifier="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -809,6 +1153,38 @@ class TestDEDWDWeatherAmqpProducer:
         finally:
             producer.close()
 
+    def test_send_alert_single_fresh_connection(self, artemis_container):
+        """Send exactly one Alert message on a fresh producer connection."""
+        payload = Test_Alert.create_instance()
+
+        producer = DEDWDWeatherAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_alert(
+                data=payload,
+                _state="value",
+                _severity="value",
+                _identifier="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.Weather.amqp.Alert'
+        assert received.body is not None
+        assert received.subject == "{state}/{severity}/{identifier}".format(state="value", severity="value", identifier="value")
+
 
 
 class TestDEDWDRadarAmqpProducer:
@@ -829,6 +1205,45 @@ class TestDEDWDRadarAmqpProducer:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__(DEDWDRadarAmqpProducer)
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     def test_send_radar_product_catalog(self, artemis_container):
         """Send and receive a RadarProductCatalog message via ActiveMQ Artemis."""
@@ -855,6 +1270,7 @@ class TestDEDWDRadarAmqpProducer:
                 producer.send_radar_product_catalog(
                     data=payload,
                     _kind="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -886,6 +1302,36 @@ class TestDEDWDRadarAmqpProducer:
                 assert received.subject == "{kind}".format(kind="value")
         finally:
             producer.close()
+
+    def test_send_radar_product_catalog_single_fresh_connection(self, artemis_container):
+        """Send exactly one RadarProductCatalog message on a fresh producer connection."""
+        payload = Test_RadarProductCatalog.create_instance()
+
+        producer = DEDWDRadarAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_radar_product_catalog(
+                data=payload,
+                _kind="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.Radar.amqp.RadarProductCatalog'
+        assert received.body is not None
+        assert received.subject == "{kind}".format(kind="value")
     
     def test_send_radar_file_product(self, artemis_container):
         """Send and receive a RadarFileProduct message via ActiveMQ Artemis."""
@@ -913,6 +1359,7 @@ class TestDEDWDRadarAmqpProducer:
                     data=payload,
                     _product_type="value",
                     _file_id="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -945,6 +1392,37 @@ class TestDEDWDRadarAmqpProducer:
         finally:
             producer.close()
 
+    def test_send_radar_file_product_single_fresh_connection(self, artemis_container):
+        """Send exactly one RadarFileProduct message on a fresh producer connection."""
+        payload = Test_RadarFileProduct.create_instance()
+
+        producer = DEDWDRadarAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_radar_file_product(
+                data=payload,
+                _product_type="value",
+                _file_id="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.Radar.amqp.RadarFileProduct'
+        assert received.body is not None
+        assert received.subject == "{product_type}/{file_id}".format(product_type="value", file_id="value")
+
 
 
 class TestDEDWDForecastAmqpProducer:
@@ -965,6 +1443,45 @@ class TestDEDWDForecastAmqpProducer:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__(DEDWDForecastAmqpProducer)
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     def test_send_forecast_model_catalog(self, artemis_container):
         """Send and receive a ForecastModelCatalog message via ActiveMQ Artemis."""
@@ -991,6 +1508,7 @@ class TestDEDWDForecastAmqpProducer:
                 producer.send_forecast_model_catalog(
                     data=payload,
                     _kind="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -1022,6 +1540,36 @@ class TestDEDWDForecastAmqpProducer:
                 assert received.subject == "{kind}".format(kind="value")
         finally:
             producer.close()
+
+    def test_send_forecast_model_catalog_single_fresh_connection(self, artemis_container):
+        """Send exactly one ForecastModelCatalog message on a fresh producer connection."""
+        payload = Test_ForecastModelCatalog.create_instance()
+
+        producer = DEDWDForecastAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_forecast_model_catalog(
+                data=payload,
+                _kind="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.Forecast.amqp.ForecastModelCatalog'
+        assert received.body is not None
+        assert received.subject == "{kind}".format(kind="value")
     
     def test_send_icon_d2_forecast_file(self, artemis_container):
         """Send and receive a IconD2ForecastFile message via ActiveMQ Artemis."""
@@ -1049,6 +1597,7 @@ class TestDEDWDForecastAmqpProducer:
                     data=payload,
                     _variable="value",
                     _file_id="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -1080,4 +1629,35 @@ class TestDEDWDForecastAmqpProducer:
                 assert received.subject == "{variable}/{file_id}".format(variable="value", file_id="value")
         finally:
             producer.close()
+
+    def test_send_icon_d2_forecast_file_single_fresh_connection(self, artemis_container):
+        """Send exactly one IconD2ForecastFile message on a fresh producer connection."""
+        payload = Test_IconD2ForecastFile.create_instance()
+
+        producer = DEDWDForecastAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_icon_d2_forecast_file(
+                data=payload,
+                _variable="value",
+                _file_id="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'DE.DWD.Forecast.amqp.IconD2ForecastFile'
+        assert received.body is not None
+        assert received.subject == "{variable}/{file_id}".format(variable="value", file_id="value")
 

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/__init__.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/__init__.py
@@ -1,15 +1,15 @@
-from .hourlyobservation import HourlyObservation
-from .stationmetadata import StationMetadata
-from .precipitation10min import Precipitation10Min
-from .radarfileproduct import RadarFileProduct
-from .radarproductcatalog import RadarProductCatalog
-from .alert import Alert
-from .solar10min import Solar10Min
-from .icond2forecastfile import IconD2ForecastFile
 from .wind10min import Wind10Min
+from .precipitation10min import Precipitation10Min
+from .icond2forecastfile import IconD2ForecastFile
 from .extremewind10min import ExtremeWind10Min
-from .airtemperature10min import AirTemperature10Min
+from .radarproductcatalog import RadarProductCatalog
+from .radarfileproduct import RadarFileProduct
 from .extremetemperature10min import ExtremeTemperature10Min
+from .airtemperature10min import AirTemperature10Min
+from .solar10min import Solar10Min
+from .stationmetadata import StationMetadata
 from .forecastmodelcatalog import ForecastModelCatalog
+from .hourlyobservation import HourlyObservation
+from .alert import Alert
 
-__all__ = ["HourlyObservation", "StationMetadata", "Precipitation10Min", "RadarFileProduct", "RadarProductCatalog", "Alert", "Solar10Min", "IconD2ForecastFile", "Wind10Min", "ExtremeWind10Min", "AirTemperature10Min", "ExtremeTemperature10Min", "ForecastModelCatalog"]
+__all__ = ["Wind10Min", "Precipitation10Min", "IconD2ForecastFile", "ExtremeWind10Min", "RadarProductCatalog", "RadarFileProduct", "ExtremeTemperature10Min", "AirTemperature10Min", "Solar10Min", "StationMetadata", "ForecastModelCatalog", "HourlyObservation", "Alert"]

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/airtemperature10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/airtemperature10min.py
@@ -167,13 +167,13 @@ class AirTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='cazuuouoxurmpybiliaa',
-            timestamp='sdjqwhinwflhyotphtdy',
-            quality_level=int(48),
-            pressure_station_level=float(84.66123837106787),
-            air_temperature_2m=float(77.11116452346558),
-            air_temperature_5cm=float(58.24600410747712),
-            relative_humidity=float(11.0646145088803),
-            dew_point_temperature=float(16.166624283596743),
-            state='tqxncrthpbyjckpvebgq'
+            station_id='fscwtswqaxghhzgnlroc',
+            timestamp='tguexouwgvjuegvbmgau',
+            quality_level=int(95),
+            pressure_station_level=float(42.710993960526665),
+            air_temperature_2m=float(77.18876486408539),
+            air_temperature_5cm=float(35.34159046118578),
+            relative_humidity=float(72.0268423710957),
+            dew_point_temperature=float(60.70408837624493),
+            state='jvgfgtuixrditlddqwol'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/alert.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/alert.py
@@ -183,21 +183,21 @@ class Alert:
             An instance of the dataclass.
         """
         return cls(
-            identifier='ulgitsphabndlbufaqyo',
-            sender='qvxctuomfjeskqtrjqxa',
-            sent='twgtttpmmicckdwcnmnj',
-            status='ctmanncjekzrgzrmpdaf',
-            msg_type='ytmvvupzjnpdaxyrtnik',
-            severity='tslrjshvzsannvgspodv',
-            urgency='eiesqmxcmxcnhlmmeknp',
-            certainty='ewnjxushtiigayuiusgr',
-            event='ozrxrcbntebltjrcxssz',
-            headline='svvagfwndslzwdxxblqp',
-            description='ykzzhkcfbiqplkpsktkj',
-            effective='mqekplnlofkpvspihlut',
-            onset='sdwrfxrsmeodjderyrok',
-            expires='ydgksahpbtjtjzfngsyh',
-            area_desc='gxabninuagrsfinwpkvk',
-            geocodes='tpzormhdrcyrzerggsxf',
-            state='jbfmvcplouvjjcksbwoh'
+            identifier='vlldrdhotntzxwiqzoyy',
+            sender='bhkcviencldspumuobzr',
+            sent='bzlhzkxxsgnlxocznllp',
+            status='sqlqbtvvgfbhukvmzrjy',
+            msg_type='vedgigtgegldwcmtcrde',
+            severity='ppibgobouvvxrnnrmjxi',
+            urgency='hgxbfhfskegxpxnefqon',
+            certainty='vooefselmxbnituqeuuj',
+            event='dphdxjcbbksockrgmugi',
+            headline='gygxvnjmccpxtyscgrxf',
+            description='sxvhsvqcahfkoexdbgru',
+            effective='sxurfmkdvjihmwjkknvh',
+            onset='rejqdlbtaxikkejnnokf',
+            expires='jkaxjnpljyawmqdokmqu',
+            area_desc='yqpryjejzvpqixlxmqdf',
+            geocodes='aicwrvmajlxcactuhdsd',
+            state='egfcjfpsgyumanyqcbmo'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/extremetemperature10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/extremetemperature10min.py
@@ -161,10 +161,10 @@ class ExtremeTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='mvqbadyhtglughiusirh',
-            timestamp='oerjsxxzwomknwqxzkln',
-            quality_level=int(29),
-            air_temperature_maximum_2m=float(74.08344413161765),
-            air_temperature_minimum_5cm=float(20.030387691241803),
-            state='rrxpwzgvsbnziuvlfjrd'
+            station_id='npknhndkcufkjoofbdmz',
+            timestamp='rsyacnbxkdmgvaathnay',
+            quality_level=int(6),
+            air_temperature_maximum_2m=float(39.23455089375091),
+            air_temperature_minimum_5cm=float(11.798902772312925),
+            state='mwbyqiixdmacosexgavo'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/extremewind10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/extremewind10min.py
@@ -163,11 +163,11 @@ class ExtremeWind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='oeggdevnmyjqkvryyudr',
-            timestamp='gkilorjwozhlfbyoynwo',
-            quality_level=int(94),
-            wind_speed_maximum=float(14.929069593042332),
-            wind_speed_minimum=float(63.54870629551851),
-            wind_direction_at_maximum=float(72.06952883594278),
-            state='cifayqqcuqqhxvnlrqsn'
+            station_id='uoylicxqmbotsipjbfix',
+            timestamp='lxahnrnllxqixivxpavr',
+            quality_level=int(39),
+            wind_speed_maximum=float(35.45438453520499),
+            wind_speed_minimum=float(91.50046610229593),
+            wind_direction_at_maximum=float(22.196277379948626),
+            state='cvuzckkwradntrccyptz'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/forecastmodelcatalog.py
@@ -159,9 +159,9 @@ class ForecastModelCatalog:
             An instance of the dataclass.
         """
         return cls(
-            model='nlnltemvsohhybumnqlz',
-            file_url='hvselofqftemhhnfvpsg',
-            description='fdkolxnbkefezpyrvnzo',
-            state='gcakrgwtncsujykargjf',
-            kind='kpjmxldevfmbfwhxtkwc'
+            model='ewpdwhnlnzcqowpfcrll',
+            file_url='ozoghuniphphzrrhocxi',
+            description='thnrbfdggflruzjpqmot',
+            state='oukafgzylpzsoqwxmygs',
+            kind='tfmqkbexiwlzmwsnvqwg'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/hourlyobservation.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/hourlyobservation.py
@@ -163,11 +163,11 @@ class HourlyObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='rjhayjqamcbvygpdduhj',
-            timestamp='kybpuzrydgyxmelaltvx',
-            quality_level=int(98),
-            parameter='lxxrowmgkxisrciekobx',
-            value=float(60.18531927478732),
-            unit='siuqjkfzaueqtlssntez',
-            state='bptvultztuytjtreffln'
+            station_id='bbztsrqhgbtygdkcnztm',
+            timestamp='olwauiukgwhabjlmqbwz',
+            quality_level=int(99),
+            parameter='uizmkubiaqdhbgxaaupu',
+            value=float(18.29489336752914),
+            unit='rublzbwrhvlwqzqvlgon',
+            state='ucjaeufgmgoplrxaokxi'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/icond2forecastfile.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/icond2forecastfile.py
@@ -45,7 +45,7 @@ class IconD2ForecastFile:
     level_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_type"))
     level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     variable: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="variable"))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
@@ -61,6 +61,8 @@ class IconD2ForecastFile:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -71,6 +73,8 @@ class IconD2ForecastFile:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -175,17 +179,17 @@ class IconD2ForecastFile:
             An instance of the dataclass.
         """
         return cls(
-            file_url='ngjdgygbmdvlipdhlwdp',
-            model='fnykyflqiegvtcstrqwy',
-            file_name='vhsvgktoefykndqovwid',
-            run='goxayybiunemiftmebej',
-            forecast_hour=int(18),
-            parameter='hqboqiozxbtgblsaktzb',
-            level_type='ypljxpfwdzoykyqldkmx',
-            level='hoocswsagalysjlafxrt',
-            modified='vhwjildjmgnjxqyavsko',
-            size_bytes=int(4),
-            state='ddasfaoqjsmvjkfdwrxw',
-            variable='aocdaixyeevzuccbyiik',
-            file_id='yaekiuyogmczeygteaod'
+            file_url='jkfzjasldhhcdhxcdqqc',
+            model='lfnczxdawssnnpfuhmqf',
+            file_name='xlmzmgrcyzqarysapctc',
+            run='nnwiezrpebeedvhjrbyr',
+            forecast_hour=int(14),
+            parameter='stzuwetgvktmxeruurgl',
+            level_type='ltsagblgtvyfurjbkcjq',
+            level='axkbpizwngaxxntvtmzq',
+            modified='jisvjrdzhbzqfsdzsujn',
+            size_bytes=int(100),
+            state='dfsskwakppvmdehpizvg',
+            variable='fvrpkszcznodgvgfsjaa',
+            file_id='lvyswqwpjohvqpfypjfq'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/precipitation10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/precipitation10min.py
@@ -161,10 +161,10 @@ class Precipitation10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='xersfdolhlgxtypopzyk',
-            timestamp='mfpotdctxfwpeojtoura',
-            quality_level=int(53),
-            precipitation_height=float(44.95484290377004),
-            precipitation_indicator=int(57),
-            state='ryjlyytsqouxbcwmfcwq'
+            station_id='zjeekspomdbbzpbgivfp',
+            timestamp='irjbkifrqlkpwthxpqvj',
+            quality_level=int(20),
+            precipitation_height=float(80.22418580281642),
+            precipitation_indicator=int(17),
+            state='yhmtojcblinpbfksuiru'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/radarfileproduct.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/radarfileproduct.py
@@ -35,7 +35,7 @@ class RadarFileProduct:
     product: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product"))
     file_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_name"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     product_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product_type"))
@@ -51,6 +51,8 @@ class RadarFileProduct:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -61,6 +63,8 @@ class RadarFileProduct:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -165,12 +169,12 @@ class RadarFileProduct:
             An instance of the dataclass.
         """
         return cls(
-            file_url='ssuzclwcbhywhncpbmsl',
-            product='lbohbulvsevaklhjyxrj',
-            file_name='relybinnusxvsgldvfcx',
-            modified='zrgvbouytapybvbxtobe',
-            size_bytes=int(48),
-            file_id='ltfvnpdwlyfvboerlqoc',
-            state='bespnrwlnpwwrsuhhcmf',
-            product_type='gephfjxgqruimkozktxq'
+            file_url='fuplfkcmiaghbpegtvks',
+            product='qvjbaluaguuzjzfopxlc',
+            file_name='bfzfpfbcqhtjadiwkrpm',
+            modified='zmucesjckpcowgfykbmo',
+            size_bytes=int(51),
+            file_id='togkqbxckyjebcxratgj',
+            state='gfvidlzjkjvdbnfqoyhh',
+            product_type='cglpkczlbfjbefwwmbzh'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/radarproductcatalog.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/radarproductcatalog.py
@@ -159,9 +159,9 @@ class RadarProductCatalog:
             An instance of the dataclass.
         """
         return cls(
-            product='fudnfjlwaqusgchygpak',
-            file_url='ziybhjytrexnvqxkczjt',
-            description='rdgtfrvggqkevppsjpgl',
-            state='mbrifyuiknhufjmbxoug',
-            kind='bryijbrrfafnevtizwer'
+            product='nbtcvnjioafbsbzdafsi',
+            file_url='ngstolkkmkymskajjfzb',
+            description='yfmrfyhygihpgbhwdckv',
+            state='xjsgdeeklzmwopncjrbt',
+            kind='btkmjlmoxuicmabozqxq'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/solar10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/solar10min.py
@@ -165,12 +165,12 @@ class Solar10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='ymzqinpewqvxatqfxlcm',
-            timestamp='kqagdtmxukzfacuwgcxp',
-            quality_level=int(30),
-            global_radiation=float(66.33834732373776),
-            sunshine_duration=float(77.99887336658183),
-            diffuse_radiation=float(82.83058011112063),
-            longwave_radiation=float(96.35281244421766),
-            state='mnkktogbsxjfqaeyzoad'
+            station_id='hjckuqwirsopriktmecg',
+            timestamp='nlemhyakugqdjqnwwvwy',
+            quality_level=int(4),
+            global_radiation=float(30.51514400065688),
+            sunshine_duration=float(74.95493906492543),
+            diffuse_radiation=float(47.98940760408264),
+            longwave_radiation=float(12.028736263575778),
+            state='avtiipzpukiqgmlmczzb'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/stationmetadata.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/stationmetadata.py
@@ -165,12 +165,12 @@ class StationMetadata:
             An instance of the dataclass.
         """
         return cls(
-            station_id='lyzhfnzlalbdtpnzihnu',
-            station_name='kujnyhyhzxgetkbbhnyx',
-            latitude=float(52.17100803355499),
-            longitude=float(35.7968339705412),
-            elevation=float(53.5716295745416),
-            state='tzlscjyqfhefngmyytqo',
-            from_date='uqtyorhbtwmffknzkhmv',
-            to_date='nlxvxbaqdbsfmwdjojlg'
+            station_id='rzjtcnuptrotqcqzlqhr',
+            station_name='byocqvqqckqsjvgauagu',
+            latitude=float(66.42443795621446),
+            longitude=float(98.05132381411855),
+            elevation=float(65.61581809305221),
+            state='frzjawduifopreufwtqi',
+            from_date='mitozaxxyzthybsslcgy',
+            to_date='jdenzylrkkbzoqxhncij'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/wind10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/src/dwd_amqp_producer_data/wind10min.py
@@ -161,10 +161,10 @@ class Wind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='ohwihabtmlbjigvhixpt',
-            timestamp='rjfqdxbslpnazmpsojvg',
-            quality_level=int(93),
-            wind_speed=float(5.807688561407199),
-            wind_direction=float(43.63553171735567),
-            state='gzhjlklijcwkzzyygubp'
+            station_id='cqywayhikypzashdctni',
+            timestamp='uegdgwlprdedmqustypb',
+            quality_level=int(87),
+            wind_speed=float(75.19519843285943),
+            wind_direction=float(23.34535367692272),
+            state='ejxgumqrrkhlyatfdnkc'
         )

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_airtemperature10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_airtemperature10min.py
@@ -28,15 +28,15 @@ class Test_AirTemperature10Min(unittest.TestCase):
         Create instance of AirTemperature10Min for testing
         """
         instance = AirTemperature10Min(
-            station_id='cazuuouoxurmpybiliaa',
-            timestamp='sdjqwhinwflhyotphtdy',
-            quality_level=int(48),
-            pressure_station_level=float(84.66123837106787),
-            air_temperature_2m=float(77.11116452346558),
-            air_temperature_5cm=float(58.24600410747712),
-            relative_humidity=float(11.0646145088803),
-            dew_point_temperature=float(16.166624283596743),
-            state='tqxncrthpbyjckpvebgq'
+            station_id='fscwtswqaxghhzgnlroc',
+            timestamp='tguexouwgvjuegvbmgau',
+            quality_level=int(95),
+            pressure_station_level=float(42.710993960526665),
+            air_temperature_2m=float(77.18876486408539),
+            air_temperature_5cm=float(35.34159046118578),
+            relative_humidity=float(72.0268423710957),
+            dew_point_temperature=float(60.70408837624493),
+            state='jvgfgtuixrditlddqwol'
         )
         return instance
 
@@ -45,7 +45,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'cazuuouoxurmpybiliaa'
+        test_value = 'fscwtswqaxghhzgnlroc'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -53,7 +53,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'sdjqwhinwflhyotphtdy'
+        test_value = 'tguexouwgvjuegvbmgau'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -61,7 +61,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(48)
+        test_value = int(95)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -69,7 +69,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test pressure_station_level property
         """
-        test_value = float(84.66123837106787)
+        test_value = float(42.710993960526665)
         self.instance.pressure_station_level = test_value
         self.assertEqual(self.instance.pressure_station_level, test_value)
     
@@ -77,7 +77,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_2m property
         """
-        test_value = float(77.11116452346558)
+        test_value = float(77.18876486408539)
         self.instance.air_temperature_2m = test_value
         self.assertEqual(self.instance.air_temperature_2m, test_value)
     
@@ -85,7 +85,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_5cm property
         """
-        test_value = float(58.24600410747712)
+        test_value = float(35.34159046118578)
         self.instance.air_temperature_5cm = test_value
         self.assertEqual(self.instance.air_temperature_5cm, test_value)
     
@@ -93,7 +93,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test relative_humidity property
         """
-        test_value = float(11.0646145088803)
+        test_value = float(72.0268423710957)
         self.instance.relative_humidity = test_value
         self.assertEqual(self.instance.relative_humidity, test_value)
     
@@ -101,7 +101,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test dew_point_temperature property
         """
-        test_value = float(16.166624283596743)
+        test_value = float(60.70408837624493)
         self.instance.dew_point_temperature = test_value
         self.assertEqual(self.instance.dew_point_temperature, test_value)
     
@@ -109,7 +109,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'tqxncrthpbyjckpvebgq'
+        test_value = 'jvgfgtuixrditlddqwol'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_alert.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_alert.py
@@ -28,23 +28,23 @@ class Test_Alert(unittest.TestCase):
         Create instance of Alert for testing
         """
         instance = Alert(
-            identifier='ulgitsphabndlbufaqyo',
-            sender='qvxctuomfjeskqtrjqxa',
-            sent='twgtttpmmicckdwcnmnj',
-            status='ctmanncjekzrgzrmpdaf',
-            msg_type='ytmvvupzjnpdaxyrtnik',
-            severity='tslrjshvzsannvgspodv',
-            urgency='eiesqmxcmxcnhlmmeknp',
-            certainty='ewnjxushtiigayuiusgr',
-            event='ozrxrcbntebltjrcxssz',
-            headline='svvagfwndslzwdxxblqp',
-            description='ykzzhkcfbiqplkpsktkj',
-            effective='mqekplnlofkpvspihlut',
-            onset='sdwrfxrsmeodjderyrok',
-            expires='ydgksahpbtjtjzfngsyh',
-            area_desc='gxabninuagrsfinwpkvk',
-            geocodes='tpzormhdrcyrzerggsxf',
-            state='jbfmvcplouvjjcksbwoh'
+            identifier='vlldrdhotntzxwiqzoyy',
+            sender='bhkcviencldspumuobzr',
+            sent='bzlhzkxxsgnlxocznllp',
+            status='sqlqbtvvgfbhukvmzrjy',
+            msg_type='vedgigtgegldwcmtcrde',
+            severity='ppibgobouvvxrnnrmjxi',
+            urgency='hgxbfhfskegxpxnefqon',
+            certainty='vooefselmxbnituqeuuj',
+            event='dphdxjcbbksockrgmugi',
+            headline='gygxvnjmccpxtyscgrxf',
+            description='sxvhsvqcahfkoexdbgru',
+            effective='sxurfmkdvjihmwjkknvh',
+            onset='rejqdlbtaxikkejnnokf',
+            expires='jkaxjnpljyawmqdokmqu',
+            area_desc='yqpryjejzvpqixlxmqdf',
+            geocodes='aicwrvmajlxcactuhdsd',
+            state='egfcjfpsgyumanyqcbmo'
         )
         return instance
 
@@ -53,7 +53,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test identifier property
         """
-        test_value = 'ulgitsphabndlbufaqyo'
+        test_value = 'vlldrdhotntzxwiqzoyy'
         self.instance.identifier = test_value
         self.assertEqual(self.instance.identifier, test_value)
     
@@ -61,7 +61,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sender property
         """
-        test_value = 'qvxctuomfjeskqtrjqxa'
+        test_value = 'bhkcviencldspumuobzr'
         self.instance.sender = test_value
         self.assertEqual(self.instance.sender, test_value)
     
@@ -69,7 +69,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sent property
         """
-        test_value = 'twgtttpmmicckdwcnmnj'
+        test_value = 'bzlhzkxxsgnlxocznllp'
         self.instance.sent = test_value
         self.assertEqual(self.instance.sent, test_value)
     
@@ -77,7 +77,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test status property
         """
-        test_value = 'ctmanncjekzrgzrmpdaf'
+        test_value = 'sqlqbtvvgfbhukvmzrjy'
         self.instance.status = test_value
         self.assertEqual(self.instance.status, test_value)
     
@@ -85,7 +85,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test msg_type property
         """
-        test_value = 'ytmvvupzjnpdaxyrtnik'
+        test_value = 'vedgigtgegldwcmtcrde'
         self.instance.msg_type = test_value
         self.assertEqual(self.instance.msg_type, test_value)
     
@@ -93,7 +93,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = 'tslrjshvzsannvgspodv'
+        test_value = 'ppibgobouvvxrnnrmjxi'
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     
@@ -101,7 +101,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test urgency property
         """
-        test_value = 'eiesqmxcmxcnhlmmeknp'
+        test_value = 'hgxbfhfskegxpxnefqon'
         self.instance.urgency = test_value
         self.assertEqual(self.instance.urgency, test_value)
     
@@ -109,7 +109,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test certainty property
         """
-        test_value = 'ewnjxushtiigayuiusgr'
+        test_value = 'vooefselmxbnituqeuuj'
         self.instance.certainty = test_value
         self.assertEqual(self.instance.certainty, test_value)
     
@@ -117,7 +117,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test event property
         """
-        test_value = 'ozrxrcbntebltjrcxssz'
+        test_value = 'dphdxjcbbksockrgmugi'
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -125,7 +125,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test headline property
         """
-        test_value = 'svvagfwndslzwdxxblqp'
+        test_value = 'gygxvnjmccpxtyscgrxf'
         self.instance.headline = test_value
         self.assertEqual(self.instance.headline, test_value)
     
@@ -133,7 +133,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'ykzzhkcfbiqplkpsktkj'
+        test_value = 'sxvhsvqcahfkoexdbgru'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -141,7 +141,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test effective property
         """
-        test_value = 'mqekplnlofkpvspihlut'
+        test_value = 'sxurfmkdvjihmwjkknvh'
         self.instance.effective = test_value
         self.assertEqual(self.instance.effective, test_value)
     
@@ -149,7 +149,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test onset property
         """
-        test_value = 'sdwrfxrsmeodjderyrok'
+        test_value = 'rejqdlbtaxikkejnnokf'
         self.instance.onset = test_value
         self.assertEqual(self.instance.onset, test_value)
     
@@ -157,7 +157,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test expires property
         """
-        test_value = 'ydgksahpbtjtjzfngsyh'
+        test_value = 'jkaxjnpljyawmqdokmqu'
         self.instance.expires = test_value
         self.assertEqual(self.instance.expires, test_value)
     
@@ -165,7 +165,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test area_desc property
         """
-        test_value = 'gxabninuagrsfinwpkvk'
+        test_value = 'yqpryjejzvpqixlxmqdf'
         self.instance.area_desc = test_value
         self.assertEqual(self.instance.area_desc, test_value)
     
@@ -173,7 +173,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test geocodes property
         """
-        test_value = 'tpzormhdrcyrzerggsxf'
+        test_value = 'aicwrvmajlxcactuhdsd'
         self.instance.geocodes = test_value
         self.assertEqual(self.instance.geocodes, test_value)
     
@@ -181,7 +181,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'jbfmvcplouvjjcksbwoh'
+        test_value = 'egfcjfpsgyumanyqcbmo'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_extremetemperature10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_extremetemperature10min.py
@@ -28,12 +28,12 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         Create instance of ExtremeTemperature10Min for testing
         """
         instance = ExtremeTemperature10Min(
-            station_id='mvqbadyhtglughiusirh',
-            timestamp='oerjsxxzwomknwqxzkln',
-            quality_level=int(29),
-            air_temperature_maximum_2m=float(74.08344413161765),
-            air_temperature_minimum_5cm=float(20.030387691241803),
-            state='rrxpwzgvsbnziuvlfjrd'
+            station_id='npknhndkcufkjoofbdmz',
+            timestamp='rsyacnbxkdmgvaathnay',
+            quality_level=int(6),
+            air_temperature_maximum_2m=float(39.23455089375091),
+            air_temperature_minimum_5cm=float(11.798902772312925),
+            state='mwbyqiixdmacosexgavo'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'mvqbadyhtglughiusirh'
+        test_value = 'npknhndkcufkjoofbdmz'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'oerjsxxzwomknwqxzkln'
+        test_value = 'rsyacnbxkdmgvaathnay'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(29)
+        test_value = int(6)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_maximum_2m property
         """
-        test_value = float(74.08344413161765)
+        test_value = float(39.23455089375091)
         self.instance.air_temperature_maximum_2m = test_value
         self.assertEqual(self.instance.air_temperature_maximum_2m, test_value)
     
@@ -74,7 +74,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_minimum_5cm property
         """
-        test_value = float(20.030387691241803)
+        test_value = float(11.798902772312925)
         self.instance.air_temperature_minimum_5cm = test_value
         self.assertEqual(self.instance.air_temperature_minimum_5cm, test_value)
     
@@ -82,7 +82,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'rrxpwzgvsbnziuvlfjrd'
+        test_value = 'mwbyqiixdmacosexgavo'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_extremewind10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_extremewind10min.py
@@ -28,13 +28,13 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         Create instance of ExtremeWind10Min for testing
         """
         instance = ExtremeWind10Min(
-            station_id='oeggdevnmyjqkvryyudr',
-            timestamp='gkilorjwozhlfbyoynwo',
-            quality_level=int(94),
-            wind_speed_maximum=float(14.929069593042332),
-            wind_speed_minimum=float(63.54870629551851),
-            wind_direction_at_maximum=float(72.06952883594278),
-            state='cifayqqcuqqhxvnlrqsn'
+            station_id='uoylicxqmbotsipjbfix',
+            timestamp='lxahnrnllxqixivxpavr',
+            quality_level=int(39),
+            wind_speed_maximum=float(35.45438453520499),
+            wind_speed_minimum=float(91.50046610229593),
+            wind_direction_at_maximum=float(22.196277379948626),
+            state='cvuzckkwradntrccyptz'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'oeggdevnmyjqkvryyudr'
+        test_value = 'uoylicxqmbotsipjbfix'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'gkilorjwozhlfbyoynwo'
+        test_value = 'lxahnrnllxqixivxpavr'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(94)
+        test_value = int(39)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_maximum property
         """
-        test_value = float(14.929069593042332)
+        test_value = float(35.45438453520499)
         self.instance.wind_speed_maximum = test_value
         self.assertEqual(self.instance.wind_speed_maximum, test_value)
     
@@ -75,7 +75,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_minimum property
         """
-        test_value = float(63.54870629551851)
+        test_value = float(91.50046610229593)
         self.instance.wind_speed_minimum = test_value
         self.assertEqual(self.instance.wind_speed_minimum, test_value)
     
@@ -83,7 +83,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_direction_at_maximum property
         """
-        test_value = float(72.06952883594278)
+        test_value = float(22.196277379948626)
         self.instance.wind_direction_at_maximum = test_value
         self.assertEqual(self.instance.wind_direction_at_maximum, test_value)
     
@@ -91,7 +91,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'cifayqqcuqqhxvnlrqsn'
+        test_value = 'cvuzckkwradntrccyptz'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_forecastmodelcatalog.py
@@ -28,11 +28,11 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         Create instance of ForecastModelCatalog for testing
         """
         instance = ForecastModelCatalog(
-            model='nlnltemvsohhybumnqlz',
-            file_url='hvselofqftemhhnfvpsg',
-            description='fdkolxnbkefezpyrvnzo',
-            state='gcakrgwtncsujykargjf',
-            kind='kpjmxldevfmbfwhxtkwc'
+            model='ewpdwhnlnzcqowpfcrll',
+            file_url='ozoghuniphphzrrhocxi',
+            description='thnrbfdggflruzjpqmot',
+            state='oukafgzylpzsoqwxmygs',
+            kind='tfmqkbexiwlzmwsnvqwg'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'nlnltemvsohhybumnqlz'
+        test_value = 'ewpdwhnlnzcqowpfcrll'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -49,7 +49,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'hvselofqftemhhnfvpsg'
+        test_value = 'ozoghuniphphzrrhocxi'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'fdkolxnbkefezpyrvnzo'
+        test_value = 'thnrbfdggflruzjpqmot'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'gcakrgwtncsujykargjf'
+        test_value = 'oukafgzylpzsoqwxmygs'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'kpjmxldevfmbfwhxtkwc'
+        test_value = 'tfmqkbexiwlzmwsnvqwg'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_hourlyobservation.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_hourlyobservation.py
@@ -28,13 +28,13 @@ class Test_HourlyObservation(unittest.TestCase):
         Create instance of HourlyObservation for testing
         """
         instance = HourlyObservation(
-            station_id='rjhayjqamcbvygpdduhj',
-            timestamp='kybpuzrydgyxmelaltvx',
-            quality_level=int(98),
-            parameter='lxxrowmgkxisrciekobx',
-            value=float(60.18531927478732),
-            unit='siuqjkfzaueqtlssntez',
-            state='bptvultztuytjtreffln'
+            station_id='bbztsrqhgbtygdkcnztm',
+            timestamp='olwauiukgwhabjlmqbwz',
+            quality_level=int(99),
+            parameter='uizmkubiaqdhbgxaaupu',
+            value=float(18.29489336752914),
+            unit='rublzbwrhvlwqzqvlgon',
+            state='ucjaeufgmgoplrxaokxi'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'rjhayjqamcbvygpdduhj'
+        test_value = 'bbztsrqhgbtygdkcnztm'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'kybpuzrydgyxmelaltvx'
+        test_value = 'olwauiukgwhabjlmqbwz'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(98)
+        test_value = int(99)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'lxxrowmgkxisrciekobx'
+        test_value = 'uizmkubiaqdhbgxaaupu'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -75,7 +75,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(60.18531927478732)
+        test_value = float(18.29489336752914)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -83,7 +83,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test unit property
         """
-        test_value = 'siuqjkfzaueqtlssntez'
+        test_value = 'rublzbwrhvlwqzqvlgon'
         self.instance.unit = test_value
         self.assertEqual(self.instance.unit, test_value)
     
@@ -91,7 +91,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bptvultztuytjtreffln'
+        test_value = 'ucjaeufgmgoplrxaokxi'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_icond2forecastfile.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_icond2forecastfile.py
@@ -28,19 +28,19 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         Create instance of IconD2ForecastFile for testing
         """
         instance = IconD2ForecastFile(
-            file_url='ngjdgygbmdvlipdhlwdp',
-            model='fnykyflqiegvtcstrqwy',
-            file_name='vhsvgktoefykndqovwid',
-            run='goxayybiunemiftmebej',
-            forecast_hour=int(18),
-            parameter='hqboqiozxbtgblsaktzb',
-            level_type='ypljxpfwdzoykyqldkmx',
-            level='hoocswsagalysjlafxrt',
-            modified='vhwjildjmgnjxqyavsko',
-            size_bytes=int(4),
-            state='ddasfaoqjsmvjkfdwrxw',
-            variable='aocdaixyeevzuccbyiik',
-            file_id='yaekiuyogmczeygteaod'
+            file_url='jkfzjasldhhcdhxcdqqc',
+            model='lfnczxdawssnnpfuhmqf',
+            file_name='xlmzmgrcyzqarysapctc',
+            run='nnwiezrpebeedvhjrbyr',
+            forecast_hour=int(14),
+            parameter='stzuwetgvktmxeruurgl',
+            level_type='ltsagblgtvyfurjbkcjq',
+            level='axkbpizwngaxxntvtmzq',
+            modified='jisvjrdzhbzqfsdzsujn',
+            size_bytes=int(100),
+            state='dfsskwakppvmdehpizvg',
+            variable='fvrpkszcznodgvgfsjaa',
+            file_id='lvyswqwpjohvqpfypjfq'
         )
         return instance
 
@@ -49,7 +49,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'ngjdgygbmdvlipdhlwdp'
+        test_value = 'jkfzjasldhhcdhxcdqqc'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'fnykyflqiegvtcstrqwy'
+        test_value = 'lfnczxdawssnnpfuhmqf'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -65,7 +65,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'vhsvgktoefykndqovwid'
+        test_value = 'xlmzmgrcyzqarysapctc'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -73,7 +73,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test run property
         """
-        test_value = 'goxayybiunemiftmebej'
+        test_value = 'nnwiezrpebeedvhjrbyr'
         self.instance.run = test_value
         self.assertEqual(self.instance.run, test_value)
     
@@ -81,7 +81,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test forecast_hour property
         """
-        test_value = int(18)
+        test_value = int(14)
         self.instance.forecast_hour = test_value
         self.assertEqual(self.instance.forecast_hour, test_value)
     
@@ -89,7 +89,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'hqboqiozxbtgblsaktzb'
+        test_value = 'stzuwetgvktmxeruurgl'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -97,7 +97,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level_type property
         """
-        test_value = 'ypljxpfwdzoykyqldkmx'
+        test_value = 'ltsagblgtvyfurjbkcjq'
         self.instance.level_type = test_value
         self.assertEqual(self.instance.level_type, test_value)
     
@@ -105,7 +105,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level property
         """
-        test_value = 'hoocswsagalysjlafxrt'
+        test_value = 'axkbpizwngaxxntvtmzq'
         self.instance.level = test_value
         self.assertEqual(self.instance.level, test_value)
     
@@ -113,7 +113,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'vhwjildjmgnjxqyavsko'
+        test_value = 'jisvjrdzhbzqfsdzsujn'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -121,7 +121,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(4)
+        test_value = int(100)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -129,7 +129,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'ddasfaoqjsmvjkfdwrxw'
+        test_value = 'dfsskwakppvmdehpizvg'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -137,7 +137,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test variable property
         """
-        test_value = 'aocdaixyeevzuccbyiik'
+        test_value = 'fvrpkszcznodgvgfsjaa'
         self.instance.variable = test_value
         self.assertEqual(self.instance.variable, test_value)
     
@@ -145,7 +145,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'yaekiuyogmczeygteaod'
+        test_value = 'lvyswqwpjohvqpfypjfq'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_precipitation10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_precipitation10min.py
@@ -28,12 +28,12 @@ class Test_Precipitation10Min(unittest.TestCase):
         Create instance of Precipitation10Min for testing
         """
         instance = Precipitation10Min(
-            station_id='xersfdolhlgxtypopzyk',
-            timestamp='mfpotdctxfwpeojtoura',
-            quality_level=int(53),
-            precipitation_height=float(44.95484290377004),
-            precipitation_indicator=int(57),
-            state='ryjlyytsqouxbcwmfcwq'
+            station_id='zjeekspomdbbzpbgivfp',
+            timestamp='irjbkifrqlkpwthxpqvj',
+            quality_level=int(20),
+            precipitation_height=float(80.22418580281642),
+            precipitation_indicator=int(17),
+            state='yhmtojcblinpbfksuiru'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'xersfdolhlgxtypopzyk'
+        test_value = 'zjeekspomdbbzpbgivfp'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'mfpotdctxfwpeojtoura'
+        test_value = 'irjbkifrqlkpwthxpqvj'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(53)
+        test_value = int(20)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_height property
         """
-        test_value = float(44.95484290377004)
+        test_value = float(80.22418580281642)
         self.instance.precipitation_height = test_value
         self.assertEqual(self.instance.precipitation_height, test_value)
     
@@ -74,7 +74,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_indicator property
         """
-        test_value = int(57)
+        test_value = int(17)
         self.instance.precipitation_indicator = test_value
         self.assertEqual(self.instance.precipitation_indicator, test_value)
     
@@ -82,7 +82,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'ryjlyytsqouxbcwmfcwq'
+        test_value = 'yhmtojcblinpbfksuiru'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_radarfileproduct.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_radarfileproduct.py
@@ -28,14 +28,14 @@ class Test_RadarFileProduct(unittest.TestCase):
         Create instance of RadarFileProduct for testing
         """
         instance = RadarFileProduct(
-            file_url='ssuzclwcbhywhncpbmsl',
-            product='lbohbulvsevaklhjyxrj',
-            file_name='relybinnusxvsgldvfcx',
-            modified='zrgvbouytapybvbxtobe',
-            size_bytes=int(48),
-            file_id='ltfvnpdwlyfvboerlqoc',
-            state='bespnrwlnpwwrsuhhcmf',
-            product_type='gephfjxgqruimkozktxq'
+            file_url='fuplfkcmiaghbpegtvks',
+            product='qvjbaluaguuzjzfopxlc',
+            file_name='bfzfpfbcqhtjadiwkrpm',
+            modified='zmucesjckpcowgfykbmo',
+            size_bytes=int(51),
+            file_id='togkqbxckyjebcxratgj',
+            state='gfvidlzjkjvdbnfqoyhh',
+            product_type='cglpkczlbfjbefwwmbzh'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'ssuzclwcbhywhncpbmsl'
+        test_value = 'fuplfkcmiaghbpegtvks'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -52,7 +52,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'lbohbulvsevaklhjyxrj'
+        test_value = 'qvjbaluaguuzjzfopxlc'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -60,7 +60,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'relybinnusxvsgldvfcx'
+        test_value = 'bfzfpfbcqhtjadiwkrpm'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -68,7 +68,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'zrgvbouytapybvbxtobe'
+        test_value = 'zmucesjckpcowgfykbmo'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -76,7 +76,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(48)
+        test_value = int(51)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -84,7 +84,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'ltfvnpdwlyfvboerlqoc'
+        test_value = 'togkqbxckyjebcxratgj'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     
@@ -92,7 +92,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bespnrwlnpwwrsuhhcmf'
+        test_value = 'gfvidlzjkjvdbnfqoyhh'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -100,7 +100,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product_type property
         """
-        test_value = 'gephfjxgqruimkozktxq'
+        test_value = 'cglpkczlbfjbefwwmbzh'
         self.instance.product_type = test_value
         self.assertEqual(self.instance.product_type, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_radarproductcatalog.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_radarproductcatalog.py
@@ -28,11 +28,11 @@ class Test_RadarProductCatalog(unittest.TestCase):
         Create instance of RadarProductCatalog for testing
         """
         instance = RadarProductCatalog(
-            product='fudnfjlwaqusgchygpak',
-            file_url='ziybhjytrexnvqxkczjt',
-            description='rdgtfrvggqkevppsjpgl',
-            state='mbrifyuiknhufjmbxoug',
-            kind='bryijbrrfafnevtizwer'
+            product='nbtcvnjioafbsbzdafsi',
+            file_url='ngstolkkmkymskajjfzb',
+            description='yfmrfyhygihpgbhwdckv',
+            state='xjsgdeeklzmwopncjrbt',
+            kind='btkmjlmoxuicmabozqxq'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'fudnfjlwaqusgchygpak'
+        test_value = 'nbtcvnjioafbsbzdafsi'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -49,7 +49,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'ziybhjytrexnvqxkczjt'
+        test_value = 'ngstolkkmkymskajjfzb'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'rdgtfrvggqkevppsjpgl'
+        test_value = 'yfmrfyhygihpgbhwdckv'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'mbrifyuiknhufjmbxoug'
+        test_value = 'xjsgdeeklzmwopncjrbt'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'bryijbrrfafnevtizwer'
+        test_value = 'btkmjlmoxuicmabozqxq'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_solar10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_solar10min.py
@@ -28,14 +28,14 @@ class Test_Solar10Min(unittest.TestCase):
         Create instance of Solar10Min for testing
         """
         instance = Solar10Min(
-            station_id='ymzqinpewqvxatqfxlcm',
-            timestamp='kqagdtmxukzfacuwgcxp',
-            quality_level=int(30),
-            global_radiation=float(66.33834732373776),
-            sunshine_duration=float(77.99887336658183),
-            diffuse_radiation=float(82.83058011112063),
-            longwave_radiation=float(96.35281244421766),
-            state='mnkktogbsxjfqaeyzoad'
+            station_id='hjckuqwirsopriktmecg',
+            timestamp='nlemhyakugqdjqnwwvwy',
+            quality_level=int(4),
+            global_radiation=float(30.51514400065688),
+            sunshine_duration=float(74.95493906492543),
+            diffuse_radiation=float(47.98940760408264),
+            longwave_radiation=float(12.028736263575778),
+            state='avtiipzpukiqgmlmczzb'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'ymzqinpewqvxatqfxlcm'
+        test_value = 'hjckuqwirsopriktmecg'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'kqagdtmxukzfacuwgcxp'
+        test_value = 'nlemhyakugqdjqnwwvwy'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -60,7 +60,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(30)
+        test_value = int(4)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -68,7 +68,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(66.33834732373776)
+        test_value = float(30.51514400065688)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
     
@@ -76,7 +76,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(77.99887336658183)
+        test_value = float(74.95493906492543)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -84,7 +84,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test diffuse_radiation property
         """
-        test_value = float(82.83058011112063)
+        test_value = float(47.98940760408264)
         self.instance.diffuse_radiation = test_value
         self.assertEqual(self.instance.diffuse_radiation, test_value)
     
@@ -92,7 +92,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test longwave_radiation property
         """
-        test_value = float(96.35281244421766)
+        test_value = float(12.028736263575778)
         self.instance.longwave_radiation = test_value
         self.assertEqual(self.instance.longwave_radiation, test_value)
     
@@ -100,7 +100,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'mnkktogbsxjfqaeyzoad'
+        test_value = 'avtiipzpukiqgmlmczzb'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_stationmetadata.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_stationmetadata.py
@@ -28,14 +28,14 @@ class Test_StationMetadata(unittest.TestCase):
         Create instance of StationMetadata for testing
         """
         instance = StationMetadata(
-            station_id='lyzhfnzlalbdtpnzihnu',
-            station_name='kujnyhyhzxgetkbbhnyx',
-            latitude=float(52.17100803355499),
-            longitude=float(35.7968339705412),
-            elevation=float(53.5716295745416),
-            state='tzlscjyqfhefngmyytqo',
-            from_date='uqtyorhbtwmffknzkhmv',
-            to_date='nlxvxbaqdbsfmwdjojlg'
+            station_id='rzjtcnuptrotqcqzlqhr',
+            station_name='byocqvqqckqsjvgauagu',
+            latitude=float(66.42443795621446),
+            longitude=float(98.05132381411855),
+            elevation=float(65.61581809305221),
+            state='frzjawduifopreufwtqi',
+            from_date='mitozaxxyzthybsslcgy',
+            to_date='jdenzylrkkbzoqxhncij'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'lyzhfnzlalbdtpnzihnu'
+        test_value = 'rzjtcnuptrotqcqzlqhr'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'kujnyhyhzxgetkbbhnyx'
+        test_value = 'byocqvqqckqsjvgauagu'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -60,7 +60,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(52.17100803355499)
+        test_value = float(66.42443795621446)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -68,7 +68,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(35.7968339705412)
+        test_value = float(98.05132381411855)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -76,7 +76,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test elevation property
         """
-        test_value = float(53.5716295745416)
+        test_value = float(65.61581809305221)
         self.instance.elevation = test_value
         self.assertEqual(self.instance.elevation, test_value)
     
@@ -84,7 +84,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'tzlscjyqfhefngmyytqo'
+        test_value = 'frzjawduifopreufwtqi'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -92,7 +92,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test from_date property
         """
-        test_value = 'uqtyorhbtwmffknzkhmv'
+        test_value = 'mitozaxxyzthybsslcgy'
         self.instance.from_date = test_value
         self.assertEqual(self.instance.from_date, test_value)
     
@@ -100,7 +100,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test to_date property
         """
-        test_value = 'nlxvxbaqdbsfmwdjojlg'
+        test_value = 'jdenzylrkkbzoqxhncij'
         self.instance.to_date = test_value
         self.assertEqual(self.instance.to_date, test_value)
     

--- a/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_wind10min.py
+++ b/feeders/dwd/dwd_amqp_producer/dwd_amqp_producer_data/tests/test_wind10min.py
@@ -28,12 +28,12 @@ class Test_Wind10Min(unittest.TestCase):
         Create instance of Wind10Min for testing
         """
         instance = Wind10Min(
-            station_id='ohwihabtmlbjigvhixpt',
-            timestamp='rjfqdxbslpnazmpsojvg',
-            quality_level=int(93),
-            wind_speed=float(5.807688561407199),
-            wind_direction=float(43.63553171735567),
-            state='gzhjlklijcwkzzyygubp'
+            station_id='cqywayhikypzashdctni',
+            timestamp='uegdgwlprdedmqustypb',
+            quality_level=int(87),
+            wind_speed=float(75.19519843285943),
+            wind_direction=float(23.34535367692272),
+            state='ejxgumqrrkhlyatfdnkc'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'ohwihabtmlbjigvhixpt'
+        test_value = 'cqywayhikypzashdctni'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'rjfqdxbslpnazmpsojvg'
+        test_value = 'uegdgwlprdedmqustypb'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(93)
+        test_value = int(87)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(5.807688561407199)
+        test_value = float(75.19519843285943)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -74,7 +74,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(43.63553171735567)
+        test_value = float(23.34535367692272)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -82,7 +82,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'gzhjlklijcwkzzyygubp'
+        test_value = 'ejxgumqrrkhlyatfdnkc'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/__init__.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/__init__.py
@@ -1,15 +1,15 @@
-from .airtemperature10min import AirTemperature10Min
-from .alert import Alert
-from .precipitation10min import Precipitation10Min
-from .hourlyobservation import HourlyObservation
-from .icond2forecastfile import IconD2ForecastFile
 from .extremewind10min import ExtremeWind10Min
-from .stationmetadata import StationMetadata
-from .radarproductcatalog import RadarProductCatalog
 from .forecastmodelcatalog import ForecastModelCatalog
-from .extremetemperature10min import ExtremeTemperature10Min
+from .radarproductcatalog import RadarProductCatalog
+from .hourlyobservation import HourlyObservation
 from .wind10min import Wind10Min
-from .radarfileproduct import RadarFileProduct
+from .airtemperature10min import AirTemperature10Min
+from .precipitation10min import Precipitation10Min
+from .alert import Alert
+from .stationmetadata import StationMetadata
 from .solar10min import Solar10Min
+from .extremetemperature10min import ExtremeTemperature10Min
+from .icond2forecastfile import IconD2ForecastFile
+from .radarfileproduct import RadarFileProduct
 
-__all__ = ["AirTemperature10Min", "Alert", "Precipitation10Min", "HourlyObservation", "IconD2ForecastFile", "ExtremeWind10Min", "StationMetadata", "RadarProductCatalog", "ForecastModelCatalog", "ExtremeTemperature10Min", "Wind10Min", "RadarFileProduct", "Solar10Min"]
+__all__ = ["ExtremeWind10Min", "ForecastModelCatalog", "RadarProductCatalog", "HourlyObservation", "Wind10Min", "AirTemperature10Min", "Precipitation10Min", "Alert", "StationMetadata", "Solar10Min", "ExtremeTemperature10Min", "IconD2ForecastFile", "RadarFileProduct"]

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/airtemperature10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/airtemperature10min.py
@@ -167,13 +167,13 @@ class AirTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='hxlztofueogxeuxypfzz',
-            timestamp='pqutmaubonpujqvcoxma',
-            quality_level=int(7),
-            pressure_station_level=float(69.01626185727793),
-            air_temperature_2m=float(80.31329416509307),
-            air_temperature_5cm=float(7.211462502912225),
-            relative_humidity=float(98.5844830925457),
-            dew_point_temperature=float(19.375530424055544),
-            state='nfonlwehvnourbktrdhq'
+            station_id='qgalmaidbyucqjfznara',
+            timestamp='igbvcsdbihkanetdavpb',
+            quality_level=int(10),
+            pressure_station_level=float(8.074982021512644),
+            air_temperature_2m=float(7.291295741094228),
+            air_temperature_5cm=float(12.550637033181843),
+            relative_humidity=float(89.33633056206561),
+            dew_point_temperature=float(60.079856771533855),
+            state='ivxqothhsmepxdgcjwjt'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/alert.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/alert.py
@@ -183,21 +183,21 @@ class Alert:
             An instance of the dataclass.
         """
         return cls(
-            identifier='czplzubmjxnevfrnzfsl',
-            sender='iqlmaqiafjuhlkydkdps',
-            sent='fefxjvsdpiyhtejhqeer',
-            status='wfxrkenwkoyhjpkedmij',
-            msg_type='kjpuaqayjuehckvbraax',
-            severity='iyyagxdnpzlyicbryyhm',
-            urgency='mohuhomoralyxpddllzx',
-            certainty='xmoorubaipwbywavhcgx',
-            event='znndfzdtwpcrxzfcxkwm',
-            headline='bpwcrcjbtgrcqspxrfzk',
-            description='htsxxmshkwbkfgryyogn',
-            effective='dediowooegswnzyfqlft',
-            onset='mdsfzzlwnqeklyxdmmik',
-            expires='usspredlyadxuhwtceff',
-            area_desc='ichsozaseukjtfzuyojo',
-            geocodes='wiuvqrafmigwexflnlqc',
-            state='dzfpzgdsbyfzbaeefojn'
+            identifier='zgvpqeppvayrrkojsixe',
+            sender='pzenueauuibvbpwibjsj',
+            sent='wowssmhymbcrckhxbsqe',
+            status='ajazzmzjvabsonjbikel',
+            msg_type='koiubcndwnhjdfpfqyjw',
+            severity='wiekcmqfizdlzearazpu',
+            urgency='jqqmuomovrmydegjvqtr',
+            certainty='cvrcrbknsyplqtgwfpnf',
+            event='pygdljxuqqxrldyhdytr',
+            headline='jkrfmdakwgybzzmgfwkw',
+            description='pnvqbasgywtkkpbwhcqq',
+            effective='yckrajqaiowsbbvyycxd',
+            onset='owockssqfimrqwyteudh',
+            expires='nruipumbyafeopabllep',
+            area_desc='iapwbxevvocvqhhtglis',
+            geocodes='hklzclocteccurhfcqyd',
+            state='ipfxnbnziqpnkprxzogd'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/extremetemperature10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/extremetemperature10min.py
@@ -161,10 +161,10 @@ class ExtremeTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='onbarbirsoivydqgbcmn',
-            timestamp='trxtdvlhvnwkoxummghc',
-            quality_level=int(52),
-            air_temperature_maximum_2m=float(69.584964310763),
-            air_temperature_minimum_5cm=float(88.30874742685542),
-            state='jyskvdnparegijheuqai'
+            station_id='opwapojrmvzlkvqdesky',
+            timestamp='fhhbsewxynnorozetxwj',
+            quality_level=int(53),
+            air_temperature_maximum_2m=float(2.4047830345505172),
+            air_temperature_minimum_5cm=float(58.09330484096339),
+            state='ajhgqbxhuzrupecizqbw'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/extremewind10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/extremewind10min.py
@@ -163,11 +163,11 @@ class ExtremeWind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='alummmgmqspgadutzpnw',
-            timestamp='ialqepzqxzpogfjykqcd',
-            quality_level=int(71),
-            wind_speed_maximum=float(59.105064161872136),
-            wind_speed_minimum=float(80.6471700533496),
-            wind_direction_at_maximum=float(25.647677100244458),
-            state='mqtuvboojmigsuznwrbx'
+            station_id='wvrwhapdiyjaovkcplue',
+            timestamp='pokvytcztqwlzzqlcsvu',
+            quality_level=int(70),
+            wind_speed_maximum=float(62.854226640857206),
+            wind_speed_minimum=float(97.80192261865666),
+            wind_direction_at_maximum=float(42.63721025328947),
+            state='wzezxmgdhshhakdzbyza'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/forecastmodelcatalog.py
@@ -159,9 +159,9 @@ class ForecastModelCatalog:
             An instance of the dataclass.
         """
         return cls(
-            model='zvvlskogmjjgyaelglyr',
-            file_url='ajzorvetvlvyqitfeauk',
-            description='vkkjuwzhrvnumgmavvlc',
-            state='asotdosxbvgjmenednda',
-            kind='qxreqznbwprfydcjpbdq'
+            model='aztnksxctpjnhwtwbxpo',
+            file_url='skwiluikjkhcwgjsezih',
+            description='jawvfdlztwaesvyfiarp',
+            state='wrjrhjiybxpstvtojkno',
+            kind='ktssrzjqwnbjzjoinfaz'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/hourlyobservation.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/hourlyobservation.py
@@ -163,11 +163,11 @@ class HourlyObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='qatljkudupnawjqpwzcx',
-            timestamp='nrbcqtmlmyfmxrywomxc',
-            quality_level=int(89),
-            parameter='oqzzalifalyvwbtkvmje',
-            value=float(14.379327285172117),
-            unit='pylywuffebzypqhnqrwg',
-            state='wcrmawlctzsnjkbjdsiq'
+            station_id='kknkgaagipjeznrmhxqm',
+            timestamp='yxjrgvgtyhcubkkgcbxn',
+            quality_level=int(30),
+            parameter='jnmxiluytvyiwbefksqq',
+            value=float(13.424683154305761),
+            unit='ztaatvaruazdfbbltcwz',
+            state='usjsvtxhvayodqrzuttj'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/icond2forecastfile.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/icond2forecastfile.py
@@ -45,7 +45,7 @@ class IconD2ForecastFile:
     level_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_type"))
     level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     variable: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="variable"))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
@@ -61,6 +61,8 @@ class IconD2ForecastFile:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -71,6 +73,8 @@ class IconD2ForecastFile:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -175,17 +179,17 @@ class IconD2ForecastFile:
             An instance of the dataclass.
         """
         return cls(
-            file_url='kafqjetqvwyzkkqqxuvu',
-            model='ctnxnytjeizpzdcfmgwf',
-            file_name='ypuojopissjpwkutzmgm',
-            run='xrwevxiasjxcepbhxgzj',
-            forecast_hour=int(60),
-            parameter='vmqeklsvmemiknguzhon',
-            level_type='pydfnfpdkujnergrznft',
-            level='gzpzsqvvsrzjvbjtmfnp',
-            modified='mydejxiyxkqvptuvroyc',
-            size_bytes=int(30),
-            state='bajrmrvotsuvbokkmkhg',
-            variable='aggtornxwivntrqwuwwq',
-            file_id='fnxvhvmsrleefrpmbzkg'
+            file_url='jnaggijtkqyxizqnytts',
+            model='cpiofhjxkskzzursqpri',
+            file_name='jsbqggdaceirhotvlchi',
+            run='aabmzxoojynwwnvzukzl',
+            forecast_hour=int(59),
+            parameter='uvgxljhqyyprvcohbxnl',
+            level_type='sexbcsuqmhmchtdoejef',
+            level='bpnehcbkxrlkboyfkuai',
+            modified='ekdfrmzwqsilyhxquqzz',
+            size_bytes=int(33),
+            state='eucsvapeupjimftdwfyx',
+            variable='alifvyweniagobvggphy',
+            file_id='lgvwsykbcloonlnexppz'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/precipitation10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/precipitation10min.py
@@ -161,10 +161,10 @@ class Precipitation10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='jlbctmolsamzahijwfhd',
-            timestamp='dfqphkxsffxnelqiznej',
-            quality_level=int(97),
-            precipitation_height=float(49.422891944491475),
-            precipitation_indicator=int(26),
-            state='ztlloqpgzvnsfjvkfxqr'
+            station_id='prgjzwqdvqwmayamxaqy',
+            timestamp='jikxjcznfvfxzaedwymb',
+            quality_level=int(6),
+            precipitation_height=float(5.345596740898495),
+            precipitation_indicator=int(78),
+            state='mjedbvxarbujtcrhvnwi'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/radarfileproduct.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/radarfileproduct.py
@@ -35,7 +35,7 @@ class RadarFileProduct:
     product: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product"))
     file_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_name"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     product_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product_type"))
@@ -51,6 +51,8 @@ class RadarFileProduct:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -61,6 +63,8 @@ class RadarFileProduct:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -165,12 +169,12 @@ class RadarFileProduct:
             An instance of the dataclass.
         """
         return cls(
-            file_url='hhgfbvhcfsehyvkumzwj',
-            product='clibyfjtnxhvdpolfzpc',
-            file_name='bufydcxtcjiryxnvpkyf',
-            modified='flljnysawrinzcgfysay',
-            size_bytes=int(78),
-            file_id='axlarasjztppyulfoexo',
-            state='pzvhzmgugoatztaqixfa',
-            product_type='emedmtvsawbnnxwyjdwi'
+            file_url='oonyiyifuhmtximtcitw',
+            product='ojdtssnwnyhghvaqsrqk',
+            file_name='hblsxmuizwhgwuxmpytx',
+            modified='vtnsesuzufzhokwjgtfx',
+            size_bytes=int(18),
+            file_id='wyeqdqfbvhaqdsgronjp',
+            state='mustffrunzxesxjyyfur',
+            product_type='aosboeihywzwcfasgllk'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/radarproductcatalog.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/radarproductcatalog.py
@@ -159,9 +159,9 @@ class RadarProductCatalog:
             An instance of the dataclass.
         """
         return cls(
-            product='onnfbubddikihqclxwec',
-            file_url='qphmybaqtjwoeomqamnb',
-            description='bgltqacgwlqzvgwmbgzg',
-            state='pmhmwyqnxlxharnxdnhd',
-            kind='oedpndzhaaenrvcyuxrf'
+            product='jgwaqoznwxbsyakacypl',
+            file_url='xjjnrttctcqrbqwauiha',
+            description='pookgsibehjnfkzanwts',
+            state='uofzcjfuhzpkeoiqinkk',
+            kind='gnrppojfxxlqvdenaoxp'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/solar10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/solar10min.py
@@ -165,12 +165,12 @@ class Solar10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='umxjbfnlpiywqnbzuvut',
-            timestamp='prdjugfazhktygtikofv',
-            quality_level=int(77),
-            global_radiation=float(19.808425464990343),
-            sunshine_duration=float(64.43747628640989),
-            diffuse_radiation=float(69.28593325509543),
-            longwave_radiation=float(29.884669667411835),
-            state='bjzunwzxnjcixhkycxnw'
+            station_id='ykwcakjzyfkogyqijvlo',
+            timestamp='gzabgczffsmfaactztzy',
+            quality_level=int(78),
+            global_radiation=float(76.64467028768578),
+            sunshine_duration=float(83.8136226518291),
+            diffuse_radiation=float(24.35471488235873),
+            longwave_radiation=float(73.12248661422935),
+            state='rmtprkvzgusouuvgyxlj'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/stationmetadata.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/stationmetadata.py
@@ -165,12 +165,12 @@ class StationMetadata:
             An instance of the dataclass.
         """
         return cls(
-            station_id='nipiuskcwgtwrtypucsa',
-            station_name='pasdbfxfisavqyrtruba',
-            latitude=float(8.192867004094973),
-            longitude=float(0.39973448714897275),
-            elevation=float(47.28433140372632),
-            state='rexhhsaasfmnpsudpgkw',
-            from_date='cqnyencrxibojzaxwztx',
-            to_date='ldnzbpobpxwbjlsxfguv'
+            station_id='sbheszhljmatnegppfvd',
+            station_name='sossjypyrzbgpnceameq',
+            latitude=float(42.388988749109004),
+            longitude=float(95.94938855609294),
+            elevation=float(5.300212014601746),
+            state='dahhckrnekvirgoayopa',
+            from_date='hbrujnbxnmbeztdepdye',
+            to_date='lkuhdjjxkfoytcgcncxv'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/wind10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/src/dwd_mqtt_producer_data/wind10min.py
@@ -161,10 +161,10 @@ class Wind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='brnbswzcjwcsmzrqplxb',
-            timestamp='lqditvrzlhehfkbltrlf',
-            quality_level=int(2),
-            wind_speed=float(82.97920566332544),
-            wind_direction=float(72.20313939830982),
-            state='gwgsqehzhmvtkvexynss'
+            station_id='tpxexjhjbfteiwoytidl',
+            timestamp='nhnqqhqxohyrkczncaqq',
+            quality_level=int(4),
+            wind_speed=float(41.38728282174198),
+            wind_direction=float(67.82171648655185),
+            state='uynxcxhcuwrtoxqzkhwx'
         )

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_airtemperature10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_airtemperature10min.py
@@ -28,15 +28,15 @@ class Test_AirTemperature10Min(unittest.TestCase):
         Create instance of AirTemperature10Min for testing
         """
         instance = AirTemperature10Min(
-            station_id='hxlztofueogxeuxypfzz',
-            timestamp='pqutmaubonpujqvcoxma',
-            quality_level=int(7),
-            pressure_station_level=float(69.01626185727793),
-            air_temperature_2m=float(80.31329416509307),
-            air_temperature_5cm=float(7.211462502912225),
-            relative_humidity=float(98.5844830925457),
-            dew_point_temperature=float(19.375530424055544),
-            state='nfonlwehvnourbktrdhq'
+            station_id='qgalmaidbyucqjfznara',
+            timestamp='igbvcsdbihkanetdavpb',
+            quality_level=int(10),
+            pressure_station_level=float(8.074982021512644),
+            air_temperature_2m=float(7.291295741094228),
+            air_temperature_5cm=float(12.550637033181843),
+            relative_humidity=float(89.33633056206561),
+            dew_point_temperature=float(60.079856771533855),
+            state='ivxqothhsmepxdgcjwjt'
         )
         return instance
 
@@ -45,7 +45,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'hxlztofueogxeuxypfzz'
+        test_value = 'qgalmaidbyucqjfznara'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -53,7 +53,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'pqutmaubonpujqvcoxma'
+        test_value = 'igbvcsdbihkanetdavpb'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -61,7 +61,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(7)
+        test_value = int(10)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -69,7 +69,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test pressure_station_level property
         """
-        test_value = float(69.01626185727793)
+        test_value = float(8.074982021512644)
         self.instance.pressure_station_level = test_value
         self.assertEqual(self.instance.pressure_station_level, test_value)
     
@@ -77,7 +77,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_2m property
         """
-        test_value = float(80.31329416509307)
+        test_value = float(7.291295741094228)
         self.instance.air_temperature_2m = test_value
         self.assertEqual(self.instance.air_temperature_2m, test_value)
     
@@ -85,7 +85,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_5cm property
         """
-        test_value = float(7.211462502912225)
+        test_value = float(12.550637033181843)
         self.instance.air_temperature_5cm = test_value
         self.assertEqual(self.instance.air_temperature_5cm, test_value)
     
@@ -93,7 +93,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test relative_humidity property
         """
-        test_value = float(98.5844830925457)
+        test_value = float(89.33633056206561)
         self.instance.relative_humidity = test_value
         self.assertEqual(self.instance.relative_humidity, test_value)
     
@@ -101,7 +101,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test dew_point_temperature property
         """
-        test_value = float(19.375530424055544)
+        test_value = float(60.079856771533855)
         self.instance.dew_point_temperature = test_value
         self.assertEqual(self.instance.dew_point_temperature, test_value)
     
@@ -109,7 +109,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'nfonlwehvnourbktrdhq'
+        test_value = 'ivxqothhsmepxdgcjwjt'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_alert.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_alert.py
@@ -28,23 +28,23 @@ class Test_Alert(unittest.TestCase):
         Create instance of Alert for testing
         """
         instance = Alert(
-            identifier='czplzubmjxnevfrnzfsl',
-            sender='iqlmaqiafjuhlkydkdps',
-            sent='fefxjvsdpiyhtejhqeer',
-            status='wfxrkenwkoyhjpkedmij',
-            msg_type='kjpuaqayjuehckvbraax',
-            severity='iyyagxdnpzlyicbryyhm',
-            urgency='mohuhomoralyxpddllzx',
-            certainty='xmoorubaipwbywavhcgx',
-            event='znndfzdtwpcrxzfcxkwm',
-            headline='bpwcrcjbtgrcqspxrfzk',
-            description='htsxxmshkwbkfgryyogn',
-            effective='dediowooegswnzyfqlft',
-            onset='mdsfzzlwnqeklyxdmmik',
-            expires='usspredlyadxuhwtceff',
-            area_desc='ichsozaseukjtfzuyojo',
-            geocodes='wiuvqrafmigwexflnlqc',
-            state='dzfpzgdsbyfzbaeefojn'
+            identifier='zgvpqeppvayrrkojsixe',
+            sender='pzenueauuibvbpwibjsj',
+            sent='wowssmhymbcrckhxbsqe',
+            status='ajazzmzjvabsonjbikel',
+            msg_type='koiubcndwnhjdfpfqyjw',
+            severity='wiekcmqfizdlzearazpu',
+            urgency='jqqmuomovrmydegjvqtr',
+            certainty='cvrcrbknsyplqtgwfpnf',
+            event='pygdljxuqqxrldyhdytr',
+            headline='jkrfmdakwgybzzmgfwkw',
+            description='pnvqbasgywtkkpbwhcqq',
+            effective='yckrajqaiowsbbvyycxd',
+            onset='owockssqfimrqwyteudh',
+            expires='nruipumbyafeopabllep',
+            area_desc='iapwbxevvocvqhhtglis',
+            geocodes='hklzclocteccurhfcqyd',
+            state='ipfxnbnziqpnkprxzogd'
         )
         return instance
 
@@ -53,7 +53,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test identifier property
         """
-        test_value = 'czplzubmjxnevfrnzfsl'
+        test_value = 'zgvpqeppvayrrkojsixe'
         self.instance.identifier = test_value
         self.assertEqual(self.instance.identifier, test_value)
     
@@ -61,7 +61,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sender property
         """
-        test_value = 'iqlmaqiafjuhlkydkdps'
+        test_value = 'pzenueauuibvbpwibjsj'
         self.instance.sender = test_value
         self.assertEqual(self.instance.sender, test_value)
     
@@ -69,7 +69,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sent property
         """
-        test_value = 'fefxjvsdpiyhtejhqeer'
+        test_value = 'wowssmhymbcrckhxbsqe'
         self.instance.sent = test_value
         self.assertEqual(self.instance.sent, test_value)
     
@@ -77,7 +77,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test status property
         """
-        test_value = 'wfxrkenwkoyhjpkedmij'
+        test_value = 'ajazzmzjvabsonjbikel'
         self.instance.status = test_value
         self.assertEqual(self.instance.status, test_value)
     
@@ -85,7 +85,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test msg_type property
         """
-        test_value = 'kjpuaqayjuehckvbraax'
+        test_value = 'koiubcndwnhjdfpfqyjw'
         self.instance.msg_type = test_value
         self.assertEqual(self.instance.msg_type, test_value)
     
@@ -93,7 +93,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = 'iyyagxdnpzlyicbryyhm'
+        test_value = 'wiekcmqfizdlzearazpu'
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     
@@ -101,7 +101,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test urgency property
         """
-        test_value = 'mohuhomoralyxpddllzx'
+        test_value = 'jqqmuomovrmydegjvqtr'
         self.instance.urgency = test_value
         self.assertEqual(self.instance.urgency, test_value)
     
@@ -109,7 +109,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test certainty property
         """
-        test_value = 'xmoorubaipwbywavhcgx'
+        test_value = 'cvrcrbknsyplqtgwfpnf'
         self.instance.certainty = test_value
         self.assertEqual(self.instance.certainty, test_value)
     
@@ -117,7 +117,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test event property
         """
-        test_value = 'znndfzdtwpcrxzfcxkwm'
+        test_value = 'pygdljxuqqxrldyhdytr'
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -125,7 +125,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test headline property
         """
-        test_value = 'bpwcrcjbtgrcqspxrfzk'
+        test_value = 'jkrfmdakwgybzzmgfwkw'
         self.instance.headline = test_value
         self.assertEqual(self.instance.headline, test_value)
     
@@ -133,7 +133,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'htsxxmshkwbkfgryyogn'
+        test_value = 'pnvqbasgywtkkpbwhcqq'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -141,7 +141,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test effective property
         """
-        test_value = 'dediowooegswnzyfqlft'
+        test_value = 'yckrajqaiowsbbvyycxd'
         self.instance.effective = test_value
         self.assertEqual(self.instance.effective, test_value)
     
@@ -149,7 +149,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test onset property
         """
-        test_value = 'mdsfzzlwnqeklyxdmmik'
+        test_value = 'owockssqfimrqwyteudh'
         self.instance.onset = test_value
         self.assertEqual(self.instance.onset, test_value)
     
@@ -157,7 +157,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test expires property
         """
-        test_value = 'usspredlyadxuhwtceff'
+        test_value = 'nruipumbyafeopabllep'
         self.instance.expires = test_value
         self.assertEqual(self.instance.expires, test_value)
     
@@ -165,7 +165,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test area_desc property
         """
-        test_value = 'ichsozaseukjtfzuyojo'
+        test_value = 'iapwbxevvocvqhhtglis'
         self.instance.area_desc = test_value
         self.assertEqual(self.instance.area_desc, test_value)
     
@@ -173,7 +173,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test geocodes property
         """
-        test_value = 'wiuvqrafmigwexflnlqc'
+        test_value = 'hklzclocteccurhfcqyd'
         self.instance.geocodes = test_value
         self.assertEqual(self.instance.geocodes, test_value)
     
@@ -181,7 +181,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'dzfpzgdsbyfzbaeefojn'
+        test_value = 'ipfxnbnziqpnkprxzogd'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_extremetemperature10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_extremetemperature10min.py
@@ -28,12 +28,12 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         Create instance of ExtremeTemperature10Min for testing
         """
         instance = ExtremeTemperature10Min(
-            station_id='onbarbirsoivydqgbcmn',
-            timestamp='trxtdvlhvnwkoxummghc',
-            quality_level=int(52),
-            air_temperature_maximum_2m=float(69.584964310763),
-            air_temperature_minimum_5cm=float(88.30874742685542),
-            state='jyskvdnparegijheuqai'
+            station_id='opwapojrmvzlkvqdesky',
+            timestamp='fhhbsewxynnorozetxwj',
+            quality_level=int(53),
+            air_temperature_maximum_2m=float(2.4047830345505172),
+            air_temperature_minimum_5cm=float(58.09330484096339),
+            state='ajhgqbxhuzrupecizqbw'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'onbarbirsoivydqgbcmn'
+        test_value = 'opwapojrmvzlkvqdesky'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'trxtdvlhvnwkoxummghc'
+        test_value = 'fhhbsewxynnorozetxwj'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(52)
+        test_value = int(53)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_maximum_2m property
         """
-        test_value = float(69.584964310763)
+        test_value = float(2.4047830345505172)
         self.instance.air_temperature_maximum_2m = test_value
         self.assertEqual(self.instance.air_temperature_maximum_2m, test_value)
     
@@ -74,7 +74,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_minimum_5cm property
         """
-        test_value = float(88.30874742685542)
+        test_value = float(58.09330484096339)
         self.instance.air_temperature_minimum_5cm = test_value
         self.assertEqual(self.instance.air_temperature_minimum_5cm, test_value)
     
@@ -82,7 +82,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'jyskvdnparegijheuqai'
+        test_value = 'ajhgqbxhuzrupecizqbw'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_extremewind10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_extremewind10min.py
@@ -28,13 +28,13 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         Create instance of ExtremeWind10Min for testing
         """
         instance = ExtremeWind10Min(
-            station_id='alummmgmqspgadutzpnw',
-            timestamp='ialqepzqxzpogfjykqcd',
-            quality_level=int(71),
-            wind_speed_maximum=float(59.105064161872136),
-            wind_speed_minimum=float(80.6471700533496),
-            wind_direction_at_maximum=float(25.647677100244458),
-            state='mqtuvboojmigsuznwrbx'
+            station_id='wvrwhapdiyjaovkcplue',
+            timestamp='pokvytcztqwlzzqlcsvu',
+            quality_level=int(70),
+            wind_speed_maximum=float(62.854226640857206),
+            wind_speed_minimum=float(97.80192261865666),
+            wind_direction_at_maximum=float(42.63721025328947),
+            state='wzezxmgdhshhakdzbyza'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'alummmgmqspgadutzpnw'
+        test_value = 'wvrwhapdiyjaovkcplue'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'ialqepzqxzpogfjykqcd'
+        test_value = 'pokvytcztqwlzzqlcsvu'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(71)
+        test_value = int(70)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_maximum property
         """
-        test_value = float(59.105064161872136)
+        test_value = float(62.854226640857206)
         self.instance.wind_speed_maximum = test_value
         self.assertEqual(self.instance.wind_speed_maximum, test_value)
     
@@ -75,7 +75,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_minimum property
         """
-        test_value = float(80.6471700533496)
+        test_value = float(97.80192261865666)
         self.instance.wind_speed_minimum = test_value
         self.assertEqual(self.instance.wind_speed_minimum, test_value)
     
@@ -83,7 +83,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_direction_at_maximum property
         """
-        test_value = float(25.647677100244458)
+        test_value = float(42.63721025328947)
         self.instance.wind_direction_at_maximum = test_value
         self.assertEqual(self.instance.wind_direction_at_maximum, test_value)
     
@@ -91,7 +91,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'mqtuvboojmigsuznwrbx'
+        test_value = 'wzezxmgdhshhakdzbyza'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_forecastmodelcatalog.py
@@ -28,11 +28,11 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         Create instance of ForecastModelCatalog for testing
         """
         instance = ForecastModelCatalog(
-            model='zvvlskogmjjgyaelglyr',
-            file_url='ajzorvetvlvyqitfeauk',
-            description='vkkjuwzhrvnumgmavvlc',
-            state='asotdosxbvgjmenednda',
-            kind='qxreqznbwprfydcjpbdq'
+            model='aztnksxctpjnhwtwbxpo',
+            file_url='skwiluikjkhcwgjsezih',
+            description='jawvfdlztwaesvyfiarp',
+            state='wrjrhjiybxpstvtojkno',
+            kind='ktssrzjqwnbjzjoinfaz'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'zvvlskogmjjgyaelglyr'
+        test_value = 'aztnksxctpjnhwtwbxpo'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -49,7 +49,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'ajzorvetvlvyqitfeauk'
+        test_value = 'skwiluikjkhcwgjsezih'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'vkkjuwzhrvnumgmavvlc'
+        test_value = 'jawvfdlztwaesvyfiarp'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'asotdosxbvgjmenednda'
+        test_value = 'wrjrhjiybxpstvtojkno'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'qxreqznbwprfydcjpbdq'
+        test_value = 'ktssrzjqwnbjzjoinfaz'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_hourlyobservation.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_hourlyobservation.py
@@ -28,13 +28,13 @@ class Test_HourlyObservation(unittest.TestCase):
         Create instance of HourlyObservation for testing
         """
         instance = HourlyObservation(
-            station_id='qatljkudupnawjqpwzcx',
-            timestamp='nrbcqtmlmyfmxrywomxc',
-            quality_level=int(89),
-            parameter='oqzzalifalyvwbtkvmje',
-            value=float(14.379327285172117),
-            unit='pylywuffebzypqhnqrwg',
-            state='wcrmawlctzsnjkbjdsiq'
+            station_id='kknkgaagipjeznrmhxqm',
+            timestamp='yxjrgvgtyhcubkkgcbxn',
+            quality_level=int(30),
+            parameter='jnmxiluytvyiwbefksqq',
+            value=float(13.424683154305761),
+            unit='ztaatvaruazdfbbltcwz',
+            state='usjsvtxhvayodqrzuttj'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'qatljkudupnawjqpwzcx'
+        test_value = 'kknkgaagipjeznrmhxqm'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'nrbcqtmlmyfmxrywomxc'
+        test_value = 'yxjrgvgtyhcubkkgcbxn'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(89)
+        test_value = int(30)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'oqzzalifalyvwbtkvmje'
+        test_value = 'jnmxiluytvyiwbefksqq'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -75,7 +75,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(14.379327285172117)
+        test_value = float(13.424683154305761)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -83,7 +83,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test unit property
         """
-        test_value = 'pylywuffebzypqhnqrwg'
+        test_value = 'ztaatvaruazdfbbltcwz'
         self.instance.unit = test_value
         self.assertEqual(self.instance.unit, test_value)
     
@@ -91,7 +91,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'wcrmawlctzsnjkbjdsiq'
+        test_value = 'usjsvtxhvayodqrzuttj'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_icond2forecastfile.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_icond2forecastfile.py
@@ -28,19 +28,19 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         Create instance of IconD2ForecastFile for testing
         """
         instance = IconD2ForecastFile(
-            file_url='kafqjetqvwyzkkqqxuvu',
-            model='ctnxnytjeizpzdcfmgwf',
-            file_name='ypuojopissjpwkutzmgm',
-            run='xrwevxiasjxcepbhxgzj',
-            forecast_hour=int(60),
-            parameter='vmqeklsvmemiknguzhon',
-            level_type='pydfnfpdkujnergrznft',
-            level='gzpzsqvvsrzjvbjtmfnp',
-            modified='mydejxiyxkqvptuvroyc',
-            size_bytes=int(30),
-            state='bajrmrvotsuvbokkmkhg',
-            variable='aggtornxwivntrqwuwwq',
-            file_id='fnxvhvmsrleefrpmbzkg'
+            file_url='jnaggijtkqyxizqnytts',
+            model='cpiofhjxkskzzursqpri',
+            file_name='jsbqggdaceirhotvlchi',
+            run='aabmzxoojynwwnvzukzl',
+            forecast_hour=int(59),
+            parameter='uvgxljhqyyprvcohbxnl',
+            level_type='sexbcsuqmhmchtdoejef',
+            level='bpnehcbkxrlkboyfkuai',
+            modified='ekdfrmzwqsilyhxquqzz',
+            size_bytes=int(33),
+            state='eucsvapeupjimftdwfyx',
+            variable='alifvyweniagobvggphy',
+            file_id='lgvwsykbcloonlnexppz'
         )
         return instance
 
@@ -49,7 +49,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'kafqjetqvwyzkkqqxuvu'
+        test_value = 'jnaggijtkqyxizqnytts'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'ctnxnytjeizpzdcfmgwf'
+        test_value = 'cpiofhjxkskzzursqpri'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -65,7 +65,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'ypuojopissjpwkutzmgm'
+        test_value = 'jsbqggdaceirhotvlchi'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -73,7 +73,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test run property
         """
-        test_value = 'xrwevxiasjxcepbhxgzj'
+        test_value = 'aabmzxoojynwwnvzukzl'
         self.instance.run = test_value
         self.assertEqual(self.instance.run, test_value)
     
@@ -81,7 +81,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test forecast_hour property
         """
-        test_value = int(60)
+        test_value = int(59)
         self.instance.forecast_hour = test_value
         self.assertEqual(self.instance.forecast_hour, test_value)
     
@@ -89,7 +89,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'vmqeklsvmemiknguzhon'
+        test_value = 'uvgxljhqyyprvcohbxnl'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -97,7 +97,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level_type property
         """
-        test_value = 'pydfnfpdkujnergrznft'
+        test_value = 'sexbcsuqmhmchtdoejef'
         self.instance.level_type = test_value
         self.assertEqual(self.instance.level_type, test_value)
     
@@ -105,7 +105,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level property
         """
-        test_value = 'gzpzsqvvsrzjvbjtmfnp'
+        test_value = 'bpnehcbkxrlkboyfkuai'
         self.instance.level = test_value
         self.assertEqual(self.instance.level, test_value)
     
@@ -113,7 +113,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'mydejxiyxkqvptuvroyc'
+        test_value = 'ekdfrmzwqsilyhxquqzz'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -121,7 +121,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(30)
+        test_value = int(33)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -129,7 +129,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bajrmrvotsuvbokkmkhg'
+        test_value = 'eucsvapeupjimftdwfyx'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -137,7 +137,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test variable property
         """
-        test_value = 'aggtornxwivntrqwuwwq'
+        test_value = 'alifvyweniagobvggphy'
         self.instance.variable = test_value
         self.assertEqual(self.instance.variable, test_value)
     
@@ -145,7 +145,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'fnxvhvmsrleefrpmbzkg'
+        test_value = 'lgvwsykbcloonlnexppz'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_precipitation10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_precipitation10min.py
@@ -28,12 +28,12 @@ class Test_Precipitation10Min(unittest.TestCase):
         Create instance of Precipitation10Min for testing
         """
         instance = Precipitation10Min(
-            station_id='jlbctmolsamzahijwfhd',
-            timestamp='dfqphkxsffxnelqiznej',
-            quality_level=int(97),
-            precipitation_height=float(49.422891944491475),
-            precipitation_indicator=int(26),
-            state='ztlloqpgzvnsfjvkfxqr'
+            station_id='prgjzwqdvqwmayamxaqy',
+            timestamp='jikxjcznfvfxzaedwymb',
+            quality_level=int(6),
+            precipitation_height=float(5.345596740898495),
+            precipitation_indicator=int(78),
+            state='mjedbvxarbujtcrhvnwi'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'jlbctmolsamzahijwfhd'
+        test_value = 'prgjzwqdvqwmayamxaqy'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'dfqphkxsffxnelqiznej'
+        test_value = 'jikxjcznfvfxzaedwymb'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(97)
+        test_value = int(6)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_height property
         """
-        test_value = float(49.422891944491475)
+        test_value = float(5.345596740898495)
         self.instance.precipitation_height = test_value
         self.assertEqual(self.instance.precipitation_height, test_value)
     
@@ -74,7 +74,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_indicator property
         """
-        test_value = int(26)
+        test_value = int(78)
         self.instance.precipitation_indicator = test_value
         self.assertEqual(self.instance.precipitation_indicator, test_value)
     
@@ -82,7 +82,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'ztlloqpgzvnsfjvkfxqr'
+        test_value = 'mjedbvxarbujtcrhvnwi'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_radarfileproduct.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_radarfileproduct.py
@@ -28,14 +28,14 @@ class Test_RadarFileProduct(unittest.TestCase):
         Create instance of RadarFileProduct for testing
         """
         instance = RadarFileProduct(
-            file_url='hhgfbvhcfsehyvkumzwj',
-            product='clibyfjtnxhvdpolfzpc',
-            file_name='bufydcxtcjiryxnvpkyf',
-            modified='flljnysawrinzcgfysay',
-            size_bytes=int(78),
-            file_id='axlarasjztppyulfoexo',
-            state='pzvhzmgugoatztaqixfa',
-            product_type='emedmtvsawbnnxwyjdwi'
+            file_url='oonyiyifuhmtximtcitw',
+            product='ojdtssnwnyhghvaqsrqk',
+            file_name='hblsxmuizwhgwuxmpytx',
+            modified='vtnsesuzufzhokwjgtfx',
+            size_bytes=int(18),
+            file_id='wyeqdqfbvhaqdsgronjp',
+            state='mustffrunzxesxjyyfur',
+            product_type='aosboeihywzwcfasgllk'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'hhgfbvhcfsehyvkumzwj'
+        test_value = 'oonyiyifuhmtximtcitw'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -52,7 +52,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'clibyfjtnxhvdpolfzpc'
+        test_value = 'ojdtssnwnyhghvaqsrqk'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -60,7 +60,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'bufydcxtcjiryxnvpkyf'
+        test_value = 'hblsxmuizwhgwuxmpytx'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -68,7 +68,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'flljnysawrinzcgfysay'
+        test_value = 'vtnsesuzufzhokwjgtfx'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -76,7 +76,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(78)
+        test_value = int(18)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -84,7 +84,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'axlarasjztppyulfoexo'
+        test_value = 'wyeqdqfbvhaqdsgronjp'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     
@@ -92,7 +92,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'pzvhzmgugoatztaqixfa'
+        test_value = 'mustffrunzxesxjyyfur'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -100,7 +100,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product_type property
         """
-        test_value = 'emedmtvsawbnnxwyjdwi'
+        test_value = 'aosboeihywzwcfasgllk'
         self.instance.product_type = test_value
         self.assertEqual(self.instance.product_type, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_radarproductcatalog.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_radarproductcatalog.py
@@ -28,11 +28,11 @@ class Test_RadarProductCatalog(unittest.TestCase):
         Create instance of RadarProductCatalog for testing
         """
         instance = RadarProductCatalog(
-            product='onnfbubddikihqclxwec',
-            file_url='qphmybaqtjwoeomqamnb',
-            description='bgltqacgwlqzvgwmbgzg',
-            state='pmhmwyqnxlxharnxdnhd',
-            kind='oedpndzhaaenrvcyuxrf'
+            product='jgwaqoznwxbsyakacypl',
+            file_url='xjjnrttctcqrbqwauiha',
+            description='pookgsibehjnfkzanwts',
+            state='uofzcjfuhzpkeoiqinkk',
+            kind='gnrppojfxxlqvdenaoxp'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'onnfbubddikihqclxwec'
+        test_value = 'jgwaqoznwxbsyakacypl'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -49,7 +49,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'qphmybaqtjwoeomqamnb'
+        test_value = 'xjjnrttctcqrbqwauiha'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'bgltqacgwlqzvgwmbgzg'
+        test_value = 'pookgsibehjnfkzanwts'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'pmhmwyqnxlxharnxdnhd'
+        test_value = 'uofzcjfuhzpkeoiqinkk'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'oedpndzhaaenrvcyuxrf'
+        test_value = 'gnrppojfxxlqvdenaoxp'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_solar10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_solar10min.py
@@ -28,14 +28,14 @@ class Test_Solar10Min(unittest.TestCase):
         Create instance of Solar10Min for testing
         """
         instance = Solar10Min(
-            station_id='umxjbfnlpiywqnbzuvut',
-            timestamp='prdjugfazhktygtikofv',
-            quality_level=int(77),
-            global_radiation=float(19.808425464990343),
-            sunshine_duration=float(64.43747628640989),
-            diffuse_radiation=float(69.28593325509543),
-            longwave_radiation=float(29.884669667411835),
-            state='bjzunwzxnjcixhkycxnw'
+            station_id='ykwcakjzyfkogyqijvlo',
+            timestamp='gzabgczffsmfaactztzy',
+            quality_level=int(78),
+            global_radiation=float(76.64467028768578),
+            sunshine_duration=float(83.8136226518291),
+            diffuse_radiation=float(24.35471488235873),
+            longwave_radiation=float(73.12248661422935),
+            state='rmtprkvzgusouuvgyxlj'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'umxjbfnlpiywqnbzuvut'
+        test_value = 'ykwcakjzyfkogyqijvlo'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'prdjugfazhktygtikofv'
+        test_value = 'gzabgczffsmfaactztzy'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -60,7 +60,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(77)
+        test_value = int(78)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -68,7 +68,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(19.808425464990343)
+        test_value = float(76.64467028768578)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
     
@@ -76,7 +76,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(64.43747628640989)
+        test_value = float(83.8136226518291)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -84,7 +84,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test diffuse_radiation property
         """
-        test_value = float(69.28593325509543)
+        test_value = float(24.35471488235873)
         self.instance.diffuse_radiation = test_value
         self.assertEqual(self.instance.diffuse_radiation, test_value)
     
@@ -92,7 +92,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test longwave_radiation property
         """
-        test_value = float(29.884669667411835)
+        test_value = float(73.12248661422935)
         self.instance.longwave_radiation = test_value
         self.assertEqual(self.instance.longwave_radiation, test_value)
     
@@ -100,7 +100,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bjzunwzxnjcixhkycxnw'
+        test_value = 'rmtprkvzgusouuvgyxlj'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_stationmetadata.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_stationmetadata.py
@@ -28,14 +28,14 @@ class Test_StationMetadata(unittest.TestCase):
         Create instance of StationMetadata for testing
         """
         instance = StationMetadata(
-            station_id='nipiuskcwgtwrtypucsa',
-            station_name='pasdbfxfisavqyrtruba',
-            latitude=float(8.192867004094973),
-            longitude=float(0.39973448714897275),
-            elevation=float(47.28433140372632),
-            state='rexhhsaasfmnpsudpgkw',
-            from_date='cqnyencrxibojzaxwztx',
-            to_date='ldnzbpobpxwbjlsxfguv'
+            station_id='sbheszhljmatnegppfvd',
+            station_name='sossjypyrzbgpnceameq',
+            latitude=float(42.388988749109004),
+            longitude=float(95.94938855609294),
+            elevation=float(5.300212014601746),
+            state='dahhckrnekvirgoayopa',
+            from_date='hbrujnbxnmbeztdepdye',
+            to_date='lkuhdjjxkfoytcgcncxv'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'nipiuskcwgtwrtypucsa'
+        test_value = 'sbheszhljmatnegppfvd'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'pasdbfxfisavqyrtruba'
+        test_value = 'sossjypyrzbgpnceameq'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -60,7 +60,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(8.192867004094973)
+        test_value = float(42.388988749109004)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -68,7 +68,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(0.39973448714897275)
+        test_value = float(95.94938855609294)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -76,7 +76,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test elevation property
         """
-        test_value = float(47.28433140372632)
+        test_value = float(5.300212014601746)
         self.instance.elevation = test_value
         self.assertEqual(self.instance.elevation, test_value)
     
@@ -84,7 +84,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'rexhhsaasfmnpsudpgkw'
+        test_value = 'dahhckrnekvirgoayopa'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -92,7 +92,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test from_date property
         """
-        test_value = 'cqnyencrxibojzaxwztx'
+        test_value = 'hbrujnbxnmbeztdepdye'
         self.instance.from_date = test_value
         self.assertEqual(self.instance.from_date, test_value)
     
@@ -100,7 +100,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test to_date property
         """
-        test_value = 'ldnzbpobpxwbjlsxfguv'
+        test_value = 'lkuhdjjxkfoytcgcncxv'
         self.instance.to_date = test_value
         self.assertEqual(self.instance.to_date, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_wind10min.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_data/tests/test_wind10min.py
@@ -28,12 +28,12 @@ class Test_Wind10Min(unittest.TestCase):
         Create instance of Wind10Min for testing
         """
         instance = Wind10Min(
-            station_id='brnbswzcjwcsmzrqplxb',
-            timestamp='lqditvrzlhehfkbltrlf',
-            quality_level=int(2),
-            wind_speed=float(82.97920566332544),
-            wind_direction=float(72.20313939830982),
-            state='gwgsqehzhmvtkvexynss'
+            station_id='tpxexjhjbfteiwoytidl',
+            timestamp='nhnqqhqxohyrkczncaqq',
+            quality_level=int(4),
+            wind_speed=float(41.38728282174198),
+            wind_direction=float(67.82171648655185),
+            state='uynxcxhcuwrtoxqzkhwx'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'brnbswzcjwcsmzrqplxb'
+        test_value = 'tpxexjhjbfteiwoytidl'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'lqditvrzlhehfkbltrlf'
+        test_value = 'nhnqqhqxohyrkczncaqq'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(2)
+        test_value = int(4)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(82.97920566332544)
+        test_value = float(41.38728282174198)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -74,7 +74,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(72.20313939830982)
+        test_value = float(67.82171648655185)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -82,7 +82,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'gwgsqehzhmvtkvexynss'
+        test_value = 'uynxcxhcuwrtoxqzkhwx'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/src/dwd_mqtt_producer_mqtt_client/client.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/src/dwd_mqtt_producer_mqtt_client/client.py
@@ -4,6 +4,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
     # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
@@ -34,6 +35,51 @@ from dwd_mqtt_producer_data import IconD2ForecastFile
 
 # URI template regex pattern
 _URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 
 
 def _topic_to_mqtt_wildcard(topic: str) -> str:
@@ -464,6 +510,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.StationMetadata' event to an MQTT topic.
@@ -477,6 +524,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/info"
@@ -493,6 +541,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -540,6 +589,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.AirTemperature10Min' event to an MQTT topic.
@@ -553,6 +603,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/air-temperature-10min"
@@ -569,6 +620,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -616,6 +668,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.Precipitation10Min' event to an MQTT topic.
@@ -629,6 +682,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/precipitation-10min"
@@ -645,6 +699,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -692,6 +747,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.Wind10Min' event to an MQTT topic.
@@ -705,6 +761,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/wind-10min"
@@ -721,6 +778,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -768,6 +826,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.Solar10Min' event to an MQTT topic.
@@ -781,6 +840,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/solar-10min"
@@ -797,6 +857,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -844,6 +905,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.HourlyObservation' event to an MQTT topic.
@@ -857,6 +919,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/hourly-observation"
@@ -873,6 +936,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -920,6 +984,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.ExtremeWind10Min' event to an MQTT topic.
@@ -933,6 +998,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/extreme-wind-10min"
@@ -949,6 +1015,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -996,6 +1063,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.CDC.mqtt.ExtremeTemperature10Min' event to an MQTT topic.
@@ -1009,6 +1077,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/{state}/{station_id}/extreme-temperature-10min"
@@ -1025,6 +1094,7 @@ class DEDWDCDCMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -1237,6 +1307,7 @@ class DEDWDWeatherMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.Weather.mqtt.Alert' event to an MQTT topic.
@@ -1251,6 +1322,7 @@ class DEDWDWeatherMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "alerts/de/dwd/dwd/{state}/{severity}/{identifier}/alert"
@@ -1268,6 +1340,7 @@ class DEDWDWeatherMqttMqttClient(_ClientBase):
              "subject":"{state}/{severity}/{identifier}".format(state = state,severity = severity,identifier = identifier)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -1493,6 +1566,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.Radar.mqtt.RadarProductCatalog' event to an MQTT topic.
@@ -1505,6 +1579,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/catalogs/{kind}/catalog"
@@ -1520,6 +1595,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
              "subject":"{kind}".format(kind = kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -1567,6 +1643,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.Radar.mqtt.RadarFileProduct' event to an MQTT topic.
@@ -1580,6 +1657,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/products/radar/{product_type}/{file_id}/file"
@@ -1596,6 +1674,7 @@ class DEDWDRadarMqttMqttClient(_ClientBase):
              "subject":"{product_type}/{file_id}".format(product_type = product_type,file_id = file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -1821,6 +1900,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.Forecast.mqtt.ForecastModelCatalog' event to an MQTT topic.
@@ -1833,6 +1913,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/catalogs/{kind}/catalog"
@@ -1848,6 +1929,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
              "subject":"{kind}".format(kind = kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -1895,6 +1977,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'DE.DWD.Forecast.mqtt.IconD2ForecastFile' event to an MQTT topic.
@@ -1908,6 +1991,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (False).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "weather/de/dwd/dwd/products/icon-d2/{variable}/{file_id}/file"
@@ -1924,6 +2008,7 @@ class DEDWDForecastMqttMqttClient(_ClientBase):
              "subject":"{variable}/{file_id}".format(variable = variable,file_id = file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/tests/test_client.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 import pytest_asyncio
 import asyncio
+import datetime
 import time
 import paho.mqtt.client as mqtt
 from testcontainers.core.container import DockerContainer
@@ -116,6 +117,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_station_metadata_py(mosquitto_bro
         await publisher_client.publish_de_dwd_cdc_mqtt_station_metadata(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -181,6 +183,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_air_temperature10_min_py(mosquitt
         await publisher_client.publish_de_dwd_cdc_mqtt_air_temperature10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -246,6 +249,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_precipitation10_min_py(mosquitto_
         await publisher_client.publish_de_dwd_cdc_mqtt_precipitation10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -311,6 +315,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_wind10_min_py(mosquitto_broker):
         await publisher_client.publish_de_dwd_cdc_mqtt_wind10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -376,6 +381,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_solar10_min_py(mosquitto_broker):
         await publisher_client.publish_de_dwd_cdc_mqtt_solar10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -441,6 +447,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_hourly_observation_py(mosquitto_b
         await publisher_client.publish_de_dwd_cdc_mqtt_hourly_observation(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -506,6 +513,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_extreme_wind10_min_py(mosquitto_b
         await publisher_client.publish_de_dwd_cdc_mqtt_extreme_wind10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -571,6 +579,7 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_extreme_temperature10_min_py(mosq
         await publisher_client.publish_de_dwd_cdc_mqtt_extreme_temperature10_min(
             topic=test_topic,
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -641,6 +650,7 @@ async def test_de_dwd_weather_mqtt_de_dwd_weather_mqtt_alert_py(mosquitto_broker
             state=f"test_state_{i}",
             severity=f"test_severity_{i}",
             identifier=f"test_identifier_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -709,6 +719,7 @@ async def test_de_dwd_radar_mqtt_de_dwd_radar_mqtt_radar_product_catalog_py(mosq
         await publisher_client.publish_de_dwd_radar_mqtt_radar_product_catalog(
             topic=test_topic,
             kind=f"test_kind_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -775,6 +786,7 @@ async def test_de_dwd_radar_mqtt_de_dwd_radar_mqtt_radar_file_product_py(mosquit
             topic=test_topic,
             product_type=f"test_product_type_{i}",
             file_id=f"test_file_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -843,6 +855,7 @@ async def test_de_dwd_forecast_mqtt_de_dwd_forecast_mqtt_forecast_model_catalog_
         await publisher_client.publish_de_dwd_forecast_mqtt_forecast_model_catalog(
             topic=test_topic,
             kind=f"test_kind_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -909,6 +922,7 @@ async def test_de_dwd_forecast_mqtt_de_dwd_forecast_mqtt_icon_d2_forecast_file_p
             topic=test_topic,
             variable=f"test_variable_{i}",
             file_id=f"test_file_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/__init__.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/__init__.py
@@ -1,15 +1,15 @@
 from .forecastmodelcatalog import ForecastModelCatalog
-from .radarproductcatalog import RadarProductCatalog
-from .airtemperature10min import AirTemperature10Min
-from .precipitation10min import Precipitation10Min
-from .icond2forecastfile import IconD2ForecastFile
-from .stationmetadata import StationMetadata
-from .extremewind10min import ExtremeWind10Min
-from .wind10min import Wind10Min
-from .radarfileproduct import RadarFileProduct
 from .solar10min import Solar10Min
+from .alert import Alert
+from .radarproductcatalog import RadarProductCatalog
+from .extremewind10min import ExtremeWind10Min
+from .airtemperature10min import AirTemperature10Min
+from .radarfileproduct import RadarFileProduct
+from .wind10min import Wind10Min
+from .icond2forecastfile import IconD2ForecastFile
 from .hourlyobservation import HourlyObservation
 from .extremetemperature10min import ExtremeTemperature10Min
-from .alert import Alert
+from .precipitation10min import Precipitation10Min
+from .stationmetadata import StationMetadata
 
-__all__ = ["ForecastModelCatalog", "RadarProductCatalog", "AirTemperature10Min", "Precipitation10Min", "IconD2ForecastFile", "StationMetadata", "ExtremeWind10Min", "Wind10Min", "RadarFileProduct", "Solar10Min", "HourlyObservation", "ExtremeTemperature10Min", "Alert"]
+__all__ = ["ForecastModelCatalog", "Solar10Min", "Alert", "RadarProductCatalog", "ExtremeWind10Min", "AirTemperature10Min", "RadarFileProduct", "Wind10Min", "IconD2ForecastFile", "HourlyObservation", "ExtremeTemperature10Min", "Precipitation10Min", "StationMetadata"]

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/airtemperature10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/airtemperature10min.py
@@ -167,13 +167,13 @@ class AirTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='gdkuktndhpiaaiiqnfql',
-            timestamp='uwlqcsurgkprwsqpjhct',
-            quality_level=int(16),
-            pressure_station_level=float(84.90244971661595),
-            air_temperature_2m=float(58.9329974236785),
-            air_temperature_5cm=float(95.78392558053304),
-            relative_humidity=float(43.048923151962214),
-            dew_point_temperature=float(31.529882109160745),
-            state='pmieisvblfahickrdbiy'
+            station_id='ybxiudrrsvyrqcuhewmy',
+            timestamp='fxywmpeqxfxyzzvfjdmj',
+            quality_level=int(43),
+            pressure_station_level=float(41.16375112930788),
+            air_temperature_2m=float(93.88319559671852),
+            air_temperature_5cm=float(62.58304201019126),
+            relative_humidity=float(71.54373021451505),
+            dew_point_temperature=float(69.16758414922585),
+            state='zlggiaeofjshircqlesg'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/alert.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/alert.py
@@ -183,21 +183,21 @@ class Alert:
             An instance of the dataclass.
         """
         return cls(
-            identifier='airgvxphhtnrcdksytkn',
-            sender='axjgyugnskspixigqyho',
-            sent='fdolidcclbdopmmyljac',
-            status='zsnwuvsytbsalinfrqru',
-            msg_type='lkodoeokwleiledqlfia',
-            severity='ocdxwzsadimqdtxflypd',
-            urgency='odvrbibzhmzgwlsvcnpg',
-            certainty='sfhhalesznpryvjtmbdf',
-            event='oanwjoxwkynvynfmcoqo',
-            headline='sivmquqryzrzxddyksyq',
-            description='mubrrdvnxfhmxfsuoiaf',
-            effective='dywoismvhuxcglytfdme',
-            onset='covljepfimmnenxwrlzc',
-            expires='mdzpybgixqovdsqvjmve',
-            area_desc='fvfuwhharjqxeeqqthbc',
-            geocodes='ylncseaqljcusnixvzqt',
-            state='pousijqydlhcqommkcer'
+            identifier='xifayzwstoqrhtwwlqgg',
+            sender='qmkqlevveajcnwlvapha',
+            sent='gxphcxgpfloriptzubpi',
+            status='bareqasclsfchmtbbzdi',
+            msg_type='bwphafnrhqhvxrbliqpw',
+            severity='uudhljadfemxpnkkaixg',
+            urgency='zqxrvlaxghljiemujtmk',
+            certainty='xdgrzwbomzkrxdzdoirp',
+            event='fcyzywwluqgvccdwscmi',
+            headline='szvmajanqdeyinqtilgc',
+            description='epxwpzrjolshgyxfjbpd',
+            effective='ufxkzshaopirgyioqclj',
+            onset='tgkdinwdgnsakyszgqth',
+            expires='ddkstfsadnurhmgegmgp',
+            area_desc='zuvtfcvgthycouckscxl',
+            geocodes='turyuufsheieudzgfjch',
+            state='oseqyplwnrxjqkzkkdrw'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/extremetemperature10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/extremetemperature10min.py
@@ -161,10 +161,10 @@ class ExtremeTemperature10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='rebfcjpzfkqnwsgxrmyp',
-            timestamp='rdtmhvjlzqpgttluufou',
-            quality_level=int(8),
-            air_temperature_maximum_2m=float(47.66505643287593),
-            air_temperature_minimum_5cm=float(71.20816999199896),
-            state='tojteceatcvecpourzow'
+            station_id='laynwxgjqzdguiytctya',
+            timestamp='sfsairyvtiheygnnrjqp',
+            quality_level=int(67),
+            air_temperature_maximum_2m=float(8.816756344453458),
+            air_temperature_minimum_5cm=float(82.71137962604786),
+            state='zvcmnrsxvqeuvkfktjpu'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/extremewind10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/extremewind10min.py
@@ -163,11 +163,11 @@ class ExtremeWind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='nhjamuejdxnyywzlnoyy',
-            timestamp='gblrlwilnifzvlitymxp',
-            quality_level=int(88),
-            wind_speed_maximum=float(97.2358658126792),
-            wind_speed_minimum=float(65.2054557855107),
-            wind_direction_at_maximum=float(46.16873052709371),
-            state='qrgwtvnjimjqrshurdtz'
+            station_id='shrhxqflivmeptzvduvi',
+            timestamp='qtvjkakolrpcvsqnxmzn',
+            quality_level=int(66),
+            wind_speed_maximum=float(79.40487438042649),
+            wind_speed_minimum=float(75.01260415086712),
+            wind_direction_at_maximum=float(38.442981149025144),
+            state='nrdvwxzofzqiohegluoo'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/forecastmodelcatalog.py
@@ -159,9 +159,9 @@ class ForecastModelCatalog:
             An instance of the dataclass.
         """
         return cls(
-            model='cwlfvacdumnqoymxogbt',
-            file_url='lvyirujueblxjsgqmdzp',
-            description='gbjsgropzblhnuzswtsr',
-            state='fdfbgutpgnkimkkmxjwv',
-            kind='kwjdpoldujoworuggxbs'
+            model='cncrncwsyvtgxomhqkzs',
+            file_url='pjfpwrnrojkmgfteesib',
+            description='kidhiskkdrdmyzttmrmp',
+            state='jsbkbldwdgtmcasaumez',
+            kind='edepvvaodgauvgjajgas'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/hourlyobservation.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/hourlyobservation.py
@@ -163,11 +163,11 @@ class HourlyObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='lqvzeafltbohrybpkngb',
-            timestamp='qguilmbrdbpxadjzgqyp',
-            quality_level=int(21),
-            parameter='eplydilonfrpgormleti',
-            value=float(32.86905648008067),
-            unit='iguwmrmvttssnlwserfy',
-            state='uktpubanaalodqckifpe'
+            station_id='mekixmymytadhuoeswuu',
+            timestamp='yxqktjcsdxoaeninwvjj',
+            quality_level=int(25),
+            parameter='muggshczerqqpxdkydcz',
+            value=float(7.0636128163578675),
+            unit='rxxemnxqwivmsdqqyelw',
+            state='hyprhltxbpqvswwbhhsc'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/icond2forecastfile.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/icond2forecastfile.py
@@ -45,7 +45,7 @@ class IconD2ForecastFile:
     level_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_type"))
     level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     variable: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="variable"))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
@@ -61,6 +61,8 @@ class IconD2ForecastFile:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -71,6 +73,8 @@ class IconD2ForecastFile:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -175,17 +179,17 @@ class IconD2ForecastFile:
             An instance of the dataclass.
         """
         return cls(
-            file_url='dbiblstjywjioniwcptj',
-            model='nbnmmptphtyudlurriub',
-            file_name='ojwybytfkhxcstosprfv',
-            run='sctejqzmqpdntvxnpdky',
-            forecast_hour=int(14),
-            parameter='wvoceckmlthrymqgqliu',
-            level_type='rzonlfmceqlgvmrawhwp',
-            level='uezxawhlnyiljbzxfrnd',
-            modified='poiehosforrncrfozppj',
-            size_bytes=int(64),
-            state='scboofczqgqukszbqoit',
-            variable='jorvhumsuhxwcjuyawhp',
-            file_id='msyfvfpzrmurfrxrkifp'
+            file_url='muzoqdbpvzreoewssjcr',
+            model='qrwsxweimutyusylebqk',
+            file_name='uvicyraaanjbqngcfjwr',
+            run='njarswvypgfegowogfrx',
+            forecast_hour=int(93),
+            parameter='slohgdebtggajwbpmcxb',
+            level_type='nzadzbjayoxrzicqgayh',
+            level='idduquepgkqflabxtzey',
+            modified='zhmoiiciyjojhdhydwmd',
+            size_bytes=int(74),
+            state='pycwygdokfgpxhcgvhxb',
+            variable='ateljmptbvtmxsauieni',
+            file_id='tjbfafevsohizbacbgcg'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/precipitation10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/precipitation10min.py
@@ -161,10 +161,10 @@ class Precipitation10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='iazbyymyscjvagdrttrt',
-            timestamp='ccsulgupcgljpxclchss',
-            quality_level=int(39),
-            precipitation_height=float(39.81128506093303),
-            precipitation_indicator=int(26),
-            state='bjxfzlixnqtucuohmvsi'
+            station_id='xhtstgtbeiajsgasxwbf',
+            timestamp='kqmutqshcrldhnbbpwlb',
+            quality_level=int(46),
+            precipitation_height=float(74.37237571978656),
+            precipitation_indicator=int(91),
+            state='wswcafslczliijowojng'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/radarfileproduct.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/radarfileproduct.py
@@ -35,7 +35,7 @@ class RadarFileProduct:
     product: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product"))
     file_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_name"))
     modified: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="modified"))
-    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes"))
+    size_bytes: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="size_bytes", encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v))
     file_id: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="file_id"))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     product_type: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="product_type"))
@@ -51,6 +51,8 @@ class RadarFileProduct:
         Returns:
             The dataclass representation of the dataclass.
         """
+        if 'size_bytes' in data and isinstance(data['size_bytes'], str):
+            data['size_bytes'] = int(data['size_bytes'])
         return cls(**data)
 
     def to_serializer_dict(self) -> dict:
@@ -61,6 +63,8 @@ class RadarFileProduct:
             The dictionary representation of the dataclass.
         """
         asdict_result = dataclasses.asdict(self, dict_factory=self._dict_resolver)
+        if 'size_bytes' in asdict_result and asdict_result['size_bytes'] is not None:
+            asdict_result['size_bytes'] = str(asdict_result['size_bytes'])
         return asdict_result
 
     def _dict_resolver(self, data):
@@ -165,12 +169,12 @@ class RadarFileProduct:
             An instance of the dataclass.
         """
         return cls(
-            file_url='ltbjxxpzcdqjbuljrszv',
-            product='yjptefiucckrficieipn',
-            file_name='dkcyrparsfniffqgqxih',
-            modified='mkpejjvaadmrxlqwwirg',
-            size_bytes=int(41),
-            file_id='qwkfcpydbdmajrpwvtwr',
-            state='umegdwjpaxbpxdydtebd',
-            product_type='usbkxnfcbiazyoydgetx'
+            file_url='vqcmnikbwdtoopullwlm',
+            product='hyreahijcxbizdhappnk',
+            file_name='mnfcstgeguwrevyxnvjx',
+            modified='ostmcfpdccygrlurgtcu',
+            size_bytes=int(44),
+            file_id='jicrewfoxgpurdjlkkkh',
+            state='tpciozhvmtaxidlutvfg',
+            product_type='oyxyqquynzfgxfrkqhqd'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/radarproductcatalog.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/radarproductcatalog.py
@@ -159,9 +159,9 @@ class RadarProductCatalog:
             An instance of the dataclass.
         """
         return cls(
-            product='kmsrkozwlkgtbinwwfcd',
-            file_url='fcjirvzrnzuoowrgfktb',
-            description='mtjjbmwvyprnmmhmxcim',
-            state='dprnhypwzfstcrbkycpk',
-            kind='viclbxkkpnigwjhgavwz'
+            product='vglyhiijdmpsbpgzevsc',
+            file_url='wycdoguctourjdluiiwk',
+            description='eyqvwwsyhvjysyoacdbl',
+            state='dapwbjzftuwdodjafwsn',
+            kind='oiawdfmbkprutfgbdett'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/solar10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/solar10min.py
@@ -165,12 +165,12 @@ class Solar10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='boedbgzbyopitffjpuvt',
-            timestamp='dezosfihijjxobytkpto',
-            quality_level=int(27),
-            global_radiation=float(65.70551458561256),
-            sunshine_duration=float(59.91239724878529),
-            diffuse_radiation=float(78.21627756109696),
-            longwave_radiation=float(1.1791892378967384),
-            state='bnzongumqlmjwhcvhrkz'
+            station_id='qffcnnffoffphpwskcbh',
+            timestamp='oiosjxslkgkfolsvmqta',
+            quality_level=int(6),
+            global_radiation=float(39.586150541814),
+            sunshine_duration=float(1.591066200296165),
+            diffuse_radiation=float(79.51530645528884),
+            longwave_radiation=float(0.8748711244492613),
+            state='xubniayzmwekpuxsarzu'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/stationmetadata.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/stationmetadata.py
@@ -165,12 +165,12 @@ class StationMetadata:
             An instance of the dataclass.
         """
         return cls(
-            station_id='isacqoiswlxqdryuxzfv',
-            station_name='kbtavzbglpnaotkjjvrx',
-            latitude=float(90.29245743692206),
-            longitude=float(35.68891290471936),
-            elevation=float(62.55508001698033),
-            state='fcchcyjsrtnhactteoop',
-            from_date='hgopdhrlbferpigyjxhm',
-            to_date='pbilmoymevbnlnukyxik'
+            station_id='bqkgxbfblfsfhvphpsfi',
+            station_name='yvtsdqlpmgyugpijrxtg',
+            latitude=float(51.08925728170709),
+            longitude=float(39.43890851157297),
+            elevation=float(8.798477038865759),
+            state='oomajzhdxbrlskxwkdtk',
+            from_date='peocnnfugjtrnmicvifp',
+            to_date='bmuvihwooikxhyzyucpc'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/wind10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/src/dwd_producer_data/wind10min.py
@@ -161,10 +161,10 @@ class Wind10Min:
             An instance of the dataclass.
         """
         return cls(
-            station_id='zpmptzwvlfqiwjddpdsl',
-            timestamp='eiurpdugnzwtwcbhdhdd',
-            quality_level=int(19),
-            wind_speed=float(80.27748528051835),
-            wind_direction=float(60.2995461868538),
-            state='ifuqlazchxbndauosrrl'
+            station_id='tmlyhkhxkraxncduhgaj',
+            timestamp='upjnpxieagdkoyrxijye',
+            quality_level=int(43),
+            wind_speed=float(61.24645384946105),
+            wind_direction=float(14.41929186689932),
+            state='qwalnqkgjzpxekycdbbp'
         )

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_airtemperature10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_airtemperature10min.py
@@ -28,15 +28,15 @@ class Test_AirTemperature10Min(unittest.TestCase):
         Create instance of AirTemperature10Min for testing
         """
         instance = AirTemperature10Min(
-            station_id='gdkuktndhpiaaiiqnfql',
-            timestamp='uwlqcsurgkprwsqpjhct',
-            quality_level=int(16),
-            pressure_station_level=float(84.90244971661595),
-            air_temperature_2m=float(58.9329974236785),
-            air_temperature_5cm=float(95.78392558053304),
-            relative_humidity=float(43.048923151962214),
-            dew_point_temperature=float(31.529882109160745),
-            state='pmieisvblfahickrdbiy'
+            station_id='ybxiudrrsvyrqcuhewmy',
+            timestamp='fxywmpeqxfxyzzvfjdmj',
+            quality_level=int(43),
+            pressure_station_level=float(41.16375112930788),
+            air_temperature_2m=float(93.88319559671852),
+            air_temperature_5cm=float(62.58304201019126),
+            relative_humidity=float(71.54373021451505),
+            dew_point_temperature=float(69.16758414922585),
+            state='zlggiaeofjshircqlesg'
         )
         return instance
 
@@ -45,7 +45,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'gdkuktndhpiaaiiqnfql'
+        test_value = 'ybxiudrrsvyrqcuhewmy'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -53,7 +53,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'uwlqcsurgkprwsqpjhct'
+        test_value = 'fxywmpeqxfxyzzvfjdmj'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -61,7 +61,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(16)
+        test_value = int(43)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -69,7 +69,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test pressure_station_level property
         """
-        test_value = float(84.90244971661595)
+        test_value = float(41.16375112930788)
         self.instance.pressure_station_level = test_value
         self.assertEqual(self.instance.pressure_station_level, test_value)
     
@@ -77,7 +77,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_2m property
         """
-        test_value = float(58.9329974236785)
+        test_value = float(93.88319559671852)
         self.instance.air_temperature_2m = test_value
         self.assertEqual(self.instance.air_temperature_2m, test_value)
     
@@ -85,7 +85,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_5cm property
         """
-        test_value = float(95.78392558053304)
+        test_value = float(62.58304201019126)
         self.instance.air_temperature_5cm = test_value
         self.assertEqual(self.instance.air_temperature_5cm, test_value)
     
@@ -93,7 +93,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test relative_humidity property
         """
-        test_value = float(43.048923151962214)
+        test_value = float(71.54373021451505)
         self.instance.relative_humidity = test_value
         self.assertEqual(self.instance.relative_humidity, test_value)
     
@@ -101,7 +101,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test dew_point_temperature property
         """
-        test_value = float(31.529882109160745)
+        test_value = float(69.16758414922585)
         self.instance.dew_point_temperature = test_value
         self.assertEqual(self.instance.dew_point_temperature, test_value)
     
@@ -109,7 +109,7 @@ class Test_AirTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'pmieisvblfahickrdbiy'
+        test_value = 'zlggiaeofjshircqlesg'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_alert.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_alert.py
@@ -28,23 +28,23 @@ class Test_Alert(unittest.TestCase):
         Create instance of Alert for testing
         """
         instance = Alert(
-            identifier='airgvxphhtnrcdksytkn',
-            sender='axjgyugnskspixigqyho',
-            sent='fdolidcclbdopmmyljac',
-            status='zsnwuvsytbsalinfrqru',
-            msg_type='lkodoeokwleiledqlfia',
-            severity='ocdxwzsadimqdtxflypd',
-            urgency='odvrbibzhmzgwlsvcnpg',
-            certainty='sfhhalesznpryvjtmbdf',
-            event='oanwjoxwkynvynfmcoqo',
-            headline='sivmquqryzrzxddyksyq',
-            description='mubrrdvnxfhmxfsuoiaf',
-            effective='dywoismvhuxcglytfdme',
-            onset='covljepfimmnenxwrlzc',
-            expires='mdzpybgixqovdsqvjmve',
-            area_desc='fvfuwhharjqxeeqqthbc',
-            geocodes='ylncseaqljcusnixvzqt',
-            state='pousijqydlhcqommkcer'
+            identifier='xifayzwstoqrhtwwlqgg',
+            sender='qmkqlevveajcnwlvapha',
+            sent='gxphcxgpfloriptzubpi',
+            status='bareqasclsfchmtbbzdi',
+            msg_type='bwphafnrhqhvxrbliqpw',
+            severity='uudhljadfemxpnkkaixg',
+            urgency='zqxrvlaxghljiemujtmk',
+            certainty='xdgrzwbomzkrxdzdoirp',
+            event='fcyzywwluqgvccdwscmi',
+            headline='szvmajanqdeyinqtilgc',
+            description='epxwpzrjolshgyxfjbpd',
+            effective='ufxkzshaopirgyioqclj',
+            onset='tgkdinwdgnsakyszgqth',
+            expires='ddkstfsadnurhmgegmgp',
+            area_desc='zuvtfcvgthycouckscxl',
+            geocodes='turyuufsheieudzgfjch',
+            state='oseqyplwnrxjqkzkkdrw'
         )
         return instance
 
@@ -53,7 +53,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test identifier property
         """
-        test_value = 'airgvxphhtnrcdksytkn'
+        test_value = 'xifayzwstoqrhtwwlqgg'
         self.instance.identifier = test_value
         self.assertEqual(self.instance.identifier, test_value)
     
@@ -61,7 +61,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sender property
         """
-        test_value = 'axjgyugnskspixigqyho'
+        test_value = 'qmkqlevveajcnwlvapha'
         self.instance.sender = test_value
         self.assertEqual(self.instance.sender, test_value)
     
@@ -69,7 +69,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test sent property
         """
-        test_value = 'fdolidcclbdopmmyljac'
+        test_value = 'gxphcxgpfloriptzubpi'
         self.instance.sent = test_value
         self.assertEqual(self.instance.sent, test_value)
     
@@ -77,7 +77,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test status property
         """
-        test_value = 'zsnwuvsytbsalinfrqru'
+        test_value = 'bareqasclsfchmtbbzdi'
         self.instance.status = test_value
         self.assertEqual(self.instance.status, test_value)
     
@@ -85,7 +85,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test msg_type property
         """
-        test_value = 'lkodoeokwleiledqlfia'
+        test_value = 'bwphafnrhqhvxrbliqpw'
         self.instance.msg_type = test_value
         self.assertEqual(self.instance.msg_type, test_value)
     
@@ -93,7 +93,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = 'ocdxwzsadimqdtxflypd'
+        test_value = 'uudhljadfemxpnkkaixg'
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     
@@ -101,7 +101,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test urgency property
         """
-        test_value = 'odvrbibzhmzgwlsvcnpg'
+        test_value = 'zqxrvlaxghljiemujtmk'
         self.instance.urgency = test_value
         self.assertEqual(self.instance.urgency, test_value)
     
@@ -109,7 +109,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test certainty property
         """
-        test_value = 'sfhhalesznpryvjtmbdf'
+        test_value = 'xdgrzwbomzkrxdzdoirp'
         self.instance.certainty = test_value
         self.assertEqual(self.instance.certainty, test_value)
     
@@ -117,7 +117,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test event property
         """
-        test_value = 'oanwjoxwkynvynfmcoqo'
+        test_value = 'fcyzywwluqgvccdwscmi'
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -125,7 +125,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test headline property
         """
-        test_value = 'sivmquqryzrzxddyksyq'
+        test_value = 'szvmajanqdeyinqtilgc'
         self.instance.headline = test_value
         self.assertEqual(self.instance.headline, test_value)
     
@@ -133,7 +133,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'mubrrdvnxfhmxfsuoiaf'
+        test_value = 'epxwpzrjolshgyxfjbpd'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -141,7 +141,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test effective property
         """
-        test_value = 'dywoismvhuxcglytfdme'
+        test_value = 'ufxkzshaopirgyioqclj'
         self.instance.effective = test_value
         self.assertEqual(self.instance.effective, test_value)
     
@@ -149,7 +149,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test onset property
         """
-        test_value = 'covljepfimmnenxwrlzc'
+        test_value = 'tgkdinwdgnsakyszgqth'
         self.instance.onset = test_value
         self.assertEqual(self.instance.onset, test_value)
     
@@ -157,7 +157,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test expires property
         """
-        test_value = 'mdzpybgixqovdsqvjmve'
+        test_value = 'ddkstfsadnurhmgegmgp'
         self.instance.expires = test_value
         self.assertEqual(self.instance.expires, test_value)
     
@@ -165,7 +165,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test area_desc property
         """
-        test_value = 'fvfuwhharjqxeeqqthbc'
+        test_value = 'zuvtfcvgthycouckscxl'
         self.instance.area_desc = test_value
         self.assertEqual(self.instance.area_desc, test_value)
     
@@ -173,7 +173,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test geocodes property
         """
-        test_value = 'ylncseaqljcusnixvzqt'
+        test_value = 'turyuufsheieudzgfjch'
         self.instance.geocodes = test_value
         self.assertEqual(self.instance.geocodes, test_value)
     
@@ -181,7 +181,7 @@ class Test_Alert(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'pousijqydlhcqommkcer'
+        test_value = 'oseqyplwnrxjqkzkkdrw'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_extremetemperature10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_extremetemperature10min.py
@@ -28,12 +28,12 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         Create instance of ExtremeTemperature10Min for testing
         """
         instance = ExtremeTemperature10Min(
-            station_id='rebfcjpzfkqnwsgxrmyp',
-            timestamp='rdtmhvjlzqpgttluufou',
-            quality_level=int(8),
-            air_temperature_maximum_2m=float(47.66505643287593),
-            air_temperature_minimum_5cm=float(71.20816999199896),
-            state='tojteceatcvecpourzow'
+            station_id='laynwxgjqzdguiytctya',
+            timestamp='sfsairyvtiheygnnrjqp',
+            quality_level=int(67),
+            air_temperature_maximum_2m=float(8.816756344453458),
+            air_temperature_minimum_5cm=float(82.71137962604786),
+            state='zvcmnrsxvqeuvkfktjpu'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'rebfcjpzfkqnwsgxrmyp'
+        test_value = 'laynwxgjqzdguiytctya'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'rdtmhvjlzqpgttluufou'
+        test_value = 'sfsairyvtiheygnnrjqp'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(8)
+        test_value = int(67)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_maximum_2m property
         """
-        test_value = float(47.66505643287593)
+        test_value = float(8.816756344453458)
         self.instance.air_temperature_maximum_2m = test_value
         self.assertEqual(self.instance.air_temperature_maximum_2m, test_value)
     
@@ -74,7 +74,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test air_temperature_minimum_5cm property
         """
-        test_value = float(71.20816999199896)
+        test_value = float(82.71137962604786)
         self.instance.air_temperature_minimum_5cm = test_value
         self.assertEqual(self.instance.air_temperature_minimum_5cm, test_value)
     
@@ -82,7 +82,7 @@ class Test_ExtremeTemperature10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'tojteceatcvecpourzow'
+        test_value = 'zvcmnrsxvqeuvkfktjpu'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_extremewind10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_extremewind10min.py
@@ -28,13 +28,13 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         Create instance of ExtremeWind10Min for testing
         """
         instance = ExtremeWind10Min(
-            station_id='nhjamuejdxnyywzlnoyy',
-            timestamp='gblrlwilnifzvlitymxp',
-            quality_level=int(88),
-            wind_speed_maximum=float(97.2358658126792),
-            wind_speed_minimum=float(65.2054557855107),
-            wind_direction_at_maximum=float(46.16873052709371),
-            state='qrgwtvnjimjqrshurdtz'
+            station_id='shrhxqflivmeptzvduvi',
+            timestamp='qtvjkakolrpcvsqnxmzn',
+            quality_level=int(66),
+            wind_speed_maximum=float(79.40487438042649),
+            wind_speed_minimum=float(75.01260415086712),
+            wind_direction_at_maximum=float(38.442981149025144),
+            state='nrdvwxzofzqiohegluoo'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'nhjamuejdxnyywzlnoyy'
+        test_value = 'shrhxqflivmeptzvduvi'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'gblrlwilnifzvlitymxp'
+        test_value = 'qtvjkakolrpcvsqnxmzn'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(88)
+        test_value = int(66)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_maximum property
         """
-        test_value = float(97.2358658126792)
+        test_value = float(79.40487438042649)
         self.instance.wind_speed_maximum = test_value
         self.assertEqual(self.instance.wind_speed_maximum, test_value)
     
@@ -75,7 +75,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_speed_minimum property
         """
-        test_value = float(65.2054557855107)
+        test_value = float(75.01260415086712)
         self.instance.wind_speed_minimum = test_value
         self.assertEqual(self.instance.wind_speed_minimum, test_value)
     
@@ -83,7 +83,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test wind_direction_at_maximum property
         """
-        test_value = float(46.16873052709371)
+        test_value = float(38.442981149025144)
         self.instance.wind_direction_at_maximum = test_value
         self.assertEqual(self.instance.wind_direction_at_maximum, test_value)
     
@@ -91,7 +91,7 @@ class Test_ExtremeWind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'qrgwtvnjimjqrshurdtz'
+        test_value = 'nrdvwxzofzqiohegluoo'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_forecastmodelcatalog.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_forecastmodelcatalog.py
@@ -28,11 +28,11 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         Create instance of ForecastModelCatalog for testing
         """
         instance = ForecastModelCatalog(
-            model='cwlfvacdumnqoymxogbt',
-            file_url='lvyirujueblxjsgqmdzp',
-            description='gbjsgropzblhnuzswtsr',
-            state='fdfbgutpgnkimkkmxjwv',
-            kind='kwjdpoldujoworuggxbs'
+            model='cncrncwsyvtgxomhqkzs',
+            file_url='pjfpwrnrojkmgfteesib',
+            description='kidhiskkdrdmyzttmrmp',
+            state='jsbkbldwdgtmcasaumez',
+            kind='edepvvaodgauvgjajgas'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'cwlfvacdumnqoymxogbt'
+        test_value = 'cncrncwsyvtgxomhqkzs'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -49,7 +49,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'lvyirujueblxjsgqmdzp'
+        test_value = 'pjfpwrnrojkmgfteesib'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'gbjsgropzblhnuzswtsr'
+        test_value = 'kidhiskkdrdmyzttmrmp'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'fdfbgutpgnkimkkmxjwv'
+        test_value = 'jsbkbldwdgtmcasaumez'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_ForecastModelCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'kwjdpoldujoworuggxbs'
+        test_value = 'edepvvaodgauvgjajgas'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_hourlyobservation.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_hourlyobservation.py
@@ -28,13 +28,13 @@ class Test_HourlyObservation(unittest.TestCase):
         Create instance of HourlyObservation for testing
         """
         instance = HourlyObservation(
-            station_id='lqvzeafltbohrybpkngb',
-            timestamp='qguilmbrdbpxadjzgqyp',
-            quality_level=int(21),
-            parameter='eplydilonfrpgormleti',
-            value=float(32.86905648008067),
-            unit='iguwmrmvttssnlwserfy',
-            state='uktpubanaalodqckifpe'
+            station_id='mekixmymytadhuoeswuu',
+            timestamp='yxqktjcsdxoaeninwvjj',
+            quality_level=int(25),
+            parameter='muggshczerqqpxdkydcz',
+            value=float(7.0636128163578675),
+            unit='rxxemnxqwivmsdqqyelw',
+            state='hyprhltxbpqvswwbhhsc'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'lqvzeafltbohrybpkngb'
+        test_value = 'mekixmymytadhuoeswuu'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'qguilmbrdbpxadjzgqyp'
+        test_value = 'yxqktjcsdxoaeninwvjj'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -59,7 +59,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(21)
+        test_value = int(25)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -67,7 +67,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'eplydilonfrpgormleti'
+        test_value = 'muggshczerqqpxdkydcz'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -75,7 +75,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(32.86905648008067)
+        test_value = float(7.0636128163578675)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -83,7 +83,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test unit property
         """
-        test_value = 'iguwmrmvttssnlwserfy'
+        test_value = 'rxxemnxqwivmsdqqyelw'
         self.instance.unit = test_value
         self.assertEqual(self.instance.unit, test_value)
     
@@ -91,7 +91,7 @@ class Test_HourlyObservation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'uktpubanaalodqckifpe'
+        test_value = 'hyprhltxbpqvswwbhhsc'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_icond2forecastfile.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_icond2forecastfile.py
@@ -28,19 +28,19 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         Create instance of IconD2ForecastFile for testing
         """
         instance = IconD2ForecastFile(
-            file_url='dbiblstjywjioniwcptj',
-            model='nbnmmptphtyudlurriub',
-            file_name='ojwybytfkhxcstosprfv',
-            run='sctejqzmqpdntvxnpdky',
-            forecast_hour=int(14),
-            parameter='wvoceckmlthrymqgqliu',
-            level_type='rzonlfmceqlgvmrawhwp',
-            level='uezxawhlnyiljbzxfrnd',
-            modified='poiehosforrncrfozppj',
-            size_bytes=int(64),
-            state='scboofczqgqukszbqoit',
-            variable='jorvhumsuhxwcjuyawhp',
-            file_id='msyfvfpzrmurfrxrkifp'
+            file_url='muzoqdbpvzreoewssjcr',
+            model='qrwsxweimutyusylebqk',
+            file_name='uvicyraaanjbqngcfjwr',
+            run='njarswvypgfegowogfrx',
+            forecast_hour=int(93),
+            parameter='slohgdebtggajwbpmcxb',
+            level_type='nzadzbjayoxrzicqgayh',
+            level='idduquepgkqflabxtzey',
+            modified='zhmoiiciyjojhdhydwmd',
+            size_bytes=int(74),
+            state='pycwygdokfgpxhcgvhxb',
+            variable='ateljmptbvtmxsauieni',
+            file_id='tjbfafevsohizbacbgcg'
         )
         return instance
 
@@ -49,7 +49,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'dbiblstjywjioniwcptj'
+        test_value = 'muzoqdbpvzreoewssjcr'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test model property
         """
-        test_value = 'nbnmmptphtyudlurriub'
+        test_value = 'qrwsxweimutyusylebqk'
         self.instance.model = test_value
         self.assertEqual(self.instance.model, test_value)
     
@@ -65,7 +65,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'ojwybytfkhxcstosprfv'
+        test_value = 'uvicyraaanjbqngcfjwr'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -73,7 +73,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test run property
         """
-        test_value = 'sctejqzmqpdntvxnpdky'
+        test_value = 'njarswvypgfegowogfrx'
         self.instance.run = test_value
         self.assertEqual(self.instance.run, test_value)
     
@@ -81,7 +81,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test forecast_hour property
         """
-        test_value = int(14)
+        test_value = int(93)
         self.instance.forecast_hour = test_value
         self.assertEqual(self.instance.forecast_hour, test_value)
     
@@ -89,7 +89,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test parameter property
         """
-        test_value = 'wvoceckmlthrymqgqliu'
+        test_value = 'slohgdebtggajwbpmcxb'
         self.instance.parameter = test_value
         self.assertEqual(self.instance.parameter, test_value)
     
@@ -97,7 +97,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level_type property
         """
-        test_value = 'rzonlfmceqlgvmrawhwp'
+        test_value = 'nzadzbjayoxrzicqgayh'
         self.instance.level_type = test_value
         self.assertEqual(self.instance.level_type, test_value)
     
@@ -105,7 +105,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test level property
         """
-        test_value = 'uezxawhlnyiljbzxfrnd'
+        test_value = 'idduquepgkqflabxtzey'
         self.instance.level = test_value
         self.assertEqual(self.instance.level, test_value)
     
@@ -113,7 +113,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'poiehosforrncrfozppj'
+        test_value = 'zhmoiiciyjojhdhydwmd'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -121,7 +121,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(64)
+        test_value = int(74)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -129,7 +129,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'scboofczqgqukszbqoit'
+        test_value = 'pycwygdokfgpxhcgvhxb'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -137,7 +137,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test variable property
         """
-        test_value = 'jorvhumsuhxwcjuyawhp'
+        test_value = 'ateljmptbvtmxsauieni'
         self.instance.variable = test_value
         self.assertEqual(self.instance.variable, test_value)
     
@@ -145,7 +145,7 @@ class Test_IconD2ForecastFile(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'msyfvfpzrmurfrxrkifp'
+        test_value = 'tjbfafevsohizbacbgcg'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_precipitation10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_precipitation10min.py
@@ -28,12 +28,12 @@ class Test_Precipitation10Min(unittest.TestCase):
         Create instance of Precipitation10Min for testing
         """
         instance = Precipitation10Min(
-            station_id='iazbyymyscjvagdrttrt',
-            timestamp='ccsulgupcgljpxclchss',
-            quality_level=int(39),
-            precipitation_height=float(39.81128506093303),
-            precipitation_indicator=int(26),
-            state='bjxfzlixnqtucuohmvsi'
+            station_id='xhtstgtbeiajsgasxwbf',
+            timestamp='kqmutqshcrldhnbbpwlb',
+            quality_level=int(46),
+            precipitation_height=float(74.37237571978656),
+            precipitation_indicator=int(91),
+            state='wswcafslczliijowojng'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'iazbyymyscjvagdrttrt'
+        test_value = 'xhtstgtbeiajsgasxwbf'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'ccsulgupcgljpxclchss'
+        test_value = 'kqmutqshcrldhnbbpwlb'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(39)
+        test_value = int(46)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_height property
         """
-        test_value = float(39.81128506093303)
+        test_value = float(74.37237571978656)
         self.instance.precipitation_height = test_value
         self.assertEqual(self.instance.precipitation_height, test_value)
     
@@ -74,7 +74,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test precipitation_indicator property
         """
-        test_value = int(26)
+        test_value = int(91)
         self.instance.precipitation_indicator = test_value
         self.assertEqual(self.instance.precipitation_indicator, test_value)
     
@@ -82,7 +82,7 @@ class Test_Precipitation10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bjxfzlixnqtucuohmvsi'
+        test_value = 'wswcafslczliijowojng'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_radarfileproduct.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_radarfileproduct.py
@@ -28,14 +28,14 @@ class Test_RadarFileProduct(unittest.TestCase):
         Create instance of RadarFileProduct for testing
         """
         instance = RadarFileProduct(
-            file_url='ltbjxxpzcdqjbuljrszv',
-            product='yjptefiucckrficieipn',
-            file_name='dkcyrparsfniffqgqxih',
-            modified='mkpejjvaadmrxlqwwirg',
-            size_bytes=int(41),
-            file_id='qwkfcpydbdmajrpwvtwr',
-            state='umegdwjpaxbpxdydtebd',
-            product_type='usbkxnfcbiazyoydgetx'
+            file_url='vqcmnikbwdtoopullwlm',
+            product='hyreahijcxbizdhappnk',
+            file_name='mnfcstgeguwrevyxnvjx',
+            modified='ostmcfpdccygrlurgtcu',
+            size_bytes=int(44),
+            file_id='jicrewfoxgpurdjlkkkh',
+            state='tpciozhvmtaxidlutvfg',
+            product_type='oyxyqquynzfgxfrkqhqd'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'ltbjxxpzcdqjbuljrszv'
+        test_value = 'vqcmnikbwdtoopullwlm'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -52,7 +52,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'yjptefiucckrficieipn'
+        test_value = 'hyreahijcxbizdhappnk'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -60,7 +60,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_name property
         """
-        test_value = 'dkcyrparsfniffqgqxih'
+        test_value = 'mnfcstgeguwrevyxnvjx'
         self.instance.file_name = test_value
         self.assertEqual(self.instance.file_name, test_value)
     
@@ -68,7 +68,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test modified property
         """
-        test_value = 'mkpejjvaadmrxlqwwirg'
+        test_value = 'ostmcfpdccygrlurgtcu'
         self.instance.modified = test_value
         self.assertEqual(self.instance.modified, test_value)
     
@@ -76,7 +76,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test size_bytes property
         """
-        test_value = int(41)
+        test_value = int(44)
         self.instance.size_bytes = test_value
         self.assertEqual(self.instance.size_bytes, test_value)
     
@@ -84,7 +84,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test file_id property
         """
-        test_value = 'qwkfcpydbdmajrpwvtwr'
+        test_value = 'jicrewfoxgpurdjlkkkh'
         self.instance.file_id = test_value
         self.assertEqual(self.instance.file_id, test_value)
     
@@ -92,7 +92,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'umegdwjpaxbpxdydtebd'
+        test_value = 'tpciozhvmtaxidlutvfg'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -100,7 +100,7 @@ class Test_RadarFileProduct(unittest.TestCase):
         """
         Test product_type property
         """
-        test_value = 'usbkxnfcbiazyoydgetx'
+        test_value = 'oyxyqquynzfgxfrkqhqd'
         self.instance.product_type = test_value
         self.assertEqual(self.instance.product_type, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_radarproductcatalog.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_radarproductcatalog.py
@@ -28,11 +28,11 @@ class Test_RadarProductCatalog(unittest.TestCase):
         Create instance of RadarProductCatalog for testing
         """
         instance = RadarProductCatalog(
-            product='kmsrkozwlkgtbinwwfcd',
-            file_url='fcjirvzrnzuoowrgfktb',
-            description='mtjjbmwvyprnmmhmxcim',
-            state='dprnhypwzfstcrbkycpk',
-            kind='viclbxkkpnigwjhgavwz'
+            product='vglyhiijdmpsbpgzevsc',
+            file_url='wycdoguctourjdluiiwk',
+            description='eyqvwwsyhvjysyoacdbl',
+            state='dapwbjzftuwdodjafwsn',
+            kind='oiawdfmbkprutfgbdett'
         )
         return instance
 
@@ -41,7 +41,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test product property
         """
-        test_value = 'kmsrkozwlkgtbinwwfcd'
+        test_value = 'vglyhiijdmpsbpgzevsc'
         self.instance.product = test_value
         self.assertEqual(self.instance.product, test_value)
     
@@ -49,7 +49,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test file_url property
         """
-        test_value = 'fcjirvzrnzuoowrgfktb'
+        test_value = 'wycdoguctourjdluiiwk'
         self.instance.file_url = test_value
         self.assertEqual(self.instance.file_url, test_value)
     
@@ -57,7 +57,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'mtjjbmwvyprnmmhmxcim'
+        test_value = 'eyqvwwsyhvjysyoacdbl'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -65,7 +65,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'dprnhypwzfstcrbkycpk'
+        test_value = 'dapwbjzftuwdodjafwsn'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -73,7 +73,7 @@ class Test_RadarProductCatalog(unittest.TestCase):
         """
         Test kind property
         """
-        test_value = 'viclbxkkpnigwjhgavwz'
+        test_value = 'oiawdfmbkprutfgbdett'
         self.instance.kind = test_value
         self.assertEqual(self.instance.kind, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_solar10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_solar10min.py
@@ -28,14 +28,14 @@ class Test_Solar10Min(unittest.TestCase):
         Create instance of Solar10Min for testing
         """
         instance = Solar10Min(
-            station_id='boedbgzbyopitffjpuvt',
-            timestamp='dezosfihijjxobytkpto',
-            quality_level=int(27),
-            global_radiation=float(65.70551458561256),
-            sunshine_duration=float(59.91239724878529),
-            diffuse_radiation=float(78.21627756109696),
-            longwave_radiation=float(1.1791892378967384),
-            state='bnzongumqlmjwhcvhrkz'
+            station_id='qffcnnffoffphpwskcbh',
+            timestamp='oiosjxslkgkfolsvmqta',
+            quality_level=int(6),
+            global_radiation=float(39.586150541814),
+            sunshine_duration=float(1.591066200296165),
+            diffuse_radiation=float(79.51530645528884),
+            longwave_radiation=float(0.8748711244492613),
+            state='xubniayzmwekpuxsarzu'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'boedbgzbyopitffjpuvt'
+        test_value = 'qffcnnffoffphpwskcbh'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'dezosfihijjxobytkpto'
+        test_value = 'oiosjxslkgkfolsvmqta'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -60,7 +60,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(27)
+        test_value = int(6)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -68,7 +68,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(65.70551458561256)
+        test_value = float(39.586150541814)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
     
@@ -76,7 +76,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(59.91239724878529)
+        test_value = float(1.591066200296165)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -84,7 +84,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test diffuse_radiation property
         """
-        test_value = float(78.21627756109696)
+        test_value = float(79.51530645528884)
         self.instance.diffuse_radiation = test_value
         self.assertEqual(self.instance.diffuse_radiation, test_value)
     
@@ -92,7 +92,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test longwave_radiation property
         """
-        test_value = float(1.1791892378967384)
+        test_value = float(0.8748711244492613)
         self.instance.longwave_radiation = test_value
         self.assertEqual(self.instance.longwave_radiation, test_value)
     
@@ -100,7 +100,7 @@ class Test_Solar10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'bnzongumqlmjwhcvhrkz'
+        test_value = 'xubniayzmwekpuxsarzu'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_stationmetadata.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_stationmetadata.py
@@ -28,14 +28,14 @@ class Test_StationMetadata(unittest.TestCase):
         Create instance of StationMetadata for testing
         """
         instance = StationMetadata(
-            station_id='isacqoiswlxqdryuxzfv',
-            station_name='kbtavzbglpnaotkjjvrx',
-            latitude=float(90.29245743692206),
-            longitude=float(35.68891290471936),
-            elevation=float(62.55508001698033),
-            state='fcchcyjsrtnhactteoop',
-            from_date='hgopdhrlbferpigyjxhm',
-            to_date='pbilmoymevbnlnukyxik'
+            station_id='bqkgxbfblfsfhvphpsfi',
+            station_name='yvtsdqlpmgyugpijrxtg',
+            latitude=float(51.08925728170709),
+            longitude=float(39.43890851157297),
+            elevation=float(8.798477038865759),
+            state='oomajzhdxbrlskxwkdtk',
+            from_date='peocnnfugjtrnmicvifp',
+            to_date='bmuvihwooikxhyzyucpc'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'isacqoiswlxqdryuxzfv'
+        test_value = 'bqkgxbfblfsfhvphpsfi'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -52,7 +52,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'kbtavzbglpnaotkjjvrx'
+        test_value = 'yvtsdqlpmgyugpijrxtg'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -60,7 +60,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(90.29245743692206)
+        test_value = float(51.08925728170709)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -68,7 +68,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(35.68891290471936)
+        test_value = float(39.43890851157297)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -76,7 +76,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test elevation property
         """
-        test_value = float(62.55508001698033)
+        test_value = float(8.798477038865759)
         self.instance.elevation = test_value
         self.assertEqual(self.instance.elevation, test_value)
     
@@ -84,7 +84,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'fcchcyjsrtnhactteoop'
+        test_value = 'oomajzhdxbrlskxwkdtk'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -92,7 +92,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test from_date property
         """
-        test_value = 'hgopdhrlbferpigyjxhm'
+        test_value = 'peocnnfugjtrnmicvifp'
         self.instance.from_date = test_value
         self.assertEqual(self.instance.from_date, test_value)
     
@@ -100,7 +100,7 @@ class Test_StationMetadata(unittest.TestCase):
         """
         Test to_date property
         """
-        test_value = 'pbilmoymevbnlnukyxik'
+        test_value = 'bmuvihwooikxhyzyucpc'
         self.instance.to_date = test_value
         self.assertEqual(self.instance.to_date, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_wind10min.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_data/tests/test_wind10min.py
@@ -28,12 +28,12 @@ class Test_Wind10Min(unittest.TestCase):
         Create instance of Wind10Min for testing
         """
         instance = Wind10Min(
-            station_id='zpmptzwvlfqiwjddpdsl',
-            timestamp='eiurpdugnzwtwcbhdhdd',
-            quality_level=int(19),
-            wind_speed=float(80.27748528051835),
-            wind_direction=float(60.2995461868538),
-            state='ifuqlazchxbndauosrrl'
+            station_id='tmlyhkhxkraxncduhgaj',
+            timestamp='upjnpxieagdkoyrxijye',
+            quality_level=int(43),
+            wind_speed=float(61.24645384946105),
+            wind_direction=float(14.41929186689932),
+            state='qwalnqkgjzpxekycdbbp'
         )
         return instance
 
@@ -42,7 +42,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'zpmptzwvlfqiwjddpdsl'
+        test_value = 'tmlyhkhxkraxncduhgaj'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -50,7 +50,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test timestamp property
         """
-        test_value = 'eiurpdugnzwtwcbhdhdd'
+        test_value = 'upjnpxieagdkoyrxijye'
         self.instance.timestamp = test_value
         self.assertEqual(self.instance.timestamp, test_value)
     
@@ -58,7 +58,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test quality_level property
         """
-        test_value = int(19)
+        test_value = int(43)
         self.instance.quality_level = test_value
         self.assertEqual(self.instance.quality_level, test_value)
     
@@ -66,7 +66,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(80.27748528051835)
+        test_value = float(61.24645384946105)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -74,7 +74,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(60.2995461868538)
+        test_value = float(14.41929186689932)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -82,7 +82,7 @@ class Test_Wind10Min(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'ifuqlazchxbndauosrrl'
+        test_value = 'qwalnqkgjzpxekycdbbp'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     

--- a/feeders/dwd/dwd_producer/dwd_producer_kafka_producer/src/dwd_producer_kafka_producer/producer.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_kafka_producer/src/dwd_producer_kafka_producer/producer.py
@@ -1,12 +1,58 @@
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import sys
 import json
+import re
 import uuid
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 from confluent_kafka import Producer, KafkaException, Message
 from cloudevents.kafka import to_binary, to_structured, KafkaMessage
 from cloudevents.http import CloudEvent
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 from dwd_producer_data import StationMetadata
 from dwd_producer_data import AirTemperature10Min
 from dwd_producer_data import Precipitation10Min
@@ -52,7 +98,7 @@ class DEDWDCDCEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_cdc_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
+    def send_de_dwd_cdc_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.StationMetadata' event to the Kafka topic
 
@@ -60,6 +106,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (StationMetadata): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, StationMetadata], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -71,6 +118,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -84,7 +132,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.AirTemperature10Min' event to the Kafka topic
 
@@ -92,6 +140,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (AirTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, AirTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -103,6 +152,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -116,7 +166,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
+    def send_de_dwd_cdc_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.Precipitation10Min' event to the Kafka topic
 
@@ -124,6 +174,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Precipitation10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Precipitation10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -135,6 +186,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -148,7 +200,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.Wind10Min' event to the Kafka topic
 
@@ -156,6 +208,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Wind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Wind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -167,6 +220,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -180,7 +234,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
+    def send_de_dwd_cdc_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.Solar10Min' event to the Kafka topic
 
@@ -188,6 +242,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Solar10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Solar10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -199,6 +254,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -212,7 +268,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
+    def send_de_dwd_cdc_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.HourlyObservation' event to the Kafka topic
 
@@ -220,6 +276,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (HourlyObservation): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, HourlyObservation], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -231,6 +288,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -244,7 +302,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.ExtremeWind10Min' event to the Kafka topic
 
@@ -252,6 +310,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeWind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeWind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -263,6 +322,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -276,7 +336,7 @@ class DEDWDCDCEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.ExtremeTemperature10Min' event to the Kafka topic
 
@@ -284,6 +344,7 @@ class DEDWDCDCEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -295,6 +356,7 @@ class DEDWDCDCEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -390,7 +452,7 @@ class DEDWDWeatherEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_weather_alert(self,_identifier : str, data: Alert, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
+    def send_de_dwd_weather_alert(self,_identifier : str, data: Alert, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
         """
         Sends the 'DE.DWD.Weather.Alert' event to the Kafka topic
 
@@ -398,6 +460,7 @@ class DEDWDWeatherEventProducer:
             _identifier(str):  Value for placeholder identifier in attribute subject
             data: (Alert): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Alert], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{identifier}'
@@ -409,6 +472,7 @@ class DEDWDWeatherEventProducer:
              "subject":"{identifier}".format(identifier = _identifier)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -504,7 +568,7 @@ class DEDWDRadarEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_radar_radar_product_catalog(self,_file_url : str, data: RadarProductCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
+    def send_de_dwd_radar_radar_product_catalog(self,_file_url : str, data: RadarProductCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.RadarProductCatalog' event to the Kafka topic
 
@@ -512,6 +576,7 @@ class DEDWDRadarEventProducer:
             _file_url(str):  Value for placeholder file_url in attribute subject
             data: (RadarProductCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarProductCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{file_url}'
@@ -523,6 +588,7 @@ class DEDWDRadarEventProducer:
              "subject":"{file_url}".format(file_url = _file_url)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -536,7 +602,7 @@ class DEDWDRadarEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_radar_radar_file_product(self,_file_url : str, data: RadarFileProduct, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
+    def send_de_dwd_radar_radar_file_product(self,_file_url : str, data: RadarFileProduct, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.RadarFileProduct' event to the Kafka topic
 
@@ -544,6 +610,7 @@ class DEDWDRadarEventProducer:
             _file_url(str):  Value for placeholder file_url in attribute subject
             data: (RadarFileProduct): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarFileProduct], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{file_url}'
@@ -555,6 +622,7 @@ class DEDWDRadarEventProducer:
              "subject":"{file_url}".format(file_url = _file_url)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -650,7 +718,7 @@ class DEDWDForecastEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_forecast_forecast_model_catalog(self,_file_url : str, data: ForecastModelCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
+    def send_de_dwd_forecast_forecast_model_catalog(self,_file_url : str, data: ForecastModelCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.ForecastModelCatalog' event to the Kafka topic
 
@@ -658,6 +726,7 @@ class DEDWDForecastEventProducer:
             _file_url(str):  Value for placeholder file_url in attribute subject
             data: (ForecastModelCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ForecastModelCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{file_url}'
@@ -669,6 +738,7 @@ class DEDWDForecastEventProducer:
              "subject":"{file_url}".format(file_url = _file_url)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -682,7 +752,7 @@ class DEDWDForecastEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_forecast_icon_d2_forecast_file(self,_file_url : str, data: IconD2ForecastFile, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
+    def send_de_dwd_forecast_icon_d2_forecast_file(self,_file_url : str, data: IconD2ForecastFile, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.IconD2ForecastFile' event to the Kafka topic
 
@@ -690,6 +760,7 @@ class DEDWDForecastEventProducer:
             _file_url(str):  Value for placeholder file_url in attribute subject
             data: (IconD2ForecastFile): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, IconD2ForecastFile], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{file_url}'
@@ -701,6 +772,7 @@ class DEDWDForecastEventProducer:
              "subject":"{file_url}".format(file_url = _file_url)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -796,7 +868,7 @@ class DEDWDCDCMqttEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_cdc_mqtt_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.StationMetadata' event to the Kafka topic
 
@@ -804,6 +876,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (StationMetadata): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, StationMetadata], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -814,6 +887,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -827,7 +901,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.AirTemperature10Min' event to the Kafka topic
 
@@ -835,6 +909,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (AirTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, AirTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -845,6 +920,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -858,7 +934,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.Precipitation10Min' event to the Kafka topic
 
@@ -866,6 +942,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Precipitation10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Precipitation10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -876,6 +953,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -889,7 +967,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.Wind10Min' event to the Kafka topic
 
@@ -897,6 +975,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Wind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Wind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -907,6 +986,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -920,7 +1000,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.Solar10Min' event to the Kafka topic
 
@@ -928,6 +1008,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Solar10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Solar10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -938,6 +1019,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -951,7 +1033,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.HourlyObservation' event to the Kafka topic
 
@@ -959,6 +1041,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (HourlyObservation): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, HourlyObservation], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -969,6 +1052,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -982,7 +1066,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.ExtremeWind10Min' event to the Kafka topic
 
@@ -990,6 +1074,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeWind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeWind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1000,6 +1085,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1013,7 +1099,7 @@ class DEDWDCDCMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_mqtt_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_mqtt_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.mqtt.ExtremeTemperature10Min' event to the Kafka topic
 
@@ -1021,6 +1107,7 @@ class DEDWDCDCMqttEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1031,6 +1118,7 @@ class DEDWDCDCMqttEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1126,7 +1214,7 @@ class DEDWDCDCAmqpEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_cdc_amqp_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_station_metadata(self,_station_id : str, data: StationMetadata, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, StationMetadata], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.StationMetadata' event to the Kafka topic
 
@@ -1134,6 +1222,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (StationMetadata): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, StationMetadata], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1144,6 +1233,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1157,7 +1247,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_air_temperature10_min(self,_station_id : str, data: AirTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, AirTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.AirTemperature10Min' event to the Kafka topic
 
@@ -1165,6 +1255,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (AirTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, AirTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1175,6 +1266,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1188,7 +1280,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_precipitation10_min(self,_station_id : str, data: Precipitation10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Precipitation10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.Precipitation10Min' event to the Kafka topic
 
@@ -1196,6 +1288,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Precipitation10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Precipitation10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1206,6 +1299,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1219,7 +1313,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_wind10_min(self,_station_id : str, data: Wind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Wind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.Wind10Min' event to the Kafka topic
 
@@ -1227,6 +1321,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Wind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Wind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1237,6 +1332,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1250,7 +1346,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_solar10_min(self,_station_id : str, data: Solar10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Solar10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.Solar10Min' event to the Kafka topic
 
@@ -1258,6 +1354,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Solar10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Solar10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1268,6 +1365,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1281,7 +1379,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_hourly_observation(self,_station_id : str, data: HourlyObservation, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, HourlyObservation], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.HourlyObservation' event to the Kafka topic
 
@@ -1289,6 +1387,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (HourlyObservation): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, HourlyObservation], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1299,6 +1398,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1312,7 +1412,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_extreme_wind10_min(self,_station_id : str, data: ExtremeWind10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeWind10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.ExtremeWind10Min' event to the Kafka topic
 
@@ -1320,6 +1420,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeWind10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeWind10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1330,6 +1431,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1343,7 +1445,7 @@ class DEDWDCDCAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_cdc_amqp_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
+    def send_de_dwd_cdc_amqp_extreme_temperature10_min(self,_station_id : str, data: ExtremeTemperature10Min, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ExtremeTemperature10Min], str]=None) -> None:
         """
         Sends the 'DE.DWD.CDC.amqp.ExtremeTemperature10Min' event to the Kafka topic
 
@@ -1351,6 +1453,7 @@ class DEDWDCDCAmqpEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (ExtremeTemperature10Min): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ExtremeTemperature10Min], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1361,6 +1464,7 @@ class DEDWDCDCAmqpEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1456,7 +1560,7 @@ class DEDWDWeatherMqttEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_weather_mqtt_alert(self,_state : str, _severity : str, _identifier : str, data: Alert, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
+    def send_de_dwd_weather_mqtt_alert(self,_state : str, _severity : str, _identifier : str, data: Alert, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
         """
         Sends the 'DE.DWD.Weather.mqtt.Alert' event to the Kafka topic
 
@@ -1466,6 +1570,7 @@ class DEDWDWeatherMqttEventProducer:
             _identifier(str):  Value for placeholder identifier in attribute subject
             data: (Alert): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Alert], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1476,6 +1581,7 @@ class DEDWDWeatherMqttEventProducer:
              "subject":"{state}/{severity}/{identifier}".format(state = _state,severity = _severity,identifier = _identifier)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1571,7 +1677,7 @@ class DEDWDWeatherAmqpEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_weather_amqp_alert(self,_state : str, _severity : str, _identifier : str, data: Alert, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
+    def send_de_dwd_weather_amqp_alert(self,_state : str, _severity : str, _identifier : str, data: Alert, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Alert], str]=None) -> None:
         """
         Sends the 'DE.DWD.Weather.amqp.Alert' event to the Kafka topic
 
@@ -1581,6 +1687,7 @@ class DEDWDWeatherAmqpEventProducer:
             _identifier(str):  Value for placeholder identifier in attribute subject
             data: (Alert): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Alert], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1591,6 +1698,7 @@ class DEDWDWeatherAmqpEventProducer:
              "subject":"{state}/{severity}/{identifier}".format(state = _state,severity = _severity,identifier = _identifier)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1686,7 +1794,7 @@ class DEDWDRadarMqttEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_radar_mqtt_radar_product_catalog(self,_kind : str, data: RadarProductCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
+    def send_de_dwd_radar_mqtt_radar_product_catalog(self,_kind : str, data: RadarProductCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.mqtt.RadarProductCatalog' event to the Kafka topic
 
@@ -1694,6 +1802,7 @@ class DEDWDRadarMqttEventProducer:
             _kind(str):  Value for placeholder kind in attribute subject
             data: (RadarProductCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarProductCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1704,6 +1813,7 @@ class DEDWDRadarMqttEventProducer:
              "subject":"{kind}".format(kind = _kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1717,7 +1827,7 @@ class DEDWDRadarMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_radar_mqtt_radar_file_product(self,_product_type : str, _file_id : str, data: RadarFileProduct, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
+    def send_de_dwd_radar_mqtt_radar_file_product(self,_product_type : str, _file_id : str, data: RadarFileProduct, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.mqtt.RadarFileProduct' event to the Kafka topic
 
@@ -1726,6 +1836,7 @@ class DEDWDRadarMqttEventProducer:
             _file_id(str):  Value for placeholder file_id in attribute subject
             data: (RadarFileProduct): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarFileProduct], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1736,6 +1847,7 @@ class DEDWDRadarMqttEventProducer:
              "subject":"{product_type}/{file_id}".format(product_type = _product_type,file_id = _file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1831,7 +1943,7 @@ class DEDWDRadarAmqpEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_radar_amqp_radar_product_catalog(self,_kind : str, data: RadarProductCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
+    def send_de_dwd_radar_amqp_radar_product_catalog(self,_kind : str, data: RadarProductCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarProductCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.amqp.RadarProductCatalog' event to the Kafka topic
 
@@ -1839,6 +1951,7 @@ class DEDWDRadarAmqpEventProducer:
             _kind(str):  Value for placeholder kind in attribute subject
             data: (RadarProductCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarProductCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1849,6 +1962,7 @@ class DEDWDRadarAmqpEventProducer:
              "subject":"{kind}".format(kind = _kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1862,7 +1976,7 @@ class DEDWDRadarAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_radar_amqp_radar_file_product(self,_product_type : str, _file_id : str, data: RadarFileProduct, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
+    def send_de_dwd_radar_amqp_radar_file_product(self,_product_type : str, _file_id : str, data: RadarFileProduct, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, RadarFileProduct], str]=None) -> None:
         """
         Sends the 'DE.DWD.Radar.amqp.RadarFileProduct' event to the Kafka topic
 
@@ -1871,6 +1985,7 @@ class DEDWDRadarAmqpEventProducer:
             _file_id(str):  Value for placeholder file_id in attribute subject
             data: (RadarFileProduct): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, RadarFileProduct], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1881,6 +1996,7 @@ class DEDWDRadarAmqpEventProducer:
              "subject":"{product_type}/{file_id}".format(product_type = _product_type,file_id = _file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -1976,7 +2092,7 @@ class DEDWDForecastMqttEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_forecast_mqtt_forecast_model_catalog(self,_kind : str, data: ForecastModelCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
+    def send_de_dwd_forecast_mqtt_forecast_model_catalog(self,_kind : str, data: ForecastModelCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.mqtt.ForecastModelCatalog' event to the Kafka topic
 
@@ -1984,6 +2100,7 @@ class DEDWDForecastMqttEventProducer:
             _kind(str):  Value for placeholder kind in attribute subject
             data: (ForecastModelCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ForecastModelCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -1994,6 +2111,7 @@ class DEDWDForecastMqttEventProducer:
              "subject":"{kind}".format(kind = _kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -2007,7 +2125,7 @@ class DEDWDForecastMqttEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_forecast_mqtt_icon_d2_forecast_file(self,_variable : str, _file_id : str, data: IconD2ForecastFile, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
+    def send_de_dwd_forecast_mqtt_icon_d2_forecast_file(self,_variable : str, _file_id : str, data: IconD2ForecastFile, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.mqtt.IconD2ForecastFile' event to the Kafka topic
 
@@ -2016,6 +2134,7 @@ class DEDWDForecastMqttEventProducer:
             _file_id(str):  Value for placeholder file_id in attribute subject
             data: (IconD2ForecastFile): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, IconD2ForecastFile], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -2026,6 +2145,7 @@ class DEDWDForecastMqttEventProducer:
              "subject":"{variable}/{file_id}".format(variable = _variable,file_id = _file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -2121,7 +2241,7 @@ class DEDWDForecastAmqpEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_dwd_forecast_amqp_forecast_model_catalog(self,_kind : str, data: ForecastModelCatalog, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
+    def send_de_dwd_forecast_amqp_forecast_model_catalog(self,_kind : str, data: ForecastModelCatalog, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, ForecastModelCatalog], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.amqp.ForecastModelCatalog' event to the Kafka topic
 
@@ -2129,6 +2249,7 @@ class DEDWDForecastAmqpEventProducer:
             _kind(str):  Value for placeholder kind in attribute subject
             data: (ForecastModelCatalog): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, ForecastModelCatalog], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -2139,6 +2260,7 @@ class DEDWDForecastAmqpEventProducer:
              "subject":"{kind}".format(kind = _kind)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -2152,7 +2274,7 @@ class DEDWDForecastAmqpEventProducer:
             self.producer.flush()
 
 
-    def send_de_dwd_forecast_amqp_icon_d2_forecast_file(self,_variable : str, _file_id : str, data: IconD2ForecastFile, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
+    def send_de_dwd_forecast_amqp_icon_d2_forecast_file(self,_variable : str, _file_id : str, data: IconD2ForecastFile, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, IconD2ForecastFile], str]=None) -> None:
         """
         Sends the 'DE.DWD.Forecast.amqp.IconD2ForecastFile' event to the Kafka topic
 
@@ -2161,6 +2283,7 @@ class DEDWDForecastAmqpEventProducer:
             _file_id(str):  Value for placeholder file_id in attribute subject
             data: (IconD2ForecastFile): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, IconD2ForecastFile], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         """
@@ -2171,6 +2294,7 @@ class DEDWDForecastAmqpEventProducer:
              "subject":"{variable}/{file_id}".format(variable = _variable,file_id = _file_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))

--- a/feeders/dwd/dwd_producer/dwd_producer_kafka_producer/tests/test_producer.py
+++ b/feeders/dwd/dwd_producer/dwd_producer_kafka_producer/tests/test_producer.py
@@ -138,7 +138,8 @@ def test_de_dwd_cdc_dedwdcdcstationmetadata(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_station_metadata(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_station_metadata(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -201,7 +202,8 @@ def test_de_dwd_cdc_dedwdcdcairtemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_air_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_air_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -264,7 +266,8 @@ def test_de_dwd_cdc_dedwdcdcprecipitation10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_precipitation10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_precipitation10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -327,7 +330,8 @@ def test_de_dwd_cdc_dedwdcdcwind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -390,7 +394,8 @@ def test_de_dwd_cdc_dedwdcdcsolar10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_solar10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_solar10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -453,7 +458,8 @@ def test_de_dwd_cdc_dedwdcdchourlyobservation(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_hourly_observation(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_hourly_observation(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -516,7 +522,8 @@ def test_de_dwd_cdc_dedwdcdcextremewind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_extreme_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_extreme_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -579,7 +586,8 @@ def test_de_dwd_cdc_dedwdcdcextremetemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_extreme_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_extreme_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -642,7 +650,8 @@ def test_de_dwd_weather_dedwdweatheralert(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_weather_alert(_identifier = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_weather_alert(_identifier = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -705,7 +714,8 @@ def test_de_dwd_radar_dedwdradarradarproductcatalog(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_radar_product_catalog(_file_url = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_radar_product_catalog(_file_url = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -768,7 +778,8 @@ def test_de_dwd_radar_dedwdradarradarfileproduct(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_radar_file_product(_file_url = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_radar_file_product(_file_url = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -831,7 +842,8 @@ def test_de_dwd_forecast_dedwdforecastforecastmodelcatalog(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_forecast_model_catalog(_file_url = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_forecast_model_catalog(_file_url = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -894,7 +906,8 @@ def test_de_dwd_forecast_dedwdforecasticond2forecastfile(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_icon_d2_forecast_file(_file_url = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_icon_d2_forecast_file(_file_url = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -957,7 +970,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttstationmetadata(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_station_metadata(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_station_metadata(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1018,7 +1032,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttairtemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_air_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_air_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1079,7 +1094,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttprecipitation10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_precipitation10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_precipitation10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1140,7 +1156,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttwind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1201,7 +1218,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttsolar10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_solar10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_solar10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1262,7 +1280,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqtthourlyobservation(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_hourly_observation(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_hourly_observation(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1323,7 +1342,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttextremewind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_extreme_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_extreme_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1384,7 +1404,8 @@ def test_de_dwd_cdc_mqtt_dedwdcdcmqttextremetemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_mqtt_extreme_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_mqtt_extreme_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1445,7 +1466,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpstationmetadata(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_station_metadata(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_station_metadata(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1506,7 +1528,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpairtemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_air_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_air_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1567,7 +1590,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpprecipitation10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_precipitation10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_precipitation10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1628,7 +1652,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpwind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1689,7 +1714,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpsolar10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_solar10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_solar10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1750,7 +1776,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqphourlyobservation(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_hourly_observation(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_hourly_observation(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1811,7 +1838,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpextremewind10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_extreme_wind10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_extreme_wind10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1872,7 +1900,8 @@ def test_de_dwd_cdc_amqp_dedwdcdcamqpextremetemperature10min(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_cdc_amqp_extreme_temperature10_min(_station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_cdc_amqp_extreme_temperature10_min(_station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1933,7 +1962,8 @@ def test_de_dwd_weather_mqtt_dedwdweathermqttalert(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_weather_mqtt_alert(_state = f'test_{i}', _severity = f'test_{i}', _identifier = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_weather_mqtt_alert(_state = f'test_{i}', _severity = f'test_{i}', _identifier = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -1994,7 +2024,8 @@ def test_de_dwd_weather_amqp_dedwdweatheramqpalert(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_weather_amqp_alert(_state = f'test_{i}', _severity = f'test_{i}', _identifier = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_weather_amqp_alert(_state = f'test_{i}', _severity = f'test_{i}', _identifier = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2055,7 +2086,8 @@ def test_de_dwd_radar_mqtt_dedwdradarmqttradarproductcatalog(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_mqtt_radar_product_catalog(_kind = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_mqtt_radar_product_catalog(_kind = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2116,7 +2148,8 @@ def test_de_dwd_radar_mqtt_dedwdradarmqttradarfileproduct(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_mqtt_radar_file_product(_product_type = f'test_{i}', _file_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_mqtt_radar_file_product(_product_type = f'test_{i}', _file_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2177,7 +2210,8 @@ def test_de_dwd_radar_amqp_dedwdradaramqpradarproductcatalog(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_amqp_radar_product_catalog(_kind = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_amqp_radar_product_catalog(_kind = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2238,7 +2272,8 @@ def test_de_dwd_radar_amqp_dedwdradaramqpradarfileproduct(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_radar_amqp_radar_file_product(_product_type = f'test_{i}', _file_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_radar_amqp_radar_file_product(_product_type = f'test_{i}', _file_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2299,7 +2334,8 @@ def test_de_dwd_forecast_mqtt_dedwdforecastmqttforecastmodelcatalog(kafka_emulat
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_mqtt_forecast_model_catalog(_kind = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_mqtt_forecast_model_catalog(_kind = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2360,7 +2396,8 @@ def test_de_dwd_forecast_mqtt_dedwdforecastmqtticond2forecastfile(kafka_emulator
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_mqtt_icon_d2_forecast_file(_variable = f'test_{i}', _file_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_mqtt_icon_d2_forecast_file(_variable = f'test_{i}', _file_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2421,7 +2458,8 @@ def test_de_dwd_forecast_amqp_dedwdforecastamqpforecastmodelcatalog(kafka_emulat
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_amqp_forecast_model_catalog(_kind = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_amqp_forecast_model_catalog(_kind = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -2482,7 +2520,8 @@ def test_de_dwd_forecast_amqp_dedwdforecastamqpicond2forecastfile(kafka_emulator
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_dwd_forecast_amqp_icon_d2_forecast_file(_variable = f'test_{i}', _file_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_dwd_forecast_amqp_icon_d2_forecast_file(_variable = f'test_{i}', _file_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)

--- a/feeders/dwd/tests/test_csv_parser.py
+++ b/feeders/dwd/tests/test_csv_parser.py
@@ -76,6 +76,15 @@ class TestMapRow:
         assert mapped["station_id"] == "73"
         assert mapped["precipitation_height"] == pytest.approx(0.2)
 
+    def test_precipitation_indicator_is_int(self):
+        # RWS_IND_10 is a categorical int code; the contract declares int32,
+        # so map_row must coerce the float-parsed value to a Python int.
+        rows = parse_dwd_csv(SAMPLE_CSV_PRECIP)
+        mapped = map_row(rows[1], "precipitation")
+        assert mapped["precipitation_indicator"] == 1
+        assert isinstance(mapped["precipitation_indicator"], int)
+        assert not isinstance(mapped["precipitation_indicator"], bool)
+
     def test_wind_mapping(self):
         rows = parse_dwd_csv(SAMPLE_CSV_WIND)
         mapped = map_row(rows[0], "wind")

--- a/feeders/dwd/xreg/dwd.xreg.json
+++ b/feeders/dwd/xreg/dwd.xreg.json
@@ -1272,28 +1272,44 @@
                     "description": "Reference details for a station, monitoring site, or reporting area in the DWD Weather source."
                   },
                   "air_temperature_2m": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "TT_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_5cm": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "TM5_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "relative_humidity": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "RF_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "dew_point_temperature": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "TD_10"
                     },
@@ -1352,14 +1368,22 @@
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "precipitation_height": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "RWS_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "precipitation_indicator": {
-                    "type": "int32",
+                    "type": [
+                      "null",
+                      "int32"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "RWS_IND_10"
                     },
@@ -1418,14 +1442,22 @@
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "FF_10"
                     },
                     "description": "Wind speed reported by the station."
                   },
                   "wind_direction": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "DD_10"
                     },
@@ -1484,28 +1516,44 @@
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "global_radiation": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "GS_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "sunshine_duration": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "SD_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "diffuse_radiation": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "DS_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "longwave_radiation": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "LS_10"
                     },
@@ -1727,21 +1775,33 @@
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed_maximum": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "FX_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_speed_minimum": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "FNX_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "wind_direction_at_maximum": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "DX_10"
                     },
@@ -1800,14 +1860,22 @@
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_maximum_2m": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "TX_10"
                     },
                     "description": "Measurement payload for weather observations, warnings, and forecast product updates in the DWD Weather source."
                   },
                   "air_temperature_minimum_5cm": {
-                    "type": "double",
+                    "type": [
+                      "null",
+                      "double"
+                    ],
+                    "default": null,
                     "altnames": {
                       "lang:de": "TN_10"
                     },


### PR DESCRIPTION
Closes #775.

## Problem

DWD's `csv_parser._safe_float` returns Python `None` for the upstream `-999` missing-value sentinel on **every** measured float column, so any measured field can be emitted as JSON `null`. The xreg contract declared those fields as bare non-nullable types (`"type":"double"` / `"int32"`), so the strict Docker E2E JsonStructure validator (`InstanceValidator(schema, extended=True)`) rejected the first `null` it saw.

## Changes

- **Contract (`feeders/dwd/xreg/dwd.xreg.json`)** — 17 measured fields across the 6 ten-minute schemas (`AirTemperature10Min`, `Precipitation10Min`, `Wind10Min`, `Solar10Min`, `ExtremeWind10Min`, `ExtremeTemperature10Min`) changed from bare types to null-first unions `["null","<type>"]` + `"default": null`. This matches the existing nullable siblings in the same manifest (`pressure_station_level`, `state`). Fields that are required keys/subject template vars (`station_id`, `timestamp`), parser-defaulted (`quality_level` → 0), or constants (`parameter`, `unit`) are intentionally left non-nullable.
- **Parser (`feeders/dwd/dwd/parsers/csv_parser.py`)** — `map_row` now int-coerces `precipitation_indicator` (`RWS_IND_10`) when non-null. It is a categorical `int32` code (0=none, 1/3/6/7/8=type) that flowed through `_safe_float` and was emitted as float `0.0`, which the `["null","int32"]` union rejects. Coercing to `int` keeps the semantically-correct `int32` type. Found by the E2E and independently flagged by the JSON Structure reviewer.
- **Producers** — regenerated all 3 transports (kafka/amqp/mqtt) with the pinned **xrcg 0.10.11**. Generated dataclasses were already `Optional` (xrcg makes any non-required field optional); the wire format is JSON-only and `None` serializes to literal `null`. The regen also picks up the generator's new `_time` send parameter — the bridge calls all send methods with kwargs, so it is safe.
- **`EVENTS.md`** — refreshed (nullability wording only; title/description preserved).
- **Test** — added `test_precipitation_indicator_is_int` regression test.

## Validation

- ✅ **DWD Docker Kafka E2E** passes (`TestDWDDockerFlow`: reference + telemetry, all schemas validate with measured fields set to `null`).
- ✅ DWD parser unit tests pass.

## Mandatory expert reviews

| Reviewer | Verdict |
| --- | --- |
| xRegistry Expert | ✅ PASS — no blockers |
| JSON Structure Expert | ✅ PASS — no blockers (independently flagged `precipitation_indicator` int/float) |
| Avro Schema Expert | ✅ PASS — no blockers |

## Pre-existing upstream bug (raised, not introduced here)

The Avro reviewer noted a **pre-existing** xrcg 0.10.11 data-template bug: `to_byte_array("application/json")` returns `str`, not `bytes` (only the `+gzip` branch encodes). Kafka tolerates `str` and the AMQP template re-encodes, so it does not affect this change. It is **not** introduced by #775 and should be filed against `xregistry/codegen` separately.
