### PR TITLE
fix(e2e): resolve three pre-existing flow-shard failures (bfs-odl, kystverket-ais, nextbus)

### DIFF
--- a/feeders/bfs-odl/bfs_odl/bfs_odl.py
+++ b/feeders/bfs-odl/bfs_odl/bfs_odl.py
@@ -39,15 +39,15 @@ WFS_PARAMS_BASE = {
     "outputFormat": "application/json",
 }
 
-_AGS_TO_CANTON = {
+_AGS_TO_STATE = {
     "01": "schleswig-holstein", "02": "hamburg", "03": "niedersachsen", "04": "bremen",
     "05": "nordrhein-westfalen", "06": "hessen", "07": "rheinland-pfalz", "08": "baden-wuerttemberg",
     "09": "bayern", "10": "saarland", "11": "berlin", "12": "brandenburg",
     "13": "mecklenburg-vorpommern", "14": "sachsen", "15": "sachsen-anhalt", "16": "thueringen",
 }
 
-def canton_from_station_id(station_id: str) -> str:
-    return _AGS_TO_CANTON.get((station_id or "")[:2], "unknown")
+def state_from_station_id(station_id: str) -> str:
+    return _AGS_TO_STATE.get((station_id or "")[:2], "unknown")
 
 
 def _load_state(state_file: str) -> dict:
@@ -103,7 +103,7 @@ class BfsOdlAPI:
         coords = geom.get("coordinates", [None, None])
         return Station(
             station_id=props["kenn"],
-            canton=canton_from_station_id(props.get("kenn", "")),
+            state=state_from_station_id(props.get("kenn", "")),
             station_code=props.get("id", ""),
             name=props.get("name", ""),
             postal_code=props.get("plz", ""),
@@ -121,7 +121,7 @@ class BfsOdlAPI:
         props = feature["properties"]
         return DoseRateMeasurement(
             station_id=props["kenn"],
-            canton=canton_from_station_id(props.get("kenn", "")),
+            state=state_from_station_id(props.get("kenn", "")),
             start_measure=props.get("start_measure", ""),
             end_measure=props.get("end_measure", ""),
             value=props.get("value"),

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer/src/bfs_odl_amqp_producer_amqp_producer/producer.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer/src/bfs_odl_amqp_producer_amqp_producer/producer.py
@@ -14,14 +14,62 @@ import sys
 import typing
 import uuid
 import json
+import re
 import threading
 import queue
 import concurrent.futures
+from datetime import datetime, timezone
 from urllib.parse import quote_plus
-from proton import Message
+from proton import Message, symbol
+from proton.reactor import AtMostOnce
 from proton.utils import BlockingConnection
 from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_binary, to_structured
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 
 # --- Azure CBS support (azure_cbs_target=servicebus) ---
 # Two CBS auth modes are supported:
@@ -36,7 +84,7 @@ import hmac
 import logging
 import time as _cbs_time
 from urllib.parse import quote
-from proton import Endpoint, symbol
+from proton import Endpoint
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, AtLeastOnce
 
@@ -484,9 +532,7 @@ class DeBfsOdlAmqpProducer:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
 
     def _init_reactor(self):
         """Start the proton reactor thread and block until CBS handshake completes.
@@ -549,6 +595,32 @@ class DeBfsOdlAmqpProducer:
         fut: "concurrent.futures.Future" = concurrent.futures.Future()
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
+            self._connection.wait(
+                lambda: (
+                    self._sender.link.queued == 0 and
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -574,6 +646,23 @@ class DeBfsOdlAmqpProducer:
         if isinstance(payload, str):
             payload = payload.encode('utf-8')
         return payload
+
+    @staticmethod
+    def _coerce_amqp_timestamp(value: typing.Any) -> typing.Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return int(value.timestamp() * 1000)
+        if isinstance(value, (int, float)):
+            return int(value)
+        text = str(value)
+        normalized = text[:-1] + '+00:00' if text.endswith('Z') else text
+        try:
+            return int(datetime.fromisoformat(normalized).timestamp() * 1000)
+        except ValueError:
+            return None
 
     @staticmethod
     def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
@@ -602,6 +691,7 @@ class DeBfsOdlAmqpProducer:
         data: Station,
         _feedurl: str,
         _station_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `de.bfs.odl.amqp.Station` message
@@ -610,6 +700,7 @@ class DeBfsOdlAmqpProducer:
         Args:
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (Station): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -622,6 +713,7 @@ class DeBfsOdlAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -651,6 +743,9 @@ class DeBfsOdlAmqpProducer:
             amqp_msg.content_type = content_type
             if headers:
                 amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))
+        if amqp_creation_time is not None:
+            amqp_msg.creation_time = amqp_creation_time
         # Apply AMQP message properties declared in protocoloptions.properties.
         amqp_msg.subject = "{station_id}".format(station_id=_station_id)
 
@@ -659,17 +754,24 @@ class DeBfsOdlAmqpProducer:
             if amqp_msg.properties is None:
                 amqp_msg.properties = {}
             amqp_msg.properties.update(app_properties)
+
+        annotations = {}
+        if annotations:
+            if amqp_msg.annotations is None:
+                amqp_msg.annotations = {}
+            amqp_msg.annotations.update(annotations)
         
         # Send message
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_station_batch(self,
         data_array: typing.List[Station],
         _feedurl: str,
         _station_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `de.bfs.odl.amqp.Station` messages
@@ -678,6 +780,7 @@ class DeBfsOdlAmqpProducer:
             data_array (typing.List[Station]): Array of message data objects
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
@@ -685,6 +788,7 @@ class DeBfsOdlAmqpProducer:
                 data=data,
                 _feedurl=_feedurl,
                 _station_id=_station_id,
+                _time=_time,
                 content_type=content_type)
     
     
@@ -692,6 +796,7 @@ class DeBfsOdlAmqpProducer:
         data: DoseRateMeasurement,
         _feedurl: str,
         _station_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `de.bfs.odl.amqp.DoseRateMeasurement` message
@@ -700,6 +805,7 @@ class DeBfsOdlAmqpProducer:
         Args:
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data (DoseRateMeasurement): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -712,6 +818,7 @@ class DeBfsOdlAmqpProducer:
             "subject":
             "{station_id}".format(station_id=_station_id),
         }
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -741,6 +848,9 @@ class DeBfsOdlAmqpProducer:
             amqp_msg.content_type = content_type
             if headers:
                 amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
+        amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))
+        if amqp_creation_time is not None:
+            amqp_msg.creation_time = amqp_creation_time
         # Apply AMQP message properties declared in protocoloptions.properties.
         amqp_msg.subject = "{station_id}".format(station_id=_station_id)
 
@@ -749,17 +859,24 @@ class DeBfsOdlAmqpProducer:
             if amqp_msg.properties is None:
                 amqp_msg.properties = {}
             amqp_msg.properties.update(app_properties)
+
+        annotations = {}
+        if annotations:
+            if amqp_msg.annotations is None:
+                amqp_msg.annotations = {}
+            amqp_msg.annotations.update(annotations)
         
         # Send message
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
     
     def send_dose_rate_measurement_batch(self,
         data_array: typing.List[DoseRateMeasurement],
         _feedurl: str,
         _station_id: str,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `de.bfs.odl.amqp.DoseRateMeasurement` messages
@@ -768,6 +885,7 @@ class DeBfsOdlAmqpProducer:
             data_array (typing.List[DoseRateMeasurement]): Array of message data objects
             _feedurl (str): Value for placeholder feedurl in attribute source
             _station_id (str): Value for placeholder station_id in attribute subject
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type (str): The content type of the message data
         """
         for data in data_array:
@@ -775,6 +893,7 @@ class DeBfsOdlAmqpProducer:
                 data=data,
                 _feedurl=_feedurl,
                 _station_id=_station_id,
+                _time=_time,
                 content_type=content_type)
     
     

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer/tests/test_producer.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer/tests/test_producer.py
@@ -5,6 +5,7 @@
 Tests for bfs_odl_amqp_producer_amqp_producer
 """
 import base64
+import datetime
 import json
 import os
 import sys
@@ -17,6 +18,7 @@ from urllib.parse import quote_plus
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
+from proton import Message, symbol
 from proton.utils import BlockingConnection
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../bfs_odl_amqp_producer_data/src')))
@@ -233,6 +235,45 @@ class TestDeBfsOdlAmqpProducer:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__(DeBfsOdlAmqpProducer)
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     def test_send_station(self, artemis_container):
         """Send and receive a Station message via ActiveMQ Artemis."""
@@ -260,6 +301,7 @@ class TestDeBfsOdlAmqpProducer:
                     data=payload,
                     _feedurl="value",
                     _station_id="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -267,6 +309,7 @@ class TestDeBfsOdlAmqpProducer:
             for i in range(5):
                 received = _receive_single_message(artemis_container)
                 properties = received.properties or {}
+                annotations = received.annotations or {}
 
                 if True:
                     body = received.body
@@ -290,6 +333,37 @@ class TestDeBfsOdlAmqpProducer:
                 assert received.subject == "{station_id}".format(station_id="value")
         finally:
             producer.close()
+
+    def test_send_station_single_fresh_connection(self, artemis_container):
+        """Send exactly one Station message on a fresh producer connection."""
+        payload = Test_Station.create_instance()
+
+        producer = DeBfsOdlAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_station(
+                data=payload,
+                _feedurl="value",
+                _station_id="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'de.bfs.odl.amqp.Station'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
     
     def test_send_dose_rate_measurement(self, artemis_container):
         """Send and receive a DoseRateMeasurement message via ActiveMQ Artemis."""
@@ -317,6 +391,7 @@ class TestDeBfsOdlAmqpProducer:
                     data=payload,
                     _feedurl="value",
                     _station_id="value",
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 
@@ -324,6 +399,7 @@ class TestDeBfsOdlAmqpProducer:
             for i in range(5):
                 received = _receive_single_message(artemis_container)
                 properties = received.properties or {}
+                annotations = received.annotations or {}
 
                 if True:
                     body = received.body
@@ -347,4 +423,35 @@ class TestDeBfsOdlAmqpProducer:
                 assert received.subject == "{station_id}".format(station_id="value")
         finally:
             producer.close()
+
+    def test_send_dose_rate_measurement_single_fresh_connection(self, artemis_container):
+        """Send exactly one DoseRateMeasurement message on a fresh producer connection."""
+        payload = Test_DoseRateMeasurement.create_instance()
+
+        producer = DeBfsOdlAmqpProducer(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            producer.send_dose_rate_measurement(
+                data=payload,
+                _feedurl="value",
+                _station_id="value",
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+        assert properties.get('cloudEvents:type') == 'de.bfs.odl.amqp.DoseRateMeasurement'
+        assert received.body is not None
+        assert received.subject == "{station_id}".format(station_id="value")
 

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import DoseRateMeasurement, Station
+from .de import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .bfs import DoseRateMeasurement, Station
+from .bfs import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/__init__.py
@@ -1,3 +1,3 @@
-from .odl import DoseRateMeasurement, Station
+from .odl import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/__init__.py
@@ -1,4 +1,4 @@
-from .doseratemeasurement import DoseRateMeasurement
 from .station import Station
+from .doseratemeasurement import DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/doseratemeasurement.py
@@ -167,13 +167,13 @@ class DoseRateMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='eafrxhjwmgwqgesrcdiu',
-            state='egrmhihqdxrlewhsuibv',
-            start_measure='esxkdyalfhuetuvyxvjz',
-            end_measure='wwnizfsbieeudeeyeywg',
-            value=float(38.519546619522835),
-            value_cosmic=float(42.75577415358166),
-            value_terrestrial=float(88.08235898273202),
-            validated=int(65),
-            nuclide='lkvqtwtzhqtetsyvazhu'
+            station_id='wgcqaznxtcztyjjomymo',
+            state='eijmxeefozivkzljtxic',
+            start_measure='fkmsdzwmujxqznvndxyb',
+            end_measure='dzkctzfkcaucpomanfod',
+            value=float(92.8440988503963),
+            value_cosmic=float(68.43473178275724),
+            value_terrestrial=float(48.620626228530675),
+            validated=int(37),
+            nuclide='iawkcnajibyucmvilfgt'
         )

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/station.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/src/bfs_odl_amqp_producer_data/de/bfs/odl/station.py
@@ -171,15 +171,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='wfuucvgaqpgvpmvbshxx',
-            state='uufiqvfyokzqftxithzn',
-            station_code='ewolkxczsmtezskuvkxi',
-            name='ubtwngnponlrnpsksiec',
-            postal_code='cslptvtovestcqlsbaow',
-            site_status=int(65),
-            site_status_text='nijwpuoijtytnawfixtf',
-            kid=int(48),
-            height_above_sea=float(89.19329084306783),
-            longitude=float(89.89010419169757),
-            latitude=float(71.54006778896422)
+            station_id='zfpxyrywuvuaelzurrcb',
+            state='bvmqgwnfgofjeyzrhrst',
+            station_code='xnguxyddothaybccdyrb',
+            name='czuzwkvaodhnkxlzuufj',
+            postal_code='qbfqygewqsxsgorfhajf',
+            site_status=int(36),
+            site_status_text='lnanfpvbywoiewlqkjgz',
+            kid=int(5),
+            height_above_sea=float(31.07472984797921),
+            longitude=float(78.73544013800094),
+            latitude=float(10.684912089111586)
         )

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/tests/test_doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/tests/test_doseratemeasurement.py
@@ -28,15 +28,15 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         Create instance of DoseRateMeasurement for testing
         """
         instance = DoseRateMeasurement(
-            station_id='eafrxhjwmgwqgesrcdiu',
-            state='egrmhihqdxrlewhsuibv',
-            start_measure='esxkdyalfhuetuvyxvjz',
-            end_measure='wwnizfsbieeudeeyeywg',
-            value=float(38.519546619522835),
-            value_cosmic=float(42.75577415358166),
-            value_terrestrial=float(88.08235898273202),
-            validated=int(65),
-            nuclide='lkvqtwtzhqtetsyvazhu'
+            station_id='wgcqaznxtcztyjjomymo',
+            state='eijmxeefozivkzljtxic',
+            start_measure='fkmsdzwmujxqznvndxyb',
+            end_measure='dzkctzfkcaucpomanfod',
+            value=float(92.8440988503963),
+            value_cosmic=float(68.43473178275724),
+            value_terrestrial=float(48.620626228530675),
+            validated=int(37),
+            nuclide='iawkcnajibyucmvilfgt'
         )
         return instance
 
@@ -45,7 +45,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'eafrxhjwmgwqgesrcdiu'
+        test_value = 'wgcqaznxtcztyjjomymo'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -53,7 +53,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'egrmhihqdxrlewhsuibv'
+        test_value = 'eijmxeefozivkzljtxic'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -61,7 +61,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test start_measure property
         """
-        test_value = 'esxkdyalfhuetuvyxvjz'
+        test_value = 'fkmsdzwmujxqznvndxyb'
         self.instance.start_measure = test_value
         self.assertEqual(self.instance.start_measure, test_value)
     
@@ -69,7 +69,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test end_measure property
         """
-        test_value = 'wwnizfsbieeudeeyeywg'
+        test_value = 'dzkctzfkcaucpomanfod'
         self.instance.end_measure = test_value
         self.assertEqual(self.instance.end_measure, test_value)
     
@@ -77,7 +77,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(38.519546619522835)
+        test_value = float(92.8440988503963)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -85,7 +85,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_cosmic property
         """
-        test_value = float(42.75577415358166)
+        test_value = float(68.43473178275724)
         self.instance.value_cosmic = test_value
         self.assertEqual(self.instance.value_cosmic, test_value)
     
@@ -93,7 +93,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_terrestrial property
         """
-        test_value = float(88.08235898273202)
+        test_value = float(48.620626228530675)
         self.instance.value_terrestrial = test_value
         self.assertEqual(self.instance.value_terrestrial, test_value)
     
@@ -101,7 +101,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test validated property
         """
-        test_value = int(65)
+        test_value = int(37)
         self.instance.validated = test_value
         self.assertEqual(self.instance.validated, test_value)
     
@@ -109,7 +109,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test nuclide property
         """
-        test_value = 'lkvqtwtzhqtetsyvazhu'
+        test_value = 'iawkcnajibyucmvilfgt'
         self.instance.nuclide = test_value
         self.assertEqual(self.instance.nuclide, test_value)
     

--- a/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/tests/test_station.py
+++ b/feeders/bfs-odl/bfs_odl_amqp_producer/bfs_odl_amqp_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='wfuucvgaqpgvpmvbshxx',
-            state='uufiqvfyokzqftxithzn',
-            station_code='ewolkxczsmtezskuvkxi',
-            name='ubtwngnponlrnpsksiec',
-            postal_code='cslptvtovestcqlsbaow',
-            site_status=int(65),
-            site_status_text='nijwpuoijtytnawfixtf',
-            kid=int(48),
-            height_above_sea=float(89.19329084306783),
-            longitude=float(89.89010419169757),
-            latitude=float(71.54006778896422)
+            station_id='zfpxyrywuvuaelzurrcb',
+            state='bvmqgwnfgofjeyzrhrst',
+            station_code='xnguxyddothaybccdyrb',
+            name='czuzwkvaodhnkxlzuufj',
+            postal_code='qbfqygewqsxsgorfhajf',
+            site_status=int(36),
+            site_status_text='lnanfpvbywoiewlqkjgz',
+            kid=int(5),
+            height_above_sea=float(31.07472984797921),
+            longitude=float(78.73544013800094),
+            latitude=float(10.684912089111586)
         )
         return instance
 
@@ -47,7 +47,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'wfuucvgaqpgvpmvbshxx'
+        test_value = 'zfpxyrywuvuaelzurrcb'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -55,7 +55,7 @@ class Test_Station(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'uufiqvfyokzqftxithzn'
+        test_value = 'bvmqgwnfgofjeyzrhrst'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -63,7 +63,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'ewolkxczsmtezskuvkxi'
+        test_value = 'xnguxyddothaybccdyrb'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -71,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'ubtwngnponlrnpsksiec'
+        test_value = 'czuzwkvaodhnkxlzuufj'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -79,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test postal_code property
         """
-        test_value = 'cslptvtovestcqlsbaow'
+        test_value = 'qbfqygewqsxsgorfhajf'
         self.instance.postal_code = test_value
         self.assertEqual(self.instance.postal_code, test_value)
     
@@ -87,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status property
         """
-        test_value = int(65)
+        test_value = int(36)
         self.instance.site_status = test_value
         self.assertEqual(self.instance.site_status, test_value)
     
@@ -95,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status_text property
         """
-        test_value = 'nijwpuoijtytnawfixtf'
+        test_value = 'lnanfpvbywoiewlqkjgz'
         self.instance.site_status_text = test_value
         self.assertEqual(self.instance.site_status_text, test_value)
     
@@ -103,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kid property
         """
-        test_value = int(48)
+        test_value = int(5)
         self.instance.kid = test_value
         self.assertEqual(self.instance.kid, test_value)
     
@@ -111,7 +111,7 @@ class Test_Station(unittest.TestCase):
         """
         Test height_above_sea property
         """
-        test_value = float(89.19329084306783)
+        test_value = float(31.07472984797921)
         self.instance.height_above_sea = test_value
         self.assertEqual(self.instance.height_above_sea, test_value)
     
@@ -119,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(89.89010419169757)
+        test_value = float(78.73544013800094)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -127,7 +127,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(71.54006778896422)
+        test_value = float(10.684912089111586)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     

--- a/feeders/bfs-odl/bfs_odl_mqtt/bfs_odl_mqtt/app.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt/bfs_odl_mqtt/app.py
@@ -4,8 +4,8 @@ Reuses the upstream HTTP client logic from the existing ``bfs_odl`` Kafka
 bridge and pushes CloudEvents into MQTT 5.0 using the xrcg-generated
 :class:`DeBfsOdlMqttMqttClient`.
 
-Topic tree: ``radiation/ch/bfs/bfs-odl/{canton}/{station_id}/{info|dose-rate}``.
-``{canton}`` is derived from the first two digits of the station Kennziffer
+Topic tree: ``radiation/de/bfs/bfs-odl/{state}/{station_id}/{info|dose-rate}``.
+``{state}`` is derived from the first two digits of the station Kennziffer
 (AGS administrative-region code) and normalized to a lowercase kebab-case slug.
 """
 
@@ -30,7 +30,7 @@ from bfs_odl_mqtt_producer_mqtt_client.client import DeBfsOdlMqttMqttClient
 logger = logging.getLogger(__name__)
 
 # AGS first-two-digit code → Bundesland name
-_AGS_TO_CANTON: Dict[str, str] = {
+_AGS_TO_STATE: Dict[str, str] = {
     "01": "schleswig-holstein",
     "02": "hamburg",
     "03": "niedersachsen",
@@ -73,20 +73,20 @@ def _uns_slug(value: str) -> str:
     return slug or "unknown"
 
 
-def _canton_from_station_id(station_id: str) -> str:
+def _state_from_station_id(station_id: str) -> str:
     """Derive the Bundesland slug from a BfS station Kennziffer (AGS prefix)."""
     prefix = station_id[:2] if len(station_id) >= 2 else ""
-    return _AGS_TO_CANTON.get(prefix, "unknown")
+    return _AGS_TO_STATE.get(prefix, "unknown")
 
 
-def _build_station(feature: Dict[str, Any], canton: str) -> Station:
+def _build_station(feature: Dict[str, Any], state: str) -> Station:
     """Build MQTT Station dataclass from a WFS GeoJSON feature."""
     props = feature["properties"]
     geom = feature.get("geometry") or {}
     coords = geom.get("coordinates", [None, None])
     return Station(
         station_id=props["kenn"],
-        canton=canton,
+        state=state,
         station_code=props.get("id", ""),
         name=props.get("name", ""),
         postal_code=props.get("plz", ""),
@@ -99,12 +99,12 @@ def _build_station(feature: Dict[str, Any], canton: str) -> Station:
     )
 
 
-def _build_measurement(feature: Dict[str, Any], canton: str) -> DoseRateMeasurement:
+def _build_measurement(feature: Dict[str, Any], state: str) -> DoseRateMeasurement:
     """Build MQTT DoseRateMeasurement dataclass from a WFS GeoJSON feature."""
     props = feature["properties"]
     return DoseRateMeasurement(
         station_id=props["kenn"],
-        canton=canton,
+        state=state,
         start_measure=props.get("start_measure", ""),
         end_measure=props.get("end_measure", ""),
         value=props.get("value"),
@@ -128,13 +128,13 @@ async def _publish_stations(
     for feature in stations:
         props = feature.get("properties", {})
         station_id = props.get("kenn", "")
-        canton = _canton_from_station_id(station_id)
+        state = _state_from_station_id(station_id)
         try:
             await mqtt_client.publish_de_bfs_odl_mqtt_station(
                 feedurl=FEED_URL,
                 station_id=station_id,
-                canton=canton,
-                data=_build_station(feature, canton),
+                state=state,
+                data=_build_station(feature, state),
             )
         except Exception as exc:
             logger.error("Error publishing station %s: %s", station_id, exc)
@@ -152,13 +152,13 @@ async def _publish_measurements(
         end_measure = props.get("end_measure", "")
         if station_id in previous_readings and previous_readings[station_id] == end_measure:
             continue
-        canton = _canton_from_station_id(station_id)
+        state = _state_from_station_id(station_id)
         try:
             await mqtt_client.publish_de_bfs_odl_mqtt_dose_rate_measurement(
                 feedurl=FEED_URL,
                 station_id=station_id,
-                canton=canton,
-                data=_build_measurement(feature, canton),
+                state=state,
+                data=_build_measurement(feature, state),
             )
             sent += 1
             previous_readings[station_id] = end_measure
@@ -204,7 +204,7 @@ async def feed(
     await mqtt_client.connect(broker_host, broker_port)
 
     stations, sample_measurements = _sample_features() if os.getenv("BFS_ODL_SAMPLE_MODE", "").lower() in ("1", "true", "yes") else (api.fetch_stations(), None)
-    logger.info("Publishing %d station info events under radiation/ch/bfs/bfs-odl/...", len(stations))
+    logger.info("Publishing %d station info events under radiation/de/bfs/bfs-odl/...", len(stations))
     await _publish_stations(mqtt_client, stations)
     logger.info("Finished publishing station catalog")
 

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .de import DoseRateMeasurement, Station
+from .de import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/__init__.py
@@ -1,3 +1,3 @@
-from .bfs import DoseRateMeasurement, Station
+from .bfs import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/__init__.py
@@ -1,3 +1,3 @@
-from .odl import DoseRateMeasurement, Station
+from .odl import Station, DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/__init__.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/__init__.py
@@ -1,4 +1,4 @@
-from .doseratemeasurement import DoseRateMeasurement
 from .station import Station
+from .doseratemeasurement import DoseRateMeasurement
 
-__all__ = ["DoseRateMeasurement", "Station"]
+__all__ = ["Station", "DoseRateMeasurement"]

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/doseratemeasurement.py
@@ -21,6 +21,7 @@ class DoseRateMeasurement:
     
     Attributes:
         station_id (str)
+        state (str)
         start_measure (str)
         end_measure (str)
         value (typing.Optional[float])
@@ -28,11 +29,11 @@ class DoseRateMeasurement:
         value_terrestrial (typing.Optional[float])
         validated (int)
         nuclide (str)
-        canton (str)
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     start_measure: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="start_measure"))
     end_measure: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="end_measure"))
     value: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value"))
@@ -40,7 +41,6 @@ class DoseRateMeasurement:
     value_terrestrial: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value_terrestrial"))
     validated: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="validated"))
     nuclide: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="nuclide"))
-    canton: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="canton"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'DoseRateMeasurement':
@@ -167,13 +167,13 @@ class DoseRateMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='hihgmdcgryzljzlbyyzt',
-            start_measure='vafnegxmweqqxcscpzgr',
-            end_measure='rysowodqbzaprvtryhcp',
-            value=float(47.81583580572195),
-            value_cosmic=float(55.4621037052584),
-            value_terrestrial=float(31.6445990287329),
-            validated=int(59),
-            nuclide='ppekoofkoelmeuvixrfw',
-            canton='qwcvsatiuqamzkwdljiv'
+            station_id='jsxurymmbhzuwabuakvr',
+            state='bmxpawjyclwjwptcichq',
+            start_measure='nkmgbbgezlezyhecljtc',
+            end_measure='xqgtdxsyiyjjaoafgact',
+            value=float(45.09616149249883),
+            value_cosmic=float(34.045552872814575),
+            value_terrestrial=float(69.45555882597706),
+            validated=int(34),
+            nuclide='eehhsuxqooxjetulbyuo'
         )

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/station.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/src/bfs_odl_mqtt_producer_data/de/bfs/odl/station.py
@@ -21,6 +21,7 @@ class Station:
     
     Attributes:
         station_id (str)
+        state (str)
         station_code (str)
         name (str)
         postal_code (str)
@@ -30,11 +31,11 @@ class Station:
         height_above_sea (typing.Optional[float])
         longitude (float)
         latitude (float)
-        canton (str)
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     station_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_code"))
     name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name"))
     postal_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="postal_code"))
@@ -44,7 +45,6 @@ class Station:
     height_above_sea: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="height_above_sea"))
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
-    canton: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="canton"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Station':
@@ -171,15 +171,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='iqseczoqvulwobsnnnky',
-            station_code='zfodxtjubvzpwrfyuseq',
-            name='auueifnviyrlrxdszrmf',
-            postal_code='dxemeuapgqwtegdvqnyl',
-            site_status=int(19),
-            site_status_text='feccyjwjijlflafynphr',
-            kid=int(8),
-            height_above_sea=float(22.25521430959404),
-            longitude=float(32.600910492964175),
-            latitude=float(42.369276190712945),
-            canton='rcumvuyknwddpmqappeg'
+            station_id='svgyechuqyyaqbftgjuj',
+            state='krgcxmsurtwolnasgnre',
+            station_code='qsnxiqpelowgwpyekirk',
+            name='snibemurtrzkhevujyws',
+            postal_code='oafsmwbcljanmlgnflwj',
+            site_status=int(61),
+            site_status_text='hbabbumfugfienizuhik',
+            kid=int(24),
+            height_above_sea=float(4.610754027261221),
+            longitude=float(12.163636182357118),
+            latitude=float(57.98521649622376)
         )

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/tests/test_doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/tests/test_doseratemeasurement.py
@@ -28,15 +28,15 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         Create instance of DoseRateMeasurement for testing
         """
         instance = DoseRateMeasurement(
-            station_id='hihgmdcgryzljzlbyyzt',
-            start_measure='vafnegxmweqqxcscpzgr',
-            end_measure='rysowodqbzaprvtryhcp',
-            value=float(47.81583580572195),
-            value_cosmic=float(55.4621037052584),
-            value_terrestrial=float(31.6445990287329),
-            validated=int(59),
-            nuclide='ppekoofkoelmeuvixrfw',
-            canton='qwcvsatiuqamzkwdljiv'
+            station_id='jsxurymmbhzuwabuakvr',
+            state='bmxpawjyclwjwptcichq',
+            start_measure='nkmgbbgezlezyhecljtc',
+            end_measure='xqgtdxsyiyjjaoafgact',
+            value=float(45.09616149249883),
+            value_cosmic=float(34.045552872814575),
+            value_terrestrial=float(69.45555882597706),
+            validated=int(34),
+            nuclide='eehhsuxqooxjetulbyuo'
         )
         return instance
 
@@ -45,15 +45,23 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'hihgmdcgryzljzlbyyzt'
+        test_value = 'jsxurymmbhzuwabuakvr'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'bmxpawjyclwjwptcichq'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
     
     def test_start_measure_property(self):
         """
         Test start_measure property
         """
-        test_value = 'vafnegxmweqqxcscpzgr'
+        test_value = 'nkmgbbgezlezyhecljtc'
         self.instance.start_measure = test_value
         self.assertEqual(self.instance.start_measure, test_value)
     
@@ -61,7 +69,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test end_measure property
         """
-        test_value = 'rysowodqbzaprvtryhcp'
+        test_value = 'xqgtdxsyiyjjaoafgact'
         self.instance.end_measure = test_value
         self.assertEqual(self.instance.end_measure, test_value)
     
@@ -69,7 +77,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(47.81583580572195)
+        test_value = float(45.09616149249883)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -77,7 +85,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_cosmic property
         """
-        test_value = float(55.4621037052584)
+        test_value = float(34.045552872814575)
         self.instance.value_cosmic = test_value
         self.assertEqual(self.instance.value_cosmic, test_value)
     
@@ -85,7 +93,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_terrestrial property
         """
-        test_value = float(31.6445990287329)
+        test_value = float(69.45555882597706)
         self.instance.value_terrestrial = test_value
         self.assertEqual(self.instance.value_terrestrial, test_value)
     
@@ -93,7 +101,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test validated property
         """
-        test_value = int(59)
+        test_value = int(34)
         self.instance.validated = test_value
         self.assertEqual(self.instance.validated, test_value)
     
@@ -101,17 +109,9 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test nuclide property
         """
-        test_value = 'ppekoofkoelmeuvixrfw'
+        test_value = 'eehhsuxqooxjetulbyuo'
         self.instance.nuclide = test_value
         self.assertEqual(self.instance.nuclide, test_value)
-    
-    def test_canton_property(self):
-        """
-        Test canton property
-        """
-        test_value = 'qwcvsatiuqamzkwdljiv'
-        self.instance.canton = test_value
-        self.assertEqual(self.instance.canton, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/tests/test_station.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='iqseczoqvulwobsnnnky',
-            station_code='zfodxtjubvzpwrfyuseq',
-            name='auueifnviyrlrxdszrmf',
-            postal_code='dxemeuapgqwtegdvqnyl',
-            site_status=int(19),
-            site_status_text='feccyjwjijlflafynphr',
-            kid=int(8),
-            height_above_sea=float(22.25521430959404),
-            longitude=float(32.600910492964175),
-            latitude=float(42.369276190712945),
-            canton='rcumvuyknwddpmqappeg'
+            station_id='svgyechuqyyaqbftgjuj',
+            state='krgcxmsurtwolnasgnre',
+            station_code='qsnxiqpelowgwpyekirk',
+            name='snibemurtrzkhevujyws',
+            postal_code='oafsmwbcljanmlgnflwj',
+            site_status=int(61),
+            site_status_text='hbabbumfugfienizuhik',
+            kid=int(24),
+            height_above_sea=float(4.610754027261221),
+            longitude=float(12.163636182357118),
+            latitude=float(57.98521649622376)
         )
         return instance
 
@@ -47,15 +47,23 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'iqseczoqvulwobsnnnky'
+        test_value = 'svgyechuqyyaqbftgjuj'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'krgcxmsurtwolnasgnre'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
     
     def test_station_code_property(self):
         """
         Test station_code property
         """
-        test_value = 'zfodxtjubvzpwrfyuseq'
+        test_value = 'qsnxiqpelowgwpyekirk'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -63,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'auueifnviyrlrxdszrmf'
+        test_value = 'snibemurtrzkhevujyws'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -71,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test postal_code property
         """
-        test_value = 'dxemeuapgqwtegdvqnyl'
+        test_value = 'oafsmwbcljanmlgnflwj'
         self.instance.postal_code = test_value
         self.assertEqual(self.instance.postal_code, test_value)
     
@@ -79,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status property
         """
-        test_value = int(19)
+        test_value = int(61)
         self.instance.site_status = test_value
         self.assertEqual(self.instance.site_status, test_value)
     
@@ -87,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status_text property
         """
-        test_value = 'feccyjwjijlflafynphr'
+        test_value = 'hbabbumfugfienizuhik'
         self.instance.site_status_text = test_value
         self.assertEqual(self.instance.site_status_text, test_value)
     
@@ -95,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kid property
         """
-        test_value = int(8)
+        test_value = int(24)
         self.instance.kid = test_value
         self.assertEqual(self.instance.kid, test_value)
     
@@ -103,7 +111,7 @@ class Test_Station(unittest.TestCase):
         """
         Test height_above_sea property
         """
-        test_value = float(22.25521430959404)
+        test_value = float(4.610754027261221)
         self.instance.height_above_sea = test_value
         self.assertEqual(self.instance.height_above_sea, test_value)
     
@@ -111,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(32.600910492964175)
+        test_value = float(12.163636182357118)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -119,17 +127,9 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(42.369276190712945)
+        test_value = float(57.98521649622376)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
-    
-    def test_canton_property(self):
-        """
-        Test canton property
-        """
-        test_value = 'rcumvuyknwddpmqappeg'
-        self.instance.canton = test_value
-        self.assertEqual(self.instance.canton, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/src/bfs_odl_mqtt_producer_mqtt_client/client.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/src/bfs_odl_mqtt_producer_mqtt_client/client.py
@@ -4,6 +4,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
     # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
@@ -23,6 +24,51 @@ from bfs_odl_mqtt_producer_data import DoseRateMeasurement
 
 # URI template regex pattern
 _URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 
 
 def _topic_to_mqtt_wildcard(topic: str) -> str:
@@ -187,8 +233,8 @@ def get_default_topic_mappings_de_bfs_odl_mqtt() -> Dict[str, str]:
         Dictionary mapping message identifiers to their default topic patterns.
     """
     return {
-        "de.bfs.odl.mqtt.Station": "radiation/ch/bfs/bfs-odl/{canton}/{station_id}/info",
-        "de.bfs.odl.mqtt.DoseRateMeasurement": "radiation/ch/bfs/bfs-odl/{canton}/{station_id}/dose-rate",
+        "de.bfs.odl.mqtt.Station": "radiation/de/bfs/bfs-odl/{state}/{station_id}/info",
+        "de.bfs.odl.mqtt.DoseRateMeasurement": "radiation/de/bfs/bfs-odl/{state}/{station_id}/dose-rate",
     }
 
 
@@ -359,11 +405,12 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
     async def publish_de_bfs_odl_mqtt_station(self,
         feedurl: str,
         station_id: str,
-        canton: str,
+        state: str,
         data: bfs_odl_mqtt_producer_data.Station,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'de.bfs.odl.mqtt.Station' event to an MQTT topic.
@@ -372,19 +419,20 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
         
             feedurl: URI template variable for 'feedurl'
             station_id: URI template variable for 'station_id'
-            canton: URI template variable for 'canton'
+            state: URI template variable for 'state'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'radiation/ch/bfs/bfs-odl/{canton}/{station_id}/info'
+            topic: Optional topic override. If not provided, uses default topic 'radiation/de/bfs/bfs-odl/{state}/{station_id}/info'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "radiation/ch/bfs/bfs-odl/{canton}/{station_id}/info"
+        target_topic = topic if topic is not None else "radiation/de/bfs/bfs-odl/{state}/{station_id}/info"
         _topic_template_values: Dict[str, str] = {
             "feedurl": str(feedurl),
             "station_id": str(station_id),
-            "canton": str(canton),
+            "state": str(state),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)
@@ -395,6 +443,7 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
@@ -438,11 +487,12 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
     async def publish_de_bfs_odl_mqtt_dose_rate_measurement(self,
         feedurl: str,
         station_id: str,
-        canton: str,
+        state: str,
         data: bfs_odl_mqtt_producer_data.DoseRateMeasurement,
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the 'de.bfs.odl.mqtt.DoseRateMeasurement' event to an MQTT topic.
@@ -451,19 +501,20 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
         
             feedurl: URI template variable for 'feedurl'
             station_id: URI template variable for 'station_id'
-            canton: URI template variable for 'canton'
+            state: URI template variable for 'state'
             data: The event data to be published.
-            topic: Optional topic override. If not provided, uses default topic 'radiation/ch/bfs/bfs-odl/{canton}/{station_id}/dose-rate'
+            topic: Optional topic override. If not provided, uses default topic 'radiation/de/bfs/bfs-odl/{state}/{station_id}/dose-rate'
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default (1).
             retain: Optional MQTT retain flag override. If not provided, uses the message default (True).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
-        target_topic = topic if topic is not None else "radiation/ch/bfs/bfs-odl/{canton}/{station_id}/dose-rate"
+        target_topic = topic if topic is not None else "radiation/de/bfs/bfs-odl/{state}/{station_id}/dose-rate"
         _topic_template_values: Dict[str, str] = {
             "feedurl": str(feedurl),
             "station_id": str(station_id),
-            "canton": str(canton),
+            "state": str(state),
         }
         if _topic_template_values:
             target_topic = _apply_topic_template(target_topic, _topic_template_values)
@@ -474,6 +525,7 @@ class DeBfsOdlMqttMqttClient(_ClientBase):
              "subject":"{station_id}".format(station_id = station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/tests/test_client.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 import pytest_asyncio
 import asyncio
+import datetime
 import time
 import paho.mqtt.client as mqtt
 from testcontainers.core.container import DockerContainer
@@ -92,6 +93,7 @@ async def test_de_bfs_odl_mqtt_de_bfs_odl_mqtt_station_py(mosquitto_broker):
             topic=test_topic,
             feedurl=f"test_feedurl_{i}",
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )
@@ -158,6 +160,7 @@ async def test_de_bfs_odl_mqtt_de_bfs_odl_mqtt_dose_rate_measurement_py(mosquitt
             topic=test_topic,
             feedurl=f"test_feedurl_{i}",
             station_id=f"test_station_id_{i}",
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/src/bfs_odl_producer_data/de/bfs/odl/doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/src/bfs_odl_producer_data/de/bfs/odl/doseratemeasurement.py
@@ -21,6 +21,7 @@ class DoseRateMeasurement:
     
     Attributes:
         station_id (str)
+        state (str)
         start_measure (str)
         end_measure (str)
         value (typing.Optional[float])
@@ -28,11 +29,11 @@ class DoseRateMeasurement:
         value_terrestrial (typing.Optional[float])
         validated (int)
         nuclide (str)
-        canton (str)
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     start_measure: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="start_measure"))
     end_measure: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="end_measure"))
     value: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value"))
@@ -40,7 +41,6 @@ class DoseRateMeasurement:
     value_terrestrial: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="value_terrestrial"))
     validated: int=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="validated"))
     nuclide: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="nuclide"))
-    canton: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="canton"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'DoseRateMeasurement':
@@ -167,13 +167,13 @@ class DoseRateMeasurement:
             An instance of the dataclass.
         """
         return cls(
-            station_id='dfggkryonnwvjbasdgfw',
-            start_measure='tdagqtghxwxhqjtjqnlp',
-            end_measure='kjsuozxedncywtvnjcvk',
-            value=float(84.8974453337415),
-            value_cosmic=float(98.341472964917),
-            value_terrestrial=float(16.86751796387793),
-            validated=int(36),
-            nuclide='ncqhwhpnetbskhtuiswv',
-            canton='qsgxxewadtzjajqfmgbx'
+            station_id='wqgpmkdxzyxnskfiojjd',
+            state='bmralenbnaveslhdbgwj',
+            start_measure='yldkrjanpbplisxrfdbk',
+            end_measure='hpdpumkeaavztxmyicbz',
+            value=float(74.75892231758088),
+            value_cosmic=float(34.515429762000124),
+            value_terrestrial=float(30.897715231593924),
+            validated=int(38),
+            nuclide='cssnfqgtmowcttyfghel'
         )

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/src/bfs_odl_producer_data/de/bfs/odl/station.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/src/bfs_odl_producer_data/de/bfs/odl/station.py
@@ -21,6 +21,7 @@ class Station:
     
     Attributes:
         station_id (str)
+        state (str)
         station_code (str)
         name (str)
         postal_code (str)
@@ -30,11 +31,11 @@ class Station:
         height_above_sea (typing.Optional[float])
         longitude (float)
         latitude (float)
-        canton (str)
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
+    state: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
     station_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_code"))
     name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="name"))
     postal_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="postal_code"))
@@ -44,7 +45,6 @@ class Station:
     height_above_sea: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="height_above_sea"))
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     latitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="latitude"))
-    canton: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="canton"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Station':
@@ -171,15 +171,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_id='zffcqdyrtbtainpftpbo',
-            station_code='gtkzrfggmmbanafcoury',
-            name='eibnwtpeorbdndyrwrur',
-            postal_code='clxbcdiylwpqcgxjwtjs',
-            site_status=int(48),
-            site_status_text='edsaevenpzkbahqzoijz',
-            kid=int(75),
-            height_above_sea=float(98.06474906775294),
-            longitude=float(8.959503319606455),
-            latitude=float(27.306637746701423),
-            canton='hobpnqbwnquyzvbhnyxv'
+            station_id='bnchrogzffgmuhebzzye',
+            state='affxdhvnmxtqpjykolbp',
+            station_code='whlhenlfhoilsyvtbgjw',
+            name='fmivaowprcddhfnnddty',
+            postal_code='erisesrcbymswevtbwaa',
+            site_status=int(99),
+            site_status_text='cltkgxpfdbioibtrclby',
+            kid=int(18),
+            height_above_sea=float(72.1195900477765),
+            longitude=float(16.101989573968623),
+            latitude=float(30.27334869268249)
         )

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/tests/test_doseratemeasurement.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/tests/test_doseratemeasurement.py
@@ -28,15 +28,15 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         Create instance of DoseRateMeasurement for testing
         """
         instance = DoseRateMeasurement(
-            station_id='dfggkryonnwvjbasdgfw',
-            start_measure='tdagqtghxwxhqjtjqnlp',
-            end_measure='kjsuozxedncywtvnjcvk',
-            value=float(84.8974453337415),
-            value_cosmic=float(98.341472964917),
-            value_terrestrial=float(16.86751796387793),
-            validated=int(36),
-            nuclide='ncqhwhpnetbskhtuiswv',
-            canton='qsgxxewadtzjajqfmgbx'
+            station_id='wqgpmkdxzyxnskfiojjd',
+            state='bmralenbnaveslhdbgwj',
+            start_measure='yldkrjanpbplisxrfdbk',
+            end_measure='hpdpumkeaavztxmyicbz',
+            value=float(74.75892231758088),
+            value_cosmic=float(34.515429762000124),
+            value_terrestrial=float(30.897715231593924),
+            validated=int(38),
+            nuclide='cssnfqgtmowcttyfghel'
         )
         return instance
 
@@ -45,15 +45,23 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'dfggkryonnwvjbasdgfw'
+        test_value = 'wqgpmkdxzyxnskfiojjd'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'bmralenbnaveslhdbgwj'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
     
     def test_start_measure_property(self):
         """
         Test start_measure property
         """
-        test_value = 'tdagqtghxwxhqjtjqnlp'
+        test_value = 'yldkrjanpbplisxrfdbk'
         self.instance.start_measure = test_value
         self.assertEqual(self.instance.start_measure, test_value)
     
@@ -61,7 +69,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test end_measure property
         """
-        test_value = 'kjsuozxedncywtvnjcvk'
+        test_value = 'hpdpumkeaavztxmyicbz'
         self.instance.end_measure = test_value
         self.assertEqual(self.instance.end_measure, test_value)
     
@@ -69,7 +77,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value property
         """
-        test_value = float(84.8974453337415)
+        test_value = float(74.75892231758088)
         self.instance.value = test_value
         self.assertEqual(self.instance.value, test_value)
     
@@ -77,7 +85,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_cosmic property
         """
-        test_value = float(98.341472964917)
+        test_value = float(34.515429762000124)
         self.instance.value_cosmic = test_value
         self.assertEqual(self.instance.value_cosmic, test_value)
     
@@ -85,7 +93,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test value_terrestrial property
         """
-        test_value = float(16.86751796387793)
+        test_value = float(30.897715231593924)
         self.instance.value_terrestrial = test_value
         self.assertEqual(self.instance.value_terrestrial, test_value)
     
@@ -93,7 +101,7 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test validated property
         """
-        test_value = int(36)
+        test_value = int(38)
         self.instance.validated = test_value
         self.assertEqual(self.instance.validated, test_value)
     
@@ -101,17 +109,9 @@ class Test_DoseRateMeasurement(unittest.TestCase):
         """
         Test nuclide property
         """
-        test_value = 'ncqhwhpnetbskhtuiswv'
+        test_value = 'cssnfqgtmowcttyfghel'
         self.instance.nuclide = test_value
         self.assertEqual(self.instance.nuclide, test_value)
-    
-    def test_canton_property(self):
-        """
-        Test canton property
-        """
-        test_value = 'qsgxxewadtzjajqfmgbx'
-        self.instance.canton = test_value
-        self.assertEqual(self.instance.canton, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/tests/test_station.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_id='zffcqdyrtbtainpftpbo',
-            station_code='gtkzrfggmmbanafcoury',
-            name='eibnwtpeorbdndyrwrur',
-            postal_code='clxbcdiylwpqcgxjwtjs',
-            site_status=int(48),
-            site_status_text='edsaevenpzkbahqzoijz',
-            kid=int(75),
-            height_above_sea=float(98.06474906775294),
-            longitude=float(8.959503319606455),
-            latitude=float(27.306637746701423),
-            canton='hobpnqbwnquyzvbhnyxv'
+            station_id='bnchrogzffgmuhebzzye',
+            state='affxdhvnmxtqpjykolbp',
+            station_code='whlhenlfhoilsyvtbgjw',
+            name='fmivaowprcddhfnnddty',
+            postal_code='erisesrcbymswevtbwaa',
+            site_status=int(99),
+            site_status_text='cltkgxpfdbioibtrclby',
+            kid=int(18),
+            height_above_sea=float(72.1195900477765),
+            longitude=float(16.101989573968623),
+            latitude=float(30.27334869268249)
         )
         return instance
 
@@ -47,15 +47,23 @@ class Test_Station(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'zffcqdyrtbtainpftpbo'
+        test_value = 'bnchrogzffgmuhebzzye'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
+    
+    def test_state_property(self):
+        """
+        Test state property
+        """
+        test_value = 'affxdhvnmxtqpjykolbp'
+        self.instance.state = test_value
+        self.assertEqual(self.instance.state, test_value)
     
     def test_station_code_property(self):
         """
         Test station_code property
         """
-        test_value = 'gtkzrfggmmbanafcoury'
+        test_value = 'whlhenlfhoilsyvtbgjw'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -63,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'eibnwtpeorbdndyrwrur'
+        test_value = 'fmivaowprcddhfnnddty'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -71,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test postal_code property
         """
-        test_value = 'clxbcdiylwpqcgxjwtjs'
+        test_value = 'erisesrcbymswevtbwaa'
         self.instance.postal_code = test_value
         self.assertEqual(self.instance.postal_code, test_value)
     
@@ -79,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status property
         """
-        test_value = int(48)
+        test_value = int(99)
         self.instance.site_status = test_value
         self.assertEqual(self.instance.site_status, test_value)
     
@@ -87,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test site_status_text property
         """
-        test_value = 'edsaevenpzkbahqzoijz'
+        test_value = 'cltkgxpfdbioibtrclby'
         self.instance.site_status_text = test_value
         self.assertEqual(self.instance.site_status_text, test_value)
     
@@ -95,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kid property
         """
-        test_value = int(75)
+        test_value = int(18)
         self.instance.kid = test_value
         self.assertEqual(self.instance.kid, test_value)
     
@@ -103,7 +111,7 @@ class Test_Station(unittest.TestCase):
         """
         Test height_above_sea property
         """
-        test_value = float(98.06474906775294)
+        test_value = float(72.1195900477765)
         self.instance.height_above_sea = test_value
         self.assertEqual(self.instance.height_above_sea, test_value)
     
@@ -111,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(8.959503319606455)
+        test_value = float(16.101989573968623)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -119,17 +127,9 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(27.306637746701423)
+        test_value = float(30.27334869268249)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
-    
-    def test_canton_property(self):
-        """
-        Test canton property
-        """
-        test_value = 'hobpnqbwnquyzvbhnyxv'
-        self.instance.canton = test_value
-        self.assertEqual(self.instance.canton, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_kafka_producer/src/bfs_odl_producer_kafka_producer/producer.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_kafka_producer/src/bfs_odl_producer_kafka_producer/producer.py
@@ -1,12 +1,58 @@
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import sys
 import json
+import re
 import uuid
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 from confluent_kafka import Producer, KafkaException, Message
 from cloudevents.kafka import to_binary, to_structured, KafkaMessage
 from cloudevents.http import CloudEvent
+
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 from bfs_odl_producer_data import Station
 from bfs_odl_producer_data import DoseRateMeasurement
 
@@ -41,7 +87,7 @@ class DeBfsOdlEventProducer:
             return default_key
         return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
 
-    def send_de_bfs_odl_station(self,_feedurl : str, _station_id : str, data: Station, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Station], str]=None) -> None:
+    def send_de_bfs_odl_station(self,_feedurl : str, _station_id : str, data: Station, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, Station], str]=None) -> None:
         """
         Sends the 'de.bfs.odl.Station' event to the Kafka topic
 
@@ -50,6 +96,7 @@ class DeBfsOdlEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (Station): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, Station], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -61,6 +108,7 @@ class DeBfsOdlEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
@@ -74,7 +122,7 @@ class DeBfsOdlEventProducer:
             self.producer.flush()
 
 
-    def send_de_bfs_odl_dose_rate_measurement(self,_feedurl : str, _station_id : str, data: DoseRateMeasurement, content_type: str = "application/json", flush_producer=True, key_mapper: typing.Callable[[CloudEvent, DoseRateMeasurement], str]=None) -> None:
+    def send_de_bfs_odl_dose_rate_measurement(self,_feedurl : str, _station_id : str, data: DoseRateMeasurement, content_type: str = "application/json", _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, DoseRateMeasurement], str]=None) -> None:
         """
         Sends the 'de.bfs.odl.DoseRateMeasurement' event to the Kafka topic
 
@@ -83,6 +131,7 @@ class DeBfsOdlEventProducer:
             _station_id(str):  Value for placeholder station_id in attribute subject
             data: (DoseRateMeasurement): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, DoseRateMeasurement], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
                 The default key is derived from the xRegistry Kafka key declaration '{station_id}'
@@ -94,6 +143,7 @@ class DeBfsOdlEventProducer:
              "subject":"{station_id}".format(station_id = _station_id)
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: json.loads(x.to_json()), key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))

--- a/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_kafka_producer/tests/test_producer.py
+++ b/feeders/bfs-odl/bfs_odl_producer/bfs_odl_producer_kafka_producer/tests/test_producer.py
@@ -105,7 +105,8 @@ def test_de_bfs_odl_debfsodlstation(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_bfs_odl_station(_feedurl = f'test_{i}', _station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_bfs_odl_station(_feedurl = f'test_{i}', _station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
@@ -168,7 +169,8 @@ def test_de_bfs_odl_debfsodldoseratemeasurement(kafka_emulator):
     
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
-        producer_instance.send_de_bfs_odl_dose_rate_measurement(_feedurl = f'test_{i}', _station_id = f'test_{i}', data = event_data)
+        producer_instance.send_de_bfs_odl_dose_rate_measurement(_feedurl = f'test_{i}', _station_id = f'test_{i}', _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            data = event_data)
     
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)

--- a/feeders/bfs-odl/tests/test_bfs_odl.py
+++ b/feeders/bfs-odl/tests/test_bfs_odl.py
@@ -101,6 +101,7 @@ class TestParseStation:
         assert station.site_status == 1
         assert station.site_status_text == "in Betrieb"
         assert station.kid == 6
+        assert station.state == "schleswig-holstein"
 
     def test_coordinates(self):
         station = BfsOdlAPI.parse_station(SAMPLE_STATION_FEATURE)

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -3549,13 +3549,6 @@
     },
     {
       "dir": "feeders/nextbus",
-      "image": "nextbus",
-      "file": "Dockerfile",
-      "test_file": "test_docker_kafka_flow.py",
-      "test_class": "TestNextbusDockerFlow"
-    },
-    {
-      "dir": "feeders/nextbus",
       "image": "nextbus-mqtt",
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -793,7 +793,7 @@ class TestBfsOdlMqttDockerFlow:
                 pass
 
         messages = _collect_messages_topic(
-            '127.0.0.1', mosquitto_bfs_odl['host_port'], 'radiation/ch/bfs/bfs-odl/#',
+            '127.0.0.1', mosquitto_bfs_odl['host_port'], 'radiation/de/bfs/bfs-odl/#',
             timeout=40.0,
         )
         assert messages, 'No retained messages received from broker'
@@ -826,7 +826,7 @@ class TestBfsOdlMqttDockerFlow:
         assert info_payload is not None, f"info payload not parseable: {info_msgs[0]['payload']!r}"
         assert dose_payload is not None, f"dose-rate payload not parseable: {dose_msgs[0]['payload']!r}"
         assert 'station_id' in info_payload, info_payload
-        assert 'canton' in info_payload, info_payload
+        assert 'state' in info_payload, info_payload
         assert 'station_id' in dose_payload, dose_payload
         assert 'value' in dose_payload, dose_payload
 

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -2363,7 +2363,7 @@ class TestAisstreamMqttDockerFlow:
 
 def _load_kystverket_ais_mqtt_schemas() -> Dict[str, Dict[str, Any]]:
     """Return ``{type_value: jstruct_schema}`` for all 3 kystverket-ais MQTT families."""
-    xreg_path = os.path.join(REPO_ROOT, 'feeders', 'kystverket-ais', 'xreg', 'ais.xreg.json')
+    xreg_path = os.path.join(REPO_ROOT, 'feeders', 'kystverket-ais', 'xreg', 'kystverket-ais.xreg.json')
     with open(xreg_path, 'r', encoding='utf-8') as fh:
         manifest = json.load(fh)
     schemagroup = manifest['schemagroups']['NO.Kystverket.AIS.jstruct']


### PR DESCRIPTION
## Summary

Fixes the three pre-existing Docker E2E flow-shard failures that #780's first
full matrix run surfaced. None are dependency regressions — all are
contract/harness drift.

| # | Source | Symptom | Root cause | Fix |
|---|--------|---------|-----------|-----|
| 1 | **bfs-odl** | `Missing required property 'state' for de.bfs.odl.Station` | Bridges + producers used `canton` (Swiss copy-paste cruft) while the authoritative xreg requires `state` | Rename `canton`→`state` in Kafka + MQTT bridges; regenerate all 3 producers (xrcg 0.10.11) |
| 2 | **kystverket-ais** (MQTT) | `FileNotFoundError: xreg/ais.xreg.json` | Harness used wrong filename | Point at `xreg/kystverket-ais.xreg.json` |
| 3 | **nextbus** (Kafka) | pytest exit 5 (no tests collected) | matrix.json references `TestNextbusDockerFlow`, which cannot exist | Remove the phantom Kafka flow matrix entry |

## Details

### 1. bfs-odl `canton` → `state`
The xreg manifest is authoritative and uses `state` (German *Bundesland*,
derived from the AGS prefix of the station Kennziffer) on both `Station` and
`DoseRateMeasurement`; the MQTT topic template is
`radiation/de/bfs/bfs-odl/{state}/{station_id}/...`. The Kafka bridge, MQTT
bridge, and generated producer dataclasses all carried `canton` — a leftover
from a Swiss-feeder copy-paste (the MQTT app even used a `radiation/ch/...`
prefix). The AMQP bridge already correctly used `state`, confirming intent.

Fix = make producers + bridges match the xreg (no schema change): renamed the
helper + field in both bridges and regenerated all three producers. The Kafka
**key/subject** remains `{station_id}`, so `state` is a payload + MQTT-topic
field only. Added a `state` assertion to the unit tests — **17 pass**.

> Generated-producer churn (random sample values in `create_instance()` and
> generated test files) is expected from regeneration.

### 2. kystverket-ais MQTT harness path
Single-line filename correction in `test_docker_mqtt_flow.py`. Verified the
file exists and the `NO.Kystverket.AIS.jstruct` schemagroup the test looks up
is present.

### 3. nextbus phantom Kafka flow entry
The nextbus Kafka bridge (`nextbus/nextbus.py`) is a **legacy
`azure.eventhub.EventHubProducerClient` poller** that reads
`FEED_CONNECTION_STRING` / `AGENCY` and hits the live Umo/NextBus API. It does
**not** use the generated Kafka producer or the `CONNECTION_STRING` convention
the flow harness requires, and it has no once/mock mode — so it is
fundamentally incompatible with `_run_kafka_flow_test`, and no such test class
can exist. nextbus's contract is already validated by the synthetic
`TestNextbusMqttDockerFlow` + `TestNextbusAmqpDockerFlow` flow tests (which
emit one sample of every xreg type), and the image is covered by the Kafka
**build** matrix entry. Removed only the phantom Kafka **flow** entry.

## Note (out of scope — flagged, not fixed)
- The nextbus Kafka bridge predates the generated-producer + `CONNECTION_STRING`
  convention; modernizing it onto the generated producer with a once/mock mode
  would give it real Kafka flow coverage like its siblings. Tracked as a
  follow-up, not addressed here.
- 11 other Kafka flow matrix entries have **case-mismatched** `test_class`
  names (e.g. `TestBafuHydroDockerFlow` vs the actual `TestBAFUHydroDockerFlow`).
  These are harmless because CI selects via `pytest -k`, which is
  case-insensitive substring matching, so they still collect. Left as-is to
  avoid churn.

## Validation
- `bfs-odl` unit suite: **17 passed**; zero `canton` references remain in the
  non-generated bridge code.
- Matrix swept programmatically: nextbus is the only entry whose `test_class`
  has **no** case-insensitive match in its target file (i.e. the only true
  exit-5 failure).
- Docker E2E itself requires Docker and runs in CI on this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
