### PR TITLE
gbfs-bikeshare: deterministic --mock mode for Docker E2E (#818)

### DIFF
--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_amqp/gbfs_bikeshare_amqp/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_amqp/gbfs_bikeshare_amqp/app.py
@@ -14,7 +14,7 @@ from gbfs_bikeshare_amqp_producer_amqp_producer.producer import (
     OrgGbfsAmqpSystemProducer,
 )
 from gbfs_bikeshare_amqp_producer_data import FreeBikeStatus, StationInformation, StationStatus, SystemInformation
-from gbfs_bikeshare_core import load_state, parse_bool, parse_feed_configuration, save_state
+from gbfs_bikeshare_core import build_offline_client_and_feeds, load_state, parse_bool, parse_feed_configuration, save_state
 from gbfs_bikeshare_core.acquisition import (
     GbfsSourceClient,
     FreeBikeStatusRecord,
@@ -129,10 +129,16 @@ def _build_producers(args: argparse.Namespace) -> tuple[OrgGbfsAmqpSystemProduce
 
 
 def feed(args: argparse.Namespace) -> None:
-    configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+    mock_mode = getattr(args, "mock", False)
     system_producer, stations_producer, free_bikes_producer = _build_producers(args)
     state = load_state(args.state_file)
-    client = GbfsSourceClient()
+    if mock_mode:
+        logger.info("--mock mode: using deterministic offline GBFS corpus (no network access)")
+        client, configured_feeds = build_offline_client_and_feeds()
+        args.once = True
+    else:
+        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+        client = GbfsSourceClient()
     sources = discover_sources(client, configured_feeds)
     if not sources:
         raise SystemExit("No GBFS feeds could be discovered successfully.")
@@ -195,6 +201,7 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser.add_argument("--reference-refresh-interval", type=int, default=int(os.getenv("REFERENCE_REFRESH_INTERVAL", "3600")))
     feed_parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE))
     feed_parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    feed_parser.add_argument("--mock", action="store_true", default=parse_bool(os.getenv("GBFS_MOCK"), default=False), help="Emit a deterministic offline GBFS corpus once (no network); for CI flow tests")
     feed_parser.add_argument("--amqp-broker-url", default=os.getenv("AMQP_BROKER_URL"))
     feed_parser.add_argument("--amqp-host", default=os.getenv("AMQP_HOST"))
     feed_parser.add_argument("--amqp-port", type=int, default=int(os.getenv("AMQP_PORT")) if os.getenv("AMQP_PORT") else None)

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/__init__.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/__init__.py
@@ -9,6 +9,7 @@ from .acquisition import (
     discover_sources,
 )
 from .config import build_kafka_config, parse_bool, parse_feed_configuration, parse_kafka_connection_string
+from .samples import MOCK_SYSTEM_ID, OfflineSession, build_offline_client_and_feeds
 from .state import load_state, save_state
 
 __all__ = [
@@ -24,6 +25,9 @@ __all__ = [
     "parse_bool",
     "parse_feed_configuration",
     "parse_kafka_connection_string",
+    "build_offline_client_and_feeds",
+    "OfflineSession",
+    "MOCK_SYSTEM_ID",
     "load_state",
     "save_state",
 ]

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/samples.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/samples.py
@@ -1,0 +1,218 @@
+"""Deterministic offline GBFS corpus for `--mock` / CI flow tests.
+
+The GBFS feeders normally poll live third-party auto-discovery endpoints
+(e.g. Citi Bike), which makes Docker E2E flow tests non-deterministic and
+prone to outages. This module provides a small, self-contained GBFS dataset
+plus an in-memory HTTP session so the bridge can exercise its real
+discovery / normalize / dedupe / emit path without any network access.
+
+The payloads mirror the GBFS v2.3 wire shapes the production parser expects,
+so a `--mock` run flows through exactly the same code as a live run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from .acquisition import GbfsSourceClient
+from .config import ConfiguredFeed
+
+MOCK_SYSTEM_ID = "sample-bikeshare"
+
+MOCK_DISCOVERY_URL = "https://mock.gbfs.invalid/gbfs/gbfs.json"
+MOCK_SYSTEM_URL = "https://mock.gbfs.invalid/gbfs/system_information.json"
+MOCK_STATION_INFO_URL = "https://mock.gbfs.invalid/gbfs/station_information.json"
+MOCK_STATION_STATUS_URL = "https://mock.gbfs.invalid/gbfs/station_status.json"
+MOCK_FREE_BIKE_URL = "https://mock.gbfs.invalid/gbfs/free_bike_status.json"
+
+MOCK_MANIFEST: Dict[str, Any] = {
+    "last_updated": 1717488120,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+        "en": {
+            "feeds": [
+                {"name": "system_information", "url": MOCK_SYSTEM_URL},
+                {"name": "station_information", "url": MOCK_STATION_INFO_URL},
+                {"name": "station_status", "url": MOCK_STATION_STATUS_URL},
+                {"name": "free_bike_status", "url": MOCK_FREE_BIKE_URL},
+            ]
+        }
+    },
+}
+
+MOCK_SYSTEM: Dict[str, Any] = {
+    "last_updated": 1717488120,
+    "ttl": 3600,
+    "version": "2.3",
+    "data": {
+        "system_id": MOCK_SYSTEM_ID,
+        "name": "Sample City Bikeshare",
+        "operator": "Sample Mobility Operator",
+        "url": "https://mock.gbfs.invalid",
+        "timezone": "Europe/Berlin",
+        "language": "en",
+        "phone_number": "+49-000-0000000",
+    },
+}
+
+MOCK_STATION_INFO: Dict[str, Any] = {
+    "last_updated": 1717488120,
+    "ttl": 3600,
+    "version": "2.3",
+    "data": {
+        "stations": [
+            {
+                "station_id": "station-001",
+                "name": "Central Station",
+                "short_name": "001",
+                "lat": 52.5200,
+                "lon": 13.4050,
+                "capacity": 24,
+                "region_id": "central",
+                "address": "1 Central Plaza",
+                "post_code": "10115",
+            },
+            {
+                "station_id": "station-002",
+                "name": "Riverside Dock",
+                "short_name": "002",
+                "lat": 52.5145,
+                "lon": 13.3899,
+                "capacity": 16,
+                "region_id": "central",
+                "address": "8 Riverside Way",
+                "post_code": "10117",
+            },
+            {
+                "station_id": "station-003",
+                "name": "University Gate",
+                "short_name": "003",
+                "lat": 52.5290,
+                "lon": 13.4100,
+                "capacity": 30,
+                "region_id": "north",
+                "address": "200 Campus Road",
+                "post_code": "10119",
+            },
+        ]
+    },
+}
+
+MOCK_STATION_STATUS: Dict[str, Any] = {
+    "last_updated": 1717488123,
+    "ttl": 30,
+    "version": "2.3",
+    "data": {
+        "stations": [
+            {
+                "station_id": "station-001",
+                "num_bikes_available": 7,
+                "num_docks_available": 17,
+                "num_ebikes_available": 3,
+                "is_installed": 1,
+                "is_renting": 1,
+                "is_returning": 1,
+                "last_reported": 1717488123,
+            },
+            {
+                "station_id": "station-002",
+                "num_bikes_available": 2,
+                "num_docks_available": 14,
+                "num_ebikes_available": 0,
+                "is_installed": 1,
+                "is_renting": 1,
+                "is_returning": 1,
+                "last_reported": 1717488123,
+            },
+            {
+                "station_id": "station-003",
+                "num_bikes_available": 15,
+                "num_docks_available": 15,
+                "num_ebikes_available": 6,
+                "is_installed": 1,
+                "is_renting": 1,
+                "is_returning": 1,
+                "last_reported": 1717488123,
+            },
+        ]
+    },
+}
+
+MOCK_FREE_BIKES: Dict[str, Any] = {
+    "last_updated": 1717488123,
+    "ttl": 15,
+    "version": "2.3",
+    "data": {
+        "bikes": [
+            {
+                "bike_id": "bike-0001",
+                "lat": 52.5180,
+                "lon": 13.3990,
+                "is_reserved": False,
+                "is_disabled": False,
+                "vehicle_type_id": "ebike",
+                "current_range_meters": 18000,
+                "last_reported": 1717488110,
+            },
+            {
+                "bike_id": "bike-0002",
+                "lat": 52.5260,
+                "lon": 13.4075,
+                "is_reserved": False,
+                "is_disabled": False,
+                "vehicle_type_id": "bike",
+                "current_range_meters": None,
+                "last_reported": 1717488112,
+            },
+        ]
+    },
+}
+
+MOCK_RESPONSES: Dict[str, Dict[str, Any]] = {
+    MOCK_DISCOVERY_URL: MOCK_MANIFEST,
+    MOCK_SYSTEM_URL: MOCK_SYSTEM,
+    MOCK_STATION_INFO_URL: MOCK_STATION_INFO,
+    MOCK_STATION_STATUS_URL: MOCK_STATION_STATUS,
+    MOCK_FREE_BIKE_URL: MOCK_FREE_BIKES,
+}
+
+
+class _OfflineResponse:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class OfflineSession:
+    """Minimal `requests.Session` stand-in serving the in-memory corpus."""
+
+    def __init__(self, mapping: Dict[str, Dict[str, Any]] | None = None):
+        self.mapping = mapping if mapping is not None else MOCK_RESPONSES
+        self.headers: Dict[str, str] = {}
+
+    def get(self, url: str, timeout: int = 30) -> _OfflineResponse:  # noqa: ARG002
+        if url not in self.mapping:
+            raise AssertionError(f"OfflineSession received an unexpected URL: {url}")
+        return _OfflineResponse(self.mapping[url])
+
+    def mount(self, prefix: str, adapter: Any) -> None:  # noqa: ARG002 - API parity
+        return None
+
+
+def build_offline_client_and_feeds() -> Tuple[GbfsSourceClient, List[ConfiguredFeed]]:
+    """Return a client + feed list wired to the deterministic offline corpus.
+
+    Used by every transport app's ``--mock`` / ``GBFS_MOCK`` path so CI flow
+    tests publish a stable reference + telemetry set without touching the
+    network.
+    """
+    client = GbfsSourceClient(session=OfflineSession())
+    feeds = [ConfiguredFeed(MOCK_DISCOVERY_URL, MOCK_SYSTEM_ID)]
+    return client, feeds

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_kafka/gbfs_bikeshare/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_kafka/gbfs_bikeshare/app.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from confluent_kafka import Producer
 
-from gbfs_bikeshare_core import build_kafka_config, load_state, parse_feed_configuration, parse_kafka_connection_string, save_state
+from gbfs_bikeshare_core import build_kafka_config, build_offline_client_and_feeds, load_state, parse_bool, parse_feed_configuration, parse_kafka_connection_string, save_state
 from gbfs_bikeshare_core.acquisition import (
     GbfsSourceClient,
     StationInformationRecord,
@@ -87,7 +87,10 @@ def _build_free_bike_status(record: FreeBikeStatusRecord) -> FreeBikeStatus:
 
 
 def feed(args: argparse.Namespace) -> None:
-    configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+    mock_mode = getattr(args, "mock", False)
+    configured_feeds = (
+        [] if mock_mode else parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+    )
     if args.connection_string:
         cfg = parse_kafka_connection_string(args.connection_string)
         bootstrap = cfg.get("bootstrap.servers")
@@ -115,7 +118,12 @@ def feed(args: argparse.Namespace) -> None:
     stations_producer = OrgGbfsStationsEventProducer(producer, topic)
     free_bikes_producer = OrgGbfsFreeBikesEventProducer(producer, topic)
     state = load_state(args.state_file)
-    client = GbfsSourceClient()
+    if mock_mode:
+        logger.info("--mock mode: using deterministic offline GBFS corpus (no network access)")
+        client, configured_feeds = build_offline_client_and_feeds()
+        args.once = True
+    else:
+        client = GbfsSourceClient()
     sources = discover_sources(client, configured_feeds)
     if not sources:
         raise SystemExit("No GBFS feeds could be discovered successfully.")
@@ -207,6 +215,7 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser.add_argument("--reference-refresh-interval", type=int, default=int(os.getenv("REFERENCE_REFRESH_INTERVAL", "3600")), help="Reference-data refresh interval in seconds")
     feed_parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE), help="Path to the JSON dedupe state file")
     feed_parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"), help="Exit after one polling cycle")
+    feed_parser.add_argument("--mock", action="store_true", default=parse_bool(os.getenv("GBFS_MOCK"), default=False), help="Emit a deterministic offline GBFS corpus once (no network); for CI flow tests")
     return parser
 
 

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_mqtt/gbfs_bikeshare_mqtt/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_mqtt/gbfs_bikeshare_mqtt/app.py
@@ -15,7 +15,7 @@ from paho.mqtt.client import CallbackAPIVersion, MQTTv5
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
 
-from gbfs_bikeshare_core import load_state, parse_bool, parse_feed_configuration, save_state
+from gbfs_bikeshare_core import build_offline_client_and_feeds, load_state, parse_bool, parse_feed_configuration, save_state
 from gbfs_bikeshare_core.acquisition import (
     GbfsSourceClient,
     FreeBikeStatusRecord,
@@ -131,10 +131,16 @@ async def _entra_token_refresh_loop(client: mqtt.Client, host: str, port: int, a
 
 
 async def feed(args: argparse.Namespace) -> None:
-    configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+    mock_mode = getattr(args, "mock", False)
     host, port, tls = _parse_broker_settings(args)
     state = load_state(args.state_file)
-    client = GbfsSourceClient()
+    if mock_mode:
+        logger.info("--mock mode: using deterministic offline GBFS corpus (no network access)")
+        client, configured_feeds = build_offline_client_and_feeds()
+        args.once = True
+    else:
+        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+        client = GbfsSourceClient()
     sources = discover_sources(client, configured_feeds)
     if not sources:
         raise SystemExit("No GBFS feeds could be discovered successfully.")
@@ -229,6 +235,7 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser.add_argument("--reference-refresh-interval", type=int, default=int(os.getenv("REFERENCE_REFRESH_INTERVAL", "3600")))
     feed_parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE))
     feed_parser.add_argument("--once", action="store_true", default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"))
+    feed_parser.add_argument("--mock", action="store_true", default=parse_bool(os.getenv("GBFS_MOCK"), default=False), help="Emit a deterministic offline GBFS corpus once (no network); for CI flow tests")
     feed_parser.add_argument("--mqtt-broker-url", default=os.getenv("MQTT_BROKER_URL"))
     feed_parser.add_argument("--mqtt-host", default=os.getenv("MQTT_HOST"))
     feed_parser.add_argument("--mqtt-port", type=int, default=int(os.getenv("MQTT_PORT", "1883")))

--- a/feeders/gbfs-bikeshare/tests/test_gbfs_bikeshare_unit.py
+++ b/feeders/gbfs-bikeshare/tests/test_gbfs_bikeshare_unit.py
@@ -211,6 +211,35 @@ def test_fetch_free_bike_status_allows_null_location():
 
 
 @pytest.mark.unit
+def test_offline_mock_corpus_round_trips_reference_and_telemetry():
+    from gbfs_bikeshare_core.acquisition import discover_sources as _discover
+    from gbfs_bikeshare_core.samples import MOCK_SYSTEM_ID, build_offline_client_and_feeds
+
+    client, feeds = build_offline_client_and_feeds()
+    sources = _discover(client, feeds)
+    assert len(sources) == 1
+    source = sources[0]
+    assert source.system_id == MOCK_SYSTEM_ID
+
+    system = client.fetch_system_information(source)
+    assert system is not None
+    system_record, _ = system
+    assert system_record.system_id == MOCK_SYSTEM_ID
+
+    stations, station_feed_url = client.fetch_station_information(source)
+    assert station_feed_url is not None
+    assert len(stations) == 3
+
+    statuses, _, _ = client.fetch_station_status(source)
+    assert len(statuses) == 3
+    assert statuses[0].is_renting is True
+
+    bikes, _, _ = client.fetch_free_bike_status(source)
+    assert len(bikes) == 2
+    assert bikes[1].current_range_meters is None
+
+
+@pytest.mark.unit
 def test_dedupe_helpers_only_publish_on_change():
     source = GbfsSource(SAMPLE_DISCOVERY_URL, "sample-system", {"station_status": SAMPLE_STATION_STATUS_URL, "free_bike_status": SAMPLE_FREE_BIKE_URL}, "en")
     client = _client()

--- a/tests/docker_e2e/test_docker_amqp_flow.py
+++ b/tests/docker_e2e/test_docker_amqp_flow.py
@@ -736,7 +736,7 @@ class TestTokyoDocomoBikeshareAmqpDockerFlow(AmqpDockerFlowBase):
 class TestGbfsBikeshareAmqpDockerFlow(AmqpDockerFlowBase):
     source_dir = "gbfs-bikeshare"
     image = "gbfs-bikeshare-amqp"
-    env = {"GBFS_FEEDS": "https://gbfs.citibikenyc.com/gbfs/gbfs.json", "ONCE_MODE": "true"}
+    env = {"GBFS_MOCK": "true"}
     expected_types = {'org.gbfs.SystemInformation', 'org.gbfs.StationInformation', 'org.gbfs.StationStatus'}
     expected_count = 3
 

--- a/tests/docker_e2e/test_docker_kafka_flow.py
+++ b/tests/docker_e2e/test_docker_kafka_flow.py
@@ -2395,13 +2395,12 @@ class TestGbfsBikeshareDockerFlow:
             reference_types=['org.gbfs.SystemInformation', 'org.gbfs.StationInformation'],
             telemetry_types=['org.gbfs.StationStatus'],
             required_exact_types=['org.gbfs.SystemInformation', 'org.gbfs.StationInformation', 'org.gbfs.StationStatus'],
+            command=['python', '-m', 'gbfs_bikeshare', 'feed', '--mock'],
             extra_env={
-                'GBFS_FEEDS': 'https://gbfs.citibikenyc.com/gbfs/gbfs.json',
-                'ONCE_MODE': 'true',
                 'KAFKA_ENABLE_TLS': 'false',
             },
             min_messages=3,
-            timeout=300,
+            timeout=120,
         )
 
 

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -5582,7 +5582,7 @@ class TestGbfsBikeshareMqttDockerFlow:
             'gbfs-bikeshare',
             gbfs_bikeshare_mqtt_image,
             mosquitto_gbfs_bikeshare,
-            extra_env={'GBFS_FEEDS': 'https://gbfs.citibikenyc.com/gbfs/gbfs.json', 'ONCE_MODE': 'true'},
+            extra_env={'GBFS_MOCK': 'true'},
             timeout=240,
         )
 


### PR DESCRIPTION
## Summary
Implements **layer 1** of the failing-feeders strategy (#818) for **gbfs-bikeshare**: a deterministic `--mock` mode so the Docker E2E flow test no longer depends on a live third-party GBFS feed.

Previously `TestGbfsBikeshareDockerFlow` polled `https://gbfs.citibikenyc.com/gbfs/gbfs.json` live, which made it flaky in CI (network/outage dependent). This is one of the live-source flow flakes surfaced repeatedly in the E2E matrix.

## Changes
- **New `gbfs_bikeshare_core/samples.py`** — a self-contained GBFS v2.3 corpus (3 stations, statuses, 2 free bikes, system info) plus an in-memory `OfflineSession` and `build_offline_client_and_feeds()`.
- **`--mock` / `GBFS_MOCK` flag** wired into all three transport apps (Kafka, MQTT, AMQP). Mock mode runs the **real** discover → normalize → dedupe → emit path against the offline corpus and forces a single cycle, so the full producer/transport pipeline is exercised without any network access.
- **E2E**: `TestGbfsBikeshareDockerFlow` now runs `feed --mock` (drops live `GBFS_FEEDS`, timeout 300→120s). Required event types unchanged (`SystemInformation`, `StationInformation`, `StationStatus`).
- **Unit test**: round-trips the offline corpus through `GbfsSourceClient`.

## Pattern
Mirrors the established in-repo `--mock` precedent (bluesky/aisstream `stream --mock`) and the blitzortung `feed --mock` template in #819. Only the HTTP source layer is swapped; the Kafka/MQTT/AMQP producers still emit to the real test broker.

## Validation
- `pytest tests/test_gbfs_bikeshare_unit.py` → 8 passed locally.
- All four modified/new modules `py_compile` clean.

Part of #818. One PR per feeder.
