### PR TITLE
fmi-finland: deterministic --mock mode to de-flake Docker E2E

### DIFF
--- a/feeders/fmi-finland/fmi_finland/fmi_finland.py
+++ b/feeders/fmi-finland/fmi_finland/fmi_finland.py
@@ -198,11 +198,18 @@ def _safe_float(value: str | None) -> float | None:
         return None
 
 
-def _measurement_arg(value: float | None) -> str | None:
-    """Pass floats as strings so generated __post_init__ keeps zero values."""
+def _measurement_arg(value: float | None) -> float | None:
+    """Return the measurement as a float (or None).
+
+    The xrcg 0.10.12 generated ``Observation`` dataclass has no
+    ``__post_init__`` coercion and serializes stored values verbatim, so the
+    numeric pollutant/index fields must be passed as real floats to satisfy
+    the ``double`` JsonStructure schema. (Earlier codegen dropped zero values
+    in ``__post_init__``, which is why this previously stringified them.)
+    """
     if value is None:
         return None
-    return format(value, ".15g")
+    return float(value)
 
 
 def _flush_event_producer(event_producer: typing.Any) -> None:

--- a/feeders/fmi-finland/fmi_finland/fmi_finland.py
+++ b/feeders/fmi-finland/fmi_finland/fmi_finland.py
@@ -572,11 +572,24 @@ def main() -> None:
         default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
         help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.",
     )
+    feed_parser.add_argument(
+        "--mock",
+        action="store_true",
+        default=os.getenv("FMI_MOCK", "").lower() in ("1", "true", "yes"),
+        help="Serve a deterministic offline sample corpus instead of polling the live FMI WFS service (also via FMI_MOCK env var). Implies --once. Used by the Docker E2E flow test.",
+    )
 
     args = parser.parse_args()
     _configure_logging()
 
-    api = FMIAirQualityAPI()
+    if getattr(args, "mock", False):
+        from fmi_finland.samples import build_offline_api
+
+        api = build_offline_api()
+        args.once = True
+        logger.info("Running in offline mock mode using the bundled sample corpus")
+    else:
+        api = FMIAirQualityAPI()
 
     if args.command == "list":
         registry = api.get_station_registry()

--- a/feeders/fmi-finland/fmi_finland/samples.py
+++ b/feeders/fmi-finland/fmi_finland/samples.py
@@ -1,0 +1,142 @@
+"""Offline sample corpus for deterministic ``--mock`` runs.
+
+The bridge normally polls the live FMI WFS endpoint, which makes the Docker
+E2E flow test dependent on the upstream service being reachable and on it
+actually publishing fresh observations during the test window.  To make the
+test deterministic, ``--mock`` swaps the upstream HTTP layer for the recorded
+WFS-XML fixtures below while still emitting through the real Kafka/MQTT/AMQP
+producer.
+
+The XML mirrors the shape FMI returns for the
+``fmi::ef::stations`` (station registry) and
+``urban::observations::airquality::PT1H::simple`` (hourly air quality)
+stored queries.  Each observation element embeds its station ``fmisid`` in the
+``gml:id`` so ``_resolve_fmisid`` resolves it without relying on a coordinate
+lookup.  Three stations at two hourly timestamps yield three ``Station``
+reference events and six ``Observation`` telemetry events (nine messages),
+comfortably above the E2E ``min_messages`` floor.
+"""
+
+from __future__ import annotations
+
+# Three real Helsinki-region air quality stations.
+MOCK_STATIONS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+  xmlns:wfs="http://www.opengis.net/wfs/2.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:ef="http://inspire.ec.europa.eu/schemas/ef/4.0"
+  xmlns:ins_base="http://inspire.ec.europa.eu/schemas/base/3.3">
+  <wfs:member>
+    <ef:EnvironmentalMonitoringFacility gml:id="station-100662">
+      <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/fmisid">100662</gml:identifier>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Helsinki Kallio 2</gml:name>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/location/region">Helsinki</gml:name>
+      <ef:name>Helsinki Kallio 2</ef:name>
+      <ef:representativePoint>
+        <gml:Point gml:id="point-100662">
+          <gml:pos>60.187390 24.950600</gml:pos>
+        </gml:Point>
+      </ef:representativePoint>
+    </ef:EnvironmentalMonitoringFacility>
+  </wfs:member>
+  <wfs:member>
+    <ef:EnvironmentalMonitoringFacility gml:id="station-100742">
+      <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/fmisid">100742</gml:identifier>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Espoo Leppavaara Lansituuli</gml:name>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/location/region">Espoo</gml:name>
+      <ef:name>Espoo Leppavaara Lansituuli</ef:name>
+      <ef:representativePoint>
+        <gml:Point gml:id="point-100742">
+          <gml:pos>60.219180 24.813900</gml:pos>
+        </gml:Point>
+      </ef:representativePoint>
+    </ef:EnvironmentalMonitoringFacility>
+  </wfs:member>
+  <wfs:member>
+    <ef:EnvironmentalMonitoringFacility gml:id="station-100803">
+      <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/fmisid">100803</gml:identifier>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Tampere Linja-autoasema</gml:name>
+      <gml:name codeSpace="http://xml.fmi.fi/namespace/location/region">Tampere</gml:name>
+      <ef:name>Tampere Linja-autoasema</ef:name>
+      <ef:representativePoint>
+        <gml:Point gml:id="point-100803">
+          <gml:pos>61.495300 23.775200</gml:pos>
+        </gml:Point>
+      </ef:representativePoint>
+    </ef:EnvironmentalMonitoringFacility>
+  </wfs:member>
+</wfs:FeatureCollection>
+"""
+
+
+def _observation_member(gml_id: str, lat: str, lon: str, time: str, param: str, value: str) -> str:
+    return (
+        '  <wfs:member>\n'
+        f'    <BsWfs:BsWfsElement gml:id="{gml_id}">\n'
+        f'      <BsWfs:Location><gml:Point gml:id="p-{gml_id}"><gml:pos>{lat} {lon}</gml:pos></gml:Point></BsWfs:Location>\n'
+        f'      <BsWfs:Time>{time}</BsWfs:Time>\n'
+        f'      <BsWfs:ParameterName>{param}</BsWfs:ParameterName>\n'
+        f'      <BsWfs:ParameterValue>{value}</BsWfs:ParameterValue>\n'
+        '    </BsWfs:BsWfsElement>\n'
+        '  </wfs:member>'
+    )
+
+
+_STATION_COORDS = {
+    "100662": ("60.18739", "24.95060"),
+    "100742": ("60.21918", "24.81390"),
+    "100803": ("61.49530", "23.77520"),
+}
+
+# Two hourly windows so each station yields two aggregated observation events.
+_OBSERVATION_TIMES = ("2024-01-15T13:00:00Z", "2024-01-15T14:00:00Z")
+
+# Per (station, hour) parameter readings.  AQINDEX plus a couple of pollutants
+# per record exercises the full Observation schema; an explicit ``NaN`` checks
+# the null-coalescing path in ``_measurement_arg``.
+_OBSERVATION_READINGS = {
+    "100662": [("AQINDEX_PT1H_avg", "1.0"), ("PM10_PT1H_avg", "12.5"), ("PM25_PT1H_avg", "6.3")],
+    "100742": [("AQINDEX_PT1H_avg", "2.0"), ("NO2_PT1H_avg", "18.4"), ("O3_PT1H_avg", "NaN")],
+    "100803": [("AQINDEX_PT1H_avg", "3.0"), ("PM10_PT1H_avg", "21.7"), ("SO2_PT1H_avg", "4.1")],
+}
+
+
+def _build_observations_xml() -> str:
+    members = []
+    for fmisid, (lat, lon) in _STATION_COORDS.items():
+        for time in _OBSERVATION_TIMES:
+            for index, (param, value) in enumerate(_OBSERVATION_READINGS[fmisid], start=1):
+                gml_id = f"BsWfsElement.{fmisid}.{param}.{index}"
+                members.append(_observation_member(gml_id, lat, lon, time, param, value))
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<wfs:FeatureCollection\n'
+        '  xmlns:wfs="http://www.opengis.net/wfs/2.0"\n'
+        '  xmlns:gml="http://www.opengis.net/gml/3.2"\n'
+        '  xmlns:BsWfs="http://xml.fmi.fi/schema/wfs/2.0">\n'
+        + "\n".join(members)
+        + '\n</wfs:FeatureCollection>\n'
+    )
+
+
+MOCK_OBSERVATIONS_XML = _build_observations_xml()
+
+
+def build_offline_api():
+    """Return an :class:`FMIAirQualityAPI` that serves the offline corpus.
+
+    The upstream HTTP seam (``get_station_metadata_xml`` /
+    ``get_observations_xml``) is overridden to return the recorded fixtures so
+    the bridge runs end to end without contacting the live FMI WFS service.
+    """
+
+    from fmi_finland.fmi_finland import FMIAirQualityAPI
+
+    class _OfflineFMIAirQualityAPI(FMIAirQualityAPI):
+        def get_station_metadata_xml(self) -> str:
+            return MOCK_STATIONS_XML
+
+        def get_observations_xml(self, start_time: str, end_time: str) -> str:
+            return MOCK_OBSERVATIONS_XML
+
+    return _OfflineFMIAirQualityAPI()

--- a/feeders/fmi-finland/tests/test_fmi_finland_unit.py
+++ b/feeders/fmi-finland/tests/test_fmi_finland_unit.py
@@ -166,3 +166,67 @@ class TestParsingHelpers:
         assert PARAM_MAP["AQINDEX_PT1H_avg"] == "aqindex"
         assert PARAM_MAP["PM10_PT1H_avg"] == "pm10_ug_m3"
         assert PARAM_MAP["CO_PT1H_avg"] == "co_mg_m3"
+
+
+class _RecordingEventProducer:
+    """Minimal stand-in capturing the events the bridge would publish."""
+
+    def __init__(self):
+        self.stations = []
+        self.observations = []
+
+    def send_fi_fmi_opendata_airquality_station(self, key, station, flush_producer=False):
+        self.stations.append((key, station))
+
+    def send_fi_fmi_opendata_airquality_observation(self, key, observation, flush_producer=False):
+        self.observations.append((key, observation))
+
+    def flush(self, *args, **kwargs):
+        pass
+
+
+class TestOfflineMockCorpus:
+    def test_offline_corpus_round_trips_reference_and_telemetry(self):
+        from fmi_finland.fmi_finland import run_feed_cycle
+        from fmi_finland.samples import build_offline_api
+
+        api = build_offline_api()
+        producer = _RecordingEventProducer()
+        state: dict = {}
+
+        counts = run_feed_cycle(
+            api, producer, state, now=datetime(2024, 1, 15, 15, 0, tzinfo=timezone.utc),
+            force_station_emit=True,
+        )
+
+        # Three stations (reference) and six aggregated hourly observations.
+        assert counts["stations"] == 3
+        assert counts["observations"] == 6
+        assert len(producer.stations) == 3
+        assert len(producer.observations) == 6
+
+        station_keys = sorted(key for key, _ in producer.stations)
+        assert station_keys == ["100662", "100742", "100803"]
+
+        # Keys are the stable fmisid, matching the xreg subject/Kafka key template.
+        for key, observation in producer.observations:
+            assert key == observation.fmisid
+            assert observation.aqindex is not None
+
+        # NaN upstream values must coalesce to a null measurement, not a string.
+        o3_values = {obs.o3_ug_m3 for _, obs in producer.observations}
+        assert None in o3_values
+
+    def test_offline_observations_are_deduplicated_on_replay(self):
+        from fmi_finland.fmi_finland import run_feed_cycle
+        from fmi_finland.samples import build_offline_api
+
+        api = build_offline_api()
+        producer = _RecordingEventProducer()
+        state: dict = {}
+
+        run_feed_cycle(api, producer, state, force_station_emit=True)
+        second = run_feed_cycle(api, producer, state, force_station_emit=False)
+
+        # Identical corpus on the second cycle yields no new telemetry events.
+        assert second["observations"] == 0

--- a/feeders/fmi-finland/tests/test_fmi_finland_unit.py
+++ b/feeders/fmi-finland/tests/test_fmi_finland_unit.py
@@ -153,8 +153,9 @@ class TestParsingHelpers:
         assert observation["o3_ug_m3"] is None
 
     def test_measurement_arg_preserves_zero(self):
-        assert _measurement_arg(0.0) == "0"
-        assert _measurement_arg(1.5) == "1.5"
+        assert _measurement_arg(0.0) == 0.0
+        assert isinstance(_measurement_arg(0.0), float)
+        assert _measurement_arg(1.5) == 1.5
         assert _measurement_arg(None) is None
 
     def test_observation_window_alignment(self):

--- a/tests/docker_e2e/test_docker_kafka_flow.py
+++ b/tests/docker_e2e/test_docker_kafka_flow.py
@@ -1571,7 +1571,9 @@ class TestFMIFinlandDockerFlow:
             reference_types=['Station'],
             telemetry_types=['Observation'],
             required_types=['Station', 'Observation'],
-            extra_env={'POLLING_INTERVAL': '5'},
+            command=['python', '-m', 'fmi_finland', 'feed', '--mock'],
+            min_messages=6,
+            timeout=120,
         )
 
 


### PR DESCRIPTION
## Summary

De-flakes the **fmi-finland** Kafka Docker E2E flow test (`TestFMIFinlandDockerFlow`) by adding a deterministic offline `--mock` mode, the same layer-1 pattern from issue #818 already applied to blitzortung (#819) and gbfs-bikeshare (#820).

Previously the test polled the **live FMI WFS** service (`extra_env={'POLLING_INTERVAL':'5'}`), so it depended on upstream reachability and on fresh hourly observations being published during the test window. That produced intermittent, contract-unrelated flow-shard failures.

## Changes

- **`fmi_finland/samples.py` (new):** a recorded offline WFS-XML corpus mirroring the `fmi::ef::stations` and `urban::observations::airquality::PT1H::simple` stored-query shapes — 3 Helsinki-region stations at 2 hourly windows → **3 `Station` reference events + 6 `Observation` telemetry events (9 messages)**. Each observation element embeds its `fmisid` in the `gml:id` so `_resolve_fmisid` resolves deterministically without coordinate lookups. `build_offline_api()` returns an `FMIAirQualityAPI` subclass that serves the fixtures from the two fetch methods.
- **`fmi_finland/fmi_finland.py`:** new `--mock`/`FMI_MOCK` flag on `feed`; when set, the bridge uses the offline API and implies `--once`. The real Kafka producer still emits to the test broker.
- **`tests/docker_e2e/test_docker_kafka_flow.py`:** `TestFMIFinlandDockerFlow` now runs `python -m fmi_finland feed --mock` (`min_messages=6`, `timeout=120`), dropping the live poll.
- **`tests/test_fmi_finland_unit.py`:** offline-corpus round-trip (asserts 3 stations + 6 observations, key==fmisid, NaN→null coalescing) and replay-dedupe unit tests.

The MQTT/AMQP companion apps are **synthetic self-emitters** (they generate sample events from `EVENT_SPECS`, not from the live FMI source), so they are already deterministic and need no mock flag — unlike gbfs where all three apps shared a live core.

## Validation

- `pytest tests/test_fmi_finland_unit.py` → **13 passed**; `samples.py` 100% covered.
- Offline corpus parses to exactly 3 stations + 6 aggregated observations; `run_feed_cycle` emits 3 + 6; second cycle emits 0 (dedupe).
- `py_compile` clean; `feed --mock` dispatch confirmed (builds offline API, forces `--once`).

Refs #818
