### PR TITLE
ci(e2e): weekly full run + scoped/smoke PR runs + flow retries

### DIFF
--- a/.github/workflows/_docker-flow-shard.yml
+++ b/.github/workflows/_docker-flow-shard.yml
@@ -36,14 +36,22 @@ jobs:
           cache: 'pip'
 
       - name: Install test dependencies
-        run: pip install -r tests/docker_e2e/requirements.txt
+        run: |
+          pip install -r tests/docker_e2e/requirements.txt
+          pip install pytest-rerunfailures
 
       - name: Run Kafka flow test
         run: |
+          # Bounded retry absorbs transient live-upstream flakes (an upstream
+          # that simply did not emit within the window under runner load).
+          # Deterministic contract failures (wrong key/subject, invalid schema,
+          # missing event types) fail identically on every attempt, so they are
+          # not masked. The weekly scheduled full run is the authoritative gate.
           pytest tests/docker_e2e/${{ matrix.test_file || 'test_docker_kafka_flow.py' }} \
             -v --timeout=600 \
+            --reruns 2 --reruns-delay 15 \
             -k "${{ matrix.test_class }}" \
             --tb=long
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
           WSDOT_ACCESS_CODE: ${{ secrets.WSDOT_ACCESS_CODE }}

--- a/.github/workflows/test-docker-e2e.yml
+++ b/.github/workflows/test-docker-e2e.yml
@@ -1,20 +1,42 @@
 name: Docker E2E Tests
 
 # Strategy: a `discover` job inspects the changed files and decides which
-# feeders to build + test. If only one feeder's files changed, only that
-# feeder's docker-build + docker-kafka-flow jobs run. If any infrastructure
-# path changed (tests/docker_e2e/**, this workflow, tools/**, catalog.json)
-# the full matrix runs. workflow_dispatch / schedule also force full.
+# feeders to build + test.
+#   - push / pull_request -> change-scoped: only the touched feeders' build +
+#     flow jobs run. A test-harness change (tests/docker_e2e/**, this workflow,
+#     the reusable _docker-*-shard.yml workflows, non-additive catalog.json)
+#     runs a small curated SMOKE set spanning Kafka/MQTT/AMQP instead of the
+#     full matrix. tools/** and docs changes run zero E2E jobs (images build
+#     from committed feeder code, not from tools/).
+#   - schedule (weekly) -> the full matrix. This is the authoritative gate.
+#   - workflow_dispatch -> honours the `scope` input (full / smoke / changed).
+#
+# The full ~664-job matrix is reserved for the weekly run because, under runner
+# load, it starves live-upstream flow tests into transient failures. Scoped PR
+# runs stay fast and reliable; the weekly run catches cross-feeder drift.
 #
 # The authoritative feeder list lives in tests/docker_e2e/matrix.json so
-# adding a feeder is a JSON edit, not a YAML edit.
+# adding a feeder is a JSON edit, not a YAML edit. Smoke feeders carry a
+# "smoke": true flag there.
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # Weekly full run: Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Run scope for manual dispatch.'
+        type: choice
+        default: full
+        options:
+          - full
+          - smoke
+          - changed
 
 jobs:
   discover:
@@ -62,6 +84,7 @@ jobs:
         id: compute
         env:
           EVENT_NAME: ${{ github.event_name }}
+          SCOPE: ${{ github.event.inputs.scope }}
           CHANGED_FILES_PATH: changed-files.txt
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}

--- a/tests/docker_e2e/discover_matrix.py
+++ b/tests/docker_e2e/discover_matrix.py
@@ -3,7 +3,9 @@
 
 Inputs (env):
   CHANGED_FILES : newline-separated list of changed file paths.
-  EVENT_NAME    : github.event_name (workflow_dispatch / schedule force full).
+  EVENT_NAME    : github.event_name (schedule forces full; see SCOPE).
+  SCOPE         : manual override for workflow_dispatch: full / smoke / changed
+                  (default full). Ignored for push/pull_request/schedule.
   BASE_SHA      : merge base SHA (optional; enables additive-infra scoping).
   HEAD_SHA      : head SHA (optional; defaults to HEAD).
 
@@ -15,17 +17,28 @@ Outputs (GITHUB_OUTPUT):
   full_run        : "true" or "false"
   reason          : short human-readable reason.
 
-Logic:
-  - If event is workflow_dispatch/schedule, or any changed file matches an
-    INFRA path that is NOT additive-safe, emit the full matrix.
-  - Else compute the set of top-level dirs touched; intersect with the
-    matrix `dir` fields; emit only those entries.
-  - Additive-safe infra files (matrix.json, catalog.json,
-    test_docker_*_flow.py) contribute their newly-added source dirs to the
-    scoped set when the diff is purely additive (existing entries
-    unchanged); otherwise they force the full run.
-  - Always emit a `{include:[]}` shape so an empty selection still produces
-    a valid (no-op) matrix.
+Run-scoping policy (the full 664-job matrix is expensive and, under runner
+load, starves live-upstream flow tests into transient failures, so we reserve
+it for the weekly scheduled run and on-demand dispatch):
+
+  - schedule .............. FULL matrix (weekly authoritative gate).
+  - workflow_dispatch ..... honours SCOPE (full | smoke | changed; default full).
+  - push / pull_request ... change-scoped:
+      * feeder dir changed -> just that feeder's build+flow jobs.
+      * additive-safe infra (matrix.json / catalog.json / test_docker_*_flow.py
+        purely additive) -> the newly-added feeders' jobs.
+      * harness change (anything under tests/docker_e2e/** that is NOT
+        additive-safe, the e2e workflow yml, the reusable shard ymls, or a
+        non-additive catalog.json) -> the SMOKE set: a small curated,
+        transport-spanning subset (entries flagged "smoke": true in
+        matrix.json) that cheaply proves the harness still works across
+        Kafka/MQTT/AMQP. Full feeder coverage for harness changes comes from
+        the weekly scheduled run.
+      * nothing matched (e.g. tools/** or docs only) -> zero jobs (no-op);
+        tools/** does not affect Docker E2E because images are built from the
+        committed feeder code, not regenerated from tools/.
+  - Always emit a `{include:[]}` shape so an empty selection still produces a
+    valid (no-op) matrix.
 """
 from __future__ import annotations
 
@@ -51,12 +64,17 @@ MATRIX_PATH = ROOT / "tests" / "docker_e2e" / "matrix.json"
 SHARD_COUNT = 4
 SHARD_CAP = 250  # < 256 GitHub limit, leaves headroom inside each shard
 
-# Anything under these paths invalidates per-feeder scoping and forces full
-# run UNLESS the change is purely additive (handled per-file below).
+# Anything under these paths is a test-harness change: it invalidates
+# per-feeder scoping because it can affect every feeder's E2E run. A
+# non-additive change here triggers the SMOKE set (not the full matrix) on
+# push/PR; the weekly scheduled run provides full coverage. Note: tools/** is
+# deliberately NOT here -- Docker E2E builds images from committed feeder code
+# and never regenerates producers from tools/, so tool changes need no E2E.
 INFRA_PATTERNS = [
     re.compile(r"^tests/docker_e2e/"),
     re.compile(r"^\.github/workflows/test-docker-e2e\.yml$"),
-    re.compile(r"^tools/"),
+    re.compile(r"^\.github/workflows/_docker-build-shard\.yml$"),
+    re.compile(r"^\.github/workflows/_docker-flow-shard\.yml$"),
     re.compile(r"^catalog\.json$"),
 ]
 
@@ -312,49 +330,75 @@ def shard_entries(entries: list) -> list[list]:
 def main() -> int:
     matrix = json.loads(MATRIX_PATH.read_text())
     event = os.environ.get("EVENT_NAME", "")
+    scope = os.environ.get("SCOPE", "").strip().lower()
     base_sha = os.environ.get("BASE_SHA", "").strip()
     changed = _load_changed_files()
 
-    force_full = event in ("workflow_dispatch", "schedule") or not changed
-    reason = (
-        f"event={event}, force full"
-        if event in ("workflow_dispatch", "schedule")
-        else "no changed files detected, force full"
-        if not changed
-        else ""
-    )
+    force_full = False
+    smoke = False
+    reason = ""
+
+    if event == "schedule":
+        force_full = True
+        reason = "scheduled run: full weekly matrix"
+    elif event == "workflow_dispatch":
+        # Manual dispatch honours the SCOPE input (default full).
+        if scope == "smoke":
+            smoke = True
+            reason = "manual dispatch: smoke scope"
+        elif scope == "changed":
+            reason = "manual dispatch: changed scope"
+        else:
+            force_full = True
+            reason = "manual dispatch: full scope"
+    elif not changed:
+        # No diff to scope from (e.g. first push of a branch); be safe with
+        # the smoke set rather than the full matrix on push/PR.
+        smoke = True
+        reason = "no changed files detected, running smoke set"
 
     extra_dirs: set[str] = set()
-    if not force_full:
+    if not force_full and not smoke and event not in ("schedule", "workflow_dispatch"):
         infra_hits = [p for p in changed if is_infra(p)]
         if infra_hits:
             additive_paths = [p for p in infra_hits if is_additive_candidate(p)]
             hard_infra = [p for p in infra_hits if not is_additive_candidate(p)]
             if hard_infra:
-                force_full = True
-                reason = f"infra paths changed: {', '.join(hard_infra[:5])}"
+                # Non-additive harness change: run the smoke set on push/PR.
+                # The weekly scheduled run covers the full feeder matrix.
+                smoke = True
+                reason = (
+                    "harness paths changed, running smoke set: "
+                    + ", ".join(hard_infra[:5])
+                )
             elif additive_paths and base_sha:
                 extra, blockers = scope_additive_infra(
                     additive_paths, base_sha, matrix
                 )
                 if blockers:
-                    force_full = True
+                    smoke = True
                     reason = (
-                        "infra changes not provably additive: "
+                        "infra changes not provably additive, running smoke set: "
                         + ", ".join(blockers[:5])
                     )
                 else:
                     extra_dirs.update(extra)
             elif additive_paths and not base_sha:
-                force_full = True
+                smoke = True
                 reason = (
-                    "infra paths changed and no BASE_SHA to verify additive: "
-                    + ", ".join(additive_paths[:5])
+                    "infra paths changed and no BASE_SHA to verify additive, "
+                    "running smoke set: " + ", ".join(additive_paths[:5])
                 )
 
     if force_full:
         build = matrix["build"]
         flow = matrix["flow"]
+    elif smoke:
+        build = [m for m in matrix["build"] if m.get("smoke")]
+        flow = [m for m in matrix["flow"] if m.get("smoke")]
+        reason = (
+            f"{reason} -> {len(build)} build / {len(flow)} flow smoke job(s)"
+        )
     else:
         touched_dirs = {top_dir(p) for p in changed if not is_infra(p)}
         touched_dirs.update(extra_dirs)

--- a/tests/docker_e2e/matrix.json
+++ b/tests/docker_e2e/matrix.json
@@ -25,7 +25,8 @@
     },
     {
       "dir": "feeders/bluesky",
-      "module": "bluesky"
+      "module": "bluesky",
+      "smoke": true
     },
     {
       "dir": "feeders/bluesky",
@@ -37,7 +38,8 @@
       "dir": "feeders/aisstream",
       "image": "aisstream-kafka",
       "file": "Dockerfile",
-      "module": "aisstream"
+      "module": "aisstream",
+      "smoke": true
     },
     {
       "dir": "feeders/aisstream",
@@ -269,19 +271,22 @@
       "dir": "feeders/pegelonline",
       "image": "pegelonline-kafka",
       "file": "Dockerfile.kafka",
-      "module": "pegelonline_kafka"
+      "module": "pegelonline_kafka",
+      "smoke": true
     },
     {
       "dir": "feeders/pegelonline",
       "image": "pegelonline-mqtt",
       "file": "Dockerfile.mqtt",
-      "module": "pegelonline_mqtt"
+      "module": "pegelonline_mqtt",
+      "smoke": true
     },
     {
       "dir": "feeders/pegelonline",
       "image": "pegelonline-amqp",
       "file": "Dockerfile.amqp",
-      "module": "pegelonline_amqp"
+      "module": "pegelonline_amqp",
+      "smoke": true
     },
     {
       "dir": "feeders/rss",
@@ -2091,21 +2096,24 @@
       "dir": "feeders/pegelonline",
       "image": "pegelonline-kafka",
       "file": "Dockerfile.kafka",
-      "test_class": "TestPegelonlineDockerFlow"
+      "test_class": "TestPegelonlineDockerFlow",
+      "smoke": true
     },
     {
       "dir": "feeders/pegelonline",
       "image": "pegelonline-mqtt",
       "file": "Dockerfile.mqtt",
       "test_file": "test_docker_mqtt_flow.py",
-      "test_class": "TestPegelonlineMqttDockerFlow"
+      "test_class": "TestPegelonlineMqttDockerFlow",
+      "smoke": true
     },
     {
       "dir": "feeders/pegelonline",
       "image": "pegelonline-amqp",
       "file": "Dockerfile.amqp",
       "test_file": "test_docker_amqp_artemis_flow.py",
-      "test_class": "TestPegelonlineAmqpArtemisFlow"
+      "test_class": "TestPegelonlineAmqpArtemisFlow",
+      "smoke": true
     },
     {
       "dir": "feeders/pegelonline",
@@ -2698,7 +2706,8 @@
       "image": "aisstream-kafka",
       "file": "Dockerfile",
       "test_file": "test_docker_kafka_flow.py",
-      "test_class": "TestAisstreamKafkaDockerFlow"
+      "test_class": "TestAisstreamKafkaDockerFlow",
+      "smoke": true
     },
     {
       "dir": "feeders/aisstream",
@@ -2754,7 +2763,8 @@
       "image": "bluesky-kafka",
       "file": "Dockerfile",
       "test_file": "test_docker_kafka_flow.py",
-      "test_class": "TestBlueskyDockerFlow"
+      "test_class": "TestBlueskyDockerFlow",
+      "smoke": true
     },
     {
       "dir": "feeders/bluesky",

--- a/tests/docker_e2e/test_discover_matrix.py
+++ b/tests/docker_e2e/test_discover_matrix.py
@@ -92,5 +92,114 @@ def test_scoped_change_selects_that_feeders_jobs(tmp_path, monkeypatch):
     assert all(m["dir"] == target for m in flow)
 
 
+def _run(monkeypatch, tmp_path, *, event, changed="", scope=None, base=None):
+    out = tmp_path / "gh_output"
+    out.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("EVENT_NAME", event)
+    monkeypatch.setenv("CHANGED_FILES", changed)
+    monkeypatch.delenv("CHANGED_FILES_PATH", raising=False)
+    if scope is None:
+        monkeypatch.delenv("SCOPE", raising=False)
+    else:
+        monkeypatch.setenv("SCOPE", scope)
+    if base is None:
+        monkeypatch.delenv("BASE_SHA", raising=False)
+    else:
+        monkeypatch.setenv("BASE_SHA", base)
+    assert dm.main() == 0
+    vals = _parse_github_output(out)
+    return (
+        vals,
+        json.loads(vals["build_matrix"])["include"],
+        json.loads(vals["flow_matrix"])["include"],
+    )
+
+
+def test_tools_change_selects_zero_jobs(tmp_path, monkeypatch):
+    # tools/** does not affect Docker E2E (images build from committed feeder
+    # code, not from tools/), so a tools-only change must run no E2E jobs and
+    # must NOT escalate to the full matrix.
+    vals, build, flow = _run(
+        monkeypatch, tmp_path, event="push", changed="tools/deploy/build_wheel.py"
+    )
+    assert vals["full_run"] == "false"
+    assert build == []
+    assert flow == []
+
+
+def test_docs_change_selects_zero_jobs(tmp_path, monkeypatch):
+    vals, build, flow = _run(
+        monkeypatch, tmp_path, event="push", changed="docs/readme.md"
+    )
+    assert vals["full_run"] == "false"
+    assert build == [] and flow == []
+
+
+def test_harness_change_runs_smoke_set(tmp_path, monkeypatch):
+    matrix = json.loads(MATRIX_PATH.read_text())
+    smoke_build = [m for m in matrix["build"] if m.get("smoke")]
+    smoke_flow = [m for m in matrix["flow"] if m.get("smoke")]
+    assert smoke_build and smoke_flow, "matrix.json must define a smoke set"
+    vals, build, flow = _run(
+        monkeypatch, tmp_path, event="push", changed="tests/docker_e2e/conftest.py"
+    )
+    assert vals["full_run"] == "false"
+    assert build == smoke_build
+    assert flow == smoke_flow
+
+
+def test_shard_workflow_change_runs_smoke_set(tmp_path, monkeypatch):
+    vals, build, flow = _run(
+        monkeypatch,
+        tmp_path,
+        event="push",
+        changed=".github/workflows/_docker-flow-shard.yml",
+    )
+    assert vals["full_run"] == "false"
+    assert all(m.get("smoke") for m in build)
+    assert build, "shard-workflow change must run the smoke set"
+
+
+def test_schedule_forces_full(tmp_path, monkeypatch):
+    matrix = json.loads(MATRIX_PATH.read_text())
+    vals, build, flow = _run(monkeypatch, tmp_path, event="schedule")
+    assert vals["full_run"] == "true"
+    assert len(build) == len(matrix["build"])
+    assert len(flow) == len(matrix["flow"])
+
+
+def test_dispatch_default_full(tmp_path, monkeypatch):
+    matrix = json.loads(MATRIX_PATH.read_text())
+    # No scope input -> default full.
+    vals, build, _ = _run(monkeypatch, tmp_path, event="workflow_dispatch", scope="")
+    assert vals["full_run"] == "true"
+    assert len(build) == len(matrix["build"])
+
+
+def test_dispatch_smoke_scope(tmp_path, monkeypatch):
+    vals, build, flow = _run(
+        monkeypatch, tmp_path, event="workflow_dispatch", scope="smoke"
+    )
+    assert vals["full_run"] == "false"
+    assert build and all(m.get("smoke") for m in build)
+    assert flow and all(m.get("smoke") for m in flow)
+
+
+def test_dispatch_changed_scope(tmp_path, monkeypatch):
+    matrix = json.loads(MATRIX_PATH.read_text())
+    target = matrix["build"][0]["dir"]
+    feeder = target.split("/", 1)[1]
+    vals, build, flow = _run(
+        monkeypatch,
+        tmp_path,
+        event="workflow_dispatch",
+        scope="changed",
+        changed=f"{target}/{feeder}/{feeder}.py",
+    )
+    assert vals["full_run"] == "false"
+    assert build and all(m["dir"] == target for m in build)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why

The full ~664-job Docker E2E matrix is expensive and, under runner load, starves live-upstream flow tests into transient failures. PR #817 is the motivating case: a `tools/`-only change force-escalated to a full run that then flaked on ~33 live feeders and had to be admin-merged. This PR makes PR/push runs fast and reliable and reserves the full matrix for a weekly scheduled run.

## Changes

**`tests/docker_e2e/discover_matrix.py`** — run-scoping policy:
- `schedule` -> **full** matrix (authoritative weekly gate).
- `workflow_dispatch` -> honours a new **`scope`** input (`full` | `smoke` | `changed`), default `full`.
- `push` / `pull_request` -> **change-scoped**:
  - `tools/**` removed from the infra-trigger set entirely. Docker E2E builds images from committed feeder code and never regenerates producers from `tools/`, so a tools-only change now runs **zero** E2E jobs instead of escalating to full (this is the exact #817 trigger).
  - A non-additive **harness** change (`tests/docker_e2e/**`, this workflow, the reusable `_docker-*-shard.yml` workflows, non-additive `catalog.json`) runs a small curated **SMOKE** set spanning Kafka/MQTT/AMQP instead of the full matrix. The weekly run covers the rest.
  - Additive scoping (new feeder via `matrix.json` / `catalog.json` / `test_docker_*_flow.py`) is unchanged; non-additive fallbacks now go to smoke, not full.

**`.github/workflows/test-docker-e2e.yml`** — add weekly `schedule` cron (Mon 06:00 UTC) and the `workflow_dispatch` `scope` choice input; pass `SCOPE` to discover.

**`tests/docker_e2e/matrix.json`** — flag a transport-spanning smoke set (`"smoke": true`): pegelonline kafka/mqtt/amqp + deterministic mock bluesky/aisstream kafka, build + flow (5 + 5).

**`.github/workflows/_docker-flow-shard.yml`** — add `pytest-rerunfailures` (`--reruns 2 --reruns-delay 15`) to absorb transient live-upstream flakes. Deterministic contract failures (wrong key/subject, invalid schema, missing event types) fail identically on every attempt, so they are **not** masked. Flow job timeout bumped 10 -> 15 min for rerun headroom.

**`tests/docker_e2e/test_discover_matrix.py`** — new regression tests: `tools/`->0, docs->0, harness->smoke, shard-yml->smoke, `schedule`->full, dispatch `full`/`smoke`/`changed`.

## Validation

- `pytest tests/docker_e2e/test_discover_matrix.py` — **11 passed**.
- Manual scenario sweep (push feeder / push tools / push harness / push docs / dispatch full|smoke|changed / schedule) all produce the intended scoping.
- Both workflow YAMLs parse.

## Notes / trade-offs

- Harness changes get a fast smoke signal on PR, not full feeder coverage; the **weekly** run is the full gate. This is the deliberate cost of "full only once a week".
- `main` is unprotected (no required status checks), so the matrix-shape change does not strand any required check.
- Reviewed with the rubber-duck agent; adopted: keep `tools/` out of E2E, `smoke: true` matrix annotation over hardcoding, narrow the masking risk. Dominant flow flake (live-upstream message starvation) surfaces as `AssertionError` overlapping real "never emits" bugs, so signature-filtered reruns add little; bounded plain reruns + weekly full is the chosen lever.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
