### PR TITLE
ci(e2e): scope feeder-local test-class edits to that feeder's flow job

### DIFF
--- a/tests/docker_e2e/discover_matrix.py
+++ b/tests/docker_e2e/discover_matrix.py
@@ -233,20 +233,72 @@ def _class_blocks(text: str) -> dict[str, str]:
     for node in tree.body:
         if not isinstance(node, ast.ClassDef):
             continue
-        start = node.lineno - 1
+        # Include any class-level decorators (which precede ``node.lineno``)
+        # in the hashed span so a decorator-only change (e.g. adding
+        # @pytest.mark.skip) registers as a class-body change rather than
+        # silently slipping past both this hash and the non-class hash.
+        start = min([node.lineno] + [d.lineno for d in node.decorator_list]) - 1
         end = getattr(node, "end_lineno", None) or start + 1
         body = "".join(lines[start:end])
         out[node.name] = hashlib.sha256(body.encode("utf-8")).hexdigest()
     return out
 
 
+def _module_nonclass_hash(text: str) -> str | None:
+    """Hash of all top-level statements that are NOT class definitions.
+
+    Returns None if the source cannot be parsed. Used to prove that a change
+    to a test file is confined to test-class bodies and does not touch shared
+    module-level code (imports, fixtures, helper functions) that could affect
+    every feeder's E2E run.
+    """
+    import ast
+
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    lines = text.splitlines(keepends=True)
+    segments: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            continue
+        start = node.lineno - 1
+        end = getattr(node, "end_lineno", None) or start + 1
+        segments.append("".join(lines[start:end]))
+    return hashlib.sha256("\x00".join(segments).encode("utf-8")).hexdigest()
+
+
 def additive_test_file(base_txt: str, head_txt: str, matrix: dict) -> list[str] | None:
+    """Scope a Docker-E2E test-file change to the affected feeder dirs.
+
+    Returns the list of feeder dirs whose flow jobs should run, or None to
+    signal the change cannot be attributed to specific feeders (the caller
+    then falls back to the smoke set).
+
+    A change is attributable when it is confined to test-class bodies and
+    every added/modified class maps to a feeder dir via the matrix. It bails
+    (None) when shared module-level code changed (imports, fixtures, helper
+    functions), when an existing class was removed, or when a *modified*
+    existing class has no matrix mapping (e.g. a shared base class) -- any of
+    which can affect feeders we cannot enumerate from the class alone. This
+    lets a PR that flips one feeder's own test class to ``--mock`` run that
+    feeder's flow job instead of the whole smoke set.
+    """
+    # Shared, non-class module-level code must be byte-identical; otherwise a
+    # changed import / fixture / helper could affect every feeder's run.
+    base_shared = _module_nonclass_hash(base_txt)
+    head_shared = _module_nonclass_hash(head_txt)
+    if base_shared is None or head_shared is None or base_shared != head_shared:
+        return None
+
     base_classes = _class_blocks(base_txt)
     head_classes = _class_blocks(head_txt)
-    # No removals or body changes of existing classes.
-    for cls, base_hash in base_classes.items():
-        if cls not in head_classes or head_classes[cls] != base_hash:
+    # No removals of existing classes (a deletion may alter shared behavior).
+    for cls in base_classes:
+        if cls not in head_classes:
             return None
+
     # Map test_class -> dir via matrix entries.
     cls_to_dir = {}
     for entry in matrix.get("flow", []):
@@ -254,10 +306,24 @@ def additive_test_file(base_txt: str, head_txt: str, matrix: dict) -> list[str] 
         d = entry.get("dir")
         if tc and d:
             cls_to_dir[tc] = d
+
     touched: set[str] = set()
-    for cls in set(head_classes) - set(base_classes):
-        d = cls_to_dir.get(cls)
-        if d:
+    for cls, head_hash in head_classes.items():
+        base_hash = base_classes.get(cls)
+        if base_hash is None:
+            # Newly added class: additive. Attribute to its feeder if mapped;
+            # an unmapped new class selects no job (matches the prior add-only
+            # behavior -- nothing references it yet, so it is safe).
+            d = cls_to_dir.get(cls)
+            if d:
+                touched.add(d)
+        elif base_hash != head_hash:
+            # Modified existing class body. Attribute to its feeder dir. A
+            # modified class that is NOT a flow-matrix entry is a shared base
+            # class whose change can affect many feeders -> cannot scope.
+            d = cls_to_dir.get(cls)
+            if d is None:
+                return None
             touched.add(d)
     return sorted(touched)
 

--- a/tests/docker_e2e/test_discover_matrix.py
+++ b/tests/docker_e2e/test_discover_matrix.py
@@ -201,5 +201,113 @@ def test_dispatch_changed_scope(tmp_path, monkeypatch):
     assert build and all(m["dir"] == target for m in build)
 
 
+# --- additive_test_file: feeder-scoped edits to existing test classes -------
+
+_FLOW_MATRIX = {
+    "flow": [
+        {"dir": "feeders/blitzortung", "test_class": "TestBlitzortungDockerFlow"},
+        {"dir": "feeders/gbfs-bikeshare", "test_class": "TestGbfsMqttDockerFlow"},
+    ]
+}
+
+
+def _test_file(blitz_cmd: str = "feed", gbfs_env: str = "live", helper: str = "x") -> str:
+    return (
+        "import os\n"
+        "import pytest\n"
+        "\n"
+        f"def _shared_helper():\n    return '{helper}'\n"
+        "\n"
+        "class TestBlitzortungDockerFlow:\n"
+        f"    command = ['python', '-m', 'blitzortung', '{blitz_cmd}']\n"
+        "    def test_it(self):\n        assert True\n"
+        "\n"
+        "class TestGbfsMqttDockerFlow:\n"
+        f"    env = {{'GBFS_MOCK': '{gbfs_env}'}}\n"
+        "    def test_it(self):\n        assert True\n"
+    )
+
+
+def test_additive_test_file_scopes_modified_class_to_its_feeder():
+    base = _test_file(blitz_cmd="feed")
+    head = _test_file(blitz_cmd="feed --mock")
+    dirs = dm.additive_test_file(base, head, _FLOW_MATRIX)
+    assert dirs == ["feeders/blitzortung"]
+
+
+def test_additive_test_file_scopes_only_changed_classes():
+    base = _test_file(blitz_cmd="feed", gbfs_env="live")
+    head = _test_file(blitz_cmd="feed", gbfs_env="true")
+    dirs = dm.additive_test_file(base, head, _FLOW_MATRIX)
+    assert dirs == ["feeders/gbfs-bikeshare"]
+
+
+def test_additive_test_file_shared_helper_change_bails_to_smoke():
+    base = _test_file(helper="x")
+    head = _test_file(helper="y")  # module-level helper changed
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) is None
+
+
+def test_additive_test_file_added_class_is_additive():
+    base = _test_file()
+    head = _test_file() + (
+        "\nclass TestNewFeederDockerFlow:\n    def test_it(self):\n        assert True\n"
+    )
+    # New unmapped class selects no job but is still additive (not None).
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) == []
+
+
+def test_additive_test_file_removed_class_bails_to_smoke():
+    base = _test_file()
+    head = (
+        "import os\nimport pytest\n\n"
+        "def _shared_helper():\n    return 'x'\n\n"
+        "class TestBlitzortungDockerFlow:\n"
+        "    command = ['python', '-m', 'blitzortung', 'feed']\n"
+        "    def test_it(self):\n        assert True\n"
+    )  # TestGbfsMqttDockerFlow removed
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) is None
+
+
+def test_additive_test_file_modified_unmapped_class_bails_to_smoke():
+    base = (
+        "import pytest\n\n"
+        "class AmqpDockerFlowBase:\n    timeout = 60\n"
+        "    def run(self):\n        return 1\n"
+    )
+    head = base.replace("timeout = 60", "timeout = 90")
+    # A shared base class (no matrix entry) changed -> cannot scope.
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) is None
+
+
+def test_additive_test_file_decorator_change_on_mapped_class_scopes():
+    # A class-level decorator change must register as a class change (the
+    # decorator precedes `class`, so without span widening it would be
+    # invisible to both hashes and silently under-scope).
+    base = (
+        "import pytest\n\n"
+        "class TestBlitzortungDockerFlow:\n    def test_it(self):\n        assert True\n"
+    )
+    head = (
+        "import pytest\n\n"
+        "@pytest.mark.skip(reason='flaky')\n"
+        "class TestBlitzortungDockerFlow:\n    def test_it(self):\n        assert True\n"
+    )
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) == ["feeders/blitzortung"]
+
+
+def test_additive_test_file_decorator_change_on_unmapped_class_bails():
+    base = (
+        "import pytest\n\n"
+        "class AmqpDockerFlowBase:\n    def run(self):\n        return 1\n"
+    )
+    head = (
+        "import pytest\n\n"
+        "@pytest.mark.usefixtures('broker')\n"
+        "class AmqpDockerFlowBase:\n    def run(self):\n        return 1\n"
+    )
+    assert dm.additive_test_file(base, head, _FLOW_MATRIX) is None
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

#822's Docker-E2E discover heuristic flags any PR touching `tests/docker_e2e/*` as `infra changes not provably additive` and runs only the 5-feeder **smoke** set when a change cannot be proven additive. `additive_test_file()` only treated *added* whole classes as additive — it returned `None` (→ smoke) for **any** body change to an *existing* test class. So a PR that flips one feeder's own test class to `--mock` (exactly what #819/#820/#821 did) never ran **that feeder's** flow job on the PR; only the weekly full run exercised it.

## Change

`additive_test_file()` now attributes a **modified existing class** to its feeder dir (via the matrix `test_class → dir` map) instead of bailing — while staying conservative:

- `_module_nonclass_hash()` proves no shared module-level code (imports, fixtures, helper functions) changed; any such change **still bails to smoke** because it can affect every feeder.
- A **removed** class, or a **modified** class with no matrix mapping (a shared base class like `AmqpDockerFlowBase`), **still bails to smoke**.
- **Newly added** classes keep the prior add-only semantics (additive; selects the feeder's job if mapped, else no job).
- `_class_blocks()` now folds **class-level decorators** into the hashed span so a decorator-only change (e.g. `@pytest.mark.skip`) registers as a class change rather than slipping past both hashes and silently under-scoping. *(Found via rubber-duck review.)*

Net effect: a PR that edits one feeder's own E2E test class body now runs that feeder's flow job on the PR. Genuinely shared changes (helpers, fixtures, base classes) still fall back to the smoke set; the weekly full run remains the backstop.

## Scope

Limited to the **E2E flow** discover (`tests/docker_e2e/discover_matrix.py`). The sibling container-build discover (`tools/ci/discover_container_matrix.py`) still treats test-file edits as infra → full build; that is wasteful but not incorrect (a test-only change rebuilds images it does not need). Left as a separate follow-up to keep this PR single-topic.

## Tests

- `python -m pytest tests/docker_e2e/test_discover_matrix.py` → **19 passed**. 8 new cases: modified mapped class → that feeder; only-changed-class scoping; shared-helper edit → smoke; added (unmapped) class → additive; removed class → smoke; modified unmapped base class → smoke; decorator change on mapped class → that feeder; decorator change on unmapped class → smoke.
- Integration-verified against the real `test_docker_kafka_flow.py` + `matrix.json`: a single class-body edit scopes to exactly that feeder; a module-level edit bails to smoke.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>