### PR TITLE
fix(gracedb): deterministic GRACEDB_MOCK E2E + fix CloudEvents time drift (#818)

### DIFF
--- a/feeders/gracedb/gracedb/gracedb.py
+++ b/feeders/gracedb/gracedb/gracedb.py
@@ -40,6 +40,67 @@ DEFAULT_POLL_COUNT = 25
 DEFAULT_CATEGORIES = "Production,MDC"
 
 
+def _mock_enabled() -> bool:
+    return os.getenv("GRACEDB_MOCK", "").lower() in ("1", "true", "yes")
+
+
+def created_to_rfc3339(created: Optional[str]) -> str:
+    """Convert a GraceDB ``created`` timestamp to an RFC 3339 string.
+
+    GraceDB publishes ``created`` as e.g. ``"2024-01-01 00:00:00 UTC"`` which is
+    not valid RFC 3339 and is rejected by the generated Kafka producer's
+    CloudEvents ``time`` normalization. Parse the known GraceDB shape and emit a
+    ``Z``-suffixed RFC 3339 timestamp; fall back to the current UTC instant when
+    the upstream value is missing or in an unexpected format so the producer
+    never receives an invalid ``time``.
+    """
+    text = (created or "").strip()
+    if text:
+        candidate = text[:-4].strip() if text.upper().endswith(" UTC") else text
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                dt = datetime.strptime(candidate, fmt).replace(tzinfo=timezone.utc)
+                return dt.isoformat().replace("+00:00", "Z")
+            except ValueError:
+                continue
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# Deterministic canned superevent used by the ``GRACEDB_MOCK`` offline mode so
+# the Docker E2E flow tests do not depend on a real gravitational-wave candidate
+# being published by GraceDB within the test window. The shape mirrors the live
+# ``/api/superevents/`` JSON so it flows through the same ``parse_superevent``
+# normalization path the live poller uses, exercising the real producer code.
+SAMPLE_SUPEREVENTS = [
+    {
+        "superevent_id": "MS240101a",
+        "category": "Production",
+        "created": "2024-01-01 00:00:00 UTC",
+        "t_start": 1388534400.0,
+        "t_0": 1388534401.0,
+        "t_end": 1388534402.0,
+        "far": 1.2e-09,
+        "time_coinc_far": None,
+        "space_coinc_far": None,
+        "labels": ["ADVOK", "GCN_PRELIM_SENT"],
+        "gw_id": None,
+        "submitter": "mock",
+        "em_type": None,
+        "preferred_event_data": {
+            "graceid": "G000001",
+            "pipeline": "gstlal",
+            "group": "CBC",
+            "instruments": "H1,L1,V1",
+            "search": "AllSky",
+            "far_is_upper_limit": False,
+            "nevents": 1,
+        },
+        "links": {"self": "https://gracedb.ligo.org/api/superevents/MS240101a/"},
+    },
+]
+
+
+
 def is_topic_segment(value: str) -> bool:
     return bool(value) and all(char not in value for char in ("/", "+", "#", "\x00"))
 
@@ -58,6 +119,7 @@ class GraceDBPoller:
         self.last_polled_file = last_polled_file
         self.poll_count = poll_count
         self.categories = set(c.strip() for c in (categories or DEFAULT_CATEGORIES).split(','))
+        self.mock = _mock_enabled()
         self.event_producer: Optional[OrgLigoGracedbEventProducer] = None
         if kafka_config is not None:
             producer = Producer(kafka_config)
@@ -65,6 +127,9 @@ class GraceDBPoller:
 
     async def fetch_superevents(self, count: Optional[int] = None) -> List[Dict[str, Any]]:
         """Fetch superevents from the GraceDB public API."""
+        if self.mock:
+            logger.info("GRACEDB_MOCK enabled: returning %d canned superevent(s)", len(SAMPLE_SUPEREVENTS))
+            return [dict(raw) for raw in SAMPLE_SUPEREVENTS]
         url = f"{BASE_API_URL}?format=json&count={count or self.poll_count}"
         async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}, timeout=aiohttp.ClientTimeout(total=30)) as session:
             try:
@@ -147,6 +212,8 @@ class GraceDBPoller:
         """
         seen_ids = self.load_seen_ids()
         poll_interval = timedelta(minutes=2)
+        # Mock mode is for the deterministic E2E flow test: emit one cycle and exit.
+        once = once or self.mock
 
         while True:
             start_poll_time = datetime.now(timezone.utc)
@@ -164,7 +231,7 @@ class GraceDBPoller:
                 self.event_producer.send_org_ligo_gracedb_superevent(
                     _source_uri=BASE_API_URL,
                     _superevent_id=superevent.superevent_id,
-                    _created=superevent.created,
+                    _time=created_to_rfc3339(superevent.created),
                     data=superevent,
                     flush_producer=False,
                 )

--- a/feeders/gracedb/gracedb_amqp/gracedb_amqp/app.py
+++ b/feeders/gracedb/gracedb_amqp/gracedb_amqp/app.py
@@ -28,6 +28,11 @@ class _MqttProducerAdapter:
         kwargs.pop("flush_producer", None)
         data = kwargs["data"]
         normalized = {key[1:] if key.startswith("_") else key: value for key, value in kwargs.items()}
+        # The Kafka producer takes a uniform CloudEvents ``_time`` override, but
+        # the AMQP/MQTT publish method takes the named ``created`` template
+        # variable. Translate so the shared bridge call site works everywhere.
+        if "time" in normalized and "created" not in normalized:
+            normalized["created"] = normalized.pop("time")
         normalized["category"] = data.category
         normalized["group"] = data.group
         task = asyncio.create_task(self._publish(**normalized))

--- a/feeders/gracedb/gracedb_mqtt/gracedb_mqtt/app.py
+++ b/feeders/gracedb/gracedb_mqtt/gracedb_mqtt/app.py
@@ -30,6 +30,11 @@ class _MqttProducerAdapter:
         kwargs.pop("flush_producer", None)
         data = kwargs["data"]
         normalized = {key[1:] if key.startswith("_") else key: value for key, value in kwargs.items()}
+        # The Kafka producer takes a uniform CloudEvents ``_time`` override, but
+        # the MQTT publish method takes the named ``created`` template variable.
+        # Translate so the shared bridge call site works across both transports.
+        if "time" in normalized and "created" not in normalized:
+            normalized["created"] = normalized.pop("time")
         normalized["category"] = data.category
         normalized["group"] = data.group
         task = asyncio.create_task(self._publish(**normalized))

--- a/feeders/gracedb/tests/test_once_mode.py
+++ b/feeders/gracedb/tests/test_once_mode.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gracedb.gracedb import GraceDBPoller
+from gracedb.gracedb import GraceDBPoller, SAMPLE_SUPEREVENTS, created_to_rfc3339
 
 
 @pytest.fixture
@@ -53,3 +53,51 @@ def test_once_flag_in_argparse():
     source = inspect.getsource(mod.main)
     assert "--once" in source, "main() argparse must declare --once"
     assert "ONCE_MODE" in source, "--once default must honor ONCE_MODE env var"
+
+
+def test_mock_mode_returns_canned_superevents(tmp_path, monkeypatch):
+    """GRACEDB_MOCK makes fetch_superevents return the deterministic corpus."""
+    monkeypatch.setenv("GRACEDB_MOCK", "true")
+    p = GraceDBPoller(last_polled_file=str(tmp_path / "seen.json"), categories="Production,MDC")
+    assert p.mock is True
+
+    raw = asyncio.run(p.fetch_superevents())
+    assert len(raw) == len(SAMPLE_SUPEREVENTS) >= 1
+
+    parsed = [p.parse_superevent(r) for r in raw]
+    assert all(se is not None for se in parsed)
+    assert parsed[0].superevent_id == "MS240101a"
+    assert parsed[0].category == "Production"
+    assert parsed[0].group == "CBC"
+
+
+def test_mock_mode_forces_single_cycle(tmp_path, monkeypatch):
+    """In mock mode poll_and_send exits after one cycle even without --once."""
+    monkeypatch.setenv("GRACEDB_MOCK", "true")
+    p = GraceDBPoller(last_polled_file=str(tmp_path / "seen.json"), categories="Production,MDC")
+    p.event_producer = MagicMock()
+    p.event_producer.producer = MagicMock()
+
+    async def runner():
+        await asyncio.wait_for(p.poll_and_send(once=False), timeout=5)
+
+    asyncio.run(runner())
+    # One Superevent emitted from the canned corpus, then exit.
+    assert p.event_producer.send_org_ligo_gracedb_superevent.call_count == 1
+
+
+def test_created_to_rfc3339_parses_gracedb_format():
+    """GraceDB's 'YYYY-MM-DD HH:MM:SS UTC' must become Z-suffixed RFC 3339."""
+    assert created_to_rfc3339("2024-01-01 00:00:00 UTC") == "2024-01-01T00:00:00Z"
+    assert created_to_rfc3339("2024-06-15T12:30:45") == "2024-06-15T12:30:45Z"
+
+
+def test_created_to_rfc3339_falls_back_on_bad_input():
+    """Unparseable/empty input yields a valid RFC 3339 'now' rather than crashing."""
+    import re
+    pat = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+    assert pat.match(created_to_rfc3339(""))
+    assert pat.match(created_to_rfc3339("not a date"))
+    assert pat.match(created_to_rfc3339(None))
+
+

--- a/tests/docker_e2e/test_docker_amqp_flow.py
+++ b/tests/docker_e2e/test_docker_amqp_flow.py
@@ -459,7 +459,7 @@ class TestBfsOdlAmqpDockerFlow(AmqpDockerFlowBase):
 class TestGracedbAmqpDockerFlow(AmqpDockerFlowBase):
     source_dir = "gracedb"
     image = "gracedb-amqp"
-    env = {"ONCE_MODE": "true"}
+    env = {"ONCE_MODE": "true", "GRACEDB_MOCK": "true"}
     expected_types = {'org.ligo.gracedb.Superevent'}
     expected_count = 1
 

--- a/tests/docker_e2e/test_docker_kafka_flow.py
+++ b/tests/docker_e2e/test_docker_kafka_flow.py
@@ -999,6 +999,7 @@ class TestGraceDBDockerFlow:
             kafka, gracedb_image, self.TOPIC,
             reference_types=None,
             telemetry_types=['Superevent'],
+            extra_env={'GRACEDB_MOCK': 'true', 'ONCE_MODE': 'true'},
             min_messages=1,
         )
 

--- a/tests/docker_e2e/test_docker_mqtt_flow.py
+++ b/tests/docker_e2e/test_docker_mqtt_flow.py
@@ -4919,7 +4919,7 @@ def mosquitto_gracedb():
 
 class TestGraceDbMqttDockerFlow:
     def test_emits_mqtt_uns_topics(self, mosquitto_gracedb, gracedb_mqtt_image):
-        _run_mqtt_contract_flow('gracedb', gracedb_mqtt_image, mosquitto_gracedb, timeout=900)
+        _run_mqtt_contract_flow('gracedb', gracedb_mqtt_image, mosquitto_gracedb, extra_env={'GRACEDB_MOCK': 'true', 'ONCE_MODE': 'true'}, timeout=240)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## What

De-flake the **gracedb** Docker E2E flow tests (part of #818) and fix a
pre-existing bridge bug they surfaced.

### Deterministic mock mode
- New `GRACEDB_MOCK` offline mode emits a deterministic canned superevent
  (`SAMPLE_SUPEREVENTS`) through the **real** `parse_superevent` +
  generated-producer path, then exits after a single cycle (mock implies
  `--once`). Env-based, so all three transports (Kafka, MQTT, AMQP) are
  covered through the shared `GraceDBPoller`.
- The three gracedb flow tests now run with `GRACEDB_MOCK=true` +
  `ONCE_MODE=true` instead of waiting (up to 900s) for a live GW candidate.

### Pre-existing bug fixed (Real Bug, not a test workaround)
The gracedb **Kafka** feeder crashed on its first emit and was only ever
run on the weekly full E2E lane, so it stayed hidden:

- The bridge passed `_created=` to `send_org_ligo_gracedb_superevent`, but
  since the **0.10.12 fleet regen** the generated Kafka producer takes a
  uniform CloudEvents `_time` override (RFC 3339 validated) and **no longer
  accepts `_created`** → `TypeError` on every publish.
- GraceDB's `created` value (`"YYYY-MM-DD HH:MM:SS UTC"`) is **not** RFC 3339,
  so even the renamed param would fail the producer's `time` normalization.
  Added `created_to_rfc3339()` (Z-suffixed, wall-clock fallback for
  missing/odd values) and pass it as `_time`.
- The MQTT/AMQP hand-written producer adapters take the **named** `created`
  template variable, so they translate the bridge's `_time` back to
  `created` before calling the generated publish method. (Generated code is
  untouched; only the hand-written adapters + bridge changed.)

## Testing
- 6 gracedb unit tests pass: mock fetch/parse, single-cycle exit,
  `created_to_rfc3339` parse + fallback.
- All three Docker E2E flow tests pass **deterministically** locally:
  - Kafka `TestGraceDBDockerFlow` — 38s
  - MQTT `TestGraceDbMqttDockerFlow` — 64s
  - AMQP `TestGracedbAmqpDockerFlow` — 173s

## Notes
Generated producer code was not hand-edited. The CE-time fix lives in the
bridge (`created_to_rfc3339`) and the two hand-written transport adapters.

Refs #818.
