### PR TITLE
fix(nws-alerts): map MQTT severity to per-severity publish methods

### DIFF
--- a/feeders/nws-alerts/nws_alerts_mqtt/nws_alerts_mqtt/app.py
+++ b/feeders/nws-alerts/nws_alerts_mqtt/nws_alerts_mqtt/app.py
@@ -29,11 +29,11 @@ from nws_alerts_mqtt_producer_mqtt_client.client import NWSAlertsMqttMqttClient
 logger = logging.getLogger("nws_alerts_mqtt")
 
 SEVERITY_METHODS = {
-    "minor": "publish_nws_weather_alert_mqtt",
-    "moderate": "publish_nws_weather_alert_mqtt",
-    "severe": "publish_nws_weather_alert_mqtt",
-    "extreme": "publish_nws_weather_alert_mqtt",
-    "unknown": "publish_nws_weather_alert_mqtt",
+    "minor": "publish_nws_weather_alert_minor_mqtt",
+    "moderate": "publish_nws_weather_alert_moderate_mqtt",
+    "severe": "publish_nws_weather_alert_severe_mqtt",
+    "extreme": "publish_nws_weather_alert_extreme_mqtt",
+    "unknown": "publish_nws_weather_alert_unknown_mqtt",
 }
 
 
@@ -74,7 +74,6 @@ class NWSAlertsMqttBridge:
         await method(
             alert_id=uns_slug(alert.alert_id),
             state=uns_slug(alert.state),
-            severity=severity,
             event_type=uns_slug(alert.event_type),
             data=_to_mqtt_alert(alert),
             qos=1,


### PR DESCRIPTION
## Summary
Fixes a real pre-existing bug in the nws-alerts **MQTT** bridge surfaced by the MQTT Docker flow.

`SEVERITY_METHODS` mapped every CAP severity to a single non-existent client method `publish_nws_weather_alert_mqtt` and the call site passed `severity=`. The generated MQTT client emits **per-severity** methods because severity is an MQTT topic axis (`alerts/us/noaa/nws-alerts/{state}/<severity>/{event_type}/{alert_id}/alert`):

- `publish_nws_weather_alert_minor_mqtt`
- `publish_nws_weather_alert_moderate_mqtt`
- `publish_nws_weather_alert_severe_mqtt`
- `publish_nws_weather_alert_extreme_mqtt`
- `publish_nws_weather_alert_unknown_mqtt`

None accept a `severity` argument. So every MQTT publish (live poll **and** mock corpus) raised `AttributeError: ... has no attribute 'publish_nws_weather_alert_mqtt'`.

## Fix
- Map each severity to its suffixed client method.
- Drop the `severity=` kwarg (baked into the method/topic literal).

## Validation
- `TestNwsAlertsMqttDockerFlow` Docker E2E flow **passes** (1 passed, 55.5s) — builds the image, runs the broker, validates topic/subject/schema.

No contract or generated-code change; bridge-only fix.
