### PR TITLE
Fix MQTT generated-client drift for xrcg 0.10.14

### DIFF
--- a/feeders/aisstream/aisstream_mqtt_producer/aisstream_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/aisstream/aisstream_mqtt_producer/aisstream_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,11 @@ async def test_io_aisstream_mqtt_io_aisstream_mqtt_position_report_py(mosquitto_
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -159,8 +162,11 @@ async def test_io_aisstream_mqtt_io_aisstream_mqtt_ship_static_py(mosquitto_brok
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -224,8 +230,11 @@ async def test_io_aisstream_mqtt_io_aisstream_mqtt_aid_to_navigation_py(mosquitt
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/autobahn/autobahn_mqtt_producer/autobahn_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/autobahn/autobahn_mqtt_producer/autobahn_mqtt_producer_mqtt_client/tests/test_client.py
@@ -99,8 +99,9 @@ async def test_de_autobahn_mqtt_de_autobahn_roadwork_appeared_mqtt_py(mosquitto_
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -165,8 +166,9 @@ async def test_de_autobahn_mqtt_de_autobahn_roadwork_updated_mqtt_py(mosquitto_b
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -231,8 +233,9 @@ async def test_de_autobahn_mqtt_de_autobahn_roadwork_resolved_mqtt_py(mosquitto_
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -297,8 +300,9 @@ async def test_de_autobahn_mqtt_de_autobahn_short_term_roadwork_appeared_mqtt_py
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -363,8 +367,9 @@ async def test_de_autobahn_mqtt_de_autobahn_short_term_roadwork_updated_mqtt_py(
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -429,8 +434,9 @@ async def test_de_autobahn_mqtt_de_autobahn_short_term_roadwork_resolved_mqtt_py
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -495,8 +501,9 @@ async def test_de_autobahn_mqtt_de_autobahn_closure_appeared_mqtt_py(mosquitto_b
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -561,8 +568,9 @@ async def test_de_autobahn_mqtt_de_autobahn_closure_updated_mqtt_py(mosquitto_br
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -627,8 +635,9 @@ async def test_de_autobahn_mqtt_de_autobahn_closure_resolved_mqtt_py(mosquitto_b
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -693,8 +702,9 @@ async def test_de_autobahn_mqtt_de_autobahn_entry_exit_closure_appeared_mqtt_py(
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -759,8 +769,9 @@ async def test_de_autobahn_mqtt_de_autobahn_entry_exit_closure_updated_mqtt_py(m
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -825,8 +836,9 @@ async def test_de_autobahn_mqtt_de_autobahn_entry_exit_closure_resolved_mqtt_py(
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -891,8 +903,9 @@ async def test_de_autobahn_mqtt_de_autobahn_warning_appeared_mqtt_py(mosquitto_b
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -957,8 +970,9 @@ async def test_de_autobahn_mqtt_de_autobahn_warning_updated_mqtt_py(mosquitto_br
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1023,8 +1037,9 @@ async def test_de_autobahn_mqtt_de_autobahn_warning_resolved_mqtt_py(mosquitto_b
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1089,8 +1104,9 @@ async def test_de_autobahn_mqtt_de_autobahn_weight_limit35_restriction_appeared_
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1155,8 +1171,9 @@ async def test_de_autobahn_mqtt_de_autobahn_weight_limit35_restriction_updated_m
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1221,8 +1238,9 @@ async def test_de_autobahn_mqtt_de_autobahn_weight_limit35_restriction_resolved_
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1287,8 +1305,9 @@ async def test_de_autobahn_mqtt_de_autobahn_webcam_appeared_mqtt_py(mosquitto_br
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1353,8 +1372,9 @@ async def test_de_autobahn_mqtt_de_autobahn_webcam_updated_mqtt_py(mosquitto_bro
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1419,8 +1439,9 @@ async def test_de_autobahn_mqtt_de_autobahn_webcam_resolved_mqtt_py(mosquitto_br
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1485,8 +1506,9 @@ async def test_de_autobahn_mqtt_de_autobahn_parking_lorry_appeared_mqtt_py(mosqu
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1551,8 +1573,9 @@ async def test_de_autobahn_mqtt_de_autobahn_parking_lorry_updated_mqtt_py(mosqui
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1617,8 +1640,9 @@ async def test_de_autobahn_mqtt_de_autobahn_parking_lorry_resolved_mqtt_py(mosqu
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1683,8 +1707,9 @@ async def test_de_autobahn_mqtt_de_autobahn_electric_charging_station_appeared_m
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1749,8 +1774,9 @@ async def test_de_autobahn_mqtt_de_autobahn_electric_charging_station_updated_mq
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1815,8 +1841,9 @@ async def test_de_autobahn_mqtt_de_autobahn_electric_charging_station_resolved_m
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1881,8 +1908,9 @@ async def test_de_autobahn_mqtt_de_autobahn_strong_electric_charging_station_app
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1947,8 +1975,9 @@ async def test_de_autobahn_mqtt_de_autobahn_strong_electric_charging_station_upd
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -2013,8 +2042,9 @@ async def test_de_autobahn_mqtt_de_autobahn_strong_electric_charging_station_res
             identifier=f"test_identifier_{i}",
             event_time=f"test_event_time_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/bafu-hydro/bafu_hydro_mqtt_producer/bafu_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/bafu-hydro/bafu_hydro_mqtt_producer/bafu_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_ch_bafu_hydrology_mqtt_ch_bafu_hydrology_mqtt_station_py(mosquitt
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body_name="test_water_body_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_ch_bafu_hydrology_mqtt_ch_bafu_hydrology_mqtt_water_level_observa
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body_name="test_water_body_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt_producer/bfs_odl_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_de_bfs_odl_mqtt_de_bfs_odl_mqtt_station_py(mosquitto_broker):
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_de_bfs_odl_mqtt_de_bfs_odl_mqtt_dose_rate_measurement_py(mosquitt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/billetto/billetto_mqtt_producer/billetto_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/billetto/billetto_mqtt_producer/billetto_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,11 @@ async def test_billetto_events_mqtt_billetto_events_mqtt_event_py(mosquitto_brok
             event_id=f"test_event_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            category="test_category",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/blitzortung/blitzortung_mqtt_producer/blitzortung_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/blitzortung/blitzortung_mqtt_producer/blitzortung_mqtt_producer_mqtt_client/tests/test_client.py
@@ -93,8 +93,10 @@ async def test_blitzortung_lightning_mqtt_blitzortung_lightning_mqtt_lightning_s
             stroke_id=f"test_stroke_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            geohash5="test_geohash5",
+            geohash7="test_geohash7",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/bluesky/bluesky_mqtt_producer/bluesky_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/bluesky/bluesky_mqtt_producer/bluesky_mqtt_producer_mqtt_client/tests/test_client.py
@@ -101,8 +101,10 @@ async def test_blueskyfirehose_mqtt_bluesky_feed_post_mqtt_py(mosquitto_broker):
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -167,8 +169,10 @@ async def test_blueskyfirehose_mqtt_bluesky_feed_like_mqtt_py(mosquitto_broker):
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -233,8 +237,10 @@ async def test_blueskyfirehose_mqtt_bluesky_feed_repost_mqtt_py(mosquitto_broker
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -299,8 +305,10 @@ async def test_blueskyfirehose_mqtt_bluesky_graph_follow_mqtt_py(mosquitto_broke
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -365,8 +373,10 @@ async def test_blueskyfirehose_mqtt_bluesky_graph_block_mqtt_py(mosquitto_broker
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -431,8 +441,10 @@ async def test_blueskyfirehose_mqtt_bluesky_actor_profile_mqtt_py(mosquitto_brok
             firehoseurl=f"test_firehoseurl_{i}",
             did=f"test_did_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            collection="test_collection",
+            lang="test_lang",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/bom-australia/bom_australia_mqtt_producer/bom_australia_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/bom-australia/bom_australia_mqtt_producer/bom_australia_mqtt_producer_mqtt_client/tests/test_client.py
@@ -97,8 +97,9 @@ async def test_au_gov_bom_weather_mqtt_au_gov_bom_weather_mqtt_station_py(mosqui
             station_wmo=f"test_station_wmo_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -163,8 +164,9 @@ async def test_au_gov_bom_weather_mqtt_au_gov_bom_weather_mqtt_weather_observati
             station_wmo=f"test_station_wmo_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice_mqtt_producer/canada_eccc_wateroffice_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice_mqtt_producer/canada_eccc_wateroffice_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_ca_gov_eccc_hydro_mqtt_ca_gov_eccc_hydro_mqtt_station_py(mosquitt
             station_number=f"test_station_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_ca_gov_eccc_hydro_mqtt_ca_gov_eccc_hydro_mqtt_observation_py(mosq
             station_number=f"test_station_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/carbon-intensity/carbon_intensity_mqtt_producer/carbon_intensity_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/carbon-intensity/carbon_intensity_mqtt_producer/carbon_intensity_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_uk_org_carbonintensity_mqtt_uk_org_carbonintensity_mqtt_intensity
             period_from=f"test_period_from_{i}",
             ce_id=f"test_ce_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -161,8 +162,9 @@ async def test_uk_org_carbonintensity_mqtt_uk_org_carbonintensity_mqtt_generatio
             period_from=f"test_period_from_{i}",
             ce_id=f"test_ce_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -227,8 +229,9 @@ async def test_uk_org_carbonintensity_mqtt_uk_org_carbonintensity_mqtt_regional_
             region_id=f"test_region_id_{i}",
             ce_id=f"test_ce_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/cbp-border-wait/cbp_border_wait_mqtt_producer/cbp_border_wait_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/cbp-border-wait/cbp_border_wait_mqtt_producer/cbp_border_wait_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_gov_cbp_borderwait_mqtt_gov_cbp_borderwait_mqtt_port_py(mosquitto
             topic=test_topic,
             port_number=f"test_port_number_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            border_slug="test_border_slug",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_gov_cbp_borderwait_mqtt_gov_cbp_borderwait_mqtt_wait_time_py(mosq
             topic=test_topic,
             port_number=f"test_port_number_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            border_slug="test_border_slug",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/cdec-reservoirs/cdec_reservoirs_mqtt_producer/cdec_reservoirs_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/cdec-reservoirs/cdec_reservoirs_mqtt_producer/cdec_reservoirs_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_gov_ca_water_cdec_mqtt_gov_ca_water_cdec_mqtt_reservoir_reading_p
             sensor_num=f"test_sensor_num_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/chmi-hydro/chmi_hydro_mqtt_producer/chmi_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/chmi-hydro/chmi_hydro_mqtt_producer/chmi_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_cz_gov_chmi_hydro_mqtt_cz_gov_chmi_hydro_mqtt_station_py(mosquitt
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            stream_name="test_stream_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_cz_gov_chmi_hydro_mqtt_cz_gov_chmi_hydro_mqtt_water_level_observa
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            stream_name="test_stream_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/defra-aurn/defra_aurn_mqtt_producer/defra_aurn_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/defra-aurn/defra_aurn_mqtt_producer/defra_aurn_mqtt_producer_mqtt_client/tests/test_client.py
@@ -97,8 +97,9 @@ async def test_uk_gov_defra_aurn_stations_mqtt_uk_gov_defra_aurn_stations_mqtt_s
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -166,8 +167,11 @@ async def test_uk_gov_defra_aurn_timeseries_mqtt_uk_gov_defra_aurn_timeseries_mq
             timeseries_id=f"test_timeseries_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            station_id="test_station_id",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -232,8 +236,11 @@ async def test_uk_gov_defra_aurn_timeseries_mqtt_uk_gov_defra_aurn_timeseries_mq
             timeseries_id=f"test_timeseries_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            station_id="test_station_id",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/dwd/dwd_mqtt_producer/dwd_mqtt_producer_mqtt_client/tests/test_client.py
@@ -119,8 +119,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_station_metadata_py(mosquitto_bro
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -185,8 +186,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_air_temperature10_min_py(mosquitt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -251,8 +253,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_precipitation10_min_py(mosquitto_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -317,8 +320,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_wind10_min_py(mosquitto_broker):
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -383,8 +387,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_solar10_min_py(mosquitto_broker):
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -449,8 +454,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_hourly_observation_py(mosquitto_b
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -515,8 +521,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_extreme_wind10_min_py(mosquitto_b
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -581,8 +588,9 @@ async def test_de_dwd_cdc_mqtt_de_dwd_cdc_mqtt_extreme_temperature10_min_py(mosq
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/eaws-albina/eaws_albina_mqtt_producer/eaws_albina_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/eaws-albina/eaws_albina_mqtt_producer/eaws_albina_mqtt_producer_mqtt_client/tests/test_client.py
@@ -90,8 +90,10 @@ async def test_org_eaws_albina_mqtt_org_eaws_albina_mqtt_avalanche_bulletin_py(m
             topic=test_topic,
             region_id=f"test_region_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            danger_level="test_danger_level",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/elexon-bmrs/elexon_bmrs_mqtt_producer/elexon_bmrs_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/elexon-bmrs/elexon_bmrs_mqtt_producer/elexon_bmrs_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,9 @@ async def test_uk_co_elexon_bmrs_mqtt_uk_co_elexon_bmrs_mqtt_generation_mix_py(m
             settlement_period=f"test_settlement_period_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            settlement_date="test_settlement_date",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_uk_co_elexon_bmrs_mqtt_uk_co_elexon_bmrs_mqtt_demand_outturn_py(m
             settlement_period=f"test_settlement_period_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            settlement_date="test_settlement_date",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -228,8 +230,9 @@ async def test_uk_co_elexon_bmrs_mqtt_uk_co_elexon_bmrs_mqtt_info_py(mosquitto_b
             settlement_period=f"test_settlement_period_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            settlement_date="test_settlement_date",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/entur-norway/entur_norway_mqtt_producer/entur_norway_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/entur-norway/entur_norway_mqtt_producer/entur_norway_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,10 @@ async def test_no_entur_mqtt_no_entur_mqtt_estimated_vehicle_journey_py(mosquitt
             operating_day=f"test_operating_day_{i}",
             service_journey_id=f"test_service_journey_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            operator_ref="test_operator_ref",
+            line_ref="test_line_ref",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -161,8 +163,10 @@ async def test_no_entur_mqtt_no_entur_mqtt_monitored_vehicle_journey_py(mosquitt
             operating_day=f"test_operating_day_{i}",
             service_journey_id=f"test_service_journey_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            operator_ref="test_operator_ref",
+            line_ref="test_line_ref",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -226,8 +230,9 @@ async def test_no_entur_mqtt_no_entur_mqtt_pt_situation_element_py(mosquitto_bro
             topic=test_topic,
             situation_number=f"test_situation_number_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            severity="test_severity",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/environment-canada/environment_canada_mqtt_producer/environment_canada_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/environment-canada/environment_canada_mqtt_producer/environment_canada_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_ca_gov_eccc_weather_mqtt_ca_gov_eccc_weather_mqtt_station_py(mosq
             msc_id=f"test_msc_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            province="test_province",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_ca_gov_eccc_weather_mqtt_ca_gov_eccc_weather_mqtt_weather_observa
             msc_id=f"test_msc_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            province="test_province",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/epa-uv/epa_uv_mqtt_producer/epa_uv_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,11 @@ async def test_us_epa_uvindex_mqtt_us_epa_uvindex_mqtt_hourly_forecast_py(mosqui
             topic=test_topic,
             location_id=f"test_location_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            city_slug="test_city_slug",
+            forecast_hour="test_forecast_hour",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +160,11 @@ async def test_us_epa_uvindex_mqtt_us_epa_uvindex_mqtt_daily_forecast_py(mosquit
             topic=test_topic,
             location_id=f"test_location_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            city_slug="test_city_slug",
+            forecast_date="test_forecast_date",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/eurdep-radiation/eurdep_radiation_mqtt_producer/eurdep_radiation_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/eurdep-radiation/eurdep_radiation_mqtt_producer/eurdep_radiation_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_eu_jrc_eurdep_mqtt_eu_jrc_eurdep_mqtt_station_py(mosquitto_broker
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_eu_jrc_eurdep_mqtt_eu_jrc_eurdep_mqtt_dose_rate_reading_py(mosqui
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/fienta/fienta_mqtt_producer/fienta_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/fienta/fienta_mqtt_producer/fienta_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,11 @@ async def test_com_fienta_mqtt_com_fienta_mqtt_event_py(mosquitto_broker):
             event_id=f"test_event_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            category="test_category",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +163,11 @@ async def test_com_fienta_mqtt_com_fienta_mqtt_event_sale_status_py(mosquitto_br
             event_id=f"test_event_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            category="test_category",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/fmi-finland/fmi_finland_mqtt_producer/fmi_finland_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/fmi-finland/fmi_finland_mqtt_producer/fmi_finland_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_fi_fmi_opendata_airquality_mqtt_fi_fmi_opendata_airquality_mqtt_s
             fmisid=f"test_fmisid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_fi_fmi_opendata_airquality_mqtt_fi_fmi_opendata_airquality_mqtt_o
             fmisid=f"test_fmisid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/french-road-traffic/french_road_traffic_mqtt_producer/french_road_traffic_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/french-road-traffic/french_road_traffic_mqtt_producer/french_road_traffic_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,9 @@ async def test_fr_gouv_transport_bison_fute_traffic_flow_mqtt_fr_gouv_transport_
             site_id=f"test_site_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -166,8 +167,9 @@ async def test_fr_gouv_transport_bison_fute_road_event_mqtt_fr_gouv_transport_bi
             situation_id=f"test_situation_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/gdacs/gdacs_mqtt_producer/gdacs_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/gdacs/gdacs_mqtt_producer/gdacs_mqtt_producer_mqtt_client/tests/test_client.py
@@ -91,8 +91,10 @@ async def test_gdacs_alerts_mqtt_gdacs_alerts_mqtt_disaster_alert_py(mosquitto_b
             event_type=f"test_event_type_{i}",
             event_id=f"test_event_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            alert_color="test_alert_color",
+            country="test_country",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_at_geosphere_tawes_mqtt_at_geosphere_tawes_mqtt_weather_station_p
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            bundesland="test_bundesland",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_at_geosphere_tawes_mqtt_at_geosphere_tawes_mqtt_weather_observati
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            bundesland="test_bundesland",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/german-waters/german_waters_mqtt_producer/german_waters_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_de_waters_hydrology_mqtt_de_waters_hydrology_mqtt_station_py(mosq
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body="test_water_body",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_de_waters_hydrology_mqtt_de_waters_hydrology_mqtt_water_level_obs
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body="test_water_body",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/gios-poland/gios_poland_mqtt_producer/gios_poland_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/gios-poland/gios_poland_mqtt_producer/gios_poland_mqtt_producer_mqtt_client/tests/test_client.py
@@ -98,8 +98,10 @@ async def test_pl_gov_gios_airquality_mqtt_pl_gov_gios_airquality_mqtt_station_p
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            voivodeship="test_voivodeship",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -165,8 +167,10 @@ async def test_pl_gov_gios_airquality_mqtt_pl_gov_gios_airquality_mqtt_sensor_py
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            voivodeship="test_voivodeship",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -232,8 +236,10 @@ async def test_pl_gov_gios_airquality_mqtt_pl_gov_gios_airquality_mqtt_measureme
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            voivodeship="test_voivodeship",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -298,8 +304,10 @@ async def test_pl_gov_gios_airquality_mqtt_pl_gov_gios_airquality_mqtt_air_quali
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            voivodeship="test_voivodeship",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/gracedb/gracedb_mqtt_producer/gracedb_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/gracedb/gracedb_mqtt_producer/gracedb_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,10 @@ async def test_org_ligo_gracedb_mqtt_org_ligo_gracedb_mqtt_superevent_py(mosquit
             superevent_id=f"test_superevent_id_{i}",
             created=f"test_created_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            category="test_category",
+            group="test_group",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/gtfs/gtfs_mqtt_producer/gtfs_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/gtfs/gtfs_mqtt_producer/gtfs_mqtt_producer_mqtt_client/tests/test_client.py
@@ -154,8 +154,10 @@ async def test_generaltransitfeedrealtime_mqtt_general_transit_feed_real_time_ve
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            route_id="test_route_id",
+            vehicle_id="test_vehicle_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -221,8 +223,10 @@ async def test_generaltransitfeedrealtime_mqtt_general_transit_feed_real_time_tr
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            route_id="test_route_id",
+            trip_id="test_trip_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -288,8 +292,10 @@ async def test_generaltransitfeedrealtime_mqtt_general_transit_feed_real_time_al
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            route_id="test_route_id",
+            alert_id="test_alert_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -358,8 +364,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_agency_
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -425,8 +432,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_areas_m
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -492,8 +500,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_attribu
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -559,8 +568,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_booking_rules_
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -626,8 +636,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_at
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -693,8 +704,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_le
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -760,8 +772,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_me
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -827,8 +840,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_pr
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -894,8 +908,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_ru
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -961,8 +976,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_fare_tr
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1028,8 +1044,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_feed_in
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1095,8 +1112,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_frequen
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1162,8 +1180,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_levels_
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1229,8 +1248,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_locatio
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1296,8 +1316,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_locatio
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1363,8 +1384,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_locatio
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1430,8 +1452,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_network
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1497,8 +1520,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_pathway
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1564,8 +1588,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_route_n
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1631,8 +1656,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_routes_
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1698,8 +1724,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_shapes_
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1765,8 +1792,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_stop_ar
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1832,8 +1860,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_stops_m
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1899,8 +1928,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_stop_ti
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -1966,8 +1996,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_timefra
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -2033,8 +2064,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_transfe
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -2100,8 +2132,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_transla
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -2167,8 +2200,9 @@ async def test_generaltransitfeedstatic_mqtt_general_transit_feed_static_trips_m
             agencyid=f"test_agencyid_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            row_id="test_row_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/hko-hong-kong/hko_hong_kong_mqtt_producer/hko_hong_kong_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/hko-hong-kong/hko_hong_kong_mqtt_producer/hko_hong_kong_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_hk_gov_hko_weather_mqtt_hk_gov_hko_weather_mqtt_station_py(mosqui
             place_id=f"test_place_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_hk_gov_hko_weather_mqtt_hk_gov_hko_weather_mqtt_weather_observati
             place_id=f"test_place_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/hongkong-epd/hongkong_epd_mqtt_producer/hongkong_epd_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/hongkong-epd/hongkong_epd_mqtt_producer/hongkong_epd_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_hk_gov_epd_aqhi_mqtt_hk_gov_epd_aqhi_mqtt_station_py(mosquitto_br
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_hk_gov_epd_aqhi_mqtt_hk_gov_epd_aqhi_mqtt_aqhireading_py(mosquitt
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_fr_gov_eaufrance_hubeau_hydrometrie_mqtt_fr_gov_eaufrance_hub_eau
             code_station=f"test_code_station_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_fr_gov_eaufrance_hubeau_hydrometrie_mqtt_fr_gov_eaufrance_hub_eau
             code_station=f"test_code_station_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/imgw-hydro/imgw_hydro_mqtt_producer/imgw_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/imgw-hydro/imgw_hydro_mqtt_producer/imgw_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_pl_gov_imgw_hydro_mqtt_pl_gov_imgw_hydro_mqtt_station_py(mosquitt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_pl_gov_imgw_hydro_mqtt_pl_gov_imgw_hydro_mqtt_water_level_observa
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/irceline-belgium/irceline_belgium_mqtt_producer/irceline_belgium_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/irceline-belgium/irceline_belgium_mqtt_producer/irceline_belgium_mqtt_producer_mqtt_client/tests/test_client.py
@@ -97,8 +97,9 @@ async def test_be_irceline_stations_mqtt_be_irceline_stations_mqtt_station_py(mo
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -166,8 +167,11 @@ async def test_be_irceline_timeseries_mqtt_be_irceline_timeseries_mqtt_timeserie
             timeseries_id=f"test_timeseries_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            station_id="test_station_id",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -232,8 +236,11 @@ async def test_be_irceline_timeseries_mqtt_be_irceline_timeseries_mqtt_observati
             timeseries_id=f"test_timeseries_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            station_id="test_station_id",
+            pollutant="test_pollutant",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel_mqtt_producer/ireland_opw_waterlevel_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel_mqtt_producer/ireland_opw_waterlevel_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_ie_gov_opw_waterlevel_mqtt_ie_gov_opw_waterlevel_mqtt_station_py(
             station_ref=f"test_station_ref_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_ie_gov_opw_waterlevel_mqtt_ie_gov_opw_waterlevel_mqtt_water_level
             station_ref=f"test_station_ref_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,10 @@ async def test_jp_jma_amedas_mqtt_jp_jma_amedas_mqtt_station_py(mosquitto_broker
             station_code=f"test_station_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +164,10 @@ async def test_jp_jma_amedas_mqtt_jp_jma_amedas_mqtt_observation_py(mosquitto_br
             station_code=f"test_station_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/jma-bosai-quake/jma_bosai_quake_mqtt_producer/jma_bosai_quake_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/jma-bosai-quake/jma_bosai_quake_mqtt_producer/jma_bosai_quake_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,10 @@ async def test_jp_jma_quake_mqtt_jp_jma_quake_mqtt_earthquake_report_py(mosquitt
             serial=f"test_serial_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            magnitude_bucket="test_magnitude_bucket",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_mqtt_client/tests/test_client.py
@@ -97,8 +97,10 @@ async def test_jp_jma_volcano_mqtt_jp_jma_volcano_mqtt_volcano_py(mosquitto_brok
             volcano_code=f"test_volcano_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -164,8 +166,10 @@ async def test_jp_jma_volcano_mqtt_jp_jma_volcano_mqtt_volcanic_warning_py(mosqu
             volcano_code=f"test_volcano_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -231,8 +235,10 @@ async def test_jp_jma_volcano_mqtt_jp_jma_volcano_mqtt_volcanic_eruption_py(mosq
             volcano_code=f"test_volcano_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_mqtt_client/tests/test_client.py
@@ -98,8 +98,11 @@ async def test_jp_jma_warning_mqtt_jp_jma_warning_mqtt_office_py(mosquitto_broke
             area_code=f"test_area_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            severity="test_severity",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -166,8 +169,11 @@ async def test_jp_jma_warning_mqtt_jp_jma_warning_mqtt_weather_warning_py(mosqui
             area_code=f"test_area_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            severity="test_severity",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -234,8 +240,10 @@ async def test_jp_jma_warning_mqtt_jp_jma_warning_mqtt_tsunami_alert_py(mosquitt
             serial=f"test_serial_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            prefecture="test_prefecture",
+            severity="test_severity",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/kmi-belgium/kmi_belgium_mqtt_producer/kmi_belgium_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/kmi-belgium/kmi_belgium_mqtt_producer/kmi_belgium_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_be_gov_kmi_weather_mqtt_be_gov_kmi_weather_mqtt_station_py(mosqui
             station_code=f"test_station_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_be_gov_kmi_weather_mqtt_be_gov_kmi_weather_mqtt_weather_observati
             station_code=f"test_station_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/kystverket-ais/kystverket_ais_mqtt_producer/kystverket_ais_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/kystverket-ais/kystverket_ais_mqtt_producer/kystverket_ais_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,11 @@ async def test_no_kystverket_ais_mqtt_no_kystverket_ais_mqtt_position_report_py(
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -159,8 +162,11 @@ async def test_no_kystverket_ais_mqtt_no_kystverket_ais_mqtt_ship_static_py(mosq
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -224,8 +230,11 @@ async def test_no_kystverket_ais_mqtt_no_kystverket_ais_mqtt_aid_to_navigation_p
             topic=test_topic,
             mmsi=f"test_mmsi_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flag="test_flag",
+            ship_type="test_ship_type",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/laqn-london/laqn_london_mqtt_producer/laqn_london_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/laqn-london/laqn_london_mqtt_producer/laqn_london_mqtt_producer_mqtt_client/tests/test_client.py
@@ -99,8 +99,10 @@ async def test_uk_kcl_laqn_mqtt_uk_kcl_laqn_mqtt_site_py(mosquitto_broker):
             site_code=f"test_site_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            borough="test_borough",
+            species_code="test_species_code",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -165,8 +167,10 @@ async def test_uk_kcl_laqn_mqtt_uk_kcl_laqn_mqtt_measurement_py(mosquitto_broker
             site_code=f"test_site_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            borough="test_borough",
+            species_code="test_species_code",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -231,8 +235,10 @@ async def test_uk_kcl_laqn_mqtt_uk_kcl_laqn_mqtt_daily_index_py(mosquitto_broker
             site_code=f"test_site_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            borough="test_borough",
+            species_code="test_species_code",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -300,8 +306,10 @@ async def test_uk_kcl_laqn_species_mqtt_uk_kcl_laqn_species_mqtt_species_py(mosq
             species_code=f"test_species_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            borough="test_borough",
+            site_code="test_site_code",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt_producer/luchtmeetnet_nl_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt_producer/luchtmeetnet_nl_mqtt_producer_mqtt_client/tests/test_client.py
@@ -99,8 +99,10 @@ async def test_nl_rivm_luchtmeetnet_mqtt_nl_rivm_luchtmeetnet_mqtt_station_py(mo
             station_number=f"test_station_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            formula="test_formula",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -165,8 +167,10 @@ async def test_nl_rivm_luchtmeetnet_mqtt_nl_rivm_luchtmeetnet_mqtt_measurement_p
             station_number=f"test_station_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            formula="test_formula",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -231,8 +235,10 @@ async def test_nl_rivm_luchtmeetnet_mqtt_nl_rivm_luchtmeetnet_mqtt_lki_py(mosqui
             station_number=f"test_station_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            formula="test_formula",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -300,8 +306,10 @@ async def test_nl_rivm_luchtmeetnet_components_mqtt_nl_rivm_luchtmeetnet_compone
             formula=f"test_formula_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            station_number="test_station_number",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/madrid-traffic/madrid_traffic_mqtt_producer/madrid_traffic_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/madrid-traffic/madrid_traffic_mqtt_producer/madrid_traffic_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_es_madrid_informo_mqtt_es_madrid_informo_measurement_point_mqtt_p
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_es_madrid_informo_mqtt_es_madrid_informo_traffic_reading_mqtt_py(
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            district="test_district",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/meteoalarm/meteoalarm_mqtt_producer/meteoalarm_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/meteoalarm/meteoalarm_mqtt_producer/meteoalarm_mqtt_producer_mqtt_client/tests/test_client.py
@@ -90,8 +90,11 @@ async def test_meteoalarm_warnings_mqtt_meteoalarm_warnings_mqtt_weather_warning
             topic=test_topic,
             identifier=f"test_identifier_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            severity="test_severity",
+            awareness_type="test_awareness_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nasa-firms/nasa_firms_mqtt_producer/nasa_firms_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nasa-firms/nasa_firms_mqtt_producer/nasa_firms_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,10 @@ async def test_nasa_firms_mqtt_nasa_firms_mqtt_fire_detection_py(mosquitto_broke
             record_id=f"test_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            confidence_level="test_confidence_level",
+            tile="test_tile",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/ndw-road-traffic/ndw_road_traffic_mqtt_producer/ndw_road_traffic_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/ndw-road-traffic/ndw_road_traffic_mqtt_producer/ndw_road_traffic_mqtt_producer_mqtt_client/tests/test_client.py
@@ -119,8 +119,9 @@ async def test_nl_ndw_avg_mqtt_nl_ndw_avg_point_measurement_site_mqtt_py(mosquit
             measurement_site_id=f"test_measurement_site_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -185,8 +186,9 @@ async def test_nl_ndw_avg_mqtt_nl_ndw_avg_route_measurement_site_mqtt_py(mosquit
             measurement_site_id=f"test_measurement_site_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -251,8 +253,9 @@ async def test_nl_ndw_avg_mqtt_nl_ndw_avg_traffic_observation_mqtt_py(mosquitto_
             measurement_site_id=f"test_measurement_site_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -317,8 +320,9 @@ async def test_nl_ndw_avg_mqtt_nl_ndw_avg_travel_time_observation_mqtt_py(mosqui
             measurement_site_id=f"test_measurement_site_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -387,8 +391,9 @@ async def test_nl_ndw_drip_mqtt_nl_ndw_drip_drip_sign_mqtt_py(mosquitto_broker):
             vms_index=f"test_vms_index_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -454,8 +459,9 @@ async def test_nl_ndw_drip_mqtt_nl_ndw_drip_drip_display_state_mqtt_py(mosquitto
             vms_index=f"test_vms_index_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -523,8 +529,9 @@ async def test_nl_ndw_msi_mqtt_nl_ndw_msi_msi_sign_mqtt_py(mosquitto_broker):
             sign_id=f"test_sign_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -589,8 +596,9 @@ async def test_nl_ndw_msi_mqtt_nl_ndw_msi_msi_display_state_mqtt_py(mosquitto_br
             sign_id=f"test_sign_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -658,8 +666,9 @@ async def test_nl_ndw_situations_mqtt_nl_ndw_situations_roadwork_mqtt_py(mosquit
             situation_record_id=f"test_situation_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -724,8 +733,9 @@ async def test_nl_ndw_situations_mqtt_nl_ndw_situations_bridge_opening_mqtt_py(m
             situation_record_id=f"test_situation_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -790,8 +800,9 @@ async def test_nl_ndw_situations_mqtt_nl_ndw_situations_temporary_closure_mqtt_p
             situation_record_id=f"test_situation_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -856,8 +867,9 @@ async def test_nl_ndw_situations_mqtt_nl_ndw_situations_temporary_speed_limit_mq
             situation_record_id=f"test_situation_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -922,8 +934,9 @@ async def test_nl_ndw_situations_mqtt_nl_ndw_situations_safety_related_message_m
             situation_record_id=f"test_situation_record_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            road="test_road",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology_mqtt_producer/nepal_bipad_hydrology_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology_mqtt_producer/nepal_bipad_hydrology_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_np_gov_bipad_hydrology_mqtt_np_gov_bipad_hydrology_mqtt_river_sta
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_np_gov_bipad_hydrology_mqtt_np_gov_bipad_hydrology_mqtt_water_lev
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nextbus/nextbus_mqtt_producer/nextbus_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nextbus/nextbus_mqtt_producer/nextbus_mqtt_producer_mqtt_client/tests/test_client.py
@@ -100,8 +100,10 @@ async def test_nextbus_mqtt_nextbus_vehicle_position_mqtt_py(mosquitto_broker):
             vehicle_id=f"test_vehicle_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event_type="test_event_type",
+            stop_or_vehicle_id="test_stop_or_vehicle_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -168,8 +170,9 @@ async def test_nextbus_mqtt_nextbus_route_config_mqtt_py(mosquitto_broker):
             stop_or_vehicle_id=f"test_stop_or_vehicle_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -236,8 +239,9 @@ async def test_nextbus_mqtt_nextbus_schedule_mqtt_py(mosquitto_broker):
             stop_or_vehicle_id=f"test_stop_or_vehicle_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -304,8 +308,9 @@ async def test_nextbus_mqtt_nextbus_message_mqtt_py(mosquitto_broker):
             stop_or_vehicle_id=f"test_stop_or_vehicle_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt_producer/nifc_usa_wildfires_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt_producer/nifc_usa_wildfires_mqtt_producer_mqtt_client/tests/test_client.py
@@ -93,8 +93,10 @@ async def test_gov_nifc_wildfires_mqtt_gov_nifc_wildfires_mqtt_wildfire_incident
             irwin_id=f"test_irwin_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            status="test_status",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nina-bbk/nina_bbk_mqtt_producer/nina_bbk_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nina-bbk/nina_bbk_mqtt_producer/nina_bbk_mqtt_producer_mqtt_client/tests/test_client.py
@@ -90,8 +90,10 @@ async def test_nina_warnings_mqtt_nina_warnings_mqtt_civil_warning_py(mosquitto_
             topic=test_topic,
             warning_id=f"test_warning_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            severity="test_severity",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/noaa-goes/noaa_goes_mqtt_producer/noaa_goes_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/noaa-goes/noaa_goes_mqtt_producer/noaa_goes_mqtt_producer_mqtt_client/tests/test_client.py
@@ -104,8 +104,9 @@ async def test_microsoft_opendata_us_noaa_swpc_goes_mqtt_microsoft_open_data_us_
             time_tag=f"test_time_tag_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -172,8 +173,9 @@ async def test_microsoft_opendata_us_noaa_swpc_goes_mqtt_microsoft_open_data_us_
             time_tag=f"test_time_tag_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -240,8 +242,9 @@ async def test_microsoft_opendata_us_noaa_swpc_goes_mqtt_microsoft_open_data_us_
             time_tag=f"test_time_tag_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -307,8 +310,9 @@ async def test_microsoft_opendata_us_noaa_swpc_goes_mqtt_microsoft_open_data_us_
             time_tag=f"test_time_tag_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -440,8 +444,9 @@ async def test_microsoft_opendata_us_noaa_swpc_goes_mqtt_microsoft_open_data_us_
             begin_time=f"test_begin_time_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            flare_class="test_flare_class",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/noaa-ndbc/noaa_ndbc_mqtt_producer/noaa_ndbc_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/noaa-ndbc/noaa_ndbc_mqtt_producer/noaa_ndbc_mqtt_producer_mqtt_client/tests/test_client.py
@@ -108,8 +108,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -174,8 +175,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -240,8 +242,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -306,8 +309,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -372,8 +376,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -438,8 +443,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -504,8 +510,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -570,8 +577,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -636,8 +644,9 @@ async def test_microsoft_opendata_us_noaa_ndbc_mqtt_microsoft_open_data_us_noaa_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/noaa-nws/noaa_nws_mqtt_producer/noaa_nws_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/noaa-nws/noaa_nws_mqtt_producer/noaa_nws_mqtt_producer_mqtt_client/tests/test_client.py
@@ -169,8 +169,10 @@ async def test_microsoft_opendata_us_noaa_nws_observations_mqtt_microsoft_open_d
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            zone_id="test_zone_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -235,8 +237,10 @@ async def test_microsoft_opendata_us_noaa_nws_observations_mqtt_microsoft_open_d
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            zone_id="test_zone_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/noaa/noaa_mqtt_producer/noaa_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/noaa/noaa_mqtt_producer/noaa_mqtt_producer_mqtt_client/tests/test_client.py
@@ -116,8 +116,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -182,8 +183,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -248,8 +250,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -314,8 +317,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -380,8 +384,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -446,8 +451,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -512,8 +518,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -578,8 +585,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -644,8 +652,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -710,8 +719,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -778,8 +788,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             _dataschema=f"test_dataschema_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -844,8 +855,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -910,8 +922,9 @@ async def test_microsoft_opendata_us_noaa_mqtt_microsoft_open_data_us_noaa_mqtt_
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nve-hydro/nve_hydro_mqtt_producer/nve_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nve-hydro/nve_hydro_mqtt_producer/nve_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_no_nve_hydrology_mqtt_no_nve_hydrology_mqtt_station_py(mosquitto_
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            river_name="test_river_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_no_nve_hydrology_mqtt_no_nve_hydrology_mqtt_water_level_observati
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            river_name="test_river_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nws-alerts/nws_alerts_mqtt_producer/nws_alerts_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nws-alerts/nws_alerts_mqtt_producer/nws_alerts_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,10 @@ async def test_nws_alerts_mqtt_nws_weather_alert_minor_mqtt_py(mosquitto_broker)
             alert_id=f"test_alert_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -158,8 +160,10 @@ async def test_nws_alerts_mqtt_nws_weather_alert_moderate_mqtt_py(mosquitto_brok
             alert_id=f"test_alert_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -224,8 +228,10 @@ async def test_nws_alerts_mqtt_nws_weather_alert_severe_mqtt_py(mosquitto_broker
             alert_id=f"test_alert_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -290,8 +296,10 @@ async def test_nws_alerts_mqtt_nws_weather_alert_extreme_mqtt_py(mosquitto_broke
             alert_id=f"test_alert_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -356,8 +364,10 @@ async def test_nws_alerts_mqtt_nws_weather_alert_unknown_mqtt_py(mosquitto_broke
             alert_id=f"test_alert_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            event_type="test_event_type",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/nws-forecasts/nws_forecasts_mqtt_producer/nws_forecasts_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/nws-forecasts/nws_forecasts_mqtt_producer/nws_forecasts_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,11 @@ async def test_microsoft_opendata_us_noaa_nws_forecasts_mqtt_microsoft_open_data
             zone_id=f"test_zone_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            zone_type="test_zone_type",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +165,11 @@ async def test_microsoft_opendata_us_noaa_nws_forecasts_mqtt_microsoft_open_data
             zone_id=f"test_zone_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            zone_type="test_zone_type",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -228,8 +234,11 @@ async def test_microsoft_opendata_us_noaa_nws_forecasts_mqtt_microsoft_open_data
             zone_id=f"test_zone_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+            zone_type="test_zone_type",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/pegelonline/pegelonline_mqtt_producer/pegelonline_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,9 @@ async def test_de_wsv_pegelonline_mqtt_de_wsv_pegelonline_mqtt_station_py(mosqui
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_shortname="test_water_shortname",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +163,9 @@ async def test_de_wsv_pegelonline_mqtt_de_wsv_pegelonline_mqtt_current_measureme
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_shortname="test_water_shortname",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/ptwc-tsunami/ptwc_tsunami_mqtt_producer/ptwc_tsunami_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/ptwc-tsunami/ptwc_tsunami_mqtt_producer/ptwc_tsunami_mqtt_producer_mqtt_client/tests/test_client.py
@@ -90,8 +90,10 @@ async def test_ptwc_bulletins_mqtt_ptwc_bulletins_mqtt_tsunami_bulletin_py(mosqu
             topic=test_topic,
             bulletin_id=f"test_bulletin_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+            ptwc_level="test_ptwc_level",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/seattle-911/seattle_911_mqtt_producer/seattle_911_mqtt_producer_mqtt_client/tests/test_client.py
@@ -91,8 +91,9 @@ async def test_us_wa_seattle_fire911_mqtt_us_wa_seattle_fire911_mqtt_incident_py
             incident_number=f"test_incident_number_{i}",
             incident_datetime_utc=f"test_incident_datetime_utc_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            incident_type_slug="test_incident_type_slug",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/seattle-street-closures/seattle_street_closures_mqtt_producer/seattle_street_closures_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/seattle-street-closures/seattle_street_closures_mqtt_producer/seattle_street_closures_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_us_wa_seattle_streetclosures_mqtt_us_wa_seattle_street_closures_s
             closure_id=f"test_closure_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            neighborhood="test_neighborhood",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/sensor-community/sensor_community_mqtt_producer/sensor_community_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/sensor-community/sensor_community_mqtt_producer/sensor_community_mqtt_producer_mqtt_client/tests/test_client.py
@@ -95,8 +95,10 @@ async def test_io_sensor_community_mqtt_io_sensor_community_mqtt_sensor_info_py(
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -162,8 +164,10 @@ async def test_io_sensor_community_mqtt_io_sensor_community_mqtt_sensor_reading_
             sensor_id=f"test_sensor_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            geohash5="test_geohash5",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/singapore-nea/singapore_nea_mqtt_producer/singapore_nea_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/singapore-nea/singapore_nea_mqtt_producer/singapore_nea_mqtt_producer_mqtt_client/tests/test_client.py
@@ -101,8 +101,10 @@ async def test_sg_gov_nea_weather_mqtt_sg_gov_nea_weather_station_mqtt_py(mosqui
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -167,8 +169,10 @@ async def test_sg_gov_nea_weather_mqtt_sg_gov_nea_weather_weather_observation_mq
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -236,8 +240,10 @@ async def test_sg_gov_nea_airquality_mqtt_sg_gov_nea_air_quality_region_mqtt_py(
             region=f"test_region_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            station_id="test_station_id",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -302,8 +308,10 @@ async def test_sg_gov_nea_airquality_mqtt_sg_gov_nea_air_quality_psireading_mqtt
             region=f"test_region_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            station_id="test_station_id",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -368,8 +376,10 @@ async def test_sg_gov_nea_airquality_mqtt_sg_gov_nea_air_quality_pm25_reading_mq
             region=f"test_region_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            station_id="test_station_id",
+            event="test_event",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/smhi-hydro/smhi_hydro_mqtt_producer/smhi_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/smhi-hydro/smhi_hydro_mqtt_producer/smhi_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_se_gov_smhi_hydro_mqtt_se_gov_smhi_hydro_mqtt_station_py(mosquitt
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            catchment_name="test_catchment_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_se_gov_smhi_hydro_mqtt_se_gov_smhi_hydro_mqtt_discharge_observati
             topic=test_topic,
             station_id=f"test_station_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            catchment_name="test_catchment_name",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/smhi-weather/smhi_weather_mqtt_producer/smhi_weather_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/smhi-weather/smhi_weather_mqtt_producer/smhi_weather_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_se_gov_smhi_weather_mqtt_se_gov_smhi_weather_mqtt_station_py(mosq
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            lan="test_lan",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_se_gov_smhi_weather_mqtt_se_gov_smhi_weather_mqtt_weather_observa
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            lan="test_lan",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/snotel/snotel_mqtt_producer/snotel_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/snotel/snotel_mqtt_producer/snotel_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_gov_usda_nrcs_snotel_mqtt_gov_usda_nrcs_snotel_mqtt_station_py(mo
             station_triplet=f"test_station_triplet_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_gov_usda_nrcs_snotel_mqtt_gov_usda_nrcs_snotel_mqtt_snow_observat
             station_triplet=f"test_station_triplet_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/syke-hydro/syke_hydro_mqtt_producer/syke_hydro_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/syke-hydro/syke_hydro_mqtt_producer/syke_hydro_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_fi_syke_hydrology_mqtt_fi_syke_hydrology_mqtt_station_py(mosquitt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_fi_syke_hydrology_mqtt_fi_syke_hydrology_mqtt_water_level_observa
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            basin="test_basin",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/ticketmaster/ticketmaster_mqtt_producer/ticketmaster_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/ticketmaster/ticketmaster_mqtt_producer/ticketmaster_mqtt_producer_mqtt_client/tests/test_client.py
@@ -101,8 +101,11 @@ async def test_ticketmaster_events_mqtt_ticketmaster_events_mqtt_event_py(mosqui
             event_id=f"test_event_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            venue_id="test_venue_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -170,8 +173,11 @@ async def test_ticketmaster_reference_mqtt_ticketmaster_reference_mqtt_venue_py(
             entity_id=f"test_entity_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            venue_id="test_venue_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -236,8 +242,11 @@ async def test_ticketmaster_reference_mqtt_ticketmaster_reference_mqtt_attractio
             entity_id=f"test_entity_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            segment="test_segment",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -302,8 +311,11 @@ async def test_ticketmaster_reference_mqtt_ticketmaster_reference_mqtt_classific
             entity_id=f"test_entity_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            segment="test_segment",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -368,8 +380,11 @@ async def test_ticketmaster_reference_mqtt_ticketmaster_reference_mqtt_info_py(m
             entity_id=f"test_entity_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            country="test_country",
+            city="test_city",
+            segment="test_segment",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare_mqtt_producer/tokyo_docomo_bikeshare_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare_mqtt_producer/tokyo_docomo_bikeshare_mqtt_producer_mqtt_client/tests/test_client.py
@@ -97,8 +97,10 @@ async def test_jp_odpt_docomobikeshare_system_mqtt_jp_odpt_docomo_bikeshare_bike
             system_id=f"test_system_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            ward="test_ward",
+            station_id="test_station_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -167,8 +169,9 @@ async def test_jp_odpt_docomobikeshare_stations_mqtt_jp_odpt_docomo_bikeshare_bi
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            ward="test_ward",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -234,8 +237,9 @@ async def test_jp_odpt_docomobikeshare_stations_mqtt_jp_odpt_docomo_bikeshare_bi
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            ward="test_ward",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/uba-airdata/uba_airdata_mqtt_producer/uba_airdata_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/uba-airdata/uba_airdata_mqtt_producer/uba_airdata_mqtt_producer_mqtt_client/tests/test_client.py
@@ -98,8 +98,10 @@ async def test_de_uba_airdata_mqtt_de_uba_airdata_mqtt_station_py(mosquitto_brok
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            bundesland="test_bundesland",
+            component_id="test_component_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -165,8 +167,10 @@ async def test_de_uba_airdata_mqtt_de_uba_airdata_mqtt_measure_py(mosquitto_brok
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            bundesland="test_bundesland",
+            component_id="test_component_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -235,8 +239,10 @@ async def test_de_uba_airdata_components_mqtt_de_uba_airdata_components_mqtt_com
             component_id=f"test_component_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            bundesland="test_bundesland",
+            station_id="test_station_id",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring_mqtt_producer/uk_ea_flood_monitoring_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring_mqtt_producer/uk_ea_flood_monitoring_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_uk_gov_environment_ea_floodmonitoring_mqtt_uk_gov_environment_ea_
             station_reference=f"test_station_reference_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            river="test_river",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_uk_gov_environment_ea_floodmonitoring_mqtt_uk_gov_environment_ea_
             station_reference=f"test_station_reference_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            river="test_river",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt_producer/usgs_nwis_wq_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt_producer/usgs_nwis_wq_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,9 @@ async def test_usgs_waterquality_sites_mqtt_usgs_water_quality_sites_mqtt_monito
             site_number=f"test_site_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -167,8 +168,9 @@ async def test_usgs_waterquality_readings_mqtt_usgs_water_quality_readings_mqtt_
             parameter_code=f"test_parameter_code_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            state="test_state",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/vatsim/vatsim_mqtt_producer/vatsim_mqtt_producer_mqtt_client/tests/test_client.py
@@ -224,8 +224,9 @@ async def test_net_vatsim_mqtt_net_vatsim_mqtt_facility_status_py(mosquitto_brok
             topic=test_topic,
             callsign=f"test_callsign_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            facility="test_facility",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/wallonia-issep/wallonia_issep_mqtt_producer/wallonia_issep_mqtt_producer_mqtt_client/tests/test_client.py
@@ -92,8 +92,9 @@ async def test_be_issep_airquality_sensors_mqtt_be_issep_airquality_sensors_mqtt
             topic=test_topic,
             configuration_id=f"test_configuration_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            province="test_province",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -157,8 +158,9 @@ async def test_be_issep_airquality_sensors_mqtt_be_issep_airquality_sensors_mqtt
             topic=test_topic,
             configuration_id=f"test_configuration_id_{i}",
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            province="test_province",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/waterinfo-vmm/waterinfo_vmm_mqtt_producer/waterinfo_vmm_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/waterinfo-vmm/waterinfo_vmm_mqtt_producer/waterinfo_vmm_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,8 +94,9 @@ async def test_be_vlaanderen_waterinfo_vmm_mqtt_be_vlaanderen_waterinfo_vmm_mqtt
             station_no=f"test_station_no_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body="test_water_body",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -160,8 +161,9 @@ async def test_be_vlaanderen_waterinfo_vmm_mqtt_be_vlaanderen_waterinfo_vmm_mqtt
             station_no=f"test_station_no_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            water_body="test_water_body",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/wsdot/wsdot_mqtt_producer/wsdot_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/wsdot/wsdot_mqtt_producer/wsdot_mqtt_producer_mqtt_client/tests/test_client.py
@@ -118,8 +118,9 @@ async def test_us_wa_wsdot_traffic_mqtt_us_wa_wsdot_traffic_traffic_flow_station
             flow_data_id=f"test_flow_data_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -185,8 +186,9 @@ async def test_us_wa_wsdot_traffic_mqtt_us_wa_wsdot_traffic_traffic_flow_reading
             flow_data_id=f"test_flow_data_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -255,8 +257,9 @@ async def test_us_wa_wsdot_traveltimes_mqtt_us_wa_wsdot_traveltimes_travel_time_
             travel_time_id=f"test_travel_time_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -325,8 +328,9 @@ async def test_us_wa_wsdot_mountainpass_mqtt_us_wa_wsdot_mountainpass_mountain_p
             mountain_pass_id=f"test_mountain_pass_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -395,8 +399,9 @@ async def test_us_wa_wsdot_weather_mqtt_us_wa_wsdot_weather_weather_station_mqtt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -462,8 +467,9 @@ async def test_us_wa_wsdot_weather_mqtt_us_wa_wsdot_weather_weather_reading_mqtt
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -532,8 +538,9 @@ async def test_us_wa_wsdot_tolls_mqtt_us_wa_wsdot_tolls_toll_rate_mqtt_py(mosqui
             trip_name=f"test_trip_name_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -603,8 +610,9 @@ async def test_us_wa_wsdot_cvrestrictions_mqtt_us_wa_wsdot_cvrestrictions_commer
             bridge_number=f"test_bridge_number_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -673,8 +681,9 @@ async def test_us_wa_wsdot_border_mqtt_us_wa_wsdot_border_border_crossing_mqtt_p
             crossing_name=f"test_crossing_name_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -743,8 +752,9 @@ async def test_us_wa_wsdot_ferries_mqtt_us_wa_wsdot_ferries_vessel_location_mqtt
             vessel_id=f"test_vessel_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            region="test_region",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/xceed/xceed_mqtt_producer/xceed_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/xceed/xceed_mqtt_producer/xceed_mqtt_producer_mqtt_client/tests/test_client.py
@@ -96,8 +96,9 @@ async def test_xceed_mqtt_xceed_mqtt_event_py(mosquitto_broker):
             event_id=f"test_event_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json"
-        )
+            content_type="application/json",
+            city="test_city",
+)
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/tools/install-avrotize.ps1
+++ b/tools/install-avrotize.ps1
@@ -66,7 +66,7 @@ $activateScript = "$venvPath\Scripts\Activate.ps1"
 if (Test-Path $activateScript) {
     Write-Host "Activating virtual environment and installing avrotize..."
     & $activateScript
-    pip install avrotize==3.5.11 xrcg==0.10.13
+    pip install avrotize==3.5.11 xrcg==0.10.14
     Write-Host "avrotize has been installed successfully in the virtual environment."
 } else {
     Write-Host "Failed to activate virtual environment."

--- a/tools/require-xrcg.ps1
+++ b/tools/require-xrcg.ps1
@@ -1,4 +1,4 @@
-$script:RequiredXrcgVersion = '0.10.13'
+$script:RequiredXrcgVersion = '0.10.14'
 
 function Assert-XrcgVersion {
     param(


### PR DESCRIPTION
## Summary\n- update generated MQTT client test call sites to the xrcg 0.10.14 signature\n- pin the repo toolchain to xrcg 0.10.14\n\n## Validation\n- python -m pytest feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt_producer/nifc_usa_wildfires_mqtt_producer_mqtt_client/tests/test_client.py -q