### PR TITLE
fix(seattle-911): honor ONCE_MODE for notebook runs

### DIFF
--- a/feeders/seattle-911/seattle_911/seattle_911.py
+++ b/feeders/seattle-911/seattle_911/seattle_911.py
@@ -280,7 +280,12 @@ def main() -> None:
         ),
         help="Path to the persisted dedupe state file",
     )
-    parser.add_argument("--once", action="store_true", help="Poll once and exit")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes"),
+        help="Poll once and exit (also via ONCE_MODE env var).",
+    )
     args = parser.parse_args()
 
     kafka_config = parse_connection_string(args.connection_string)

--- a/feeders/seattle-911/tests/test_seattle_911_unit.py
+++ b/feeders/seattle-911/tests/test_seattle_911_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for the Seattle Fire 911 bridge."""
 
-from unittest.mock import Mock, patch
+import sys
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -85,6 +86,43 @@ class TestFetchIncidents:
             DEFAULT_CONNECT_TIMEOUT_SECONDS,
             DEFAULT_READ_TIMEOUT_SECONDS,
         )
+
+
+@pytest.mark.unit
+class TestOnceMode:
+    def test_main_respects_explicit_once_flag(self, monkeypatch):
+        fake_producer = MagicMock()
+        fake_event_producer = MagicMock()
+        fake_bridge = MagicMock()
+
+        monkeypatch.setattr("seattle_911.seattle_911.Producer", MagicMock(return_value=fake_producer))
+        monkeypatch.setattr("seattle_911.seattle_911.USWASeattleFire911EventProducer", MagicMock(return_value=fake_event_producer))
+        monkeypatch.setattr("seattle_911.seattle_911.SeattleFire911Bridge", MagicMock(return_value=fake_bridge))
+        monkeypatch.setattr(sys, "argv", ["seattle-911", "--connection-string", "BootstrapServer=localhost:9092;EntityPath=seattle-911", "--once"])
+        monkeypatch.delenv("ONCE_MODE", raising=False)
+
+        import seattle_911.seattle_911 as bridge
+
+        bridge.main()
+
+        fake_bridge.poll_and_send.assert_called_once_with(fake_event_producer, once=True)
+
+    def test_main_respects_once_mode_env_var(self, monkeypatch):
+        fake_producer = MagicMock()
+        fake_event_producer = MagicMock()
+        fake_bridge = MagicMock()
+
+        monkeypatch.setattr("seattle_911.seattle_911.Producer", MagicMock(return_value=fake_producer))
+        monkeypatch.setattr("seattle_911.seattle_911.USWASeattleFire911EventProducer", MagicMock(return_value=fake_event_producer))
+        monkeypatch.setattr("seattle_911.seattle_911.SeattleFire911Bridge", MagicMock(return_value=fake_bridge))
+        monkeypatch.setattr(sys, "argv", ["seattle-911", "--connection-string", "BootstrapServer=localhost:9092;EntityPath=seattle-911"])
+        monkeypatch.setenv("ONCE_MODE", "true")
+
+        import seattle_911.seattle_911 as bridge
+
+        bridge.main()
+
+        fake_bridge.poll_and_send.assert_called_once_with(fake_event_producer, once=True)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- make the Seattle Fire 911 feeder honor `ONCE_MODE=true` as well as `--once`
- add unit tests covering both the CLI flag and env-var path

## Validation
- `python -m pytest feeders/seattle-911/tests -q`