### PR TITLE
fix(noaa-swpc-l1): align MQTT publish test with generated client

### DIFF
--- a/feeders/noaa-swpc-l1/tests/test_mqtt_app.py
+++ b/feeders/noaa-swpc-l1/tests/test_mqtt_app.py
@@ -143,6 +143,6 @@ def test_feed_once_publishes_row_and_saves_state(tmp_path, sample_row):
     published = client.published[0]
     assert published["feedurl"] == mqtt_app.FEED_URL
     assert published["spacecraft"] == "dscovr"
-    assert published["time_tag"] == sample_row.time_tag.isoformat()
+    assert published["_time"] == sample_row.time_tag.isoformat()
     assert published["data"].speed == sample_row.speed
     assert mqtt_app.load_state(str(state_file))["last_time_tag"] == sample_row.time_tag.isoformat()


### PR DESCRIPTION
Fix stale MQTT publish assertion to match the current generated client contract.\n\nVerified with:\n- python -m pytest -q feeders/noaa-swpc-l1/tests/test_mqtt_app.py\n- python -m pytest -q feeders/snotel/tests/test_snotel_unit.py