### PR TITLE
fix(nextbus): use valid PEP 508 requires-python spec

### DIFF
--- a/feeders/nextbus/pyproject.toml
+++ b/feeders/nextbus/pyproject.toml
@@ -14,7 +14,7 @@ description = "A project to fetch data from NextBus API"
 authors = [
     { name = "Clemens Vasters", email = "clemensv@microsoft.com" },
 ]
-requires-python = "^3.10"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "azure-eventhub>=5.15.1,<6.0.0",
     "cloudevents>=1.12.1,<2.0.0",


### PR DESCRIPTION
Fixes the invalid requires-python = '^3.10' setting in feeders/nextbus/pyproject.toml, which breaks pip wheel --no-deps --no-build-isolation . for Fabric notebook wheel builds.

Validation:
- python -m pip wheel --no-deps --no-build-isolation . in the isolated worktree succeeded after the fix.