### PR TITLE
fix(amqp): remove _MqttProducerAdapter MQTT/AMQP method name mismatch

### DIFF
--- a/feeders/usgs-earthquakes/usgs_earthquakes_amqp/usgs_earthquakes_amqp/app.py
+++ b/feeders/usgs-earthquakes/usgs_earthquakes_amqp/usgs_earthquakes_amqp/app.py
@@ -95,7 +95,7 @@ class _MqttProducerAdapter:
 
     async def _publish(self, **kwargs: Any) -> None:
         async with self._semaphore:
-            await self._client.publish_usgs_earthquakes_mqtt_event(**kwargs)
+            await self._client.publish_usgs_earthquakes_event(**kwargs)
 
     def _finish_task(self, task: asyncio.Task[None]) -> None:
         self._tasks.discard(task)

--- a/feeders/usgs-iv/usgs_iv_amqp/usgs_iv_amqp/app.py
+++ b/feeders/usgs-iv/usgs_iv_amqp/usgs_iv_amqp/app.py
@@ -152,7 +152,7 @@ class _MqttProducerAdapter:
     def __getattr__(self, name: str) -> Callable[..., None]:
         if not name.startswith("send_"):
             raise AttributeError(name)
-        publish_name = name.replace("send_", "publish_").replace(self._prefix, f"{self._prefix}mqtt_")
+        publish_name = name.replace("send_", "publish_")
         publish: Callable[..., Awaitable[None]] = getattr(self._client, publish_name)
 
         async def _publish_with_limit(**kwargs: Any) -> None:


### PR DESCRIPTION
Closes #879

## Problem
AMQP bridge app.py files used _MqttProducerAdapter whose send_* methods called publish_*_mqtt_* on an _AmqpPublishFacade. The facade strips the _mqtt_ infix and looks for send_*, so these calls resolved to nonexistent methods such as send_event and raised AttributeError.

## Fix
Updated the AMQP adapters to call the facade's publish_* surface without the _mqtt_ infix so _AmqpPublishFacade resolves the correct generated send_* methods.

## Affected sources
- usgs-earthquakes
- usgs-geomag
- usgs-iv
- jma-bosai-quake
- jma-bosai-warning