### PR TITLE
fix(usgs-iv, german-waters): fix _datetime kwarg and UTF-8 encoding

### DIFF
--- a/feeders/german-waters/Dockerfile
+++ b/feeders/german-waters/Dockerfile
@@ -10,6 +10,9 @@ LABEL org.opencontainers.image.license="MIT"
 # Set the working directory in the container
 WORKDIR /app
 
+ENV PYTHONIOENCODING=utf-8
+ENV LANG=C.UTF-8
+
 # Copy the current directory contents into the container at /app
 COPY . /app
 


### PR DESCRIPTION
Closes #859
Closes #887

## Changes
- usgs-iv: fix unexpected _datetime kwarg in send_usgs_instantaneous_values_streamflow call
- german-waters: add PYTHONIOENCODING=utf-8 and LANG=C.UTF-8 to Dockerfile to prevent UnicodeEncodeError on Unicode characters in station data