### PR TITLE
fix(dockerfile-amqp): trailing backslash and missing kafka producer_data installs

### DIFF
--- a/feeders/bfs-odl/Dockerfile.amqp
+++ b/feeders/bfs-odl/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./bfs_odl_amqp_producer/bfs_odl_amqp_producer_data \
- && pip install --no-cache-dir ./bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./bfs_odl_producer/bfs_odl_producer_data && pip install --no-cache-dir ./bfs_odl_amqp_producer/bfs_odl_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./bfs_odl_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/blitzortung/Dockerfile.amqp
+++ b/feeders/blitzortung/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./blitzortung_amqp_producer/blitzortung_amqp_producer_data \
- && pip install --no-cache-dir ./blitzortung_amqp_producer/blitzortung_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./blitzortung_producer/blitzortung_producer_data && pip install --no-cache-dir ./blitzortung_amqp_producer/blitzortung_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./blitzortung_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/digitraffic-maritime/Dockerfile.amqp
+++ b/feeders/digitraffic-maritime/Dockerfile.amqp
@@ -25,7 +25,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./digitraffic_maritime_amqp_producer/digitraffic_maritime_amqp_producer_data \
- && pip install --no-cache-dir ./digitraffic_maritime_amqp_producer/digitraffic_maritime_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./digitraffic_maritime_producer/digitraffic_maritime_producer_data && pip install --no-cache-dir ./digitraffic_maritime_amqp_producer/digitraffic_maritime_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./digitraffic_maritime_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/epa-uv/Dockerfile.amqp
+++ b/feeders/epa-uv/Dockerfile.amqp
@@ -25,7 +25,7 @@ RUN set -eux; \
 
 COPY . /app
 
-RUN pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_data  && pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./epa_uv_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+RUN pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_data  && pip install --no-cache-dir ./epa_uv_producer/epa_uv_producer_data && pip install --no-cache-dir ./epa_uv_amqp_producer/epa_uv_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./epa_uv_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
 
 ENV AMQP_BROKER_URL=""
 ENV AMQP_ADDRESS="epa-uv"

--- a/feeders/gracedb/Dockerfile.amqp
+++ b/feeders/gracedb/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./gracedb_amqp_producer/gracedb_amqp_producer_data \
- && pip install --no-cache-dir ./gracedb_amqp_producer/gracedb_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./gracedb_producer/gracedb_producer_data && pip install --no-cache-dir ./gracedb_amqp_producer/gracedb_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./gracedb_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/hongkong-epd/Dockerfile.amqp
+++ b/feeders/hongkong-epd/Dockerfile.amqp
@@ -25,7 +25,7 @@ RUN set -eux; \
 
 COPY . /app
 
-RUN pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data  && pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./hongkong_epd_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+RUN pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_data  && pip install --no-cache-dir ./hongkong_epd_producer/hongkong_epd_producer_data && pip install --no-cache-dir ./hongkong_epd_amqp_producer/hongkong_epd_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./hongkong_epd_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
 
 ENV AMQP_BROKER_URL=""
 ENV AMQP_ADDRESS="hongkong-epd"

--- a/feeders/inpe-deter-brazil/Dockerfile.amqp
+++ b/feeders/inpe-deter-brazil/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./inpe_deter_brazil_amqp_producer/inpe_deter_brazil_amqp_producer_data \
- && pip install --no-cache-dir ./inpe_deter_brazil_amqp_producer/inpe_deter_brazil_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./inpe_deter_brazil_producer/inpe_deter_brazil_producer_data && pip install --no-cache-dir ./inpe_deter_brazil_amqp_producer/inpe_deter_brazil_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./inpe_deter_brazil_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/jma-bosai-quake/Dockerfile.amqp
+++ b/feeders/jma-bosai-quake/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./jma_bosai_quake_amqp_producer/jma_bosai_quake_amqp_producer_data \
- && pip install --no-cache-dir ./jma_bosai_quake_amqp_producer/jma_bosai_quake_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./jma_bosai_quake_producer/jma_bosai_quake_producer_data && pip install --no-cache-dir ./jma_bosai_quake_amqp_producer/jma_bosai_quake_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./jma_bosai_quake_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/jma-bosai-warning/Dockerfile.amqp
+++ b/feeders/jma-bosai-warning/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data \
- && pip install --no-cache-dir ./jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./jma_bosai_warning_producer/jma_bosai_warning_producer_data && pip install --no-cache-dir ./jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./jma_bosai_warning_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/meteoalarm/Dockerfile.amqp
+++ b/feeders/meteoalarm/Dockerfile.amqp
@@ -25,7 +25,7 @@ RUN set -eux; \
 
 COPY . /app
 
-RUN pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_data  && pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./meteoalarm_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
+RUN pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_data  && pip install --no-cache-dir ./meteoalarm_producer/meteoalarm_producer_data && pip install --no-cache-dir ./meteoalarm_amqp_producer/meteoalarm_amqp_producer_amqp_producer  && pip install --no-cache-dir .  && pip install --no-cache-dir ./meteoalarm_amqp  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev  && rm -rf /root/.cache /var/lib/apt/lists/*
 
 ENV AMQP_BROKER_URL=""
 ENV AMQP_ADDRESS="meteoalarm"

--- a/feeders/nasa-firms/Dockerfile.amqp
+++ b/feeders/nasa-firms/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./nasa_firms_amqp_producer/nasa_firms_amqp_producer_data \
- && pip install --no-cache-dir ./nasa_firms_amqp_producer/nasa_firms_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./nasa_firms_producer/nasa_firms_producer_data && pip install --no-cache-dir ./nasa_firms_amqp_producer/nasa_firms_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./nasa_firms_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/seattle-street-closures/Dockerfile.amqp
+++ b/feeders/seattle-street-closures/Dockerfile.amqp
@@ -20,7 +20,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 COPY . /app
 RUN pip install --no-cache-dir ./seattle_street_closures_amqp_producer/seattle_street_closures_amqp_producer_data \
- && pip install --no-cache-dir ./seattle_street_closures_amqp_producer/seattle_street_closures_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./seattle_street_closures_producer/seattle_street_closures_producer_data && pip install --no-cache-dir ./seattle_street_closures_amqp_producer/seattle_street_closures_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./seattle_street_closures_amqp \
  && apt-get purge -y --auto-remove build-essential cmake pkg-config swig libssl-dev libsasl2-dev python3-dev \

--- a/feeders/usgs-earthquakes/Dockerfile.amqp
+++ b/feeders/usgs-earthquakes/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./usgs_earthquakes_amqp_producer/usgs_earthquakes_amqp_producer_data \
- && pip install --no-cache-dir ./usgs_earthquakes_amqp_producer/usgs_earthquakes_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./usgs_earthquakes_producer/usgs_earthquakes_producer_data && pip install --no-cache-dir ./usgs_earthquakes_amqp_producer/usgs_earthquakes_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./usgs_earthquakes_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/usgs-geomag/Dockerfile.amqp
+++ b/feeders/usgs-geomag/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./usgs_geomag_amqp_producer/usgs_geomag_amqp_producer_data \
- && pip install --no-cache-dir ./usgs_geomag_amqp_producer/usgs_geomag_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./usgs_geomag_producer/usgs_geomag_producer_data && pip install --no-cache-dir ./usgs_geomag_amqp_producer/usgs_geomag_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./usgs_geomag_amqp \
  && apt-get purge -y --auto-remove \

--- a/feeders/usgs-iv/Dockerfile.amqp
+++ b/feeders/usgs-iv/Dockerfile.amqp
@@ -28,7 +28,7 @@ RUN set -eux; \
 COPY . /app
 
 RUN pip install --no-cache-dir ./usgs_iv_amqp_producer/usgs_iv_amqp_producer_data \
- && pip install --no-cache-dir ./usgs_iv_amqp_producer/usgs_iv_amqp_producer_amqp_producer \
+ && pip install --no-cache-dir ./usgs_iv_producer/usgs_iv_producer_data && pip install --no-cache-dir ./usgs_iv_amqp_producer/usgs_iv_amqp_producer_amqp_producer \
  && pip install --no-cache-dir . \
  && pip install --no-cache-dir ./usgs_iv_amqp \
  && apt-get purge -y --auto-remove \


### PR DESCRIPTION
Closes #878
Closes #875

## Changes
- Fixed trailing backslash on last pip install line in 10 Dockerfile.amqp files (issue #878)
- Added missing Kafka _producer_data install before main package install in Dockerfile.amqp files (issue #875)