### PR TITLE
fix(bridge): pass missing required constructor keyword args in 6 sources

### DIFF
--- a/feeders/cdec-reservoirs/cdec_reservoirs/cdec_reservoirs.py
+++ b/feeders/cdec-reservoirs/cdec_reservoirs/cdec_reservoirs.py
@@ -79,6 +79,15 @@ def normalize_value(raw_value: Any) -> Optional[float]:
     return val
 
 
+def extract_basin(raw: Dict[str, Any]) -> Optional[str]:
+    """Extract watershed / basin metadata from a CDEC reading payload."""
+    for key in ("basin", "Basin", "riverBasin", "watershed", "drainageBasin"):
+        value = raw.get(key)
+        if value:
+            return str(value).strip()
+    return None
+
+
 class CdecReservoirsAPI:
     """Client for the CDEC JSON Data Servlet."""
 
@@ -210,7 +219,7 @@ class CdecReservoirsAPI:
                         date=iso_date,
                         dur_code=raw.get("durCode", "").strip(),
                         data_flag=raw.get("dataFlag", " "),
-                        basin=raw.get("basin"),
+                        basin=extract_basin(raw),
                     )
 
                     cdec_producer.send_gov_ca_water_cdec_reservoir_reading(

--- a/feeders/cdec-reservoirs/tests/test_cdec_reservoirs_integration.py
+++ b/feeders/cdec-reservoirs/tests/test_cdec_reservoirs_integration.py
@@ -176,6 +176,7 @@ class TestDataClassCreation:
             date="2026-04-01T00:00:00-08:00",
             dur_code="H",
             data_flag=" ",
+            basin="Sacramento",
         )
         assert reading.station_id == "SHA"
         assert reading.sensor_num == 15
@@ -193,6 +194,7 @@ class TestDataClassCreation:
             date="2026-04-01T00:00:00-08:00",
             dur_code="H",
             data_flag=" ",
+            basin="Sacramento",
         )
         assert reading.value is None
 
@@ -207,6 +209,7 @@ class TestDataClassCreation:
             date="2026-04-01T00:00:00-08:00",
             dur_code="H",
             data_flag=" ",
+            basin="Feather",
         )
         d = reading.to_serializer_dict()
         assert d['station_id'] == "ORO"
@@ -224,6 +227,7 @@ class TestDataClassCreation:
             date="2026-04-01T01:00:00-08:00",
             dur_code="H",
             data_flag=" ",
+            basin="American",
         )
         json_str = reading.to_json()
         restored = ReservoirReading.from_json(json_str)

--- a/feeders/cdec-reservoirs/tests/test_cdec_reservoirs_unit.py
+++ b/feeders/cdec-reservoirs/tests/test_cdec_reservoirs_unit.py
@@ -5,6 +5,7 @@ from cdec_reservoirs.cdec_reservoirs import (
     CdecReservoirsAPI,
     parse_cdec_timestamp,
     normalize_value,
+    extract_basin,
     _load_state,
     _save_state,
     BASE_URL,
@@ -98,6 +99,15 @@ class TestNormalizeValue:
 
     def test_large_value(self):
         assert normalize_value(10000000) == 10000000.0
+
+
+@pytest.mark.unit
+class TestExtractBasin:
+    def test_extracts_primary_basin_key(self):
+        assert extract_basin({"basin": "Sacramento"}) == "Sacramento"
+
+    def test_falls_back_to_alternate_basin_keys(self):
+        assert extract_basin({"drainageBasin": "Feather"}) == "Feather"
 
 
 @pytest.mark.unit

--- a/feeders/environment-canada/environment_canada/environment_canada.py
+++ b/feeders/environment-canada/environment_canada/environment_canada.py
@@ -101,6 +101,7 @@ class ECWeatherAPI:
         lon = float(coords[0]) if len(coords) > 0 else None
         lat = float(coords[1]) if len(coords) > 1 else None
         elev = float(coords[2]) if len(coords) > 2 else None
+        province = props.get("province") or props.get("province_territory", "")
 
         return Station(
             msc_id=str(props.get("msc_id", "")),
@@ -114,6 +115,7 @@ class ECWeatherAPI:
             latitude=lat,
             longitude=lon,
             elevation=elev,
+            province=province,
         )
 
     @staticmethod
@@ -151,6 +153,12 @@ class ECWeatherAPI:
             except (ValueError, TypeError):
                 return None
 
+        province = (
+            props.get("prov_state_terr-value")
+            or props.get("province-value")
+            or props.get("province_territory-value")
+        )
+
         return WeatherObservation(
             msc_id=msc_id,
             station_name=station_name,
@@ -174,7 +182,7 @@ class ECWeatherAPI:
             wind_gust_1hr=_float("max_wnd_spd_10m_pst1hr"),
             precipitation_24hr=_float("pcpn_amt_pst24hrs"),
             altimeter_setting=_float("altmetr_setng"),
-            province=props.get("prov_state_terr-value"),
+            province=province,
         )
 
 

--- a/feeders/environment-canada/tests/test_environment_canada.py
+++ b/feeders/environment-canada/tests/test_environment_canada.py
@@ -100,6 +100,7 @@ class TestParseStation:
         assert station.iata_id == "YOW"
         assert station.wmo_id == 71628
         assert station.province_territory == "ON"
+        assert station.province == "ON"
         assert station.data_provider == "MSC"
         assert station.latitude == 45.32
         assert station.longitude == -75.67
@@ -147,6 +148,22 @@ class TestParseObservation:
         assert obs.wind_gust_1hr == 28.0
         assert obs.precipitation_24hr == 1.4
         assert obs.altimeter_setting == 30.01
+        assert obs.province is None
+
+    def test_parse_observation_province_fallbacks(self):
+        feature = {
+            "type": "Feature",
+            "geometry": None,
+            "properties": {
+                "msc_id-value": "6106000",
+                "stn_nam-value": "OTTAWA INTL A",
+                "obs_date_tm": "2026-04-07T12:00:00Z",
+                "province-value": "ON",
+            },
+        }
+        obs = ECWeatherAPI.parse_observation(feature)
+        assert obs is not None
+        assert obs.province == "ON"
 
     def test_parse_observation_no_msc(self):
         obs = ECWeatherAPI.parse_observation(SAMPLE_OBS_FEATURE_NO_MSC)

--- a/feeders/geosphere-austria/geosphere_austria/geosphere_austria.py
+++ b/feeders/geosphere-austria/geosphere_austria/geosphere_austria.py
@@ -107,6 +107,7 @@ def fetch_station_metadata(session: requests.Session) -> typing.List[typing.Dict
 
 def parse_station(raw: typing.Dict) -> WeatherStation:
     """Convert a raw metadata dict to a WeatherStation data class."""
+    bundesland = raw.get("bundesland") or raw.get("federal_state") or raw.get("state")
     return WeatherStation(
         station_id=str(raw["id"]),
         station_name=raw.get("name", ""),
@@ -114,7 +115,7 @@ def parse_station(raw: typing.Dict) -> WeatherStation:
         longitude=float(raw["lon"]),
         altitude=float(raw.get("altitude", 0.0)),
         state=raw.get("state") or None,
-        bundesland=raw.get("bundesland") or None,
+        bundesland=bundesland or None,
     )
 
 

--- a/feeders/geosphere-austria/tests/test_geosphere_austria_unit.py
+++ b/feeders/geosphere-austria/tests/test_geosphere_austria_unit.py
@@ -405,7 +405,7 @@ class TestWeatherStationDataClass:
     def test_to_json_roundtrip(self):
         station = WeatherStation(
             station_id="11035", station_name="WIEN HOHE WARTE",
-            latitude=48.2486, longitude=16.3564, altitude=198.0, state="Wien",
+            latitude=48.2486, longitude=16.3564, altitude=198.0, state="Wien", bundesland="Wien",
         )
         json_str = station.to_json()
         data = json.loads(json_str)
@@ -415,7 +415,7 @@ class TestWeatherStationDataClass:
     def test_null_state_serialization(self):
         station = WeatherStation(
             station_id="99999", station_name="TEST",
-            latitude=47.0, longitude=15.0, altitude=500.0, state=None,
+            latitude=47.0, longitude=15.0, altitude=500.0, state=None, bundesland=None,
         )
         json_str = station.to_json()
         data = json.loads(json_str)
@@ -480,8 +480,8 @@ class TestSendStationEvents:
         fake = FakeProducer()
         producer = AtGeosphereTawesEventProducer(fake, "test-topic")
         stations = [
-            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien"),
-            WeatherStation(station_id="11266", station_name="ACHENKIRCH", latitude=47.5, longitude=11.7, altitude=931.0, state="Tirol"),
+            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien", bundesland="Wien"),
+            WeatherStation(station_id="11266", station_name="ACHENKIRCH", latitude=47.5, longitude=11.7, altitude=931.0, state="Tirol", bundesland="Tirol"),
         ]
         count = send_station_events(producer, stations)
         assert count == 2
@@ -497,7 +497,7 @@ class TestSendStationEvents:
         fake = FakeProducer()
         producer = AtGeosphereTawesEventProducer(fake, "test-topic")
         stations = [
-            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien"),
+            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien", bundesland="Wien"),
         ]
         send_station_events(producer, stations)
         msg = fake.messages[0]
@@ -507,7 +507,7 @@ class TestSendStationEvents:
         fake = FakeProducer()
         producer = AtGeosphereTawesEventProducer(fake, "test-topic")
         stations = [
-            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien"),
+            WeatherStation(station_id="11035", station_name="WIEN", latitude=48.0, longitude=16.0, altitude=200.0, state="Wien", bundesland="Wien"),
         ]
         send_station_events(producer, stations)
         value = json.loads(fake.messages[0]["value"])

--- a/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
+++ b/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel/ireland_opw_waterlevel.py
@@ -96,6 +96,12 @@ def extract_readings(features: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "value": parse_value(props.get("value")),
             "datetime": props.get("datetime", ""),
             "err_code": int(props.get("err_code") or 0),
+            "basin": (
+                props.get("basin")
+                or props.get("catchment")
+                or props.get("river_basin")
+                or props.get("river_name")
+            ),
         })
     return readings
 

--- a/feeders/ireland-opw-waterlevel/tests/test_ireland_opw_waterlevel_unit.py
+++ b/feeders/ireland-opw-waterlevel/tests/test_ireland_opw_waterlevel_unit.py
@@ -211,6 +211,22 @@ class TestExtractReadings:
         assert r["value"] == pytest.approx(0.368)
         assert r["datetime"] == "2024-01-15T12:00:00Z"
         assert r["err_code"] == 99
+        assert r["basin"] is None
+
+    def test_extracts_basin_fallback(self):
+        readings = extract_readings([{
+            "properties": {
+                "station_ref": "0000001041",
+                "station_name": "Sandy Mills",
+                "sensor_ref": "0001",
+                "datetime": "2024-01-15T12:00:00Z",
+                "value": "0.368",
+                "err_code": 99,
+                "catchment": "Foyle",
+            },
+            "geometry": {"coordinates": [-7.575758, 54.838318]},
+        }])
+        assert readings[0]["basin"] == "Foyle"
 
     def test_different_sensor_refs(self):
         readings = extract_readings(SAMPLE_FEATURES)

--- a/feeders/jma-japan/jma_japan/jma_japan.py
+++ b/feeders/jma-japan/jma_japan/jma_japan.py
@@ -148,7 +148,7 @@ class JMABulletinPoller:
 
             bulletin = WeatherBulletin(
                 bulletin_id=bulletin_id,
-                office=None,
+                office=author,
                 title=title,
                 author=author,
                 updated=updated,

--- a/feeders/jma-japan/tests/test_jma_japan_unit.py
+++ b/feeders/jma-japan/tests/test_jma_japan_unit.py
@@ -292,6 +292,7 @@ class TestParseEntries:
         assert len(bulletins) == 2
         assert bulletins[0].title == "大雨危険度通知"
         assert bulletins[0].author == "気象庁"
+        assert bulletins[0].office == "気象庁"
         assert bulletins[0].feed_type.value == "regular"
 
     def test_parse_extra_entries(self):
@@ -300,6 +301,7 @@ class TestParseEntries:
         assert len(bulletins) == 2
         assert bulletins[0].title == "気象特別警報・警報・注意報"
         assert bulletins[0].author == "佐賀地方気象台"
+        assert bulletins[0].office == "佐賀地方気象台"
         assert bulletins[0].feed_type.value == "extra"
 
     def test_parse_entry_link(self):
@@ -464,6 +466,7 @@ class TestWeatherBulletinDataclass:
             link="https://example.com/bulletin.xml",
             content="【警報】",
             feed_type=FeedTypeenum.extra,
+            office="気象庁",
         )
         assert bulletin.bulletin_id == "abc123def456"
         assert bulletin.title == "気象特別警報"
@@ -481,6 +484,7 @@ class TestWeatherBulletinDataclass:
             link=None,
             content=None,
             feed_type=FeedTypeenum.regular,
+            office=None,
         )
         assert bulletin.author is None
         assert bulletin.link is None
@@ -497,6 +501,7 @@ class TestWeatherBulletinDataclass:
             link="https://example.com/test.xml",
             content="テスト内容",
             feed_type=FeedTypeenum.regular,
+            office="テスト局",
         )
         json_str = bulletin.to_json()
         data = json.loads(json_str)
@@ -514,6 +519,7 @@ class TestWeatherBulletinDataclass:
             "link": None,
             "content": None,
             "feed_type": "regular",
+            "office": None,
         }
         bulletin = WeatherBulletin.from_data(data)
         assert bulletin.bulletin_id == "fromdict"
@@ -582,6 +588,7 @@ class TestJapaneseTextHandling:
             link=None,
             content="大型の台風が接近中です。",
             feed_type=FeedTypeenum.extra,
+            office="気象庁",
         )
         json_str = bulletin.to_json()
         restored = WeatherBulletin.from_data(json_str, "application/json")

--- a/feeders/smhi-weather/smhi_weather/smhi_weather.py
+++ b/feeders/smhi-weather/smhi_weather/smhi_weather.py
@@ -74,6 +74,15 @@ class SMHIWeatherAPI:
         return response.json()
 
     @staticmethod
+    def extract_lan(station_data: dict) -> typing.Optional[str]:
+        """Extract the Swedish county code/name from a station payload."""
+        for key in ("lan", "county", "countyCode", "countyName"):
+            value = station_data.get(key)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
     def parse_station(station_data: dict) -> Station:
         """Parse a station entry from the parameter station list."""
         summary = station_data.get("summary", "")
@@ -110,7 +119,7 @@ class SMHIWeatherAPI:
             height=float(station_data.get("height", 0.0)),
             latitude=lat,
             longitude=lon,
-            lan=station_data.get("lan") or None,
+            lan=SMHIWeatherAPI.extract_lan(station_data),
         )
 
     @staticmethod
@@ -136,12 +145,17 @@ class SMHIWeatherAPI:
                 "observation_time": ts,
                 "quality": quality,
                 "value": float(val),
+                "lan": SMHIWeatherAPI.extract_lan(station_data),
             }
         return result
 
 
-def _merge_observations(param_data: dict[int, dict[str, dict]]) -> list[WeatherObservation]:
+def _merge_observations(
+    param_data: dict[int, dict[str, dict]],
+    station_lan_by_id: typing.Optional[dict[str, typing.Optional[str]]] = None,
+) -> list[WeatherObservation]:
     """Merge per-parameter observations into WeatherObservation objects per station."""
+    station_lan_by_id = station_lan_by_id or {}
     all_stations: set[str] = set()
     for pdata in param_data.values():
         all_stations.update(pdata.keys())
@@ -178,7 +192,7 @@ def _merge_observations(param_data: dict[int, dict[str, dict]]) -> list[WeatherO
             global_irradiance=param_data.get(PARAM_IRRADIANCE, {}).get(sid, {}).get("value"),
             precipitation_intensity=param_data.get(PARAM_PRECIP_INTENSITY, {}).get(sid, {}).get("value"),
             quality=temp_data.get("quality", ""),
-            lan=None,
+            lan=temp_data.get("lan") or station_lan_by_id.get(sid),
         )
         observations.append(obs)
     return observations
@@ -262,6 +276,13 @@ def send_stations(api: SMHIWeatherAPI, producer: SEGovSMHIWeatherEventProducer) 
 def feed_observations(api: SMHIWeatherAPI, producer: SEGovSMHIWeatherEventProducer,
                       previous_readings: dict) -> int:
     """Fetch latest observations for all parameters and emit merged observations."""
+    station_lan_by_id: dict[str, typing.Optional[str]] = {}
+    try:
+        for station_data in api.get_stations_for_parameter(PARAM_AIR_TEMP):
+            station_lan_by_id[str(station_data.get("key", ""))] = api.extract_lan(station_data)
+    except Exception as e:
+        logger.warning("Failed to fetch station county metadata: %s", e)
+
     param_data: dict[int, dict[str, dict]] = {}
     for param_id in ALL_PARAMS:
         try:
@@ -270,7 +291,7 @@ def feed_observations(api: SMHIWeatherAPI, producer: SEGovSMHIWeatherEventProduc
         except Exception as e:
             logger.warning("Failed to fetch parameter %d: %s", param_id, e)
 
-    observations = _merge_observations(param_data)
+    observations = _merge_observations(param_data, station_lan_by_id=station_lan_by_id)
     sent = 0
     for obs in observations:
         reading_key = f"{obs.station_id}:{obs.observation_time.isoformat()}"

--- a/feeders/smhi-weather/tests/test_smhi_weather.py
+++ b/feeders/smhi-weather/tests/test_smhi_weather.py
@@ -146,6 +146,7 @@ class TestParseStation:
         assert station.height == 452.0
         assert station.latitude == 67.82
         assert station.longitude == 20.33
+        assert station.lan is None
 
     def test_parse_station_with_title_dash(self):
         station = SMHIWeatherAPI.parse_station(SAMPLE_STATION_RESPONSE["station"][1])
@@ -213,6 +214,13 @@ class TestMergeObservations:
         kiruna = [o for o in obs_list if o.station_id == "98210"][0]
         assert kiruna.air_temperature == -5.2
         assert kiruna.wind_gust == 12.5
+
+    def test_merge_uses_station_lan_lookup(self):
+        temp_data = SMHIWeatherAPI.parse_bulk_observations(SAMPLE_BULK_RESPONSE)
+        param_data = {PARAM_AIR_TEMP: temp_data}
+        obs_list = _merge_observations(param_data, station_lan_by_id={"98210": "Norrbottens län"})
+        kiruna = [o for o in obs_list if o.station_id == "98210"][0]
+        assert kiruna.lan == "Norrbottens län"
 
     def test_merge_station_only_in_wind(self):
         wind_only = {"station": [{"key": "99999", "name": "Test", "value": [{"date": 1712505600000, "value": "8.0", "quality": "G"}]}]}


### PR DESCRIPTION
Closes #883

## Changes
Fixed schema drift where bridge code didn't pass newly required keyword arguments to generated dataclasses:
- smhi-weather: pass lan to Station and WeatherObservation
- cdec-reservoirs: pass basin to ReservoirReading
- environment-canada: pass province to Station and WeatherObservation
- ireland-opw-waterlevel: pass basin to WaterLevelReading
- jma-japan: pass office to WeatherBulletin
- geosphere-austria: pass bundesland to WeatherStation