### PR TITLE
fix(e2e): make Kafka topic creation idempotent

### DIFF
--- a/tests/docker_e2e/helpers.py
+++ b/tests/docker_e2e/helpers.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 import docker
 from docker.models.containers import Container
 from docker.models.images import Image
-from confluent_kafka import Consumer
+from confluent_kafka import Consumer, KafkaError, KafkaException
 from confluent_kafka.admin import AdminClient, NewTopic
 from json_structure import InstanceValidator, SchemaValidator
 from testcontainers.kafka import KafkaContainer
@@ -218,13 +218,13 @@ class KafkaFixture:
 
     def create_topic(self, topic: str, partitions: int = 1) -> None:
         admin = AdminClient({'bootstrap.servers': self.external_address})
-        fut = admin.create_topics([NewTopic(topic, num_partitions=partitions, replication_factor=1)])
-        for _topic, f in fut.items():
+        futures = admin.create_topics([NewTopic(topic, num_partitions=partitions, replication_factor=1)])
+        for _topic, future in futures.items():
             try:
-                f.result(timeout=10)
-            except Exception as exc:
-                message = str(exc).lower()
-                if 'already exists' in message or 'topic_already_exists' in message:
+                future.result(timeout=10)
+            except KafkaException as exc:
+                error = exc.args[0] if exc.args else None
+                if isinstance(error, KafkaError) and error.code() == KafkaError.TOPIC_ALREADY_EXISTS:
                     continue
                 raise
         time.sleep(1)

--- a/tests/docker_e2e/test_helpers.py
+++ b/tests/docker_e2e/test_helpers.py
@@ -1,0 +1,46 @@
+import pytest
+from types import SimpleNamespace
+
+from confluent_kafka import KafkaError, KafkaException
+
+import helpers
+
+
+class _FakeFuture:
+    def __init__(self, exc=None):
+        self._exc = exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+
+
+class _FakeAdminClient:
+    def __init__(self, futures):
+        self._futures = futures
+
+    def create_topics(self, topics):
+        return dict(self._futures)
+
+
+def _make_fixture():
+    fixture = helpers.KafkaFixture()
+    fixture._kafka = SimpleNamespace(get_bootstrap_server=lambda: 'localhost:9092')
+    return fixture
+
+
+def test_create_topic_ignores_existing_topics(monkeypatch):
+    existing_error = KafkaException(KafkaError(KafkaError.TOPIC_ALREADY_EXISTS, 'topic exists'))
+    monkeypatch.setattr(helpers, 'AdminClient', lambda *args, **kwargs: _FakeAdminClient({'test-topic': _FakeFuture(existing_error)}))
+    monkeypatch.setattr(helpers.time, 'sleep', lambda _seconds: None)
+
+    _make_fixture().create_topic('test-topic')
+
+
+def test_create_topic_reraises_non_existing_topic_errors(monkeypatch):
+    unexpected_error = KafkaException(KafkaError(KafkaError.UNKNOWN_TOPIC_OR_PART, 'bad request'))
+    monkeypatch.setattr(helpers, 'AdminClient', lambda *args, **kwargs: _FakeAdminClient({'test-topic': _FakeFuture(unexpected_error)}))
+    monkeypatch.setattr(helpers.time, 'sleep', lambda _seconds: None)
+
+    with pytest.raises(KafkaException):
+        _make_fixture().create_topic('test-topic')


### PR DESCRIPTION
## Summary
- ignore TOPIC_ALREADY_EXISTS in the shared Docker E2E Kafka helper so retries/parallel runs do not fail on re-created topics
- add regression tests for idempotent existing-topic handling and unexpected Kafka errors

## Validation
- python -m pytest -q tests/docker_e2e/test_helpers.py
- python -m pytest -q tests/docker_e2e/test_docker_kafka_flow.py -k 'TestPegelonlineDockerFlow'