### PR TITLE
fix(gtfs): make container build path discover packages

### DIFF
--- a/.github/workflows/test-gtfs.yml
+++ b/.github/workflows/test-gtfs.yml
@@ -29,35 +29,19 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install Poetry
+      - name: Install test dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Configure Poetry
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-
-      - name: Cache Poetry dependencies
-        uses: actions/cache@v5
-        with:
-          path: ./feeders/gtfs/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            venv-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-ansi
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
 
       - name: Run unit tests
-        run: poetry run pytest tests/test_gtfs_bridge_unit.py -v --tb=short
+        run: pytest tests/test_gtfs_bridge_unit.py -v --tb=short
 
       - name: Run integration tests
-        run: poetry run pytest tests/test_gtfs_bridge_integration.py -v --tb=short
+        run: pytest tests/test_gtfs_bridge_integration.py -v --tb=short
 
       - name: Run all tests with coverage
-        run: poetry run pytest tests/ -v --cov=gtfs_rt_bridge --cov-report=term-missing --cov-report=xml --cov-fail-under=20
+        run: pytest tests/ -v --cov=gtfs_rt_bridge --cov-report=term-missing --cov-report=xml --cov-fail-under=20
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7

--- a/feeders/gtfs/Dockerfile
+++ b/feeders/gtfs/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y git
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install --no-cache-dir ./gtfs_rt_producer/gtfs_rt_producer_data \
+    && pip install --no-cache-dir ./gtfs_rt_producer/gtfs_rt_producer_kafka_producer \
+    && pip install --no-cache-dir .
 
 # Define environment variables (default values)
 

--- a/feeders/gtfs/pyproject.toml
+++ b/feeders/gtfs/pyproject.toml
@@ -44,3 +44,7 @@ dev = [
 root = "../.."
 version_scheme = "post-release"
 local_scheme = "no-local-version"
+
+[tool.setuptools]
+packages = ["gtfs_rt_bridge"]
+package-dir = {"" = "gtfs_rt_bridge/src"}


### PR DESCRIPTION
Fix the GTFS container build regression by installing generated producer packages before the local package and by explicitly discovering the GTFS bridge package during wheel builds.\n\nValidation:\n- python -m pytest tests/docker_e2e/test_docker_build.py -k 'gtfs' -q