### PR TITLE
fix(docker): install producer_data sub-packages before main package in all Dockerfiles

### DIFF
--- a/feeders/aviationweather/Dockerfile
+++ b/feeders/aviationweather/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./aviationweather_producer/aviationweather_producer_data \
+ && pip install ./aviationweather_producer/aviationweather_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV AVIATIONWEATHER_LAST_POLLED_FILE="/mnt/fileshare/aviationweather_last_polled.json"

--- a/feeders/bafu-hydro/Dockerfile
+++ b/feeders/bafu-hydro/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./bafu_hydro_producer/bafu_hydro_producer_data \
+ && pip install ./bafu_hydro_producer/bafu_hydro_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/bfs-odl/Dockerfile
+++ b/feeders/bfs-odl/Dockerfile
@@ -12,7 +12,9 @@ COPY . /app
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./bfs_odl_producer/bfs_odl_producer_data \
+ && pip install ./bfs_odl_producer/bfs_odl_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/blitzortung/Dockerfile
+++ b/feeders/blitzortung/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./blitzortung_producer/blitzortung_producer_data \
+ && pip install ./blitzortung_producer/blitzortung_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV BLITZORTUNG_WS_URLS="wss://live.lightningmaps.org:443/,wss://live2.lightningmaps.org:443/"

--- a/feeders/carbon-intensity/Dockerfile
+++ b/feeders/carbon-intensity/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./carbon_intensity_producer/carbon_intensity_producer_data \
+ && pip install ./carbon_intensity_producer/carbon_intensity_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CARBON_INTENSITY_LAST_POLLED_FILE="/mnt/fileshare/carbon_intensity_last_polled.json"

--- a/feeders/cbp-border-wait/Dockerfile
+++ b/feeders/cbp-border-wait/Dockerfile
@@ -12,7 +12,9 @@ COPY . /app
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./cbp_border_wait_producer/cbp_border_wait_producer_data \
+ && pip install ./cbp_border_wait_producer/cbp_border_wait_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/cdec-reservoirs/Dockerfile
+++ b/feeders/cdec-reservoirs/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./cdec_reservoirs_producer/cdec_reservoirs_producer_data \
+ && pip install ./cdec_reservoirs_producer/cdec_reservoirs_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/digitraffic-maritime/Dockerfile
+++ b/feeders/digitraffic-maritime/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./digitraffic_maritime_producer/digitraffic_maritime_producer_data \
+ && pip install ./digitraffic_maritime_producer/digitraffic_maritime_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV DIGITRAFFIC_SUBSCRIBE="location,metadata"

--- a/feeders/dwd-pollenflug/Dockerfile
+++ b/feeders/dwd-pollenflug/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./dwd_pollenflug_producer/dwd_pollenflug_producer_data \
+ && pip install ./dwd_pollenflug_producer/dwd_pollenflug_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV DWD_POLLENFLUG_LAST_POLLED_FILE="/mnt/fileshare/dwd_pollenflug_last_polled.json"

--- a/feeders/dwd/Dockerfile
+++ b/feeders/dwd/Dockerfile
@@ -27,7 +27,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./dwd_producer/dwd_producer_data \
+ && pip install ./dwd_producer/dwd_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/eaws-albina/Dockerfile
+++ b/feeders/eaws-albina/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./eaws_albina_producer/eaws_albina_producer_data \
+ && pip install ./eaws_albina_producer/eaws_albina_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV ALBINA_LAST_POLLED_FILE="/mnt/fileshare/albina_last_polled.json"

--- a/feeders/elexon-bmrs/Dockerfile
+++ b/feeders/elexon-bmrs/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./elexon_bmrs_producer/elexon_bmrs_producer_data \
+ && pip install ./elexon_bmrs_producer/elexon_bmrs_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV BMRS_LAST_POLLED_FILE="/mnt/fileshare/bmrs_last_polled.json"

--- a/feeders/energidataservice-dk/Dockerfile
+++ b/feeders/energidataservice-dk/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./energidataservice_dk_producer/energidataservice_dk_producer_data \
+ && pip install ./energidataservice_dk_producer/energidataservice_dk_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV EDS_LAST_POLLED_FILE="/mnt/fileshare/eds_last_polled.json"

--- a/feeders/energy-charts/Dockerfile
+++ b/feeders/energy-charts/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./energy_charts_producer/energy_charts_producer_data \
+ && pip install ./energy_charts_producer/energy_charts_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV ENERGY_CHARTS_LAST_POLLED_FILE="/mnt/fileshare/energy_charts_last_polled.json"

--- a/feeders/epa-uv/Dockerfile
+++ b/feeders/epa-uv/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./epa_uv_producer/epa_uv_producer_data \
+ && pip install ./epa_uv_producer/epa_uv_producer_kafka_producer \
+ && pip install .
 
 ENV EPA_UV_STATE_FILE="/mnt/fileshare/epa_uv_state.json"
 ENV EPA_UV_LOCATIONS="Seattle,WA"

--- a/feeders/eurdep-radiation/Dockerfile
+++ b/feeders/eurdep-radiation/Dockerfile
@@ -12,7 +12,9 @@ COPY . /app
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./eurdep_radiation_producer/eurdep_radiation_producer_data \
+ && pip install ./eurdep_radiation_producer/eurdep_radiation_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/german-waters/Dockerfile
+++ b/feeders/german-waters/Dockerfile
@@ -19,7 +19,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./german_waters_producer/german_waters_producer_data \
+ && pip install ./german_waters_producer/german_waters_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/gios-poland/Dockerfile
+++ b/feeders/gios-poland/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./gios_poland_producer/gios_poland_producer_data \
+ && pip install ./gios_poland_producer/gios_poland_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV GIOS_LAST_POLLED_FILE="/mnt/fileshare/gios_last_polled.json"

--- a/feeders/gracedb/Dockerfile
+++ b/feeders/gracedb/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./gracedb_producer/gracedb_producer_data \
+ && pip install ./gracedb_producer/gracedb_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/hubeau-hydrometrie/Dockerfile
+++ b/feeders/hubeau-hydrometrie/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data \
+ && pip install ./hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 CMD ["python", "-m", "hubeau_hydrometrie", "feed"]

--- a/feeders/inpe-deter-brazil/Dockerfile
+++ b/feeders/inpe-deter-brazil/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./inpe_deter_brazil_producer/inpe_deter_brazil_producer_data \
+ && pip install ./inpe_deter_brazil_producer/inpe_deter_brazil_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/irail/Dockerfile
+++ b/feeders/irail/Dockerfile
@@ -12,7 +12,9 @@ COPY . /app
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./irail_producer/irail_producer_data \
+ && pip install ./irail_producer/irail_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/ireland-opw-waterlevel/Dockerfile
+++ b/feeders/ireland-opw-waterlevel/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./ireland_opw_waterlevel_producer/ireland_opw_waterlevel_producer_data \
+ && pip install ./ireland_opw_waterlevel_producer/ireland_opw_waterlevel_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/jma-japan/Dockerfile
+++ b/feeders/jma-japan/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./jma_japan_producer/jma_japan_producer_data \
+ && pip install ./jma_japan_producer/jma_japan_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV JMA_LAST_POLLED_FILE="/mnt/fileshare/jma_last_polled.json"

--- a/feeders/king-county-marine/Dockerfile
+++ b/feeders/king-county-marine/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./king_county_marine_producer/king_county_marine_producer_data \
+ && pip install ./king_county_marine_producer/king_county_marine_producer_kafka_producer \
+ && pip install .
 
 ENV KING_COUNTY_MARINE_STATE_FILE="/mnt/fileshare/king_county_marine_state.json"
 ENV CONNECTION_STRING=""

--- a/feeders/kystverket-ais/Dockerfile
+++ b/feeders/kystverket-ais/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./kystverket_ais_producer/kystverket_ais_producer_data \
+ && pip install ./kystverket_ais_producer/kystverket_ais_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV AIS_TCP_HOST="153.44.253.27"

--- a/feeders/mode-s/Dockerfile
+++ b/feeders/mode-s/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./mode_s_producer/mode_s_producer_data \
+ && pip install ./mode_s_producer/mode_s_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV DUMP1090_HOST="localhost"

--- a/feeders/nasa-firms/Dockerfile
+++ b/feeders/nasa-firms/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nasa_firms_producer/nasa_firms_producer_data \
+ && pip install ./nasa_firms_producer/nasa_firms_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/nepal-bipad-hydrology/Dockerfile
+++ b/feeders/nepal-bipad-hydrology/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nepal_bipad_hydrology_producer/nepal_bipad_hydrology_producer_data \
+ && pip install ./nepal_bipad_hydrology_producer/nepal_bipad_hydrology_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/nextbus/Dockerfile
+++ b/feeders/nextbus/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nextbus_producer/nextbus_producer_data \
+ && pip install ./nextbus_producer/nextbus_producer_kafka_producer \
+ && pip install .
 
 ENV FEED_CONNECTION_STRING=""
 ENV FEED_EVENT_HUB_NAME=""

--- a/feeders/nifc-usa-wildfires/Dockerfile
+++ b/feeders/nifc-usa-wildfires/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nifc_usa_wildfires_producer/nifc_usa_wildfires_producer_data \
+ && pip install ./nifc_usa_wildfires_producer/nifc_usa_wildfires_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/noaa-goes/Dockerfile
+++ b/feeders/noaa-goes/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./noaa_goes_producer/noaa_goes_producer_data \
+ && pip install ./noaa_goes_producer/noaa_goes_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV SWPC_LAST_POLLED_FILE="/mnt/fileshare/swpc_last_polled.json"

--- a/feeders/noaa-ndbc/Dockerfile
+++ b/feeders/noaa-ndbc/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./noaa_ndbc_producer/noaa_ndbc_producer_data \
+ && pip install ./noaa_ndbc_producer/noaa_ndbc_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV NDBC_LAST_POLLED_FILE="/mnt/fileshare/ndbc_last_polled.json"

--- a/feeders/noaa-nws/Dockerfile
+++ b/feeders/noaa-nws/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./noaa_nws_producer/noaa_nws_producer_data \
+ && pip install ./noaa_nws_producer/noaa_nws_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV NWS_LAST_POLLED_FILE="/mnt/fileshare/nws_last_polled.json"

--- a/feeders/noaa/Dockerfile
+++ b/feeders/noaa/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./noaa_producer/noaa_producer_data \
+ && pip install ./noaa_producer/noaa_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV NOAA_LAST_POLLED_FILE="/mnt/fileshare/noaa_last_polled.json"

--- a/feeders/nve-hydro/Dockerfile
+++ b/feeders/nve-hydro/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nve_hydro_producer/nve_hydro_producer_data \
+ && pip install ./nve_hydro_producer/nve_hydro_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV NVE_API_KEY=""

--- a/feeders/nws-forecasts/Dockerfile
+++ b/feeders/nws-forecasts/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./nws_forecasts_producer/nws_forecasts_producer_data \
+ && pip install ./nws_forecasts_producer/nws_forecasts_producer_kafka_producer \
+ && pip install .
 
 ENV NWS_FORECAST_ZONES="WAZ312,WAZ315,WAZ316,WAZ317,PZZ130,PZZ131,PZZ132,PZZ133,PZZ134,PZZ135"
 ENV NWS_FORECAST_STATE_FILE="/mnt/fileshare/nws_forecasts_state.json"

--- a/feeders/paris-bicycle-counters/Dockerfile
+++ b/feeders/paris-bicycle-counters/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./paris_bicycle_counters_producer/paris_bicycle_counters_producer_data \
+ && pip install ./paris_bicycle_counters_producer/paris_bicycle_counters_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV PYTHONUNBUFFERED=1

--- a/feeders/rss/Dockerfile
+++ b/feeders/rss/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./rssbridge_producer/rssbridge_producer_data \
+ && pip install ./rssbridge_producer/rssbridge_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/seattle-911/Dockerfile
+++ b/feeders/seattle-911/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./seattle_911_producer/seattle_911_producer_data \
+ && pip install ./seattle_911_producer/seattle_911_producer_kafka_producer \
+ && pip install .
 
 ENV SEATTLE_911_LAST_POLLED_FILE="/mnt/fileshare/seattle_911_last_polled.json"
 ENV CONNECTION_STRING=""

--- a/feeders/seattle-street-closures/Dockerfile
+++ b/feeders/seattle-street-closures/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./seattle_street_closures_producer/seattle_street_closures_producer_data \
+ && pip install ./seattle_street_closures_producer/seattle_street_closures_producer_kafka_producer \
+ && pip install .
 
 ENV SEATTLE_STREET_CLOSURES_STATE_FILE="/mnt/fileshare/seattle_street_closures_state.json"
 ENV CONNECTION_STRING=""

--- a/feeders/syke-hydro/Dockerfile
+++ b/feeders/syke-hydro/Dockerfile
@@ -9,7 +9,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./syke_hydro_producer/syke_hydro_producer_data \
+ && pip install ./syke_hydro_producer/syke_hydro_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 

--- a/feeders/tokyo-docomo-bikeshare/Dockerfile
+++ b/feeders/tokyo-docomo-bikeshare/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./tokyo_docomo_bikeshare_producer/tokyo_docomo_bikeshare_producer_data \
+ && pip install ./tokyo_docomo_bikeshare_producer/tokyo_docomo_bikeshare_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/uk-ea-flood-monitoring/Dockerfile
+++ b/feeders/uk-ea-flood-monitoring/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./uk_ea_flood_monitoring_producer/uk_ea_flood_monitoring_producer_data \
+ && pip install ./uk_ea_flood_monitoring_producer/uk_ea_flood_monitoring_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/usgs-earthquakes/Dockerfile
+++ b/feeders/usgs-earthquakes/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./usgs_earthquakes_producer/usgs_earthquakes_producer_data \
+ && pip install ./usgs_earthquakes_producer/usgs_earthquakes_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/usgs-geomag/Dockerfile
+++ b/feeders/usgs-geomag/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./usgs_geomag_producer/usgs_geomag_producer_data \
+ && pip install ./usgs_geomag_producer/usgs_geomag_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV GEOMAG_LAST_POLLED_FILE="/mnt/fileshare/usgs_geomag_last_polled.json"

--- a/feeders/usgs-iv/Dockerfile
+++ b/feeders/usgs-iv/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./usgs_iv_producer/usgs_iv_producer_data \
+ && pip install ./usgs_iv_producer/usgs_iv_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/usgs-nwis-wq/Dockerfile
+++ b/feeders/usgs-nwis-wq/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./usgs_nwis_wq_producer/usgs_nwis_wq_producer_data \
+ && pip install ./usgs_nwis_wq_producer/usgs_nwis_wq_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/vatsim/Dockerfile
+++ b/feeders/vatsim/Dockerfile
@@ -16,7 +16,9 @@ COPY . /app
 # Install the required Python packages
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./vatsim_producer/vatsim_producer_data \
+ && pip install ./vatsim_producer/vatsim_producer_kafka_producer \
+ && pip install .
 
 # Define environment variables (default values)
 ENV CONNECTION_STRING=""

--- a/feeders/wikimedia-eventstreams/Dockerfile
+++ b/feeders/wikimedia-eventstreams/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./wikimedia_eventstreams_producer/wikimedia_eventstreams_producer_data \
+ && pip install ./wikimedia_eventstreams_producer/wikimedia_eventstreams_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV LOG_LEVEL="INFO"

--- a/feeders/wikimedia-osm-diffs/Dockerfile
+++ b/feeders/wikimedia-osm-diffs/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 COPY . /app
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_data \
+ && pip install ./wikimedia_osm_diffs_producer/wikimedia_osm_diffs_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV LOG_LEVEL="INFO"

--- a/feeders/wsdot/Dockerfile
+++ b/feeders/wsdot/Dockerfile
@@ -12,7 +12,9 @@ COPY . /app
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
-RUN pip install .
+RUN pip install ./wsdot_producer/wsdot_producer_data \
+ && pip install ./wsdot_producer/wsdot_producer_kafka_producer \
+ && pip install .
 
 ENV CONNECTION_STRING=""
 ENV WSDOT_ACCESS_CODE=""


### PR DESCRIPTION
Completes the fix started in #890 (which fixed Dockerfile.amqp for 15 sources). All 52 main Dockerfiles were missing the sub-package pip install steps, causing ModuleNotFoundError on container startup.