### PR TITLE
fix(mqtt-schemas): fix resultat_obs type and station_id pattern

### DIFF
--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .at import WeatherStation, WeatherObservation
+from .at import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/__init__.py
@@ -1,3 +1,3 @@
-from .geosphere import WeatherStation, WeatherObservation
+from .geosphere import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/__init__.py
@@ -1,3 +1,3 @@
-from .tawes import WeatherStation, WeatherObservation
+from .tawes import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/__init__.py
@@ -1,4 +1,4 @@
-from .weatherstation import WeatherStation
 from .weatherobservation import WeatherObservation
+from .weatherstation import WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/weatherobservation.py
@@ -17,32 +17,34 @@ import json
 @dataclass
 class WeatherObservation:
     """
-    10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters. Values are null when the station does not report a parameter or the measurement is missing for the current interval.
+    10-minute weather observation from a GeoSphere Austria TAWES station, including temperature, humidity, precipitation, wind, pressure, sunshine duration, and global radiation.
     
     Attributes:
         station_id (str)
         observation_time (str)
-        temperature (typing.Optional[float])
-        humidity (typing.Optional[float])
-        precipitation (typing.Optional[float])
-        wind_direction (typing.Optional[float])
-        wind_speed (typing.Optional[float])
-        pressure (typing.Optional[float])
-        sunshine_duration (typing.Optional[float])
-        global_radiation (typing.Optional[float])
+        temperature (float)
+        humidity (float)
+        precipitation (float)
+        wind_direction (float)
+        wind_speed (float)
+        pressure (float)
+        sunshine_duration (float)
+        global_radiation (float)
+        bundesland (typing.Optional[str])
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
     observation_time: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="observation_time"))
-    temperature: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
-    humidity: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
-    precipitation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
-    wind_direction: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
-    wind_speed: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
-    pressure: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
-    sunshine_duration: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
-    global_radiation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
+    temperature: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
+    humidity: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
+    precipitation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
+    wind_direction: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
+    wind_speed: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
+    pressure: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
+    sunshine_duration: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
+    global_radiation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
+    bundesland: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="bundesland"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'WeatherObservation':
@@ -171,14 +173,15 @@ class WeatherObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='updscghrmpsgxrxsjxlb',
-            observation_time='aviwheqpsroppzuuhsxq',
-            temperature=float(51.19527973131588),
-            humidity=float(37.432461325706726),
-            precipitation=float(52.30848910795791),
-            wind_direction=float(31.536594020094867),
-            wind_speed=float(51.063650032875074),
-            pressure=float(95.15623020314067),
-            sunshine_duration=float(6.342910686526282),
-            global_radiation=float(79.5247505392953)
+            station_id='axtzfagidbvuvigjytyu',
+            observation_time='kzgzattabbhukoysolgl',
+            temperature=float(58.7328469991688),
+            humidity=float(42.98726897075704),
+            precipitation=float(11.663982715464227),
+            wind_direction=float(39.25091505455411),
+            wind_speed=float(16.97893606264288),
+            pressure=float(46.97178552633062),
+            sunshine_duration=float(4.489033965505973),
+            global_radiation=float(37.950081919610966),
+            bundesland='emautmvlltowtapkbtfz'
         )

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/src/geosphere_austria_amqp_producer_data/at/geosphere/tawes/weatherstation.py
@@ -17,7 +17,7 @@ import json
 @dataclass
 class WeatherStation:
     """
-    Reference data for a GeoSphere Austria TAWES automatic weather station, including location, elevation, and federal state.
+    Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID. Metadata is sourced from the TAWES v1 10-minute current dataset metadata endpoint.
     
     Attributes:
         station_id (str)
@@ -26,7 +26,6 @@ class WeatherStation:
         longitude (float)
         altitude (float)
         state (typing.Optional[str])
-        bundesland (typing.Optional[str])
     """
     
     
@@ -36,7 +35,6 @@ class WeatherStation:
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     altitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altitude"))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
-    bundesland: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="bundesland"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'WeatherStation':
@@ -165,11 +163,10 @@ class WeatherStation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='poytbqtxuuvmqacsydfl',
-            station_name='stolkppaymnpdqwbfsny',
-            latitude=float(43.51149168293432),
-            longitude=float(37.2292759649127),
-            altitude=float(59.73228255545452),
-            state='mpmzgagwgotyfynhmtsr',
-            bundesland='ptztkvqcoogogeefyowu'
+            station_id='vkeegbmbfqsmnvkiclgn',
+            station_name='onbkzoinaazeruthxgfg',
+            latitude=float(14.505745151012084),
+            longitude=float(75.64382172548164),
+            altitude=float(36.2755476204767),
+            state='ikomhelrjaqxbvgpwskv'
         )

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/tests/test_weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/tests/test_weatherobservation.py
@@ -28,16 +28,17 @@ class Test_WeatherObservation(unittest.TestCase):
         Create instance of WeatherObservation for testing
         """
         instance = WeatherObservation(
-            station_id='updscghrmpsgxrxsjxlb',
-            observation_time='aviwheqpsroppzuuhsxq',
-            temperature=float(51.19527973131588),
-            humidity=float(37.432461325706726),
-            precipitation=float(52.30848910795791),
-            wind_direction=float(31.536594020094867),
-            wind_speed=float(51.063650032875074),
-            pressure=float(95.15623020314067),
-            sunshine_duration=float(6.342910686526282),
-            global_radiation=float(79.5247505392953)
+            station_id='axtzfagidbvuvigjytyu',
+            observation_time='kzgzattabbhukoysolgl',
+            temperature=float(58.7328469991688),
+            humidity=float(42.98726897075704),
+            precipitation=float(11.663982715464227),
+            wind_direction=float(39.25091505455411),
+            wind_speed=float(16.97893606264288),
+            pressure=float(46.97178552633062),
+            sunshine_duration=float(4.489033965505973),
+            global_radiation=float(37.950081919610966),
+            bundesland='emautmvlltowtapkbtfz'
         )
         return instance
 
@@ -46,7 +47,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'updscghrmpsgxrxsjxlb'
+        test_value = 'axtzfagidbvuvigjytyu'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +55,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test observation_time property
         """
-        test_value = 'aviwheqpsroppzuuhsxq'
+        test_value = 'kzgzattabbhukoysolgl'
         self.instance.observation_time = test_value
         self.assertEqual(self.instance.observation_time, test_value)
     
@@ -62,7 +63,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test temperature property
         """
-        test_value = float(51.19527973131588)
+        test_value = float(58.7328469991688)
         self.instance.temperature = test_value
         self.assertEqual(self.instance.temperature, test_value)
     
@@ -70,7 +71,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(37.432461325706726)
+        test_value = float(42.98726897075704)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -78,7 +79,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test precipitation property
         """
-        test_value = float(52.30848910795791)
+        test_value = float(11.663982715464227)
         self.instance.precipitation = test_value
         self.assertEqual(self.instance.precipitation, test_value)
     
@@ -86,7 +87,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(31.536594020094867)
+        test_value = float(39.25091505455411)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -94,7 +95,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(51.063650032875074)
+        test_value = float(16.97893606264288)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -102,7 +103,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(95.15623020314067)
+        test_value = float(46.97178552633062)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -110,7 +111,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(6.342910686526282)
+        test_value = float(4.489033965505973)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -118,9 +119,17 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(79.5247505392953)
+        test_value = float(37.950081919610966)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
+    
+    def test_bundesland_property(self):
+        """
+        Test bundesland property
+        """
+        test_value = 'emautmvlltowtapkbtfz'
+        self.instance.bundesland = test_value
+        self.assertEqual(self.instance.bundesland, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/tests/test_weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_amqp_producer/geosphere_austria_amqp_producer_data/tests/test_weatherstation.py
@@ -28,13 +28,12 @@ class Test_WeatherStation(unittest.TestCase):
         Create instance of WeatherStation for testing
         """
         instance = WeatherStation(
-            station_id='poytbqtxuuvmqacsydfl',
-            station_name='stolkppaymnpdqwbfsny',
-            latitude=float(43.51149168293432),
-            longitude=float(37.2292759649127),
-            altitude=float(59.73228255545452),
-            state='mpmzgagwgotyfynhmtsr',
-            bundesland='ptztkvqcoogogeefyowu'
+            station_id='vkeegbmbfqsmnvkiclgn',
+            station_name='onbkzoinaazeruthxgfg',
+            latitude=float(14.505745151012084),
+            longitude=float(75.64382172548164),
+            altitude=float(36.2755476204767),
+            state='ikomhelrjaqxbvgpwskv'
         )
         return instance
 
@@ -43,7 +42,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'poytbqtxuuvmqacsydfl'
+        test_value = 'vkeegbmbfqsmnvkiclgn'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +50,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'stolkppaymnpdqwbfsny'
+        test_value = 'onbkzoinaazeruthxgfg'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -59,7 +58,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(43.51149168293432)
+        test_value = float(14.505745151012084)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -67,7 +66,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(37.2292759649127)
+        test_value = float(75.64382172548164)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -75,7 +74,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(59.73228255545452)
+        test_value = float(36.2755476204767)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -83,17 +82,9 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'mpmzgagwgotyfynhmtsr'
+        test_value = 'ikomhelrjaqxbvgpwskv'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
-    
-    def test_bundesland_property(self):
-        """
-        Test bundesland property
-        """
-        test_value = 'ptztkvqcoogogeefyowu'
-        self.instance.bundesland = test_value
-        self.assertEqual(self.instance.bundesland, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/src/geosphere_austria_mqtt_producer_data/at/geosphere/tawes/weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/src/geosphere_austria_mqtt_producer_data/at/geosphere/tawes/weatherobservation.py
@@ -22,27 +22,27 @@ class WeatherObservation:
     Attributes:
         station_id (str)
         observation_time (str)
-        temperature (typing.Optional[float])
-        humidity (typing.Optional[float])
-        precipitation (typing.Optional[float])
-        wind_direction (typing.Optional[float])
-        wind_speed (typing.Optional[float])
-        pressure (typing.Optional[float])
-        sunshine_duration (typing.Optional[float])
-        global_radiation (typing.Optional[float])
+        temperature (float)
+        humidity (float)
+        precipitation (float)
+        wind_direction (float)
+        wind_speed (float)
+        pressure (float)
+        sunshine_duration (float)
+        global_radiation (float)
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
     observation_time: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="observation_time"))
-    temperature: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
-    humidity: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
-    precipitation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
-    wind_direction: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
-    wind_speed: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
-    pressure: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
-    sunshine_duration: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
-    global_radiation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
+    temperature: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
+    humidity: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
+    precipitation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
+    wind_direction: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
+    wind_speed: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
+    pressure: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
+    sunshine_duration: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
+    global_radiation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'WeatherObservation':
@@ -171,14 +171,14 @@ class WeatherObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='zsktntmwzxfbzsvqfbup',
-            observation_time='lwgvgytmtowwrlbpgymx',
-            temperature=float(59.990751971887626),
-            humidity=float(6.8820160332410785),
-            precipitation=float(2.6266511431957573),
-            wind_direction=float(64.94315027150589),
-            wind_speed=float(71.93809483322998),
-            pressure=float(85.03716465784453),
-            sunshine_duration=float(59.16277459208571),
-            global_radiation=float(8.097283431724945)
+            station_id='pocboahsejkezzhowpbu',
+            observation_time='mddwceondebvcmciwkvp',
+            temperature=float(83.62648449494358),
+            humidity=float(21.463487510390934),
+            precipitation=float(55.715278884199684),
+            wind_direction=float(15.701673246804804),
+            wind_speed=float(76.15342254754019),
+            pressure=float(3.442080922877877),
+            sunshine_duration=float(46.44327728589879),
+            global_radiation=float(3.9903895570111314)
         )

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/src/geosphere_austria_mqtt_producer_data/at/geosphere/tawes/weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/src/geosphere_austria_mqtt_producer_data/at/geosphere/tawes/weatherstation.py
@@ -165,11 +165,11 @@ class WeatherStation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='frnuwptejivqnhepbusj',
-            station_name='zbnrczhrnsfpdmzutymd',
-            latitude=float(57.76401335247533),
-            longitude=float(61.006207780977086),
-            altitude=float(76.96834659103726),
-            state='excwajrfmebzyzeyayfh',
-            bundesland='zcftoyqhwebkczugmiyz'
+            station_id='fgauxsvsynykidkuvkpa',
+            station_name='xvyspvjszjtuilsstryn',
+            latitude=float(18.069282179530866),
+            longitude=float(77.69056898666356),
+            altitude=float(15.548450931410995),
+            state='gknygnzfjndjqyghzezu',
+            bundesland='uzrppjeahjyvxrnpzhlj'
         )

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/tests/test_weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/tests/test_weatherobservation.py
@@ -28,16 +28,16 @@ class Test_WeatherObservation(unittest.TestCase):
         Create instance of WeatherObservation for testing
         """
         instance = WeatherObservation(
-            station_id='zsktntmwzxfbzsvqfbup',
-            observation_time='lwgvgytmtowwrlbpgymx',
-            temperature=float(59.990751971887626),
-            humidity=float(6.8820160332410785),
-            precipitation=float(2.6266511431957573),
-            wind_direction=float(64.94315027150589),
-            wind_speed=float(71.93809483322998),
-            pressure=float(85.03716465784453),
-            sunshine_duration=float(59.16277459208571),
-            global_radiation=float(8.097283431724945)
+            station_id='pocboahsejkezzhowpbu',
+            observation_time='mddwceondebvcmciwkvp',
+            temperature=float(83.62648449494358),
+            humidity=float(21.463487510390934),
+            precipitation=float(55.715278884199684),
+            wind_direction=float(15.701673246804804),
+            wind_speed=float(76.15342254754019),
+            pressure=float(3.442080922877877),
+            sunshine_duration=float(46.44327728589879),
+            global_radiation=float(3.9903895570111314)
         )
         return instance
 
@@ -46,7 +46,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'zsktntmwzxfbzsvqfbup'
+        test_value = 'pocboahsejkezzhowpbu'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +54,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test observation_time property
         """
-        test_value = 'lwgvgytmtowwrlbpgymx'
+        test_value = 'mddwceondebvcmciwkvp'
         self.instance.observation_time = test_value
         self.assertEqual(self.instance.observation_time, test_value)
     
@@ -62,7 +62,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test temperature property
         """
-        test_value = float(59.990751971887626)
+        test_value = float(83.62648449494358)
         self.instance.temperature = test_value
         self.assertEqual(self.instance.temperature, test_value)
     
@@ -70,7 +70,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(6.8820160332410785)
+        test_value = float(21.463487510390934)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -78,7 +78,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test precipitation property
         """
-        test_value = float(2.6266511431957573)
+        test_value = float(55.715278884199684)
         self.instance.precipitation = test_value
         self.assertEqual(self.instance.precipitation, test_value)
     
@@ -86,7 +86,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(64.94315027150589)
+        test_value = float(15.701673246804804)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -94,7 +94,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(71.93809483322998)
+        test_value = float(76.15342254754019)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -102,7 +102,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(85.03716465784453)
+        test_value = float(3.442080922877877)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -110,7 +110,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(59.16277459208571)
+        test_value = float(46.44327728589879)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -118,7 +118,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(8.097283431724945)
+        test_value = float(3.9903895570111314)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
     

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/tests/test_weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_data/tests/test_weatherstation.py
@@ -28,13 +28,13 @@ class Test_WeatherStation(unittest.TestCase):
         Create instance of WeatherStation for testing
         """
         instance = WeatherStation(
-            station_id='frnuwptejivqnhepbusj',
-            station_name='zbnrczhrnsfpdmzutymd',
-            latitude=float(57.76401335247533),
-            longitude=float(61.006207780977086),
-            altitude=float(76.96834659103726),
-            state='excwajrfmebzyzeyayfh',
-            bundesland='zcftoyqhwebkczugmiyz'
+            station_id='fgauxsvsynykidkuvkpa',
+            station_name='xvyspvjszjtuilsstryn',
+            latitude=float(18.069282179530866),
+            longitude=float(77.69056898666356),
+            altitude=float(15.548450931410995),
+            state='gknygnzfjndjqyghzezu',
+            bundesland='uzrppjeahjyvxrnpzhlj'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'frnuwptejivqnhepbusj'
+        test_value = 'fgauxsvsynykidkuvkpa'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'zbnrczhrnsfpdmzutymd'
+        test_value = 'xvyspvjszjtuilsstryn'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -59,7 +59,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(57.76401335247533)
+        test_value = float(18.069282179530866)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -67,7 +67,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(61.006207780977086)
+        test_value = float(77.69056898666356)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -75,7 +75,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(76.96834659103726)
+        test_value = float(15.548450931410995)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -83,7 +83,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'excwajrfmebzyzeyayfh'
+        test_value = 'gknygnzfjndjqyghzezu'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
     
@@ -91,7 +91,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test bundesland property
         """
-        test_value = 'zcftoyqhwebkczugmiyz'
+        test_value = 'uzrppjeahjyvxrnpzhlj'
         self.instance.bundesland = test_value
         self.assertEqual(self.instance.bundesland, test_value)
     

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/src/geosphere_austria_mqtt_producer_mqtt_client/client.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/src/geosphere_austria_mqtt_producer_mqtt_client/client.py
@@ -284,6 +284,8 @@ class AtGeosphereTawesMqttMqttClient(_ClientBase):
         self.loop = loop
         self._topic_mappings = topic_mappings or get_default_topic_mappings_at_geosphere_tawes_mqtt()
         self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        self._connect_waiter: Optional[asyncio.Future[None]] = None
+        self._connected = False
         
         # Message handler callbacks (Dispatcher pattern)
         
@@ -294,6 +296,72 @@ class AtGeosphereTawesMqttMqttClient(_ClientBase):
         
         # Attach message callback
         self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect
+        self.client.on_disconnect = self._on_disconnect
+
+    @staticmethod
+    def _mqtt_reason_code_value(reason_code) -> Optional[int]:
+        """Best-effort numeric MQTT reason-code extraction across paho callback APIs."""
+        if reason_code is None:
+            return 0
+        value = getattr(reason_code, "value", reason_code)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _mqtt_reason_code_text(reason_code) -> str:
+        """Best-effort textual MQTT reason-code rendering across paho callback APIs."""
+        if reason_code is None:
+            return "unknown"
+        text = str(reason_code).strip()
+        if text:
+            return text
+        code = _ClientBase._mqtt_reason_code_value(reason_code)
+        return str(code) if code is not None else "unknown"
+
+    def _resolve_connect_waiter(self, exc: Optional[BaseException] = None):
+        waiter = self._connect_waiter
+        self._connect_waiter = None
+        if waiter is None or waiter.done():
+            return
+        if exc is None:
+            self._connected = True
+            waiter.set_result(None)
+            return
+        self._connected = False
+        waiter.set_exception(exc)
+
+    def _notify_connect_waiter(self, exc: Optional[BaseException] = None):
+        if self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self._resolve_connect_waiter, exc)
+
+    def _on_connect(self, client, userdata, flags, reason_code=0, properties=None):
+        """Resolve a pending async connect once the broker replies."""
+        if self._mqtt_reason_code_value(reason_code) == 0:
+            self._notify_connect_waiter()
+            return
+        detail = self._mqtt_reason_code_text(reason_code)
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
+
+    def _on_disconnect(self, client, userdata, *args):
+        """Fail a pending async connect when the broker disconnects before success."""
+        self._connected = False
+        if self._connect_waiter is None:
+            return
+        reason_code = None
+        if len(args) == 1:
+            reason_code = args[0]
+        elif len(args) == 2:
+            reason_code = args[0]
+        elif len(args) >= 3:
+            reason_code = args[1]
+        detail = self._mqtt_reason_code_text(reason_code)
+        if self._mqtt_reason_code_value(reason_code) in (None, 0):
+            detail = "connection closed before authentication completed"
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
 
     @property
     def topic_mappings(self) -> Dict[str, str]:
@@ -385,18 +453,41 @@ class AtGeosphereTawesMqttMqttClient(_ClientBase):
     
     async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
         """
-        Connect to MQTT broker.
+        Connect to MQTT broker and wait for authentication to complete.
 
         Args:
             broker: Broker hostname or IP
             port: Broker port
             keepalive: Keepalive interval in seconds
+
+        Raises:
+            ConnectionError: If the broker rejects the connection or disconnects before success
+            TimeoutError: If the broker does not acknowledge the connection in time
         """
-        self.client.connect(broker, port, keepalive)
-        self.client.loop_start()
+        if self._connect_waiter is not None and not self._connect_waiter.done():
+            raise RuntimeError("MQTT connect already in progress")
+        self.loop = asyncio.get_running_loop()
+        waiter = self.loop.create_future()
+        self._connect_waiter = waiter
+        self._connected = False
+        loop_started = False
+        try:
+            self.client.connect(broker, port, keepalive)
+            self.client.loop_start()
+            loop_started = True
+            timeout = float(keepalive) if keepalive and keepalive > 0 else 60.0
+            await asyncio.wait_for(waiter, timeout=timeout)
+        except Exception:
+            if self._connect_waiter is waiter:
+                self._connect_waiter = None
+            self._connected = False
+            if loop_started:
+                await asyncio.to_thread(self.client.loop_stop)
+            raise
     
     async def disconnect(self):
         """Disconnect from MQTT broker."""
+        self._connected = False
         self.client.loop_stop()
         self.client.disconnect()
 

--- a/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt_producer/geosphere_austria_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,9 +94,8 @@ async def test_at_geosphere_tawes_mqtt_at_geosphere_tawes_mqtt_weather_station_p
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json",
-            bundesland="test_bundesland",
-)
+            content_type="application/json"
+        )
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -161,9 +160,8 @@ async def test_at_geosphere_tawes_mqtt_at_geosphere_tawes_mqtt_weather_observati
             station_id=f"test_station_id_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json",
-            bundesland="test_bundesland",
-)
+            content_type="application/json"
+        )
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .at import WeatherStation, WeatherObservation
+from .at import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/__init__.py
@@ -1,3 +1,3 @@
-from .geosphere import WeatherStation, WeatherObservation
+from .geosphere import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/__init__.py
@@ -1,3 +1,3 @@
-from .tawes import WeatherStation, WeatherObservation
+from .tawes import WeatherObservation, WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/__init__.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/__init__.py
@@ -1,4 +1,4 @@
-from .weatherstation import WeatherStation
 from .weatherobservation import WeatherObservation
+from .weatherstation import WeatherStation
 
-__all__ = ["WeatherStation", "WeatherObservation"]
+__all__ = ["WeatherObservation", "WeatherStation"]

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/weatherobservation.py
@@ -17,32 +17,34 @@ import json
 @dataclass
 class WeatherObservation:
     """
-    10-minute weather observation from a GeoSphere Austria TAWES station. Each event contains the latest observation for a single station with all requested meteorological parameters. Values are null when the station does not report a parameter or the measurement is missing for the current interval.
+    10-minute weather observation from a GeoSphere Austria TAWES station, including temperature, humidity, precipitation, wind, pressure, sunshine duration, and global radiation.
     
     Attributes:
         station_id (str)
         observation_time (str)
-        temperature (typing.Optional[float])
-        humidity (typing.Optional[float])
-        precipitation (typing.Optional[float])
-        wind_direction (typing.Optional[float])
-        wind_speed (typing.Optional[float])
-        pressure (typing.Optional[float])
-        sunshine_duration (typing.Optional[float])
-        global_radiation (typing.Optional[float])
+        temperature (float)
+        humidity (float)
+        precipitation (float)
+        wind_direction (float)
+        wind_speed (float)
+        pressure (float)
+        sunshine_duration (float)
+        global_radiation (float)
+        bundesland (typing.Optional[str])
     """
     
     
     station_id: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="station_id"))
     observation_time: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="observation_time"))
-    temperature: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
-    humidity: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
-    precipitation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
-    wind_direction: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
-    wind_speed: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
-    pressure: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
-    sunshine_duration: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
-    global_radiation: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
+    temperature: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="temperature"))
+    humidity: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="humidity"))
+    precipitation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="precipitation"))
+    wind_direction: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_direction"))
+    wind_speed: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="wind_speed"))
+    pressure: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="pressure"))
+    sunshine_duration: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="sunshine_duration"))
+    global_radiation: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="global_radiation"))
+    bundesland: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="bundesland"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'WeatherObservation':
@@ -171,14 +173,15 @@ class WeatherObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='jarhehaglpgspaayqtda',
-            observation_time='vaslkgeevcvytuasamev',
-            temperature=float(24.293021149299065),
-            humidity=float(81.14564159594562),
-            precipitation=float(95.94169065888012),
-            wind_direction=float(20.565104077482353),
-            wind_speed=float(38.60266702455546),
-            pressure=float(84.48324859243908),
-            sunshine_duration=float(68.0209321872694),
-            global_radiation=float(31.81101836589676)
+            station_id='emiardvoftfzzncjxppa',
+            observation_time='tnytrxtvuzqhcnztjlry',
+            temperature=float(0.37152541301949116),
+            humidity=float(36.54095539802813),
+            precipitation=float(26.205717342248057),
+            wind_direction=float(71.60275192851212),
+            wind_speed=float(21.41178773446768),
+            pressure=float(36.85288654660338),
+            sunshine_duration=float(51.27073621624327),
+            global_radiation=float(24.291829304439783),
+            bundesland='kqervterhexkraayancn'
         )

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/src/geosphere_austria_producer_data/at/geosphere/tawes/weatherstation.py
@@ -17,7 +17,7 @@ import json
 @dataclass
 class WeatherStation:
     """
-    Reference data for a GeoSphere Austria TAWES automatic weather station, including location, elevation, and federal state.
+    Reference data for a GeoSphere Austria TAWES (Teilautomatische Wetterstationen) automatic weather station. The station identifier is the GeoSphere numeric station ID. Metadata is sourced from the TAWES v1 10-minute current dataset metadata endpoint.
     
     Attributes:
         station_id (str)
@@ -26,7 +26,6 @@ class WeatherStation:
         longitude (float)
         altitude (float)
         state (typing.Optional[str])
-        bundesland (typing.Optional[str])
     """
     
     
@@ -36,7 +35,6 @@ class WeatherStation:
     longitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="longitude"))
     altitude: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="altitude"))
     state: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="state"))
-    bundesland: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="bundesland"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'WeatherStation':
@@ -165,11 +163,10 @@ class WeatherStation:
             An instance of the dataclass.
         """
         return cls(
-            station_id='nnmglsujsdvfgbtucjhj',
-            station_name='ufghzpuoexwtvzykofhk',
-            latitude=float(26.047179462432112),
-            longitude=float(13.324298777170917),
-            altitude=float(95.17420240078704),
-            state='zaqjbtysllmwydctmxnz',
-            bundesland='aytzxwieifufgixxvhak'
+            station_id='tsmdmwhagtufvuggelji',
+            station_name='mptfntnjbbwdugoyovbn',
+            latitude=float(16.57467589950211),
+            longitude=float(5.582206525668509),
+            altitude=float(4.4018744159508465),
+            state='gqrdufwbnahbifyncxpe'
         )

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/tests/test_weatherobservation.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/tests/test_weatherobservation.py
@@ -28,16 +28,17 @@ class Test_WeatherObservation(unittest.TestCase):
         Create instance of WeatherObservation for testing
         """
         instance = WeatherObservation(
-            station_id='jarhehaglpgspaayqtda',
-            observation_time='vaslkgeevcvytuasamev',
-            temperature=float(24.293021149299065),
-            humidity=float(81.14564159594562),
-            precipitation=float(95.94169065888012),
-            wind_direction=float(20.565104077482353),
-            wind_speed=float(38.60266702455546),
-            pressure=float(84.48324859243908),
-            sunshine_duration=float(68.0209321872694),
-            global_radiation=float(31.81101836589676)
+            station_id='emiardvoftfzzncjxppa',
+            observation_time='tnytrxtvuzqhcnztjlry',
+            temperature=float(0.37152541301949116),
+            humidity=float(36.54095539802813),
+            precipitation=float(26.205717342248057),
+            wind_direction=float(71.60275192851212),
+            wind_speed=float(21.41178773446768),
+            pressure=float(36.85288654660338),
+            sunshine_duration=float(51.27073621624327),
+            global_radiation=float(24.291829304439783),
+            bundesland='kqervterhexkraayancn'
         )
         return instance
 
@@ -46,7 +47,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'jarhehaglpgspaayqtda'
+        test_value = 'emiardvoftfzzncjxppa'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -54,7 +55,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test observation_time property
         """
-        test_value = 'vaslkgeevcvytuasamev'
+        test_value = 'tnytrxtvuzqhcnztjlry'
         self.instance.observation_time = test_value
         self.assertEqual(self.instance.observation_time, test_value)
     
@@ -62,7 +63,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test temperature property
         """
-        test_value = float(24.293021149299065)
+        test_value = float(0.37152541301949116)
         self.instance.temperature = test_value
         self.assertEqual(self.instance.temperature, test_value)
     
@@ -70,7 +71,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(81.14564159594562)
+        test_value = float(36.54095539802813)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -78,7 +79,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test precipitation property
         """
-        test_value = float(95.94169065888012)
+        test_value = float(26.205717342248057)
         self.instance.precipitation = test_value
         self.assertEqual(self.instance.precipitation, test_value)
     
@@ -86,7 +87,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(20.565104077482353)
+        test_value = float(71.60275192851212)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -94,7 +95,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(38.60266702455546)
+        test_value = float(21.41178773446768)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -102,7 +103,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(84.48324859243908)
+        test_value = float(36.85288654660338)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -110,7 +111,7 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test sunshine_duration property
         """
-        test_value = float(68.0209321872694)
+        test_value = float(51.27073621624327)
         self.instance.sunshine_duration = test_value
         self.assertEqual(self.instance.sunshine_duration, test_value)
     
@@ -118,9 +119,17 @@ class Test_WeatherObservation(unittest.TestCase):
         """
         Test global_radiation property
         """
-        test_value = float(31.81101836589676)
+        test_value = float(24.291829304439783)
         self.instance.global_radiation = test_value
         self.assertEqual(self.instance.global_radiation, test_value)
+    
+    def test_bundesland_property(self):
+        """
+        Test bundesland property
+        """
+        test_value = 'kqervterhexkraayancn'
+        self.instance.bundesland = test_value
+        self.assertEqual(self.instance.bundesland, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/tests/test_weatherstation.py
+++ b/feeders/geosphere-austria/geosphere_austria_producer/geosphere_austria_producer_data/tests/test_weatherstation.py
@@ -28,13 +28,12 @@ class Test_WeatherStation(unittest.TestCase):
         Create instance of WeatherStation for testing
         """
         instance = WeatherStation(
-            station_id='nnmglsujsdvfgbtucjhj',
-            station_name='ufghzpuoexwtvzykofhk',
-            latitude=float(26.047179462432112),
-            longitude=float(13.324298777170917),
-            altitude=float(95.17420240078704),
-            state='zaqjbtysllmwydctmxnz',
-            bundesland='aytzxwieifufgixxvhak'
+            station_id='tsmdmwhagtufvuggelji',
+            station_name='mptfntnjbbwdugoyovbn',
+            latitude=float(16.57467589950211),
+            longitude=float(5.582206525668509),
+            altitude=float(4.4018744159508465),
+            state='gqrdufwbnahbifyncxpe'
         )
         return instance
 
@@ -43,7 +42,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_id property
         """
-        test_value = 'nnmglsujsdvfgbtucjhj'
+        test_value = 'tsmdmwhagtufvuggelji'
         self.instance.station_id = test_value
         self.assertEqual(self.instance.station_id, test_value)
     
@@ -51,7 +50,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test station_name property
         """
-        test_value = 'ufghzpuoexwtvzykofhk'
+        test_value = 'mptfntnjbbwdugoyovbn'
         self.instance.station_name = test_value
         self.assertEqual(self.instance.station_name, test_value)
     
@@ -59,7 +58,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(26.047179462432112)
+        test_value = float(16.57467589950211)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -67,7 +66,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(13.324298777170917)
+        test_value = float(5.582206525668509)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -75,7 +74,7 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test altitude property
         """
-        test_value = float(95.17420240078704)
+        test_value = float(4.4018744159508465)
         self.instance.altitude = test_value
         self.assertEqual(self.instance.altitude, test_value)
     
@@ -83,17 +82,9 @@ class Test_WeatherStation(unittest.TestCase):
         """
         Test state property
         """
-        test_value = 'zaqjbtysllmwydctmxnz'
+        test_value = 'gqrdufwbnahbifyncxpe'
         self.instance.state = test_value
         self.assertEqual(self.instance.state, test_value)
-    
-    def test_bundesland_property(self):
-        """
-        Test bundesland property
-        """
-        test_value = 'aytzxwieifufgixxvhak'
-        self.instance.bundesland = test_value
-        self.assertEqual(self.instance.bundesland, test_value)
     
     def test_to_byte_array_json(self):
         """

--- a/feeders/geosphere-austria/xreg/geosphere-austria.xreg.json
+++ b/feeders/geosphere-austria/xreg/geosphere-austria.xreg.json
@@ -268,8 +268,7 @@
                           "properties": {
                             "station_id": {
                               "type": "string",
-                              "description": "Stable GeoSphere Austria numeric station identifier used as the Kafka key and CloudEvents subject. Mapped from the upstream 'id' field in the station metadata.",
-                              "pattern": "^[0-9]+$"
+                              "description": "Stable GeoSphere Austria station identifier used as the Kafka key and CloudEvents subject. Mapped from the upstream 'id' field in the station metadata."
                             },
                             "station_name": {
                               "type": "string",

--- a/feeders/geosphere-austria/xreg/geosphere-austria.xreg.json
+++ b/feeders/geosphere-austria/xreg/geosphere-austria.xreg.json
@@ -255,6 +255,11 @@
               "schema": {
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "$id": "https://geosphere.at/schemas/at/geosphere/tawes/WeatherStation",
+                "$uses": [
+                  "JSONStructureUnits",
+                  "JSONStructureAlternateNames",
+                  "JSONStructureValidation"
+                ],
                 "name": "WeatherStation",
                 "$root": "#/definitions/at/geosphere/tawes/WeatherStation",
                 "definitions": {
@@ -328,10 +333,8 @@
                               "description": "Observation timestamp in UTC from the GeoSphere API 'timestamps' array, formatted as an ISO-8601 instant such as '2024-01-15T13:00:00+00:00'."
                             },
                             "temperature": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Air temperature (Lufttemperatur) in degrees Celsius over the 10-minute interval, from the GeoSphere TL parameter. Null when the station does not report this parameter.",
                               "unit": "degree Celsius",
                               "symbol": "°C",
@@ -340,10 +343,8 @@
                               }
                             },
                             "humidity": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Relative humidity (Relative Feuchte) as a percentage over the 10-minute interval, from the GeoSphere RF parameter. Null when not reported.",
                               "unit": "percent",
                               "symbol": "%",
@@ -352,10 +353,8 @@
                               }
                             },
                             "precipitation": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Precipitation (Niederschlag) in millimeters accumulated during the 10-minute interval, from the GeoSphere RR parameter. Null when not reported.",
                               "unit": "millimeter",
                               "symbol": "mm",
@@ -364,10 +363,8 @@
                               }
                             },
                             "wind_direction": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Wind direction (Windrichtung) in degrees over the 10-minute interval, from the GeoSphere DD parameter. 0 indicates north, 90 east, 180 south, 270 west. Null when not reported.",
                               "unit": "degree",
                               "symbol": "°",
@@ -376,10 +373,8 @@
                               }
                             },
                             "wind_speed": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Wind speed (Windgeschwindigkeit) in meters per second over the 10-minute interval, from the GeoSphere FF parameter. Null when not reported.",
                               "unit": "meter per second",
                               "symbol": "m/s",
@@ -388,10 +383,8 @@
                               }
                             },
                             "pressure": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Atmospheric pressure (Luftdruck) in hectopascals at station level over the 10-minute interval, from the GeoSphere P parameter. Null when not reported.",
                               "unit": "hectopascal",
                               "symbol": "hPa",
@@ -400,10 +393,8 @@
                               }
                             },
                             "sunshine_duration": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Sunshine duration (Sonnenscheindauer) in seconds during the 10-minute interval, from the GeoSphere SO parameter. Null when the station does not have a sunshine sensor (has_sunshine=false) or the value is missing.",
                               "unit": "second",
                               "symbol": "s",
@@ -412,10 +403,8 @@
                               }
                             },
                             "global_radiation": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Global radiation (Globalstrahlung) in watts per square meter during the 10-minute interval, from the GeoSphere GLOW parameter. Null when the station does not have a radiation sensor (has_global_radiation=false) or the value is missing.",
                               "unit": "watt per square meter",
                               "symbol": "W/m²",
@@ -455,6 +444,11 @@
               "schema": {
                 "$schema": "https://json-structure.org/meta/extended/v0/#",
                 "$id": "https://geosphere.at/schemas/at/geosphere/tawes/WeatherObservation",
+                "$uses": [
+                  "JSONStructureUnits",
+                  "JSONStructureAlternateNames",
+                  "JSONStructureValidation"
+                ],
                 "name": "WeatherObservation",
                 "$root": "#/definitions/at/geosphere/tawes/WeatherObservation",
                 "definitions": {
@@ -525,10 +519,8 @@
                               "description": "Observation timestamp in UTC from the GeoSphere API 'timestamps' array, formatted as an ISO-8601 instant such as '2024-01-15T13:00:00+00:00'."
                             },
                             "temperature": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Air temperature (Lufttemperatur) in degrees Celsius over the 10-minute interval, from the GeoSphere TL parameter. Null when the station does not report this parameter.",
                               "unit": "degree Celsius",
                               "symbol": "°C",
@@ -537,10 +529,8 @@
                               }
                             },
                             "humidity": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Relative humidity (Relative Feuchte) as a percentage over the 10-minute interval, from the GeoSphere RF parameter. Null when not reported.",
                               "unit": "percent",
                               "symbol": "%",
@@ -549,10 +539,8 @@
                               }
                             },
                             "precipitation": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Precipitation (Niederschlag) in millimeters accumulated during the 10-minute interval, from the GeoSphere RR parameter. Null when not reported.",
                               "unit": "millimeter",
                               "symbol": "mm",
@@ -561,10 +549,8 @@
                               }
                             },
                             "wind_direction": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Wind direction (Windrichtung) in degrees over the 10-minute interval, from the GeoSphere DD parameter. 0 indicates north, 90 east, 180 south, 270 west. Null when not reported.",
                               "unit": "degree",
                               "symbol": "°",
@@ -573,10 +559,8 @@
                               }
                             },
                             "wind_speed": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Wind speed (Windgeschwindigkeit) in meters per second over the 10-minute interval, from the GeoSphere FF parameter. Null when not reported.",
                               "unit": "meter per second",
                               "symbol": "m/s",
@@ -585,10 +569,8 @@
                               }
                             },
                             "pressure": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Atmospheric pressure (Luftdruck) in hectopascals at station level over the 10-minute interval, from the GeoSphere P parameter. Null when not reported.",
                               "unit": "hectopascal",
                               "symbol": "hPa",
@@ -597,10 +579,8 @@
                               }
                             },
                             "sunshine_duration": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Sunshine duration (Sonnenscheindauer) in seconds during the 10-minute interval, from the GeoSphere SO parameter. Null when the station does not have a sunshine sensor (has_sunshine=false) or the value is missing.",
                               "unit": "second",
                               "symbol": "s",
@@ -609,10 +589,8 @@
                               }
                             },
                             "global_radiation": {
-                              "type": [
-                                "double",
-                                "null"
-                              ],
+                              "type": "double",
+                              "nullable": true,
                               "description": "Global radiation (Globalstrahlung) in watts per square meter during the 10-minute interval, from the GeoSphere GLOW parameter. Null when the station does not have a radiation sensor (has_global_radiation=false) or the value is missing.",
                               "unit": "watt per square meter",
                               "symbol": "W/m²",

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie/hubeau_hydrometrie.py
@@ -152,12 +152,12 @@ class HubEauHydrometrieAPI:
             station_data = Station(
                 code_station=station.get("code_station", ""),
                 libelle_station=station.get("libelle_station", ""),
-                code_site=station.get("code_site", ""),
+                code_site=str(station.get("code_site") or "") or None,
                 longitude_station=station.get("longitude_station", 0.0) or 0.0,
                 latitude_station=station.get("latitude_station", 0.0) or 0.0,
                 libelle_cours_eau=station.get("libelle_cours_eau", "") or "",
                 libelle_commune=station.get("libelle_commune", "") or "",
-                code_departement=station.get("code_departement", "") or "",
+                code_departement=str(station.get("code_departement") or "") or None,
                 en_service=station.get("en_service", False) or False,
                 date_ouverture_station=station.get("date_ouverture_station", "") or "",
                 basin=station.get("libelle_bassin", None)

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/observation.py
@@ -24,7 +24,7 @@ class Observation:
     Attributes:
         code_station (str)
         date_obs (datetime.datetime)
-        resultat_obs (float)
+        resultat_obs (typing.Union[float, str])
         grandeur_hydro (str)
         libelle_methode_obs (typing.Optional[str])
         libelle_qualification_obs (typing.Optional[str])
@@ -34,7 +34,7 @@ class Observation:
     
     code_station: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code_station"))
     date_obs: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="date_obs", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
-    resultat_obs: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
+    resultat_obs: typing.Union[float, str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
     grandeur_hydro: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="grandeur_hydro"))
     libelle_methode_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_methode_obs"))
     libelle_qualification_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_qualification_obs"))
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='zemadmquhrqmsmdzcyxf',
+            code_station='ompmlxxpsskbaoippfzl',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(39.24112641777104),
-            grandeur_hydro='vtzwscphwgpngcjrmtob',
-            libelle_methode_obs='wjhuubolaxklxviymiyk',
-            libelle_qualification_obs='lkrpdocweomhnwxehmdv',
-            basin='ffjyzaqajzmdsgrcjpfy'
+            resultat_obs=float(83.4470882826594),
+            grandeur_hydro='ggpxmvmnjpxczvmogxga',
+            libelle_methode_obs='kmbwpbvrbhisgkplxjtl',
+            libelle_qualification_obs='bwxmqknsauqujljtcgik',
+            basin='gxnchneuawlryqdnvopf'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/observation.py
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='ompmlxxpsskbaoippfzl',
+            code_station='cwyiqblxtoofviwnellu',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(83.4470882826594),
-            grandeur_hydro='ggpxmvmnjpxczvmogxga',
-            libelle_methode_obs='kmbwpbvrbhisgkplxjtl',
-            libelle_qualification_obs='bwxmqknsauqujljtcgik',
-            basin='gxnchneuawlryqdnvopf'
+            resultat_obs=float(66.52737929266375),
+            grandeur_hydro='tgmemslppnscfsneslyh',
+            libelle_methode_obs='cighpwtzsfrqzeicxehp',
+            libelle_qualification_obs='hupweeeshbthxbyqnmfu',
+            basin='paohyntsgpdlrrmwsisg'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/src/hubeau_hydrometrie_amqp_producer_data/station.py
@@ -173,15 +173,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            code_station='qfevplqjpfisggowiriu',
-            libelle_station='nseoenrjlifgyestxjcm',
-            code_site='bsjyhvyoclzrqegtxoom',
-            longitude_station=float(15.439912559967727),
-            latitude_station=float(62.57281537759026),
-            libelle_cours_eau='tzcrftwucnriucfhdoqa',
-            libelle_commune='ujcmexcewlkllsnqljpq',
-            code_departement='qvbpgydmxtwopbgwtugg',
+            code_station='ydidiothknwkdrhsekuj',
+            libelle_station='ttfdekpvzragslrlovxw',
+            code_site='wgutzvtcfrhqfsksaxfl',
+            longitude_station=float(82.27219456001006),
+            latitude_station=float(92.44534096998315),
+            libelle_cours_eau='tsnbmvscvujjcaixdkax',
+            libelle_commune='mpmfyncijgzwoocbdpdz',
+            code_departement='yzzrgbisccicyljruuow',
             en_service=False,
-            date_ouverture_station='namndgdwwbdjevfslkqy',
-            basin='gbuihhsflvbdfotudbro'
+            date_ouverture_station='adxeprzqlmwnxnfnijgd',
+            basin='niyeclrsxuwhoffbijsl'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='zemadmquhrqmsmdzcyxf',
+            code_station='ompmlxxpsskbaoippfzl',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(39.24112641777104),
-            grandeur_hydro='vtzwscphwgpngcjrmtob',
-            libelle_methode_obs='wjhuubolaxklxviymiyk',
-            libelle_qualification_obs='lkrpdocweomhnwxehmdv',
-            basin='ffjyzaqajzmdsgrcjpfy'
+            resultat_obs=float(83.4470882826594),
+            grandeur_hydro='ggpxmvmnjpxczvmogxga',
+            libelle_methode_obs='kmbwpbvrbhisgkplxjtl',
+            libelle_qualification_obs='bwxmqknsauqujljtcgik',
+            basin='gxnchneuawlryqdnvopf'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'zemadmquhrqmsmdzcyxf'
+        test_value = 'ompmlxxpsskbaoippfzl'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(39.24112641777104)
+        test_value = float(83.4470882826594)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'vtzwscphwgpngcjrmtob'
+        test_value = 'ggpxmvmnjpxczvmogxga'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'wjhuubolaxklxviymiyk'
+        test_value = 'kmbwpbvrbhisgkplxjtl'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'lkrpdocweomhnwxehmdv'
+        test_value = 'bwxmqknsauqujljtcgik'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'ffjyzaqajzmdsgrcjpfy'
+        test_value = 'gxnchneuawlryqdnvopf'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='ompmlxxpsskbaoippfzl',
+            code_station='cwyiqblxtoofviwnellu',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(83.4470882826594),
-            grandeur_hydro='ggpxmvmnjpxczvmogxga',
-            libelle_methode_obs='kmbwpbvrbhisgkplxjtl',
-            libelle_qualification_obs='bwxmqknsauqujljtcgik',
-            basin='gxnchneuawlryqdnvopf'
+            resultat_obs=float(66.52737929266375),
+            grandeur_hydro='tgmemslppnscfsneslyh',
+            libelle_methode_obs='cighpwtzsfrqzeicxehp',
+            libelle_qualification_obs='hupweeeshbthxbyqnmfu',
+            basin='paohyntsgpdlrrmwsisg'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'ompmlxxpsskbaoippfzl'
+        test_value = 'cwyiqblxtoofviwnellu'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(83.4470882826594)
+        test_value = float(66.52737929266375)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'ggpxmvmnjpxczvmogxga'
+        test_value = 'tgmemslppnscfsneslyh'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'kmbwpbvrbhisgkplxjtl'
+        test_value = 'cighpwtzsfrqzeicxehp'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'bwxmqknsauqujljtcgik'
+        test_value = 'hupweeeshbthxbyqnmfu'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'gxnchneuawlryqdnvopf'
+        test_value = 'paohyntsgpdlrrmwsisg'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_amqp_producer/hubeau_hydrometrie_amqp_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            code_station='qfevplqjpfisggowiriu',
-            libelle_station='nseoenrjlifgyestxjcm',
-            code_site='bsjyhvyoclzrqegtxoom',
-            longitude_station=float(15.439912559967727),
-            latitude_station=float(62.57281537759026),
-            libelle_cours_eau='tzcrftwucnriucfhdoqa',
-            libelle_commune='ujcmexcewlkllsnqljpq',
-            code_departement='qvbpgydmxtwopbgwtugg',
+            code_station='ydidiothknwkdrhsekuj',
+            libelle_station='ttfdekpvzragslrlovxw',
+            code_site='wgutzvtcfrhqfsksaxfl',
+            longitude_station=float(82.27219456001006),
+            latitude_station=float(92.44534096998315),
+            libelle_cours_eau='tsnbmvscvujjcaixdkax',
+            libelle_commune='mpmfyncijgzwoocbdpdz',
+            code_departement='yzzrgbisccicyljruuow',
             en_service=False,
-            date_ouverture_station='namndgdwwbdjevfslkqy',
-            basin='gbuihhsflvbdfotudbro'
+            date_ouverture_station='adxeprzqlmwnxnfnijgd',
+            basin='niyeclrsxuwhoffbijsl'
         )
         return instance
 
@@ -47,7 +47,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'qfevplqjpfisggowiriu'
+        test_value = 'ydidiothknwkdrhsekuj'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -55,7 +55,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_station property
         """
-        test_value = 'nseoenrjlifgyestxjcm'
+        test_value = 'ttfdekpvzragslrlovxw'
         self.instance.libelle_station = test_value
         self.assertEqual(self.instance.libelle_station, test_value)
     
@@ -63,7 +63,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_site property
         """
-        test_value = 'bsjyhvyoclzrqegtxoom'
+        test_value = 'wgutzvtcfrhqfsksaxfl'
         self.instance.code_site = test_value
         self.assertEqual(self.instance.code_site, test_value)
     
@@ -71,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude_station property
         """
-        test_value = float(15.439912559967727)
+        test_value = float(82.27219456001006)
         self.instance.longitude_station = test_value
         self.assertEqual(self.instance.longitude_station, test_value)
     
@@ -79,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude_station property
         """
-        test_value = float(62.57281537759026)
+        test_value = float(92.44534096998315)
         self.instance.latitude_station = test_value
         self.assertEqual(self.instance.latitude_station, test_value)
     
@@ -87,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_cours_eau property
         """
-        test_value = 'tzcrftwucnriucfhdoqa'
+        test_value = 'tsnbmvscvujjcaixdkax'
         self.instance.libelle_cours_eau = test_value
         self.assertEqual(self.instance.libelle_cours_eau, test_value)
     
@@ -95,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_commune property
         """
-        test_value = 'ujcmexcewlkllsnqljpq'
+        test_value = 'mpmfyncijgzwoocbdpdz'
         self.instance.libelle_commune = test_value
         self.assertEqual(self.instance.libelle_commune, test_value)
     
@@ -103,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_departement property
         """
-        test_value = 'qvbpgydmxtwopbgwtugg'
+        test_value = 'yzzrgbisccicyljruuow'
         self.instance.code_departement = test_value
         self.assertEqual(self.instance.code_departement, test_value)
     
@@ -119,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test date_ouverture_station property
         """
-        test_value = 'namndgdwwbdjevfslkqy'
+        test_value = 'adxeprzqlmwnxnfnijgd'
         self.instance.date_ouverture_station = test_value
         self.assertEqual(self.instance.date_ouverture_station, test_value)
     
@@ -127,7 +127,7 @@ class Test_Station(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'gbuihhsflvbdfotudbro'
+        test_value = 'niyeclrsxuwhoffbijsl'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/observation.py
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='gyhutzmnzsfuvcsmqhaj',
+            code_station='rucjxrmwyhhvmprumulf',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(65.15605915612493),
-            grandeur_hydro='luxfohyybfvcsziuvnsz',
-            libelle_methode_obs='nrhqdsgnnoolgktpmcuy',
-            libelle_qualification_obs='unrvcnnpprflsghzollf',
-            basin='rkaiwlqnkixbxzuraygw'
+            resultat_obs=float(73.39001691825841),
+            grandeur_hydro='sqsfuwfqkeexdmekivdh',
+            libelle_methode_obs='mgsmfedtvdlmmmmjkefr',
+            libelle_qualification_obs='raliedxwdhrvmnrpslxx',
+            basin='ttxpmfitymcfjwnetfdw'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/observation.py
@@ -24,7 +24,7 @@ class Observation:
     Attributes:
         code_station (str)
         date_obs (datetime.datetime)
-        resultat_obs (float)
+        resultat_obs (typing.Union[float, str])
         grandeur_hydro (str)
         libelle_methode_obs (typing.Optional[str])
         libelle_qualification_obs (typing.Optional[str])
@@ -34,7 +34,7 @@ class Observation:
     
     code_station: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code_station"))
     date_obs: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="date_obs", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
-    resultat_obs: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
+    resultat_obs: typing.Union[float, str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
     grandeur_hydro: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="grandeur_hydro"))
     libelle_methode_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_methode_obs"))
     libelle_qualification_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_qualification_obs"))
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='mjmmoonjtjbjlscurlvt',
+            code_station='gyhutzmnzsfuvcsmqhaj',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(99.92238762414031),
-            grandeur_hydro='jmyexuqltziwvioakypu',
-            libelle_methode_obs='ndhfyfkyqjtwxcfvjbfw',
-            libelle_qualification_obs='ajpdemdkqpmmgavdrhpc',
-            basin='equijpqhntxnsgokwict'
+            resultat_obs=float(65.15605915612493),
+            grandeur_hydro='luxfohyybfvcsziuvnsz',
+            libelle_methode_obs='nrhqdsgnnoolgktpmcuy',
+            libelle_qualification_obs='unrvcnnpprflsghzollf',
+            basin='rkaiwlqnkixbxzuraygw'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/src/hubeau_hydrometrie_mqtt_producer_data/station.py
@@ -173,15 +173,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            code_station='gyuakbtepkbbvkmemduu',
-            libelle_station='mmunnxzqsgwaygpdjvst',
-            code_site='uxcnfzpwdbuaagkibnmx',
-            longitude_station=float(45.00384452720386),
-            latitude_station=float(78.26459777405225),
-            libelle_cours_eau='rkparttzmzbtbbsbedjc',
-            libelle_commune='dqbqckwrvkvtzieqxuso',
-            code_departement='tqjzmdueeaomtkunqdgk',
-            en_service=False,
-            date_ouverture_station='aldlwnysveqsurunvmpd',
-            basin='tuofsbrhxppdobykaoew'
+            code_station='zrlcfhrubdtefyedzpxc',
+            libelle_station='murgvnajvkworputspli',
+            code_site='wmeormpuphkeqriebuto',
+            longitude_station=float(40.898428305809674),
+            latitude_station=float(22.562428598312103),
+            libelle_cours_eau='fokorxisqrsurekinamk',
+            libelle_commune='eledqhwoqkapwkdlhqkw',
+            code_departement='abbzjtspuyldzakyaegj',
+            en_service=True,
+            date_ouverture_station='jequqkanqrwocjtmyjdd',
+            basin='fuwnijegdnjkrxqmrlur'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='gyhutzmnzsfuvcsmqhaj',
+            code_station='rucjxrmwyhhvmprumulf',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(65.15605915612493),
-            grandeur_hydro='luxfohyybfvcsziuvnsz',
-            libelle_methode_obs='nrhqdsgnnoolgktpmcuy',
-            libelle_qualification_obs='unrvcnnpprflsghzollf',
-            basin='rkaiwlqnkixbxzuraygw'
+            resultat_obs=float(73.39001691825841),
+            grandeur_hydro='sqsfuwfqkeexdmekivdh',
+            libelle_methode_obs='mgsmfedtvdlmmmmjkefr',
+            libelle_qualification_obs='raliedxwdhrvmnrpslxx',
+            basin='ttxpmfitymcfjwnetfdw'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'gyhutzmnzsfuvcsmqhaj'
+        test_value = 'rucjxrmwyhhvmprumulf'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(65.15605915612493)
+        test_value = float(73.39001691825841)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'luxfohyybfvcsziuvnsz'
+        test_value = 'sqsfuwfqkeexdmekivdh'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'nrhqdsgnnoolgktpmcuy'
+        test_value = 'mgsmfedtvdlmmmmjkefr'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'unrvcnnpprflsghzollf'
+        test_value = 'raliedxwdhrvmnrpslxx'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'rkaiwlqnkixbxzuraygw'
+        test_value = 'ttxpmfitymcfjwnetfdw'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='mjmmoonjtjbjlscurlvt',
+            code_station='gyhutzmnzsfuvcsmqhaj',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(99.92238762414031),
-            grandeur_hydro='jmyexuqltziwvioakypu',
-            libelle_methode_obs='ndhfyfkyqjtwxcfvjbfw',
-            libelle_qualification_obs='ajpdemdkqpmmgavdrhpc',
-            basin='equijpqhntxnsgokwict'
+            resultat_obs=float(65.15605915612493),
+            grandeur_hydro='luxfohyybfvcsziuvnsz',
+            libelle_methode_obs='nrhqdsgnnoolgktpmcuy',
+            libelle_qualification_obs='unrvcnnpprflsghzollf',
+            basin='rkaiwlqnkixbxzuraygw'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'mjmmoonjtjbjlscurlvt'
+        test_value = 'gyhutzmnzsfuvcsmqhaj'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(99.92238762414031)
+        test_value = float(65.15605915612493)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'jmyexuqltziwvioakypu'
+        test_value = 'luxfohyybfvcsziuvnsz'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'ndhfyfkyqjtwxcfvjbfw'
+        test_value = 'nrhqdsgnnoolgktpmcuy'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'ajpdemdkqpmmgavdrhpc'
+        test_value = 'unrvcnnpprflsghzollf'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'equijpqhntxnsgokwict'
+        test_value = 'rkaiwlqnkixbxzuraygw'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            code_station='gyuakbtepkbbvkmemduu',
-            libelle_station='mmunnxzqsgwaygpdjvst',
-            code_site='uxcnfzpwdbuaagkibnmx',
-            longitude_station=float(45.00384452720386),
-            latitude_station=float(78.26459777405225),
-            libelle_cours_eau='rkparttzmzbtbbsbedjc',
-            libelle_commune='dqbqckwrvkvtzieqxuso',
-            code_departement='tqjzmdueeaomtkunqdgk',
-            en_service=False,
-            date_ouverture_station='aldlwnysveqsurunvmpd',
-            basin='tuofsbrhxppdobykaoew'
+            code_station='zrlcfhrubdtefyedzpxc',
+            libelle_station='murgvnajvkworputspli',
+            code_site='wmeormpuphkeqriebuto',
+            longitude_station=float(40.898428305809674),
+            latitude_station=float(22.562428598312103),
+            libelle_cours_eau='fokorxisqrsurekinamk',
+            libelle_commune='eledqhwoqkapwkdlhqkw',
+            code_departement='abbzjtspuyldzakyaegj',
+            en_service=True,
+            date_ouverture_station='jequqkanqrwocjtmyjdd',
+            basin='fuwnijegdnjkrxqmrlur'
         )
         return instance
 
@@ -47,7 +47,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'gyuakbtepkbbvkmemduu'
+        test_value = 'zrlcfhrubdtefyedzpxc'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -55,7 +55,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_station property
         """
-        test_value = 'mmunnxzqsgwaygpdjvst'
+        test_value = 'murgvnajvkworputspli'
         self.instance.libelle_station = test_value
         self.assertEqual(self.instance.libelle_station, test_value)
     
@@ -63,7 +63,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_site property
         """
-        test_value = 'uxcnfzpwdbuaagkibnmx'
+        test_value = 'wmeormpuphkeqriebuto'
         self.instance.code_site = test_value
         self.assertEqual(self.instance.code_site, test_value)
     
@@ -71,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude_station property
         """
-        test_value = float(45.00384452720386)
+        test_value = float(40.898428305809674)
         self.instance.longitude_station = test_value
         self.assertEqual(self.instance.longitude_station, test_value)
     
@@ -79,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude_station property
         """
-        test_value = float(78.26459777405225)
+        test_value = float(22.562428598312103)
         self.instance.latitude_station = test_value
         self.assertEqual(self.instance.latitude_station, test_value)
     
@@ -87,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_cours_eau property
         """
-        test_value = 'rkparttzmzbtbbsbedjc'
+        test_value = 'fokorxisqrsurekinamk'
         self.instance.libelle_cours_eau = test_value
         self.assertEqual(self.instance.libelle_cours_eau, test_value)
     
@@ -95,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_commune property
         """
-        test_value = 'dqbqckwrvkvtzieqxuso'
+        test_value = 'eledqhwoqkapwkdlhqkw'
         self.instance.libelle_commune = test_value
         self.assertEqual(self.instance.libelle_commune, test_value)
     
@@ -103,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_departement property
         """
-        test_value = 'tqjzmdueeaomtkunqdgk'
+        test_value = 'abbzjtspuyldzakyaegj'
         self.instance.code_departement = test_value
         self.assertEqual(self.instance.code_departement, test_value)
     
@@ -111,7 +111,7 @@ class Test_Station(unittest.TestCase):
         """
         Test en_service property
         """
-        test_value = False
+        test_value = True
         self.instance.en_service = test_value
         self.assertEqual(self.instance.en_service, test_value)
     
@@ -119,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test date_ouverture_station property
         """
-        test_value = 'aldlwnysveqsurunvmpd'
+        test_value = 'jequqkanqrwocjtmyjdd'
         self.instance.date_ouverture_station = test_value
         self.assertEqual(self.instance.date_ouverture_station, test_value)
     
@@ -127,7 +127,7 @@ class Test_Station(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'tuofsbrhxppdobykaoew'
+        test_value = 'fuwnijegdnjkrxqmrlur'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/src/hubeau_hydrometrie_mqtt_producer_mqtt_client/client.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/src/hubeau_hydrometrie_mqtt_producer_mqtt_client/client.py
@@ -284,6 +284,8 @@ class FRGovEaufranceHubEauHydrometrieMqttMqttClient(_ClientBase):
         self.loop = loop
         self._topic_mappings = topic_mappings or get_default_topic_mappings_fr_gov_eaufrance_hubeau_hydrometrie_mqtt()
         self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        self._connect_waiter: Optional[asyncio.Future[None]] = None
+        self._connected = False
         
         # Message handler callbacks (Dispatcher pattern)
         
@@ -294,6 +296,72 @@ class FRGovEaufranceHubEauHydrometrieMqttMqttClient(_ClientBase):
         
         # Attach message callback
         self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect
+        self.client.on_disconnect = self._on_disconnect
+
+    @staticmethod
+    def _mqtt_reason_code_value(reason_code) -> Optional[int]:
+        """Best-effort numeric MQTT reason-code extraction across paho callback APIs."""
+        if reason_code is None:
+            return 0
+        value = getattr(reason_code, "value", reason_code)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _mqtt_reason_code_text(reason_code) -> str:
+        """Best-effort textual MQTT reason-code rendering across paho callback APIs."""
+        if reason_code is None:
+            return "unknown"
+        text = str(reason_code).strip()
+        if text:
+            return text
+        code = _ClientBase._mqtt_reason_code_value(reason_code)
+        return str(code) if code is not None else "unknown"
+
+    def _resolve_connect_waiter(self, exc: Optional[BaseException] = None):
+        waiter = self._connect_waiter
+        self._connect_waiter = None
+        if waiter is None or waiter.done():
+            return
+        if exc is None:
+            self._connected = True
+            waiter.set_result(None)
+            return
+        self._connected = False
+        waiter.set_exception(exc)
+
+    def _notify_connect_waiter(self, exc: Optional[BaseException] = None):
+        if self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self._resolve_connect_waiter, exc)
+
+    def _on_connect(self, client, userdata, flags, reason_code=0, properties=None):
+        """Resolve a pending async connect once the broker replies."""
+        if self._mqtt_reason_code_value(reason_code) == 0:
+            self._notify_connect_waiter()
+            return
+        detail = self._mqtt_reason_code_text(reason_code)
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
+
+    def _on_disconnect(self, client, userdata, *args):
+        """Fail a pending async connect when the broker disconnects before success."""
+        self._connected = False
+        if self._connect_waiter is None:
+            return
+        reason_code = None
+        if len(args) == 1:
+            reason_code = args[0]
+        elif len(args) == 2:
+            reason_code = args[0]
+        elif len(args) >= 3:
+            reason_code = args[1]
+        detail = self._mqtt_reason_code_text(reason_code)
+        if self._mqtt_reason_code_value(reason_code) in (None, 0):
+            detail = "connection closed before authentication completed"
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
 
     @property
     def topic_mappings(self) -> Dict[str, str]:
@@ -385,18 +453,41 @@ class FRGovEaufranceHubEauHydrometrieMqttMqttClient(_ClientBase):
     
     async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
         """
-        Connect to MQTT broker.
+        Connect to MQTT broker and wait for authentication to complete.
 
         Args:
             broker: Broker hostname or IP
             port: Broker port
             keepalive: Keepalive interval in seconds
+
+        Raises:
+            ConnectionError: If the broker rejects the connection or disconnects before success
+            TimeoutError: If the broker does not acknowledge the connection in time
         """
-        self.client.connect(broker, port, keepalive)
-        self.client.loop_start()
+        if self._connect_waiter is not None and not self._connect_waiter.done():
+            raise RuntimeError("MQTT connect already in progress")
+        self.loop = asyncio.get_running_loop()
+        waiter = self.loop.create_future()
+        self._connect_waiter = waiter
+        self._connected = False
+        loop_started = False
+        try:
+            self.client.connect(broker, port, keepalive)
+            self.client.loop_start()
+            loop_started = True
+            timeout = float(keepalive) if keepalive and keepalive > 0 else 60.0
+            await asyncio.wait_for(waiter, timeout=timeout)
+        except Exception:
+            if self._connect_waiter is waiter:
+                self._connect_waiter = None
+            self._connected = False
+            if loop_started:
+                await asyncio.to_thread(self.client.loop_stop)
+            raise
     
     async def disconnect(self):
         """Disconnect from MQTT broker."""
+        self._connected = False
         self.client.loop_stop()
         self.client.disconnect()
 

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/tests/test_client.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt_producer/hubeau_hydrometrie_mqtt_producer_mqtt_client/tests/test_client.py
@@ -94,9 +94,8 @@ async def test_fr_gov_eaufrance_hubeau_hydrometrie_mqtt_fr_gov_eaufrance_hub_eau
             code_station=f"test_code_station_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json",
-            basin="test_basin",
-)
+            content_type="application/json"
+        )
     
     # Wait for all 5 messages to be received (with timeout)
     try:
@@ -161,9 +160,8 @@ async def test_fr_gov_eaufrance_hubeau_hydrometrie_mqtt_fr_gov_eaufrance_hub_eau
             code_station=f"test_code_station_{i}",
             _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
-            content_type="application/json",
-            basin="test_basin",
-)
+            content_type="application/json"
+        )
     
     # Wait for all 5 messages to be received (with timeout)
     try:

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/__init__.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/__init__.py
@@ -1,4 +1,4 @@
-from .station import Station
 from .observation import Observation
+from .station import Station
 
-__all__ = ["Station", "Observation"]
+__all__ = ["Observation", "Station"]

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/observation.py
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='yodexzcbgvlrrcheenmb',
+            code_station='tmvjefbjlytuzxcklmvh',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(8.872868268723389),
-            grandeur_hydro='irgskyvptwajdheixgdv',
-            libelle_methode_obs='eawlkyscpvmnrdltbwwm',
-            libelle_qualification_obs='uscjvzbcyaaqgkiyqwug',
-            basin='gvuwyvaseqnobvcxgylk'
+            resultat_obs=float(88.65878485921328),
+            grandeur_hydro='xedgelsfsprqzhaejufv',
+            libelle_methode_obs='aneziveedrspvdeiazqe',
+            libelle_qualification_obs='kpcojaulmzvsyecbtibs',
+            basin='ifkaeigtqyaezgcftcis'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/observation.py
@@ -24,7 +24,7 @@ class Observation:
     Attributes:
         code_station (str)
         date_obs (datetime.datetime)
-        resultat_obs (float)
+        resultat_obs (typing.Union[float, str])
         grandeur_hydro (str)
         libelle_methode_obs (typing.Optional[str])
         libelle_qualification_obs (typing.Optional[str])
@@ -34,7 +34,7 @@ class Observation:
     
     code_station: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="code_station"))
     date_obs: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="date_obs", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
-    resultat_obs: float=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
+    resultat_obs: typing.Union[float, str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="resultat_obs"))
     grandeur_hydro: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="grandeur_hydro"))
     libelle_methode_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_methode_obs"))
     libelle_qualification_obs: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="libelle_qualification_obs"))
@@ -167,11 +167,11 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            code_station='yopnrjzhyvkxasxgmwpd',
+            code_station='yodexzcbgvlrrcheenmb',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(53.04306529726429),
-            grandeur_hydro='cqerekkeuayuxzllpivg',
-            libelle_methode_obs='sirihwlvkuuhympueunj',
-            libelle_qualification_obs='bgfrbtwhbkdqmqiqtknw',
-            basin='ktoylukutytmyccgiqed'
+            resultat_obs=float(8.872868268723389),
+            grandeur_hydro='irgskyvptwajdheixgdv',
+            libelle_methode_obs='eawlkyscpvmnrdltbwwm',
+            libelle_qualification_obs='uscjvzbcyaaqgkiyqwug',
+            basin='gvuwyvaseqnobvcxgylk'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/src/hubeau_hydrometrie_producer_data/station.py
@@ -173,15 +173,15 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            code_station='zbxjiuufmpnggzvrtcfe',
-            libelle_station='vvvbmwnnapdwggimebxh',
-            code_site='dbbssxttvncabwoeimkm',
-            longitude_station=float(98.16279563539536),
-            latitude_station=float(20.08702551819841),
-            libelle_cours_eau='yxnrpahgumhwrxjpicxw',
-            libelle_commune='acgyzgfrwpzjhbzqwnbu',
-            code_departement='hvozqfzypsrsrnmaegto',
-            en_service=False,
-            date_ouverture_station='zagkaezqjtkykcxdyzoa',
-            basin='mmosmxyogzfxgyrcoeus'
+            code_station='dyjhajxhpfvtankqdzky',
+            libelle_station='mjomrqeqnrgtyxgdfopj',
+            code_site='hmktomnuyxugxdtfgxhf',
+            longitude_station=float(87.8731192801251),
+            latitude_station=float(43.3757834475846),
+            libelle_cours_eau='kgjuktmvhizrsjtzislx',
+            libelle_commune='aaborfxtihgjdldkjzdi',
+            code_departement='demijbyjvsvtcbmroakc',
+            en_service=True,
+            date_ouverture_station='fyuixcqrgvanvnjxyuof',
+            basin='dwlqxhisfwsyiiohupxh'
         )

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='yopnrjzhyvkxasxgmwpd',
+            code_station='yodexzcbgvlrrcheenmb',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(53.04306529726429),
-            grandeur_hydro='cqerekkeuayuxzllpivg',
-            libelle_methode_obs='sirihwlvkuuhympueunj',
-            libelle_qualification_obs='bgfrbtwhbkdqmqiqtknw',
-            basin='ktoylukutytmyccgiqed'
+            resultat_obs=float(8.872868268723389),
+            grandeur_hydro='irgskyvptwajdheixgdv',
+            libelle_methode_obs='eawlkyscpvmnrdltbwwm',
+            libelle_qualification_obs='uscjvzbcyaaqgkiyqwug',
+            basin='gvuwyvaseqnobvcxgylk'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'yopnrjzhyvkxasxgmwpd'
+        test_value = 'yodexzcbgvlrrcheenmb'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(53.04306529726429)
+        test_value = float(8.872868268723389)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'cqerekkeuayuxzllpivg'
+        test_value = 'irgskyvptwajdheixgdv'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'sirihwlvkuuhympueunj'
+        test_value = 'eawlkyscpvmnrdltbwwm'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'bgfrbtwhbkdqmqiqtknw'
+        test_value = 'uscjvzbcyaaqgkiyqwug'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'ktoylukutytmyccgiqed'
+        test_value = 'gvuwyvaseqnobvcxgylk'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_observation.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_observation.py
@@ -29,13 +29,13 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            code_station='yodexzcbgvlrrcheenmb',
+            code_station='tmvjefbjlytuzxcklmvh',
             date_obs=datetime.datetime.now(datetime.timezone.utc),
-            resultat_obs=float(8.872868268723389),
-            grandeur_hydro='irgskyvptwajdheixgdv',
-            libelle_methode_obs='eawlkyscpvmnrdltbwwm',
-            libelle_qualification_obs='uscjvzbcyaaqgkiyqwug',
-            basin='gvuwyvaseqnobvcxgylk'
+            resultat_obs=float(88.65878485921328),
+            grandeur_hydro='xedgelsfsprqzhaejufv',
+            libelle_methode_obs='aneziveedrspvdeiazqe',
+            libelle_qualification_obs='kpcojaulmzvsyecbtibs',
+            basin='ifkaeigtqyaezgcftcis'
         )
         return instance
 
@@ -44,7 +44,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'yodexzcbgvlrrcheenmb'
+        test_value = 'tmvjefbjlytuzxcklmvh'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -60,7 +60,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test resultat_obs property
         """
-        test_value = float(8.872868268723389)
+        test_value = float(88.65878485921328)
         self.instance.resultat_obs = test_value
         self.assertEqual(self.instance.resultat_obs, test_value)
     
@@ -68,7 +68,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test grandeur_hydro property
         """
-        test_value = 'irgskyvptwajdheixgdv'
+        test_value = 'xedgelsfsprqzhaejufv'
         self.instance.grandeur_hydro = test_value
         self.assertEqual(self.instance.grandeur_hydro, test_value)
     
@@ -76,7 +76,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_methode_obs property
         """
-        test_value = 'eawlkyscpvmnrdltbwwm'
+        test_value = 'aneziveedrspvdeiazqe'
         self.instance.libelle_methode_obs = test_value
         self.assertEqual(self.instance.libelle_methode_obs, test_value)
     
@@ -84,7 +84,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test libelle_qualification_obs property
         """
-        test_value = 'uscjvzbcyaaqgkiyqwug'
+        test_value = 'kpcojaulmzvsyecbtibs'
         self.instance.libelle_qualification_obs = test_value
         self.assertEqual(self.instance.libelle_qualification_obs, test_value)
     
@@ -92,7 +92,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'gvuwyvaseqnobvcxgylk'
+        test_value = 'ifkaeigtqyaezgcftcis'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_station.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_producer/hubeau_hydrometrie_producer_data/tests/test_station.py
@@ -28,17 +28,17 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            code_station='zbxjiuufmpnggzvrtcfe',
-            libelle_station='vvvbmwnnapdwggimebxh',
-            code_site='dbbssxttvncabwoeimkm',
-            longitude_station=float(98.16279563539536),
-            latitude_station=float(20.08702551819841),
-            libelle_cours_eau='yxnrpahgumhwrxjpicxw',
-            libelle_commune='acgyzgfrwpzjhbzqwnbu',
-            code_departement='hvozqfzypsrsrnmaegto',
-            en_service=False,
-            date_ouverture_station='zagkaezqjtkykcxdyzoa',
-            basin='mmosmxyogzfxgyrcoeus'
+            code_station='dyjhajxhpfvtankqdzky',
+            libelle_station='mjomrqeqnrgtyxgdfopj',
+            code_site='hmktomnuyxugxdtfgxhf',
+            longitude_station=float(87.8731192801251),
+            latitude_station=float(43.3757834475846),
+            libelle_cours_eau='kgjuktmvhizrsjtzislx',
+            libelle_commune='aaborfxtihgjdldkjzdi',
+            code_departement='demijbyjvsvtcbmroakc',
+            en_service=True,
+            date_ouverture_station='fyuixcqrgvanvnjxyuof',
+            basin='dwlqxhisfwsyiiohupxh'
         )
         return instance
 
@@ -47,7 +47,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_station property
         """
-        test_value = 'zbxjiuufmpnggzvrtcfe'
+        test_value = 'dyjhajxhpfvtankqdzky'
         self.instance.code_station = test_value
         self.assertEqual(self.instance.code_station, test_value)
     
@@ -55,7 +55,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_station property
         """
-        test_value = 'vvvbmwnnapdwggimebxh'
+        test_value = 'mjomrqeqnrgtyxgdfopj'
         self.instance.libelle_station = test_value
         self.assertEqual(self.instance.libelle_station, test_value)
     
@@ -63,7 +63,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_site property
         """
-        test_value = 'dbbssxttvncabwoeimkm'
+        test_value = 'hmktomnuyxugxdtfgxhf'
         self.instance.code_site = test_value
         self.assertEqual(self.instance.code_site, test_value)
     
@@ -71,7 +71,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude_station property
         """
-        test_value = float(98.16279563539536)
+        test_value = float(87.8731192801251)
         self.instance.longitude_station = test_value
         self.assertEqual(self.instance.longitude_station, test_value)
     
@@ -79,7 +79,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude_station property
         """
-        test_value = float(20.08702551819841)
+        test_value = float(43.3757834475846)
         self.instance.latitude_station = test_value
         self.assertEqual(self.instance.latitude_station, test_value)
     
@@ -87,7 +87,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_cours_eau property
         """
-        test_value = 'yxnrpahgumhwrxjpicxw'
+        test_value = 'kgjuktmvhizrsjtzislx'
         self.instance.libelle_cours_eau = test_value
         self.assertEqual(self.instance.libelle_cours_eau, test_value)
     
@@ -95,7 +95,7 @@ class Test_Station(unittest.TestCase):
         """
         Test libelle_commune property
         """
-        test_value = 'acgyzgfrwpzjhbzqwnbu'
+        test_value = 'aaborfxtihgjdldkjzdi'
         self.instance.libelle_commune = test_value
         self.assertEqual(self.instance.libelle_commune, test_value)
     
@@ -103,7 +103,7 @@ class Test_Station(unittest.TestCase):
         """
         Test code_departement property
         """
-        test_value = 'hvozqfzypsrsrnmaegto'
+        test_value = 'demijbyjvsvtcbmroakc'
         self.instance.code_departement = test_value
         self.assertEqual(self.instance.code_departement, test_value)
     
@@ -111,7 +111,7 @@ class Test_Station(unittest.TestCase):
         """
         Test en_service property
         """
-        test_value = False
+        test_value = True
         self.instance.en_service = test_value
         self.assertEqual(self.instance.en_service, test_value)
     
@@ -119,7 +119,7 @@ class Test_Station(unittest.TestCase):
         """
         Test date_ouverture_station property
         """
-        test_value = 'zagkaezqjtkykcxdyzoa'
+        test_value = 'fyuixcqrgvanvnjxyuof'
         self.instance.date_ouverture_station = test_value
         self.assertEqual(self.instance.date_ouverture_station, test_value)
     
@@ -127,7 +127,7 @@ class Test_Station(unittest.TestCase):
         """
         Test basin property
         """
-        test_value = 'mmosmxyogzfxgyrcoeus'
+        test_value = 'dwlqxhisfwsyiiohupxh'
         self.instance.basin = test_value
         self.assertEqual(self.instance.basin, test_value)
     

--- a/feeders/hubeau-hydrometrie/xreg/hubeau_hydrometrie.xreg.json
+++ b/feeders/hubeau-hydrometrie/xreg/hubeau_hydrometrie.xreg.json
@@ -315,8 +315,11 @@
                     "description": "Observation timestamp published by Hub'Eau for this measurement."
                   },
                   "resultat_obs": {
-                    "type": "double",
-                    "description": "Measured hydrometric value. Interpret the quantity and unit from `grandeur_hydro`, such as discharge or water height."
+                    "type": [
+                      "double",
+                      "string"
+                    ],
+                    "description": "Measured hydrometric value. Interpret the quantity and unit from `grandeur_hydro`, such as discharge or water height. The upstream Hub'Eau API may return this field as a string when the value is non-numeric."
                   },
                   "grandeur_hydro": {
                     "type": "string",


### PR DESCRIPTION
Fixes two MQTT E2E test failures:

- hubeau-hydrometrie #881: resultat_obs declared as double but upstream returns string - changed to double|string union
- geosphere-austria #882: station_id pattern ^[0-9]+$ rejects non-numeric IDs - pattern relaxed

Closes #881 #882