### PR TITLE
fix(australia-wildfires): implement Entra JWT MQTT auth

### DIFF
--- a/feeders/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
+++ b/feeders/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import dataclasses
+import json
 import logging
 import os
 import re
 import unicodedata
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
 
 import paho.mqtt.client as mqtt
 from paho.mqtt.client import CallbackAPIVersion, MQTTv5
@@ -55,6 +57,51 @@ def _to_mqtt_incident(incident) -> MqttFireIncident:
     return MqttFireIncident(**payload)
 
 
+def _fetch_entra_mqtt_token(audience: str, managed_identity_client_id: Optional[str] = None) -> str:
+    """Fetch an Entra access token for Event Grid MQTT from the IMDS endpoint."""
+    params = {
+        "api-version": "2018-02-01",
+        "resource": audience or "https://eventgrid.azure.net/",
+    }
+    if managed_identity_client_id:
+        params["client_id"] = managed_identity_client_id
+
+    request = Request(
+        "http://169.254.169.254/metadata/identity/oauth2/token?" + urlencode(params),
+        headers={"Metadata": "true"},
+    )
+    with urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    token = payload.get("accessToken") or payload.get("access_token")
+    if not token:
+        raise RuntimeError("IMDS token response did not contain an access token")
+    return str(token)
+
+
+def _resolve_mqtt_auth(
+    *,
+    username: Optional[str],
+    password: Optional[str],
+    client_id: Optional[str],
+    auth_mode: Optional[str] = None,
+) -> tuple[str, str]:
+    """Resolve MQTT credentials for password or Entra JWT authentication modes."""
+    auth_mode = (auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
+
+    if auth_mode != "entra":
+        return username or "", password or ""
+
+    audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
+    managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
+    resolved_username = (client_id or os.getenv("MQTT_CLIENT_ID") or username or "").strip()
+    if not resolved_username:
+        raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
+
+    resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
+    return resolved_username, resolved_password
+
+
 async def feed(
     broker_host: str,
     broker_port: int,
@@ -67,13 +114,20 @@ async def feed(
     content_mode: str = "binary",
     polling_interval: int = 300,
 ) -> None:
+    resolved_username, resolved_password = _resolve_mqtt_auth(
+        username=username,
+        password=password,
+        client_id=client_id,
+        auth_mode=os.getenv("MQTT_AUTH_MODE"),
+    )
+
     paho_client = mqtt.Client(
         callback_api_version=CallbackAPIVersion.VERSION2,
         client_id=client_id or "",
         protocol=MQTTv5,
     )
-    if username:
-        paho_client.username_pw_set(username, password or "")
+    if resolved_username or resolved_password:
+        paho_client.username_pw_set(resolved_username, resolved_password)
     if tls:
         paho_client.tls_set()
 

--- a/feeders/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/client.py
+++ b/feeders/australia-wildfires/australia_wildfires_mqtt_producer/australia_wildfires_mqtt_producer_mqtt_client/src/australia_wildfires_mqtt_producer_mqtt_client/client.py
@@ -23,7 +23,6 @@ from australia_wildfires_mqtt_producer_data import FireIncident
 # URI template regex pattern
 _URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
 
-
 def _topic_to_mqtt_wildcard(topic: str) -> str:
     """Convert URI template placeholders to MQTT wildcards (+)."""
     return _URI_TEMPLATE_PATTERN.sub('+', topic)
@@ -236,6 +235,8 @@ class AUGovEmergencyWildfiresMqttMqttClient(_ClientBase):
         self.loop = loop
         self._topic_mappings = topic_mappings or get_default_topic_mappings_au_gov_emergency_wildfires_mqtt()
         self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        self._connect_waiter: Optional[asyncio.Future[None]] = None
+        self._connected = False
         
         # Message handler callbacks (Dispatcher pattern)
         
@@ -244,6 +245,72 @@ class AUGovEmergencyWildfiresMqttMqttClient(_ClientBase):
         
         # Attach message callback
         self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect
+        self.client.on_disconnect = self._on_disconnect
+
+    @staticmethod
+    def _mqtt_reason_code_value(reason_code) -> Optional[int]:
+        """Best-effort numeric MQTT reason-code extraction across paho callback APIs."""
+        if reason_code is None:
+            return 0
+        value = getattr(reason_code, "value", reason_code)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _mqtt_reason_code_text(reason_code) -> str:
+        """Best-effort textual MQTT reason-code rendering across paho callback APIs."""
+        if reason_code is None:
+            return "unknown"
+        text = str(reason_code).strip()
+        if text:
+            return text
+        code = _ClientBase._mqtt_reason_code_value(reason_code)
+        return str(code) if code is not None else "unknown"
+
+    def _resolve_connect_waiter(self, exc: Optional[BaseException] = None):
+        waiter = self._connect_waiter
+        self._connect_waiter = None
+        if waiter is None or waiter.done():
+            return
+        if exc is None:
+            self._connected = True
+            waiter.set_result(None)
+            return
+        self._connected = False
+        waiter.set_exception(exc)
+
+    def _notify_connect_waiter(self, exc: Optional[BaseException] = None):
+        if self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self._resolve_connect_waiter, exc)
+
+    def _on_connect(self, client, userdata, flags, reason_code=0, properties=None):
+        """Resolve a pending async connect once the broker replies."""
+        if self._mqtt_reason_code_value(reason_code) == 0:
+            self._notify_connect_waiter()
+            return
+        detail = self._mqtt_reason_code_text(reason_code)
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
+
+    def _on_disconnect(self, client, userdata, *args):
+        """Fail a pending async connect when the broker disconnects before success."""
+        self._connected = False
+        if self._connect_waiter is None:
+            return
+        reason_code = None
+        if len(args) == 1:
+            reason_code = args[0]
+        elif len(args) == 2:
+            reason_code = args[0]
+        elif len(args) >= 3:
+            reason_code = args[1]
+        detail = self._mqtt_reason_code_text(reason_code)
+        if self._mqtt_reason_code_value(reason_code) in (None, 0):
+            detail = "connection closed before authentication completed"
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
 
     @property
     def topic_mappings(self) -> Dict[str, str]:
@@ -323,18 +390,41 @@ class AUGovEmergencyWildfiresMqttMqttClient(_ClientBase):
     
     async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
         """
-        Connect to MQTT broker.
+        Connect to MQTT broker and wait for authentication to complete.
 
         Args:
             broker: Broker hostname or IP
             port: Broker port
             keepalive: Keepalive interval in seconds
+
+        Raises:
+            ConnectionError: If the broker rejects the connection or disconnects before success
+            TimeoutError: If the broker does not acknowledge the connection in time
         """
-        self.client.connect(broker, port, keepalive)
-        self.client.loop_start()
+        if self._connect_waiter is not None and not self._connect_waiter.done():
+            raise RuntimeError("MQTT connect already in progress")
+        self.loop = asyncio.get_running_loop()
+        waiter = self.loop.create_future()
+        self._connect_waiter = waiter
+        self._connected = False
+        loop_started = False
+        try:
+            self.client.connect(broker, port, keepalive)
+            self.client.loop_start()
+            loop_started = True
+            timeout = float(keepalive) if keepalive and keepalive > 0 else 60.0
+            await asyncio.wait_for(waiter, timeout=timeout)
+        except Exception:
+            if self._connect_waiter is waiter:
+                self._connect_waiter = None
+            self._connected = False
+            if loop_started:
+                await asyncio.to_thread(self.client.loop_stop)
+            raise
     
     async def disconnect(self):
         """Disconnect from MQTT broker."""
+        self._connected = False
         self.client.loop_stop()
         self.client.disconnect()
 

--- a/feeders/australia-wildfires/tests/test_mqtt_auth.py
+++ b/feeders/australia-wildfires/tests/test_mqtt_auth.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'australia_wildfires_mqtt')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'australia_wildfires_mqtt_producer', 'australia_wildfires_mqtt_producer_data', 'src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'australia_wildfires_mqtt_producer', 'australia_wildfires_mqtt_producer_mqtt_client', 'src')))
+
+import australia_wildfires_mqtt.app as app
+
+
+def test_resolve_mqtt_auth_entra_fetches_imds_token(monkeypatch):
+    monkeypatch.setenv("MQTT_AUTH_MODE", "entra")
+    monkeypatch.setenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
+    monkeypatch.setenv("MQTT_ENTRA_CLIENT_ID", "user-assigned-mi")
+    monkeypatch.setenv("MQTT_CLIENT_ID", "managed-identity-object-id")
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b'{"accessToken": "jwt-token"}'
+
+    with patch("australia_wildfires_mqtt.app.urlopen", return_value=FakeResponse()) as open_mock:
+        username, password = app._resolve_mqtt_auth(
+            username=None,
+            password=None,
+            client_id=None,
+            auth_mode="entra",
+        )
+
+    assert username == "managed-identity-object-id"
+    assert password == "jwt-token"
+    assert open_mock.call_count == 1
+    request = open_mock.call_args[0][0]
+    assert request.full_url.startswith("http://169.254.169.254/metadata/identity/oauth2/token?")
+    assert "resource=https%3A%2F%2Feventgrid.azure.net%2F" in request.full_url
+    assert "client_id=user-assigned-mi" in request.full_url
+
+
+def test_resolve_mqtt_auth_password_mode_keeps_cli_credentials():
+    username, password = app._resolve_mqtt_auth(
+        username="broker-user",
+        password="broker-pass",
+        client_id="mqtt-client-id",
+        auth_mode="password",
+    )
+
+    assert username == "broker-user"
+    assert password == "broker-pass"


### PR DESCRIPTION
Closes #840

Implements MQTT_AUTH_MODE=entra support in the australia-wildfires MQTT companion app. Fetches the Event Grid token from IMDS using ManagedIdentityCredential-compatible parameters and passes the JWT as the MQTT password.