### PR TITLE
fix(aci): fix startup failures for fdsn-seismology, gbfs-bikeshare, hongkong-epd

### DIFF
--- a/feeders/fdsn-seismology/CONTAINER.md
+++ b/feeders/fdsn-seismology/CONTAINER.md
@@ -31,7 +31,7 @@ This document covers the published OCI images for **FDSN Seismology**, their env
 
 | Image | Transport | Default behavior |
 |---|---|---|
-| `ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka` | Kafka | One topic, structured CloudEvents, `Node` reference events at startup, `Earthquake` telemetry on every poll cycle |
+| `ghcr.io/clemensv/real-time-sources-fdsn-seismology` | Kafka | One topic, structured CloudEvents, `Node` reference events at startup, `Earthquake` telemetry on every poll cycle |
 | `ghcr.io/clemensv/real-time-sources-fdsn-seismology-mqtt` | MQTT 5.0 | `seismology/fdsn/{node_id}/info` retained node records and `seismology/fdsn/{contributor}/{event_id}` event topics |
 | `ghcr.io/clemensv/real-time-sources-fdsn-seismology-amqp` | AMQP 1.0 | One AMQP address (`fdsn-seismology` by default), binary CloudEvents, generic or Azure auth |
 
@@ -54,7 +54,7 @@ This document covers the published OCI images for **FDSN Seismology**, their env
 docker run --rm \
   -e CONNECTION_STRING="Endpoint=sb://<ns>.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=...;EntityPath=fdsn-seismology" \
   -e MIN_MAGNITUDE=2.5 \
-  ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka:latest
+  ghcr.io/clemensv/real-time-sources-fdsn-seismology:latest
 ```
 
 For plain Kafka in Docker E2E or local development, use:
@@ -63,7 +63,7 @@ For plain Kafka in Docker E2E or local development, use:
 docker run --rm \
   -e CONNECTION_STRING="BootstrapServer=<broker>:9092;EntityPath=fdsn-seismology" \
   -e KAFKA_ENABLE_TLS=false \
-  ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka:latest
+  ghcr.io/clemensv/real-time-sources-fdsn-seismology:latest
 ```
 
 ## Using the MQTT image

--- a/feeders/fdsn-seismology/README.md
+++ b/feeders/fdsn-seismology/README.md
@@ -58,7 +58,7 @@ This feeder does that once and republishes the result as typed CloudEvents:
 
 | Variant | Container image | Transport | Default delivery shape |
 |---|---|---|---|
-| **Kafka** | `ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka` | Apache Kafka 2.x compatible (Azure Event Hubs, Fabric Event Streams, plain Kafka) | One topic, structured CloudEvents, keys `{contributor}/{event_id}` for earthquakes and `{node_id}` for node reference records |
+| **Kafka** | `ghcr.io/clemensv/real-time-sources-fdsn-seismology` | Apache Kafka 2.x compatible (Azure Event Hubs, Fabric Event Streams, plain Kafka) | One topic, structured CloudEvents, keys `{contributor}/{event_id}` for earthquakes and `{node_id}` for node reference records |
 | **MQTT** | `ghcr.io/clemensv/real-time-sources-fdsn-seismology-mqtt` | MQTT 5.0 brokers (Mosquitto, EMQX, HiveMQ, Azure Event Grid MQTT) | UNS tree under `seismology/fdsn/...`, QoS 1, retained `Node` records, non-retained `Earthquake` events |
 | **AMQP** | `ghcr.io/clemensv/real-time-sources-fdsn-seismology-amqp` | AMQP 1.0 brokers and Azure Service Bus / Event Hubs | Single AMQP address, binary CloudEvents, SASL PLAIN / SAS CBS / Entra ID via AMQP CBS |
 

--- a/feeders/fdsn-seismology/azure-template-with-eventhub.json
+++ b/feeders/fdsn-seismology/azure-template-with-eventhub.json
@@ -14,7 +14,7 @@
     },
     "imageName": {
       "type": "string",
-      "defaultValue": "ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka:latest",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-fdsn-seismology:latest",
       "metadata": { "description": "Kafka container image reference." }
     },
     "eventHubSku": {

--- a/feeders/fdsn-seismology/azure-template.json
+++ b/feeders/fdsn-seismology/azure-template.json
@@ -23,7 +23,7 @@
     },
     "imageName": {
       "type": "string",
-      "defaultValue": "ghcr.io/clemensv/real-time-sources-fdsn-seismology-kafka:latest",
+      "defaultValue": "ghcr.io/clemensv/real-time-sources-fdsn-seismology:latest",
       "metadata": {
         "description": "Kafka container image reference."
       }

--- a/feeders/gbfs-bikeshare/CONTAINER.md
+++ b/feeders/gbfs-bikeshare/CONTAINER.md
@@ -6,7 +6,7 @@ This source ships three transport-specific images that all consume the same `GBF
 
 | Variant | Image | Default command |
 |---|---|---|
-| Kafka | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka:latest` | `python -m gbfs_bikeshare feed` |
+| Kafka | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare:latest` | `python -m gbfs_bikeshare feed` |
 | MQTT | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-mqtt:latest` | `python -m gbfs_bikeshare_mqtt feed` |
 | AMQP | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-amqp:latest` | `python -m gbfs_bikeshare_amqp feed` |
 
@@ -44,7 +44,7 @@ docker run --rm \
   -e GBFS_FEEDS="https://gbfs.citibikenyc.com/gbfs/gbfs.json" \
   -e CONNECTION_STRING="BootstrapServer=<host:port>;EntityPath=gbfs-bikeshare" \
   -e KAFKA_ENABLE_TLS=false \
-  ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka:latest
+  ghcr.io/clemensv/real-time-sources-gbfs-bikeshare:latest
 ```
 
 ### Azure templates

--- a/feeders/gbfs-bikeshare/README.md
+++ b/feeders/gbfs-bikeshare/README.md
@@ -51,7 +51,7 @@ This feeder provides one reusable bridge for common mobility scenarios:
 
 | Variant | Container image | Transport | Default delivery shape |
 |---|---|---|---|
-| **Kafka** | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka` | Apache Kafka / Event Hubs / Fabric Event Streams | topic `gbfs-bikeshare`; keys follow the CloudEvents subject (`{system_id}`, `{system_id}/{station_id}`, `{system_id}/{bike_id}`) |
+| **Kafka** | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare` | Apache Kafka / Event Hubs / Fabric Event Streams | topic `gbfs-bikeshare`; keys follow the CloudEvents subject (`{system_id}`, `{system_id}/{station_id}`, `{system_id}/{bike_id}`) |
 | **MQTT** | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-mqtt` | MQTT 5.0 / Unified Namespace | `mobility/gbfs/...` topic tree with retained reference events |
 | **AMQP** | `ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-amqp` | AMQP 1.0 / Service Bus / Artemis / RabbitMQ AMQP 1.0 | address `gbfs-bikeshare`, binary-mode CloudEvents |
 
@@ -77,7 +77,7 @@ docker run --rm \
   -e GBFS_FEEDS="https://gbfs.citibikenyc.com/gbfs/gbfs.json,https://gbfs.lyft.com/gbfs/2.3/chi/gbfs.json" \
   -e GBFS_SYSTEM_IDS="citibike-nyc,divvy-chicago" \
   -e CONNECTION_STRING="BootstrapServer=<host:port>;EntityPath=gbfs-bikeshare" \
-  ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka:latest
+  ghcr.io/clemensv/real-time-sources-gbfs-bikeshare:latest
 ```
 
 ## Upstream data-channel audit

--- a/feeders/gbfs-bikeshare/azure-template-with-eventhub.json
+++ b/feeders/gbfs-bikeshare/azure-template-with-eventhub.json
@@ -58,7 +58,7 @@
   "variables": {
     "storageAccountName": "[take(concat(replace(replace(parameters('containerGroupName'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
     "fileShareName": "bridge-state",
-    "imageName": "ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka:latest",
+    "imageName": "ghcr.io/clemensv/real-time-sources-gbfs-bikeshare:latest",
     "eventHubNamespaceName": "[concat(parameters('containerGroupName'), '-ehns')]",
     "eventHubName": "[parameters('containerGroupName')]",
     "authRuleName": "bridge-send-listen",
@@ -191,6 +191,22 @@
                   "secureValue": "[listKeys(variables('authRuleResourceId'), '2024-01-01').primaryConnectionString]"
                 },
                 {
+                  "name": "GBFS_FEEDS",
+                  "value": "[parameters('gbfsFeeds')]"
+                },
+                {
+                  "name": "GBFS_SYSTEM_IDS",
+                  "value": "[parameters('gbfsSystemIds')]"
+                },
+                {
+                  "name": "POLL_INTERVAL",
+                  "value": "[string(parameters('pollInterval'))]"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/state.json"
+                },
+                {
                   "name": "LOG_LEVEL",
                   "value": "INFO"
                 },
@@ -240,7 +256,6 @@
     }
   }
 }
-
 
 
 

--- a/feeders/gbfs-bikeshare/azure-template.json
+++ b/feeders/gbfs-bikeshare/azure-template.json
@@ -54,7 +54,7 @@
   "variables": {
     "storageAccountName": "[take(concat(replace(replace(parameters('containerGroupName'), '-', ''), '_', ''), 'stg', uniqueString(resourceGroup().id)), 24)]",
     "fileShareName": "bridge-state",
-    "imageName": "ghcr.io/clemensv/real-time-sources-gbfs-bikeshare-kafka:latest",
+    "imageName": "ghcr.io/clemensv/real-time-sources-gbfs-bikeshare:latest",
     "logAnalyticsWorkspaceName": "[concat(parameters('containerGroupName'), '-logs')]"
   },
   "resources": [
@@ -140,6 +140,22 @@
                   "secureValue": "[parameters('connectionString')]"
                 },
                 {
+                  "name": "GBFS_FEEDS",
+                  "value": "[parameters('gbfsFeeds')]"
+                },
+                {
+                  "name": "GBFS_SYSTEM_IDS",
+                  "value": "[parameters('gbfsSystemIds')]"
+                },
+                {
+                  "name": "POLL_INTERVAL",
+                  "value": "[string(parameters('pollInterval'))]"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "/mnt/bridge-state/state.json"
+                },
+                {
                   "name": "LOG_LEVEL",
                   "value": "INFO"
                 },
@@ -181,7 +197,6 @@
     }
   }
 }
-
 
 
 

--- a/feeders/hongkong-epd/azure-template-with-eventhub.json
+++ b/feeders/hongkong-epd/azure-template-with-eventhub.json
@@ -30,6 +30,21 @@
       "metadata": {
         "description": "Azure region for all resources."
       }
+    },
+    "pollInterval": {
+      "type": "int",
+      "defaultValue": 3600,
+      "minValue": 60,
+      "metadata": {
+        "description": "Polling interval in seconds."
+      }
+    },
+    "stateFile": {
+      "type": "string",
+      "defaultValue": "/mnt/bridge-state/hongkong_epd_state.json",
+      "metadata": {
+        "description": "State file path for persisted AQHI dedupe state."
+      }
     }
   },
   "variables": {
@@ -166,6 +181,14 @@
                 {
                   "name": "CONNECTION_STRING",
                   "secureValue": "[listKeys(variables('authRuleResourceId'), '2024-01-01').primaryConnectionString]"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "[string(parameters('pollInterval'))]"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "[parameters('stateFile')]"
                 },
                 {
                   "name": "LOG_LEVEL",

--- a/feeders/hongkong-epd/azure-template.json
+++ b/feeders/hongkong-epd/azure-template.json
@@ -27,6 +27,21 @@
       "metadata": {
         "description": "Azure region for all resources."
       }
+    },
+    "pollInterval": {
+      "type": "int",
+      "defaultValue": 3600,
+      "minValue": 60,
+      "metadata": {
+        "description": "Polling interval in seconds."
+      }
+    },
+    "stateFile": {
+      "type": "string",
+      "defaultValue": "/mnt/bridge-state/hongkong_epd_state.json",
+      "metadata": {
+        "description": "State file path for persisted AQHI dedupe state."
+      }
     }
   },
   "variables": {
@@ -116,6 +131,14 @@
                 {
                   "name": "CONNECTION_STRING",
                   "secureValue": "[parameters('connectionString')]"
+                },
+                {
+                  "name": "POLLING_INTERVAL",
+                  "value": "[string(parameters('pollInterval'))]"
+                },
+                {
+                  "name": "STATE_FILE",
+                  "value": "[parameters('stateFile')]"
                 },
                 {
                   "name": "LOG_LEVEL",


### PR DESCRIPTION
Closes #885

## Summary
- point fdsn-seismology and gbfs-bikeshare ACI templates at the published GHCR Kafka image names
- pass the required GBFS startup environment variables into the GBFS ACI templates so the container does not exit immediately on boot
- wire hongkong-epd ACI templates to the mounted state file and explicit poll interval for deterministic startup configuration

## Verification
- docker build -t fdsn-seismology-test feeders/fdsn-seismology
- docker build -t gbfs-bikeshare-test feeders/gbfs-bikeshare
- docker build -t hongkong-epd-test feeders/hongkong-epd
- docker run smoke checks for all three images
- python -m pytest feeders/fdsn-seismology/tests feeders/gbfs-bikeshare/tests feeders/hongkong-epd/tests -q