### PR TITLE
fix(cli): support 'feeder feed --once' backwards-compatibly (#839)

### DIFF
--- a/feeders/australia-wildfires/australia_wildfires/australia_wildfires.py
+++ b/feeders/australia-wildfires/australia_wildfires/australia_wildfires.py
@@ -459,7 +459,10 @@ def main():
                         help="Run a single polling cycle and exit (used by Fabric notebook hosting)")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List current incidents")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
 

--- a/feeders/aviationweather/Dockerfile
+++ b/feeders/aviationweather/Dockerfile
@@ -25,4 +25,4 @@ ENV AVIATIONWEATHER_LAST_POLLED_FILE="/mnt/fileshare/aviationweather_last_polled
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "aviationweather"]
+CMD ["python", "-m", "aviationweather", "feed"]

--- a/feeders/aviationweather/aviationweather/aviationweather.py
+++ b/feeders/aviationweather/aviationweather/aviationweather.py
@@ -626,7 +626,10 @@ def main():
                         default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/bom-australia/bom_australia/bom_australia.py
+++ b/feeders/bom-australia/bom_australia/bom_australia.py
@@ -624,7 +624,10 @@ def main():
                         help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List configured stations")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
 

--- a/feeders/dwd-pollenflug/Dockerfile
+++ b/feeders/dwd-pollenflug/Dockerfile
@@ -25,4 +25,4 @@ ENV DWD_POLLENFLUG_LAST_POLLED_FILE="/mnt/fileshare/dwd_pollenflug_last_polled.j
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "dwd_pollenflug"]
+CMD ["python", "-m", "dwd_pollenflug", "feed"]

--- a/feeders/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
+++ b/feeders/dwd-pollenflug/dwd_pollenflug/dwd_pollenflug.py
@@ -239,7 +239,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help="Run a single polling cycle and exit (used by scheduled hosts e.g. Fabric notebooks)")
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     once_env = os.getenv('ONCE_MODE', '').strip().lower() in ('1', 'true', 'yes')
     once = bool(args.once or once_env)

--- a/feeders/elexon-bmrs/Dockerfile
+++ b/feeders/elexon-bmrs/Dockerfile
@@ -25,4 +25,4 @@ ENV BMRS_LAST_POLLED_FILE="/mnt/fileshare/bmrs_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "elexon_bmrs"]
+CMD ["python", "-m", "elexon_bmrs", "feed"]

--- a/feeders/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
+++ b/feeders/elexon-bmrs/elexon_bmrs/elexon_bmrs.py
@@ -355,7 +355,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help='Run a single polling cycle and exit (used by Fabric notebook hosting)')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/energidataservice-dk/Dockerfile
+++ b/feeders/energidataservice-dk/Dockerfile
@@ -25,4 +25,4 @@ ENV EDS_LAST_POLLED_FILE="/mnt/fileshare/eds_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "energidataservice_dk"]
+CMD ["python", "-m", "energidataservice_dk", "feed"]

--- a/feeders/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
+++ b/feeders/energidataservice-dk/energidataservice_dk/energidataservice_dk.py
@@ -302,7 +302,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help='Run a single polling cycle and exit (used by Fabric notebook scheduler).')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     once_mode = args.once or os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes')
 

--- a/feeders/energy-charts/Dockerfile
+++ b/feeders/energy-charts/Dockerfile
@@ -27,4 +27,4 @@ ENV COUNTRY="de"
 ENV BIDDING_ZONE="DE-LU"
 
 # Run the application
-CMD ["python", "-m", "energy_charts"]
+CMD ["python", "-m", "energy_charts", "feed"]

--- a/feeders/energy-charts/energy_charts/energy_charts.py
+++ b/feeders/energy-charts/energy_charts/energy_charts.py
@@ -408,7 +408,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help="Run a single polling cycle and exit (for scheduled/notebook hosting)")
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.once:
         once_env = os.getenv('ONCE_MODE', '').strip().lower()

--- a/feeders/environment-canada/environment_canada/environment_canada.py
+++ b/feeders/environment-canada/environment_canada/environment_canada.py
@@ -294,7 +294,10 @@ def main():
                         help="Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("list", help="List SWOB stations")
-    subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser = subparsers.add_parser("feed", help="Feed data to Kafka")
+    feed_parser.add_argument("--once", action="store_true",
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
     api = ECWeatherAPI(polling_interval=args.polling_interval,

--- a/feeders/epa-uv/Dockerfile
+++ b/feeders/epa-uv/Dockerfile
@@ -18,4 +18,4 @@ ENV EPA_UV_STATE_FILE="/mnt/fileshare/epa_uv_state.json"
 ENV EPA_UV_LOCATIONS="Seattle,WA"
 ENV CONNECTION_STRING=""
 
-CMD ["python", "-m", "epa_uv"]
+CMD ["python", "-m", "epa_uv", "feed"]

--- a/feeders/epa-uv/epa_uv/epa_uv.py
+++ b/feeders/epa-uv/epa_uv/epa_uv.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from datetime import datetime
 from typing import Dict, List, Tuple
@@ -238,7 +239,10 @@ def main() -> None:
         help="Path to the dedupe state file",
     )
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     kafka_config = parse_connection_string(args.connection_string)
     kafka_topic = kafka_config.pop("kafka_topic", None)

--- a/feeders/gdacs/Dockerfile
+++ b/feeders/gdacs/Dockerfile
@@ -17,4 +17,4 @@ RUN pip install --no-cache-dir .
 ENV CONNECTION_STRING=""
 ENV LOG_LEVEL="INFO"
 
-CMD ["python", "-m", "gdacs"]
+CMD ["python", "-m", "gdacs", "feed"]

--- a/feeders/gdacs/gdacs/gdacs.py
+++ b/feeders/gdacs/gdacs/gdacs.py
@@ -417,7 +417,10 @@ def main():
                         help='Publish one deterministic mock alert and exit')
     parser.add_argument('--log-level', type=str, default='INFO',
                         help='Logging level (default: INFO)')
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     # Environment variable fallbacks
     if not args.connection_string:

--- a/feeders/gios-poland/Dockerfile
+++ b/feeders/gios-poland/Dockerfile
@@ -25,4 +25,4 @@ ENV GIOS_LAST_POLLED_FILE="/mnt/fileshare/gios_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "gios_poland"]
+CMD ["python", "-m", "gios_poland", "feed"]

--- a/feeders/gios-poland/gios_poland/gios_poland.py
+++ b/feeders/gios-poland/gios_poland/gios_poland.py
@@ -609,7 +609,10 @@ def main():
                         default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/imgw-hydro/imgw_hydro/imgw_hydro.py
+++ b/feeders/imgw-hydro/imgw_hydro/imgw_hydro.py
@@ -215,7 +215,10 @@ def main():
     subparsers.add_parser('list', help='List all stations')
     level_parser = subparsers.add_parser('level', help='Get water level for a station')
     level_parser.add_argument('station_id', help='Station ID')
-    subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser = subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)

--- a/feeders/jma-japan/Dockerfile
+++ b/feeders/jma-japan/Dockerfile
@@ -25,4 +25,4 @@ ENV JMA_LAST_POLLED_FILE="/mnt/fileshare/jma_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "jma_japan"]
+CMD ["python", "-m", "jma_japan", "feed"]

--- a/feeders/jma-japan/jma_japan/jma_japan.py
+++ b/feeders/jma-japan/jma_japan/jma_japan.py
@@ -281,7 +281,10 @@ def main():
                         default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Used by the Fabric notebook scheduler.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/king-county-marine/Dockerfile
+++ b/feeders/king-county-marine/Dockerfile
@@ -17,4 +17,4 @@ RUN pip install ./king_county_marine_producer/king_county_marine_producer_data \
 ENV KING_COUNTY_MARINE_STATE_FILE="/mnt/fileshare/king_county_marine_state.json"
 ENV CONNECTION_STRING=""
 
-CMD ["python", "-m", "king_county_marine"]
+CMD ["python", "-m", "king_county_marine", "feed"]

--- a/feeders/king-county-marine/king_county_marine/king_county_marine.py
+++ b/feeders/king-county-marine/king_county_marine/king_county_marine.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
@@ -392,7 +393,10 @@ def main() -> None:
         help="Path to the dedupe state file",
     )
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     kafka_config = parse_connection_string(args.connection_string)
     kafka_topic = kafka_config.pop("kafka_topic", None)

--- a/feeders/madrid-traffic/Dockerfile
+++ b/feeders/madrid-traffic/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install --no-cache-dir .
 
 ENV CONNECTION_STRING=""
 
-CMD ["python", "-m", "madrid_traffic"]
+CMD ["python", "-m", "madrid_traffic", "feed"]

--- a/feeders/madrid-traffic/madrid_traffic/madrid_traffic.py
+++ b/feeders/madrid-traffic/madrid_traffic/madrid_traffic.py
@@ -349,7 +349,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help='Run a single polling cycle and exit (used by Fabric notebook scheduled runs)')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     once_mode = args.once or os.getenv('ONCE_MODE', '').lower() in ('true', '1', 'yes')
 

--- a/feeders/meteoalarm/Dockerfile
+++ b/feeders/meteoalarm/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir .
 ENV CONNECTION_STRING=""
 ENV LOG_LEVEL="INFO"
 
-CMD ["python", "-m", "meteoalarm"]
+CMD ["python", "-m", "meteoalarm", "feed"]

--- a/feeders/meteoalarm/meteoalarm/meteoalarm.py
+++ b/feeders/meteoalarm/meteoalarm/meteoalarm.py
@@ -317,7 +317,10 @@ def main():
     parser.add_argument("--countries", type=str, help="Comma-separated list of countries")
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
     parser.add_argument("--log-level", type=str, default="INFO", help="Logging level")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv("METEOALARM_CONNECTION_STRING") or os.getenv("CONNECTION_STRING")

--- a/feeders/nina-bbk/Dockerfile
+++ b/feeders/nina-bbk/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir \
     nina_bbk_producer/nina_bbk_producer_kafka_producer \
     .
 
-CMD ["python", "-m", "nina_bbk"]
+CMD ["python", "-m", "nina_bbk", "feed"]

--- a/feeders/nina-bbk/nina_bbk/nina_bbk.py
+++ b/feeders/nina-bbk/nina_bbk/nina_bbk.py
@@ -361,7 +361,10 @@ def main():
     parser.add_argument("--providers", type=str, help="Comma-separated list of providers")
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
     parser.add_argument("--log-level", type=str, default="INFO", help="Logging level")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv("NINA_BBK_CONNECTION_STRING") or os.getenv("CONNECTION_STRING")

--- a/feeders/noaa-goes/Dockerfile
+++ b/feeders/noaa-goes/Dockerfile
@@ -25,4 +25,4 @@ ENV SWPC_LAST_POLLED_FILE="/mnt/fileshare/swpc_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "noaa_goes"]
+CMD ["python", "-m", "noaa_goes", "feed"]

--- a/feeders/noaa-goes/noaa_goes/noaa_goes.py
+++ b/feeders/noaa-goes/noaa_goes/noaa_goes.py
@@ -480,7 +480,10 @@ def main():
                         help='Exit after one polling cycle (also via ONCE_MODE env var). '
                              'Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
     logging.basicConfig(level=logging.INFO)
 
     if not args.connection_string:

--- a/feeders/noaa-ndbc/Dockerfile
+++ b/feeders/noaa-ndbc/Dockerfile
@@ -25,4 +25,4 @@ ENV NDBC_LAST_POLLED_FILE="/mnt/fileshare/ndbc_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "noaa_ndbc"]
+CMD ["python", "-m", "noaa_ndbc", "feed"]

--- a/feeders/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
+++ b/feeders/noaa-ndbc/noaa_ndbc/noaa_ndbc.py
@@ -1044,7 +1044,10 @@ def main():
                         default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/noaa-nws/Dockerfile
+++ b/feeders/noaa-nws/Dockerfile
@@ -25,4 +25,4 @@ ENV NWS_LAST_POLLED_FILE="/mnt/fileshare/nws_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "noaa_nws"]
+CMD ["python", "-m", "noaa_nws", "feed"]

--- a/feeders/noaa-nws/noaa_nws/noaa_nws.py
+++ b/feeders/noaa-nws/noaa_nws/noaa_nws.py
@@ -391,7 +391,10 @@ def main():
                         help='Exit after one polling cycle (also via ONCE_MODE env var). '
                              'Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')

--- a/feeders/nve-hydro/nve_hydro/nve_hydro.py
+++ b/feeders/nve-hydro/nve_hydro/nve_hydro.py
@@ -251,7 +251,10 @@ def main():
                         default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
-    subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser = subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
     subparsers.add_parser('list', help='List all stations')
 
     args = parser.parse_args()

--- a/feeders/nws-alerts/Dockerfile
+++ b/feeders/nws-alerts/Dockerfile
@@ -10,4 +10,4 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION
 RUN pip install --no-cache-dir .
 ENV CONNECTION_STRING=""
 ENV LOG_LEVEL="INFO"
-CMD ["python", "-m", "nws_alerts"]
+CMD ["python", "-m", "nws_alerts", "feed"]

--- a/feeders/nws-alerts/nws_alerts/nws_alerts.py
+++ b/feeders/nws-alerts/nws_alerts/nws_alerts.py
@@ -308,7 +308,10 @@ def main():
     parser.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL, help="Poll interval in seconds")
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
     parser.add_argument("--log-level", type=str, default="INFO", help="Logging level")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv("NWS_CONNECTION_STRING") or os.getenv("CONNECTION_STRING")

--- a/feeders/paris-bicycle-counters/Dockerfile
+++ b/feeders/paris-bicycle-counters/Dockerfile
@@ -26,4 +26,4 @@ ENV PARIS_VELO_LAST_POLLED_FILE="/mnt/fileshare/paris_velo_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "paris_bicycle_counters"]
+CMD ["python", "-m", "paris_bicycle_counters", "feed"]

--- a/feeders/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
+++ b/feeders/paris-bicycle-counters/paris_bicycle_counters/paris_bicycle_counters.py
@@ -343,7 +343,10 @@ def main():
     parser.add_argument('--once', action='store_true',
                         help='Run a single polling cycle and exit. Honors the ONCE_MODE env var when set to a truthy value.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.once:
         once_env = os.getenv('ONCE_MODE', '').strip().lower()

--- a/feeders/ptwc-tsunami/Dockerfile
+++ b/feeders/ptwc-tsunami/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir \
     ptwc_tsunami_producer/ptwc_tsunami_producer_kafka_producer \
     .
 
-CMD ["python", "-m", "ptwc_tsunami"]
+CMD ["python", "-m", "ptwc_tsunami", "feed"]

--- a/feeders/ptwc-tsunami/ptwc_tsunami/ptwc_tsunami.py
+++ b/feeders/ptwc-tsunami/ptwc_tsunami/ptwc_tsunami.py
@@ -324,7 +324,10 @@ def main():
     parser.add_argument("--feeds", type=str, help="Comma-separated list of feeds (PAAQ, PHEB)")
     parser.add_argument("--once", action="store_true", help="Poll once and exit")
     parser.add_argument("--log-level", type=str, default="INFO", help="Logging level")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv("PTWC_TSUNAMI_CONNECTION_STRING") or os.getenv("CONNECTION_STRING")

--- a/feeders/seattle-street-closures/Dockerfile
+++ b/feeders/seattle-street-closures/Dockerfile
@@ -17,4 +17,4 @@ RUN pip install ./seattle_street_closures_producer/seattle_street_closures_produ
 ENV SEATTLE_STREET_CLOSURES_STATE_FILE="/mnt/fileshare/seattle_street_closures_state.json"
 ENV CONNECTION_STRING=""
 
-CMD ["python", "-m", "seattle_street_closures"]
+CMD ["python", "-m", "seattle_street_closures", "feed"]

--- a/feeders/seattle-street-closures/seattle_street_closures/seattle_street_closures.py
+++ b/feeders/seattle-street-closures/seattle_street_closures/seattle_street_closures.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 import time
 from typing import Dict, List
 
@@ -277,7 +278,10 @@ def main() -> None:
     parser.add_argument("--once", action="store_true",
                         default=os.environ.get("ONCE_MODE", "").lower() in ("1", "true", "yes"),
                         help="Poll once and exit (also via ONCE_MODE env var)")
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     kafka_config = parse_connection_string(args.connection_string)
     kafka_topic = kafka_config.pop("kafka_topic", None)

--- a/feeders/syke-hydro/syke_hydro/syke_hydro.py
+++ b/feeders/syke-hydro/syke_hydro/syke_hydro.py
@@ -277,7 +277,10 @@ def main():
                         default=os.environ.get('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
                         help='Exit after one polling cycle (also via ONCE_MODE env var). Useful for scheduled execution in Fabric notebooks.')
     subparsers = parser.add_subparsers(dest='command')
-    subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser = subparsers.add_parser('feed', help='Feed data to Kafka')
+    feed_parser.add_argument('--once', action='store_true',
+                             default=os.getenv('ONCE_MODE', '').lower() in ('1', 'true', 'yes'),
+                             help='Exit after one polling cycle (also via ONCE_MODE env var).')
     subparsers.add_parser('list', help='List all stations')
 
     args = parser.parse_args()

--- a/feeders/usgs-geomag/Dockerfile
+++ b/feeders/usgs-geomag/Dockerfile
@@ -25,4 +25,4 @@ ENV GEOMAG_LAST_POLLED_FILE="/mnt/fileshare/usgs_geomag_last_polled.json"
 ENV CONNECTION_STRING=""
 
 # Run the application
-CMD ["python", "-m", "usgs_geomag"]
+CMD ["python", "-m", "usgs_geomag", "feed"]

--- a/feeders/usgs-geomag/usgs_geomag/usgs_geomag.py
+++ b/feeders/usgs-geomag/usgs_geomag/usgs_geomag.py
@@ -336,7 +336,10 @@ def main():
                         help='Exit after one polling cycle (also via ONCE_MODE env var). '
                              'Useful for scheduled execution in Fabric notebooks.')
 
-    args = parser.parse_args()
+    _argv = sys.argv[1:]
+    if _argv and _argv[0] == 'feed':
+        _argv = _argv[1:]
+    args = parser.parse_args(_argv)
 
     if not args.connection_string:
         args.connection_string = os.getenv('CONNECTION_STRING')


### PR DESCRIPTION
Closes #839

**Group A** (21 flat-parser feeders): argv shim strips 'feed' subcommand before argparse, so both \eeder --once\ and \eeder feed --once\ work. Dockerfiles updated to include 'feed' in CMD.

**Group B** (7 subparser feeders): added \--once\ to the \eed\ subparser (kept on top-level too for backwards compat).