### PR TITLE
fix(noaa): restore event emission in issue-886 triage

### DIFF
--- a/.github/workflows/test-noaa.yml
+++ b/.github/workflows/test-noaa.yml
@@ -29,15 +29,6 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install producer sub-packages
-        run: |
-          pip install --quiet ./noaa_producer/noaa_producer_data && \
-          pip install --quiet ./noaa_producer/noaa_producer_kafka_producer && \
-          pip install --quiet ./noaa_amqp_producer/noaa_amqp_producer_data && \
-          pip install --quiet ./noaa_amqp_producer/noaa_amqp_producer_kafka_producer && \
-          pip install --quiet ./noaa_mqtt_producer/noaa_mqtt_producer_data && \
-          pip install --quiet ./noaa_mqtt_producer/noaa_mqtt_producer_kafka_producer
-
       - name: Install package with dev extras
         run: pip install --quiet -e ".[dev]"
 

--- a/.github/workflows/test-noaa.yml
+++ b/.github/workflows/test-noaa.yml
@@ -31,12 +31,12 @@ jobs:
 
       - name: Install producer sub-packages
         run: |
-          pip install --quiet noaa_producer/noaa_producer_data
-          pip install --quiet noaa_producer/noaa_producer_kafka_producer
-          pip install --quiet noaa_amqp_producer/noaa_amqp_producer_data
-          pip install --quiet noaa_amqp_producer/noaa_amqp_producer_kafka_producer
-          pip install --quiet noaa_mqtt_producer/noaa_mqtt_producer_data
-          pip install --quiet noaa_mqtt_producer/noaa_mqtt_producer_kafka_producer
+          pip install --quiet ./noaa_producer/noaa_producer_data && \
+          pip install --quiet ./noaa_producer/noaa_producer_kafka_producer && \
+          pip install --quiet ./noaa_amqp_producer/noaa_amqp_producer_data && \
+          pip install --quiet ./noaa_amqp_producer/noaa_amqp_producer_kafka_producer && \
+          pip install --quiet ./noaa_mqtt_producer/noaa_mqtt_producer_data && \
+          pip install --quiet ./noaa_mqtt_producer/noaa_mqtt_producer_kafka_producer
 
       - name: Install package with dev extras
         run: pip install --quiet -e ".[dev]"

--- a/.github/workflows/test-noaa.yml
+++ b/.github/workflows/test-noaa.yml
@@ -29,35 +29,26 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install Poetry
+      - name: Install producer sub-packages
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          pip install --quiet noaa_producer/noaa_producer_data
+          pip install --quiet noaa_producer/noaa_producer_kafka_producer
+          pip install --quiet noaa_amqp_producer/noaa_amqp_producer_data
+          pip install --quiet noaa_amqp_producer/noaa_amqp_producer_kafka_producer
+          pip install --quiet noaa_mqtt_producer/noaa_mqtt_producer_data
+          pip install --quiet noaa_mqtt_producer/noaa_mqtt_producer_kafka_producer
 
-      - name: Configure Poetry
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-
-      - name: Cache Poetry dependencies
-        uses: actions/cache@v5
-        with:
-          path: ./feeders/noaa/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            venv-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-ansi
+      - name: Install package with dev extras
+        run: pip install --quiet -e ".[dev]"
 
       - name: Run unit tests
-        run: poetry run pytest tests/test_noaa_unit.py -v --tb=short
+        run: pytest tests/test_noaa_unit.py -v --tb=short
 
       - name: Run integration tests
-        run: poetry run pytest tests/test_noaa_integration.py -v --tb=short
+        run: pytest tests/test_noaa_integration.py -v --tb=short
 
       - name: Run all tests with coverage (excluding e2e)
-        run: poetry run pytest tests/ -v --cov=noaa --cov-report=term-missing --cov-report=xml --cov-fail-under=20 -m "not e2e"
+        run: pytest tests/ -v --cov=noaa --cov-report=term-missing --cov-report=xml --cov-fail-under=20 -m "not e2e"
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7

--- a/feeders/noaa/noaa/noaa.py
+++ b/feeders/noaa/noaa/noaa.py
@@ -38,6 +38,9 @@ USER_AGENT = os.environ.get("USER_AGENT") or (
     + os.environ.get("USER_AGENT_CONTACT", "clemensv@microsoft.com") + ")"
 )
 
+VISIBILITY_DATASCHEMA = "#/schemagroups/Microsoft.OpenData.US.NOAA.jstruct/schemas/Microsoft.OpenData.US.NOAA.Visibility"
+VISIBILITY_DATACONTENTTYPE = "application/json"
+
 class NOAADataPoller:
     """
     Class to poll NOAA data and send it to a Kafka topic.
@@ -244,6 +247,7 @@ class NOAADataPoller:
         while True:
             for station in self.stations if not self.station else [self.station]:
                 station_id = station.station_id
+                station_region = getattr(station, "region", None)
                 for product in self.PRODUCTS:
                     print(f"Polling {product} data for station {station_id}: {station.name}:", end='')
                     last_polled_time = last_polled_times.get(product, {}).get(
@@ -260,6 +264,7 @@ class NOAADataPoller:
                         if product == "water_level":
                             water_level = WaterLevel(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 stddev=float(record['s']) if 's' in record and record['s'] else 0.0,
@@ -275,6 +280,7 @@ class NOAADataPoller:
                         elif product == "predictions":
                             prediction = Predictions(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                             )
@@ -283,6 +289,7 @@ class NOAADataPoller:
                         elif product == "air_temperature":
                             air_temperature = AirTemperature(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_temp_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -294,6 +301,7 @@ class NOAADataPoller:
                         elif product == "wind":
                             wind = Wind(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 speed=float(record['s']) if 's' in record and record['s'] else 0.0,
                                 direction_degrees=record['d'] if 'd' in record and record['d'] else 0.0,
@@ -306,6 +314,7 @@ class NOAADataPoller:
                         elif product == "air_pressure":
                             air_pressure = AirPressure(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_pressure_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -317,6 +326,7 @@ class NOAADataPoller:
                         elif product == "water_temperature":
                             water_temperature = WaterTemperature(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_temp_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -328,6 +338,7 @@ class NOAADataPoller:
                         elif product == "conductivity":
                             conductivity = Conductivity(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_conductivity_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -339,6 +350,7 @@ class NOAADataPoller:
                         elif product == "visibility":
                             visibility = Visibility(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_visibility_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -346,10 +358,16 @@ class NOAADataPoller:
                                 rate_of_change_exceeded=bool(record.get('f', '').split(',')[2] == '1')
                             )
                             self.producer.send_microsoft_open_data_us_noaa_visibility(
-                                "application/json", visibility.timestamp, "", station_id, visibility, flush_producer=False)
+                                _datacontenttype=VISIBILITY_DATACONTENTTYPE,
+                                _dataschema=VISIBILITY_DATASCHEMA,
+                                _station_id=station_id,
+                                data=visibility,
+                                _time=visibility.timestamp,
+                                flush_producer=False)
                         elif product == "humidity":
                             humidity = Humidity(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 value=float(record['v']) if 'v' in record and record['v'] else 0.0,
                                 max_humidity_exceeded=bool(record.get('f', '').split(',')[0] == '1'),
@@ -361,6 +379,7 @@ class NOAADataPoller:
                         elif product == "salinity":
                             salinity = Salinity(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 salinity=float(record['s']) if 's' in record and record['s'] else 0.0,
                                 grams_per_kg=float(record['g']) if 'g' in record and record['g'] else 0.0,
@@ -370,6 +389,7 @@ class NOAADataPoller:
                         elif product == "currents":
                             currents_record = Currents(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 speed=float(record['s']) if 's' in record and record['s'] else 0.0,
                                 direction_degrees=float(record['d']) if 'd' in record and record['d'] else 0.0,
@@ -380,6 +400,7 @@ class NOAADataPoller:
                         elif product == "currents_predictions":
                             current_prediction = CurrentPredictions(
                                 station_id=station_id,
+                                region=station_region,
                                 timestamp=timestamp.isoformat(),
                                 velocity_major=float(record['Velocity_Major']) if 'Velocity_Major' in record and record['Velocity_Major'] else 0.0,
                                 mean_flood_dir=float(record['meanFloodDir']) if 'meanFloodDir' in record and record['meanFloodDir'] else 0.0,

--- a/feeders/noaa/pyproject.toml
+++ b/feeders/noaa/pyproject.toml
@@ -43,6 +43,3 @@ local_scheme = "no-local-version"
 packages = [
     "noaa",
 ]
-
-[tool.poetry]
-package-mode = false

--- a/feeders/noaa/pyproject.toml
+++ b/feeders/noaa/pyproject.toml
@@ -43,3 +43,6 @@ local_scheme = "no-local-version"
 packages = [
     "noaa",
 ]
+
+[tool.poetry]
+package-mode = false

--- a/feeders/noaa/tests/test_noaa_integration.py
+++ b/feeders/noaa/tests/test_noaa_integration.py
@@ -321,6 +321,77 @@ class TestPollAndSendResilience:
         assert len(poller.stations) == 1
         assert poller.stations[0].station_id == '8454000'
 
+    @patch('noaa.noaa.MicrosoftOpenDataUSNOAAEventProducer')
+    def test_visibility_events_use_named_required_cloudevents_fields(self, mock_ep_cls):
+        """Visibility events must populate the generated producer's required datacontenttype/dataschema fields."""
+        mock_ep = MagicMock()
+        mock_ep.producer = MagicMock()
+        mock_ep_cls.return_value = mock_ep
+
+        mock_station = MagicMock()
+        mock_station.station_id = '8454000'
+        mock_station.name = 'Providence'
+        mock_station.region = 'new-england'
+
+        poller = self._make_poller(mock_ep_cls, [mock_station])
+        poller.PRODUCTS = {'visibility': 'product=visibility'}
+
+        visibility_record = {
+            't': '2026-06-10 12:00',
+            'v': '5.5',
+            'f': '0,0,0',
+        }
+
+        with patch.object(poller, 'load_last_polled_times', return_value={}), \
+             patch.object(poller, 'poll_noaa_api', return_value=[visibility_record]), \
+             patch.object(poller, 'save_last_polled_times', side_effect=KeyboardInterrupt):
+            with pytest.raises(KeyboardInterrupt):
+                poller.poll_and_send()
+
+        mock_ep.send_microsoft_open_data_us_noaa_visibility.assert_called_once()
+        call = mock_ep.send_microsoft_open_data_us_noaa_visibility.call_args
+        assert call.kwargs['_datacontenttype'] == 'application/json'
+        assert call.kwargs['_dataschema'] == (
+            '#/schemagroups/Microsoft.OpenData.US.NOAA.jstruct/schemas/'
+            'Microsoft.OpenData.US.NOAA.Visibility'
+        )
+        assert call.kwargs['_station_id'] == '8454000'
+        assert call.kwargs['_time'] == '2026-06-10T12:00:00+00:00'
+        assert call.kwargs['flush_producer'] is False
+
+    @patch('noaa.noaa.MicrosoftOpenDataUSNOAAEventProducer')
+    def test_water_level_records_include_region_from_station_metadata(self, mock_ep_cls):
+        """NOAA measurement dataclasses need region populated from station metadata."""
+        mock_ep = MagicMock()
+        mock_ep.producer = MagicMock()
+        mock_ep_cls.return_value = mock_ep
+
+        mock_station = MagicMock()
+        mock_station.station_id = '8454000'
+        mock_station.name = 'Providence'
+        mock_station.region = 'new-england'
+
+        poller = self._make_poller(mock_ep_cls, [mock_station])
+        poller.PRODUCTS = {'water_level': 'product=water_level'}
+
+        water_level_record = {
+            't': '2026-06-10 12:00',
+            'v': '1.2',
+            's': '0.1',
+            'f': '0,0,0,0',
+            'q': 'v',
+        }
+
+        with patch.object(poller, 'load_last_polled_times', return_value={}), \
+             patch.object(poller, 'poll_noaa_api', return_value=[water_level_record]), \
+             patch.object(poller, 'save_last_polled_times', side_effect=KeyboardInterrupt):
+            with pytest.raises(KeyboardInterrupt):
+                poller.poll_and_send()
+
+        mock_ep.send_microsoft_open_data_us_noaa_water_level.assert_called_once()
+        water_level = mock_ep.send_microsoft_open_data_us_noaa_water_level.call_args.args[1]
+        assert water_level.region == 'new-england'
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary
- fix NOAA measurement event creation by threading station region into all emitted measurement dataclasses
- fix NOAA visibility emission to pass required CloudEvents metadata to the generated producer
- add regression coverage for the missing region field and malformed visibility producer call

## Triage notes for issue #886
- confirmed genuine bug: `noaa`
- inspected but did not change: `elexon-bmrs`, `gdacs`, `mode-s`, `ndw-road-traffic`, `digitraffic-maritime`, `waterinfo-vmm`, `rss` (issue body typo vs `iss`), `inpe-deter-brazil`, `imgw-hydro`, `gtfs`, `hko-hong-kong`, `kmi-belgium`
- skipped `canada-eccc-wateroffice` per issue guidance (cadence/window mismatch)

## Validation
- `cd feeders/noaa && pytest -q`
- `cd feeders/gdacs && pytest tests -q`
- `cd feeders/hko-hong-kong && pytest tests -q`
- `cd feeders/kmi-belgium && pytest tests -q`