### PR TITLE
fix(kql): add missing columns to seattle-911 and epa-uv KQL schemas

### DIFF
--- a/feeders/epa-uv/kql/epa_uv.kql
+++ b/feeders/epa-uv/kql/epa_uv.kql
@@ -28,8 +28,10 @@
 .create-merge table ['us.epa.uvindex.HourlyForecast'] (
    [location_id]: string,
    [city]: string,
+   [city_slug]: string,
    [state]: string,
    [forecast_datetime]: string,
+   [forecast_hour]: string,
    [uv_index]: int,
    [___type]: string,
    [___source]: string,
@@ -43,8 +45,10 @@
 .alter table ['us.epa.uvindex.HourlyForecast'] column-docstrings (
    [location_id]: "{\"description\": \"Stable slug derived from the configured city and state.\"}",
    [city]: "{\"description\": \"City for which the hourly UV forecast was requested.\"}",
+   [city_slug]: "{\"description\": \"Lowercase kebab-case city segment used for MQTT/UNS routing; derived from city without the state suffix.\"}",
    [state]: "{\"description\": \"Two-letter state abbreviation for the requested city.\"}",
    [forecast_datetime]: "{\"description\": \"Forecast timestamp normalized to ISO local datetime form without an explicit UTC offset.\"}",
+   [forecast_hour]: "{\"description\": \"Topic-safe retained forecast slot in YYYYMMDDTHH form, derived from forecast_datetime.\"}",
    [uv_index]: "{\"description\": \"Hourly UV Index forecast value.\"}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
@@ -63,8 +67,10 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "location_id", "path": "$.location_id"},
   {"column": "city", "path": "$.city"},
+  {"column": "city_slug", "path": "$.city_slug"},
   {"column": "state", "path": "$.state"},
   {"column": "forecast_datetime", "path": "$.forecast_datetime"},
+  {"column": "forecast_hour", "path": "$.forecast_hour"},
   {"column": "uv_index", "path": "$.uv_index"},
 ]
 ```
@@ -79,8 +85,10 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "location_id", "path": "$.data.location_id"},
   {"column": "city", "path": "$.data.city"},
+  {"column": "city_slug", "path": "$.data.city_slug"},
   {"column": "state", "path": "$.data.state"},
   {"column": "forecast_datetime", "path": "$.data.forecast_datetime"},
+  {"column": "forecast_hour", "path": "$.data.forecast_hour"},
   {"column": "uv_index", "path": "$.data.uv_index"},
 ]
 ```
@@ -96,7 +104,7 @@
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.EPA.UVIndex.HourlyForecast') | project['location_id'] = tostring(data.['location_id']),['city'] = tostring(data.['city']),['state'] = tostring(data.['state']),['forecast_datetime'] = tostring(data.['forecast_datetime']),['uv_index'] = toint(data.['uv_index']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.EPA.UVIndex.HourlyForecast') | project['location_id'] = tostring(data.['location_id']),['city'] = tostring(data.['city']),['city_slug'] = tostring(data.['city_slug']),['state'] = tostring(data.['state']),['forecast_datetime'] = tostring(data.['forecast_datetime']),['forecast_hour'] = tostring(data.['forecast_hour']),['uv_index'] = toint(data.['uv_index']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]
@@ -105,6 +113,7 @@
 .create-merge table ['us.epa.uvindex.DailyForecast'] (
    [location_id]: string,
    [city]: string,
+   [city_slug]: string,
    [state]: string,
    [forecast_date]: string,
    [uv_index]: int,
@@ -121,6 +130,7 @@
 .alter table ['us.epa.uvindex.DailyForecast'] column-docstrings (
    [location_id]: "{\"description\": \"Stable slug derived from the configured city and state.\"}",
    [city]: "{\"description\": \"City for which the daily UV forecast was requested.\"}",
+   [city_slug]: "{\"description\": \"Lowercase kebab-case city segment used for MQTT/UNS routing; derived from city without the state suffix.\"}",
    [state]: "{\"description\": \"Two-letter state abbreviation for the requested city.\"}",
    [forecast_date]: "{\"description\": \"Forecast date normalized to YYYY-MM-DD.\"}",
    [uv_index]: "{\"description\": \"Daily UV Index forecast value.\"}",
@@ -142,6 +152,7 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "location_id", "path": "$.location_id"},
   {"column": "city", "path": "$.city"},
+  {"column": "city_slug", "path": "$.city_slug"},
   {"column": "state", "path": "$.state"},
   {"column": "forecast_date", "path": "$.forecast_date"},
   {"column": "uv_index", "path": "$.uv_index"},
@@ -159,6 +170,7 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "location_id", "path": "$.data.location_id"},
   {"column": "city", "path": "$.data.city"},
+  {"column": "city_slug", "path": "$.data.city_slug"},
   {"column": "state", "path": "$.data.state"},
   {"column": "forecast_date", "path": "$.data.forecast_date"},
   {"column": "uv_index", "path": "$.data.uv_index"},
@@ -177,7 +189,7 @@
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.EPA.UVIndex.DailyForecast') | project['location_id'] = tostring(data.['location_id']),['city'] = tostring(data.['city']),['state'] = tostring(data.['state']),['forecast_date'] = tostring(data.['forecast_date']),['uv_index'] = toint(data.['uv_index']),['uv_alert'] = tostring(data.['uv_alert']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.EPA.UVIndex.DailyForecast') | project['location_id'] = tostring(data.['location_id']),['city'] = tostring(data.['city']),['city_slug'] = tostring(data.['city_slug']),['state'] = tostring(data.['state']),['forecast_date'] = tostring(data.['forecast_date']),['uv_index'] = toint(data.['uv_index']),['uv_alert'] = tostring(data.['uv_alert']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]

--- a/feeders/seattle-911/kql/seattle-911.kql
+++ b/feeders/seattle-911/kql/seattle-911.kql
@@ -28,7 +28,9 @@
 .create-merge table ['US.WA.Seattle.Fire911.Incident'] (
    [incident_number]: string,
    [incident_type]: string,
+   [incident_type_slug]: string,
    [incident_datetime]: string,
+   [incident_datetime_utc]: datetime,
    [address]: string,
    [latitude]: real,
    [longitude]: real,
@@ -44,7 +46,9 @@
 .alter table ['US.WA.Seattle.Fire911.Incident'] column-docstrings (
    [incident_number]: "{\"description\": \"Stable Seattle Fire Department incident identifier for the dispatch record.\"}",
    [incident_type]: "{\"description\": \"Seattle Fire Department response type for the incident, such as Aid Response or Medic Response.\"}",
+   [incident_type_slug]: "{\"description\": \"Deterministic lowercase kebab-case routing slug derived from incident_type (example: Aid Response - 7 per Unit -> aid-response-7-per-unit).\"}",
    [incident_datetime]: "{\"description\": \"Date and time of the call as published by the Seattle Open Data dataset, in local dataset timestamp form without an explicit UTC offset.\"}",
+   [incident_datetime_utc]: "{\"description\": \"Incident timestamp normalized to RFC 3339 UTC using America/Los_Angeles for the upstream local dataset timestamp.\"}",
    [address]: "{\"description\": \"Incident location text as published by the dataset.\"}",
    [latitude]: "{\"description\": \"Latitude of the incident location in decimal degrees north.\"}",
    [longitude]: "{\"description\": \"Longitude of the incident location in decimal degrees east of Greenwich; Seattle values are negative because they lie west of Greenwich.\"}",
@@ -65,7 +69,9 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "incident_number", "path": "$.incident_number"},
   {"column": "incident_type", "path": "$.incident_type"},
+  {"column": "incident_type_slug", "path": "$.incident_type_slug"},
   {"column": "incident_datetime", "path": "$.incident_datetime"},
+  {"column": "incident_datetime_utc", "path": "$.incident_datetime_utc"},
   {"column": "address", "path": "$.address"},
   {"column": "latitude", "path": "$.latitude"},
   {"column": "longitude", "path": "$.longitude"},
@@ -82,7 +88,9 @@
   {"column": "___subject", "path": "$.subject"},
   {"column": "incident_number", "path": "$.data.incident_number"},
   {"column": "incident_type", "path": "$.data.incident_type"},
+  {"column": "incident_type_slug", "path": "$.data.incident_type_slug"},
   {"column": "incident_datetime", "path": "$.data.incident_datetime"},
+  {"column": "incident_datetime_utc", "path": "$.data.incident_datetime_utc"},
   {"column": "address", "path": "$.data.address"},
   {"column": "latitude", "path": "$.data.latitude"},
   {"column": "longitude", "path": "$.data.longitude"},
@@ -100,7 +108,7 @@
 [{
   "IsEnabled": true,
   "Source": "_cloudevents_dispatch",
-  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.WA.Seattle.Fire911.Incident') | project['incident_number'] = tostring(data.['incident_number']),['incident_type'] = tostring(data.['incident_type']),['incident_datetime'] = tostring(data.['incident_datetime']),['address'] = tostring(data.['address']),['latitude'] = toreal(data.['latitude']),['longitude'] = toreal(data.['longitude']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
+  "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'US.WA.Seattle.Fire911.Incident') | project['incident_number'] = tostring(data.['incident_number']),['incident_type'] = tostring(data.['incident_type']),['incident_type_slug'] = tostring(data.['incident_type_slug']),['incident_datetime'] = tostring(data.['incident_datetime']),['incident_datetime_utc'] = todatetime(data.['incident_datetime_utc']),['address'] = tostring(data.['address']),['latitude'] = toreal(data.['latitude']),['longitude'] = toreal(data.['longitude']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
   "PropagateIngestionProperties": true,
 }]


### PR DESCRIPTION
## Missing KQL columns

The xreg contracts and bridge code emit these fields but the KQL table definitions, ingestion mappings, and update policies were never updated to include them:

| Table | Column | Type | Purpose |
|-------|--------|------|---------|
| US.WA.Seattle.Fire911.Incident | incident_datetime_utc | datetime | RFC 3339 UTC normalisation of incident_datetime |
| US.WA.Seattle.Fire911.Incident | incident_type_slug | string | Kebab-case routing slug for MQTT/UNS |
| us.epa.uvindex.HourlyForecast | city_slug | string | Lowercase kebab-case city for MQTT/UNS routing |
| us.epa.uvindex.HourlyForecast | forecast_hour | string | Topic-safe slot in YYYYMMDDTHH form |
| us.epa.uvindex.DailyForecast | city_slug | string | Same as above |

All columns added to table schema, both ingestion mappings (flat + ce_structured), column docstrings, and update policy projection.