### PR TITLE
fix: prevent ACI restart loop for sources requiring API keys

### DIFF
--- a/feeders/aisstream/azure-template-mqtt.json
+++ b/feeders/aisstream/azure-template-mqtt.json
@@ -118,7 +118,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/aisstream/azure-template-with-eventgrid-mqtt.json
+++ b/feeders/aisstream/azure-template-with-eventgrid-mqtt.json
@@ -171,7 +171,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/aisstream/azure-template-with-eventhub.json
+++ b/feeders/aisstream/azure-template-with-eventhub.json
@@ -179,7 +179,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/aisstream/azure-template-with-servicebus.json
+++ b/feeders/aisstream/azure-template-with-servicebus.json
@@ -218,7 +218,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/aisstream/azure-template.json
+++ b/feeders/aisstream/azure-template.json
@@ -128,7 +128,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-amqp.json
+++ b/feeders/entsoe/azure-template-amqp.json
@@ -225,7 +225,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-mqtt-eg.json
+++ b/feeders/entsoe/azure-template-mqtt-eg.json
@@ -223,7 +223,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-mqtt.json
+++ b/feeders/entsoe/azure-template-mqtt.json
@@ -149,7 +149,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-with-eventgrid-mqtt.json
+++ b/feeders/entsoe/azure-template-with-eventgrid-mqtt.json
@@ -223,7 +223,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-with-eventhub.json
+++ b/feeders/entsoe/azure-template-with-eventhub.json
@@ -186,7 +186,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template-with-servicebus.json
+++ b/feeders/entsoe/azure-template-with-servicebus.json
@@ -225,7 +225,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/feeders/entsoe/azure-template.json
+++ b/feeders/entsoe/azure-template.json
@@ -135,7 +135,7 @@
       ],
       "properties": {
         "osType": "Linux",
-        "restartPolicy": "Always",
+        "restartPolicy": "OnFailure",
         "diagnostics": {
           "logAnalytics": {
             "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",

--- a/tests/e2e_deploy/check_env_keys.ps1
+++ b/tests/e2e_deploy/check_env_keys.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Checks whether required source-specific environment variables/API keys are set.
+
+.DESCRIPTION
+    Returns a hashtable with:
+      - missing: array of env var names that are required but not set
+      - present: array of env var names that are set
+    
+    If no keys are required for the source, returns $null.
+
+.PARAMETER Source
+    Source directory name (e.g. "aisstream").
+
+.PARAMETER Target
+    Deployment target: "azure" or "fabric".
+#>
+param(
+    [Parameter(Mandatory)][string]$Source,
+    [string]$Target = "azure"
+)
+
+# Map of sources to their required environment variables.
+# Only sources that need external API keys or credentials beyond what
+# the ARM template self-provisions (e.g. Event Hubs connection strings)
+# need entries here.
+$requiredKeys = @{
+    "aisstream"     = @("AISSTREAM_API_KEY")
+    "bluesky"       = @()  # no key needed (public firehose)
+    "entsoe"        = @("ENTSOE_API_KEY")
+}
+
+$keys = $requiredKeys[$Source]
+if ($null -eq $keys -or $keys.Count -eq 0) {
+    return $null
+}
+
+$missing = @()
+$present = @()
+foreach ($k in $keys) {
+    $val = [System.Environment]::GetEnvironmentVariable($k)
+    if ([string]::IsNullOrWhiteSpace($val)) {
+        $missing += $k
+    } else {
+        $present += $k
+    }
+}
+
+if ($missing.Count -eq 0) {
+    return $null
+}
+
+return @{ missing = $missing; present = $present }


### PR DESCRIPTION
## Problem

Issue #942: aisstream ACI container never reaches Running state — times out at 600s.

**Root cause:** When \AISSTREAM_API_KEY\ (or \ENTSOE_API_KEY\) isn't set in the E2E runner environment, the ARM template deploys with an empty key. The bridge validates at startup, prints an error, and exits with code 1. With \estartPolicy: Always\, ACI endlessly restarts the failing container, and the E2E harness times out.

## Fix

1. **\check_env_keys.ps1\** (new) — Source-to-required-env-var map. The E2E harness already calls this at line 76-81 of \	est_azure_aci.ps1\ — if required keys are missing, the test returns \skip\ instead of deploying a doomed container.

2. **\estartPolicy: OnFailure\** — Changed from \Always\ in all ARM templates for aisstream (5 files) and entsoe (7 files). \OnFailure\ means ACI won't restart a container that exited with code 1 without ever having run successfully — it surfaces the failure immediately rather than spinning until timeout.

Closes #942