### PR TITLE
fix: Use OAUTH2-JWT extended auth for EG MQTT Entra JWT connections (fleet-wide)

### DIFF
--- a/.github/skills/e2e-deployment-validation/SKILL.md
+++ b/.github/skills/e2e-deployment-validation/SKILL.md
@@ -31,12 +31,38 @@ failures and never silently pass a broken source.
    exhausts workspace capacity. If per-source cleanup was skipped (e.g. agents
    ran in parallel), run the bulk cleanup script (see Step 6) at the end of
    the session before declaring the session complete.
-3. **File issues for everything** — every failure gets a GitHub issue.
-   Amend existing issues rather than creating duplicates.
+3. **File issues for failures; record warnings for no-data** — every FAIL gets
+   a GitHub issue. A WARN (no-data) is recorded in the checklist but does NOT
+   get a GitHub issue. Amend existing issues rather than creating duplicates.
 4. **Structured output** — fill in the session checklist as you go, write
    machine-readable `summary.json`.
 5. **Fail forward** — if one source fails, log it and continue to the next.
    Never abort the entire session for a single source failure.
+
+### Outcome Categories
+
+| Symbol | Status | Meaning | GitHub issue? |
+|--------|--------|---------|---------------|
+| ✅ | **PASS** | Data received end-to-end; all checks pass | No |
+| ⚠️ | **WARN** | Full stack deployed and running, but no upstream data arrived within the timeout. The infrastructure is healthy; the upstream may not have data right now (differential poller with no changes, seasonal source, quiet feed). | No — record in checklist only |
+| ❌ | **FAIL** | Stack could not be deployed, container/notebook crashed, auth broken, schema mismatch, or any error that indicates a code/config defect | Yes — file immediately |
+| 🔒 | **BLOCKED** | Stack is running but validation cannot be completed due to a known environmental limitation (e.g. MQTT external subscribe requires client cert registration). Not a source failure. | No |
+| — | **SKIP** | No template/notebook for this variant; not applicable | No |
+
+**WARN vs FAIL decision rule for no-data outcomes:**
+
+A no-data result is **WARN** if ALL of the following are true:
+- The container/notebook reached a fully `Running`/`Completed` state (no crash, no non-zero exit)
+- The infrastructure deployed successfully (Event Hubs/Service Bus/Event Grid namespace created)
+- The feeder connected to its broker (for AMQP/MQTT: check `Mqtt.Connections > 0` or SB receive attempted; for Kafka: consumer connected)
+- There is a plausible upstream reason for no data (differential source with no changes, seasonal/event-driven source, source returns empty response legitimately)
+
+A no-data result is **FAIL** if ANY of the following are true:
+- Container/notebook did not reach Running (deploy-failed)
+- Container exited with non-zero code or crashed
+- For MQTT: `Mqtt.Connections` = 0 (feeder never connected to broker)
+- For AMQP: `amqp:unauthorized-access` or similar auth error in logs
+- The feeder's own log shows an unhandled exception or repeated error loop
 
 ## Inputs
 
@@ -56,8 +82,8 @@ failures and never silently pass a broken source.
 3. For each source (sequential):
    a. Run Azure test (if applicable)
    b. Run Fabric test (if applicable)
-   c. Update checklist with results
-   d. Update the session results file and running tally after each PASS or FAIL
+   c. Update checklist with results (✅ PASS / ⚠️ WARN / ❌ FAIL / 🔒 BLOCKED / — SKIP)
+   d. Update the session results file and running tally after each result
    e. File a GitHub issue immediately for any FAIL result with root-cause details
    f. Teardown resources
 4. Write summary.json
@@ -66,7 +92,7 @@ failures and never silently pass a broken source.
 
 ### Per-Source Checklist Discipline
 
-- [ ] After each run (PASS or FAIL), update the session results file and record the result in the running tally. File a GitHub issue immediately for any FAIL result with root-cause details.
+- [ ] After each run (PASS / WARN / FAIL / BLOCKED), update the session results file and record the result in the running tally. File a GitHub issue immediately for any **FAIL** result with root-cause details. WARN results are recorded in the checklist only — do not file an issue.
 
 ## Azure ACI Validation Procedure
 
@@ -606,14 +632,26 @@ Similarly, map validation is a shared module that:
 [E2E] <source> - <target>: <failure-category>
 ```
 
-### Failure Categories
-- `no-data` — container/notebook ran but no events arrived
+### Outcome Classification
+
+| Result | When | Action |
+|--------|------|--------|
+| **PASS** | ≥1 message received, checks pass | Record ✅ in checklist |
+| **WARN** | Stack running, broker connected, but 0 messages (upstream has no data) | Record ⚠️ in checklist; no GitHub issue |
+| **FAIL** | Any deploy failure, crash, auth error, schema mismatch | Record ❌ in checklist; file GitHub issue immediately |
+| **BLOCKED** | Known env limitation (e.g. MQTT subscribe blocked) | Record 🔒 in checklist; no new issue unless root cause is new |
+
+### Failure Categories (for FAIL issues only)
+- `no-data` — container/notebook ran but no events arrived AND infrastructure/auth is broken (not just quiet upstream)
 - `dispatch-only` — events in dispatch but not in typed tables (update policy broken)
 - `schema-mismatch` — payload doesn't match xreg schema
-- `deploy-failed` — container/notebook failed to start
-- `timeout` — exceeded wait time
+- `deploy-failed` — container/notebook failed to start or reach Running state
+- `timeout` — exceeded wait time due to a defect (not quiet upstream)
 - `map-empty` — map exists but layers return zero rows
 - `stale-data` — data exists but is older than expected cadence
+
+### Warning Categories (for WARN checklist entries only, no issue filed)
+- `no-data-upstream` — stack healthy, broker connected, upstream returned no data (differential poller, seasonal source, no current events)
 
 ### Deduplication
 
@@ -627,10 +665,10 @@ If not found: create a new issue.
 ## Outputs
 
 Per session:
-- `sessions/<ts>/CHECKLIST.md` — filled-in per-source checklist
-- `sessions/<ts>/summary.json` — machine-readable pass/fail/skip counts
+- `sessions/<ts>/CHECKLIST.md` — filled-in per-source checklist (✅/⚠️/❌/🔒/—)
+- `sessions/<ts>/summary.json` — machine-readable pass/warn/fail/skip counts
 - `sessions/<ts>/log.txt` — full execution log
-- `sessions/<ts>/<source>-azure-result.json` — per-source Azure result
+- `sessions/<ts>/<source>-azure-result.json` — per-source Azure result (status: pass|warn|fail|blocked|skip)
 - `sessions/<ts>/<source>-fabric-result.json` — per-source Fabric result
 
 ## References

--- a/feeders/aisstream/aisstream_mqtt/aisstream_mqtt/app.py
+++ b/feeders/aisstream/aisstream_mqtt/aisstream_mqtt/app.py
@@ -85,7 +85,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -94,7 +94,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger("aisstream_mqtt")
 
@@ -450,7 +456,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -461,9 +467,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -474,7 +480,12 @@ async def _run(args: argparse.Namespace) -> None:
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s); mid_iso_version=%s",
                 broker_host, broker_port, tls, MID_ISO_VERSION)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     bridge = AisStreamMqttBridge(
         client,

--- a/feeders/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
+++ b/feeders/australia-wildfires/australia_wildfires_mqtt/australia_wildfires_mqtt/app.py
@@ -85,12 +85,12 @@ def _resolve_mqtt_auth(
     password: Optional[str],
     client_id: Optional[str],
     auth_mode: Optional[str] = None,
-) -> tuple[str, str]:
+) -> tuple:
     """Resolve MQTT credentials for password or Entra JWT authentication modes."""
     auth_mode = (auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return username or "", password or ""
+        return username or "", password or "", None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -99,7 +99,13 @@ def _resolve_mqtt_auth(
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_username, resolved_password, _connect_props
 
 
 async def feed(
@@ -114,7 +120,7 @@ async def feed(
     content_mode: str = "binary",
     polling_interval: int = 300,
 ) -> None:
-    resolved_username, resolved_password = _resolve_mqtt_auth(
+    resolved_username, resolved_password, _entra_props = _resolve_mqtt_auth(
         username=username,
         password=password,
         client_id=client_id,
@@ -126,9 +132,9 @@ async def feed(
         client_id=client_id or "",
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = AUGovEmergencyWildfiresMqttMqttClient(
@@ -138,8 +144,13 @@ async def feed(
     )
     api = AustraliaWildfiresAPI(polling_interval=polling_interval)
 
-    logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    logger.info("Connecting to MQTT broker %s:%s (tls=%s, auth=%s)", broker_host, broker_port, tls or _entra_props is not None, "entra" if _entra_props else "password")
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             if os.getenv("AUSTRALIA_WILDFIRES_SAMPLE_MODE", "").lower() in ("1", "true", "yes"):

--- a/feeders/aviationweather/aviationweather_mqtt/aviationweather_mqtt/app.py
+++ b/feeders/aviationweather/aviationweather_mqtt/aviationweather_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/bafu-hydro/bafu_hydro_mqtt/bafu_hydro_mqtt/app.py
+++ b/feeders/bafu-hydro/bafu_hydro_mqtt/bafu_hydro_mqtt/app.py
@@ -56,7 +56,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -65,7 +65,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +236,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -241,9 +247,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -254,7 +260,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     locations = api.get_locations()
     logger.info("Publishing %d station info events under hydro/ch/bafu/bafu-hydro/...", len(locations))

--- a/feeders/bfs-odl/bfs_odl_mqtt/bfs_odl_mqtt/app.py
+++ b/feeders/bfs-odl/bfs_odl_mqtt/bfs_odl_mqtt/app.py
@@ -54,7 +54,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -63,7 +63,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -213,7 +219,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -224,9 +230,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -237,7 +243,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     stations, sample_measurements = _sample_features() if os.getenv("BFS_ODL_SAMPLE_MODE", "").lower() in ("1", "true", "yes") else (api.fetch_stations(), None)
     logger.info("Publishing %d station info events under radiation/de/bfs/bfs-odl/...", len(stations))

--- a/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
+++ b/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/billetto.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/blitzortung/blitzortung_mqtt/blitzortung_mqtt/app.py
+++ b/feeders/blitzortung/blitzortung_mqtt/blitzortung_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/bluesky/bluesky_mqtt/bluesky_mqtt/app.py
+++ b/feeders/bluesky/bluesky_mqtt/bluesky_mqtt/app.py
@@ -60,7 +60,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -69,7 +69,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 # Outbound HTTP identity. Operators can override the entire string with the
 # USER_AGENT env var, or just the contact token with USER_AGENT_CONTACT.
@@ -449,7 +455,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -460,9 +466,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -472,7 +478,12 @@ async def _run(args: argparse.Namespace) -> None:
         loop=loop,
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     collections = None
     if args.collections:

--- a/feeders/bom-australia/bom_australia_mqtt/bom_australia_mqtt/app.py
+++ b/feeders/bom-australia/bom_australia_mqtt/bom_australia_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
+++ b/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Community', 'vars': {'province': 'ON', 'community_name': 'ottawa'}, 'sample': {'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Observation', 'vars': {'province': 'ON', 'community_name': 'ottawa'}, 'sample': {'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Forecast', 'vars': {'province': 'ON', 'community_name': 'ottawa'}, 'sample': {'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice_mqtt/canada_eccc_wateroffice_mqtt/app.py
+++ b/feeders/canada-eccc-wateroffice/canada_eccc_wateroffice_mqtt/canada_eccc_wateroffice_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, canada_eccc_wateroffice_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/carbon-intensity/carbon_intensity_mqtt/carbon_intensity_mqtt/app.py
+++ b/feeders/carbon-intensity/carbon_intensity_mqtt/carbon_intensity_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +169,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -174,9 +180,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = UkOrgCarbonintensityMqttMqttClient(
@@ -185,7 +191,12 @@ async def feed(
         loop=asyncio.get_running_loop(),
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         poller = CarbonIntensityMqttPoller(mqtt_client, state_file or os.path.expanduser("~/.carbon_intensity_mqtt_last_polled.json"))
         await poller.poll_and_send_async(once=once)

--- a/feeders/cbp-border-wait/cbp_border_wait_mqtt/cbp_border_wait_mqtt/app.py
+++ b/feeders/cbp-border-wait/cbp_border_wait_mqtt/cbp_border_wait_mqtt/app.py
@@ -48,7 +48,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -57,7 +57,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +87,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -92,9 +98,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = GovCbpBorderwaitMqttMqttClient(
         client=paho_client,
@@ -102,7 +108,12 @@ async def feed(
         loop=asyncio.get_running_loop(),
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     previous_timestamps = _load_state(state_file)
     try:
         while True:

--- a/feeders/cdec-reservoirs/cdec_reservoirs_mqtt/cdec_reservoirs_mqtt/app.py
+++ b/feeders/cdec-reservoirs/cdec_reservoirs_mqtt/cdec_reservoirs_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, cdec_reservoirs_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/chmi-hydro/chmi_hydro_mqtt/chmi_hydro_mqtt/app.py
+++ b/feeders/chmi-hydro/chmi_hydro_mqtt/chmi_hydro_mqtt/app.py
@@ -59,7 +59,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -68,7 +68,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +187,7 @@ async def feed(
     content_mode: str = "binary",
 ) -> None:
     previous_readings = _load_state(state_file)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -192,9 +198,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -205,7 +211,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     logger.info("Publishing CHMI station catalog as MQTT info events...")
     stations_by_id = await _publish_stations(mqtt_client, api)

--- a/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
+++ b/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Timeseries', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Observation', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/digitraffic-maritime/digitraffic_maritime_mqtt/digitraffic_maritime_mqtt/app.py
+++ b/feeders/digitraffic-maritime/digitraffic_maritime_mqtt/digitraffic_maritime_mqtt/app.py
@@ -47,7 +47,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -56,7 +56,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +127,7 @@ def _build_clients(args: argparse.Namespace):
     host, port, tls_from_url = _parse_broker_url(args.broker_url)
     tls = tls_from_url if args.enable_tls is None else args.enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -132,7 +138,7 @@ def _build_clients(args: argparse.Namespace):
         callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
         protocol=mqtt.MQTTv5,
         )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls:
         paho_client.tls_set(ca_certs=args.ca_file or None)

--- a/feeders/dwd-pollenflug/dwd_pollenflug_mqtt/dwd_pollenflug_mqtt/app.py
+++ b/feeders/dwd-pollenflug/dwd_pollenflug_mqtt/dwd_pollenflug_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/dwd/dwd_mqtt/dwd_mqtt/app.py
+++ b/feeders/dwd/dwd_mqtt/dwd_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/eaws-albina/eaws_albina_mqtt/eaws_albina_mqtt/app.py
+++ b/feeders/eaws-albina/eaws_albina_mqtt/eaws_albina_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +100,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -102,12 +108,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = OrgEAWSALBINAMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
+++ b/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/elexon_bmrs.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
+++ b/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/energidataservice_dk.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
+++ b/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/energy_charts.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/entur-norway/entur_norway_mqtt/entur_norway_mqtt/app.py
+++ b/feeders/entur-norway/entur_norway_mqtt/entur_norway_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +153,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -155,12 +161,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = NoEnturMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     et_requestor_id = str(uuid.uuid4())
     vm_requestor_id = str(uuid.uuid4())
     sx_requestor_id = str(uuid.uuid4())

--- a/feeders/environment-canada/environment_canada_mqtt/environment_canada_mqtt/app.py
+++ b/feeders/environment-canada/environment_canada_mqtt/environment_canada_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/epa-uv/epa_uv_mqtt/epa_uv_mqtt/app.py
+++ b/feeders/epa-uv/epa_uv_mqtt/epa_uv_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +73,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -78,9 +84,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = USEPAUVIndexMqttMqttClient(
@@ -89,7 +95,12 @@ async def feed(
         loop=asyncio.get_running_loop(),
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             hourly_sent = 0

--- a/feeders/eurdep-radiation/eurdep_radiation_mqtt/eurdep_radiation_mqtt/app.py
+++ b/feeders/eurdep-radiation/eurdep_radiation_mqtt/eurdep_radiation_mqtt/app.py
@@ -38,7 +38,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -47,7 +47,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger=logging.getLogger(__name__)
 
@@ -61,7 +67,7 @@ def _sample():
     return [station],[reading]
 
 async def feed(host:str, port:int, *, username:Optional[str]=None, password:Optional[str]=None, tls:bool=False, client_id:Optional[str]=None, once:bool=False, content_mode:str='binary', polling_interval:int=3600):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -69,11 +75,16 @@ async def feed(host:str, port:int, *, username:Optional[str]=None, password:Opti
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     client=EuJrcEurdepMqttMqttClient(client=paho, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         while True:
             if os.getenv('EURDEP_RADIATION_SAMPLE_MODE','').lower() in ('1','true','yes'):

--- a/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
+++ b/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/fienta.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
+++ b/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'region': 'central', 'fmisid': '1001'}, 'sample': {'region': 'central', 'fmisid': '1001', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Observation', 'vars': {'region': 'central', 'fmisid': '1001'}, 'sample': {'region': 'central', 'fmisid': '1001', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/french-road-traffic/french_road_traffic_mqtt/french_road_traffic_mqtt/app.py
+++ b/feeders/french-road-traffic/french_road_traffic_mqtt/french_road_traffic_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "french-road-traffic"
 XREG_FILE = "french_road_traffic.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/gdacs/gdacs_mqtt/gdacs_mqtt/app.py
+++ b/feeders/gdacs/gdacs_mqtt/gdacs_mqtt/app.py
@@ -43,7 +43,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -52,7 +52,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +110,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -112,12 +118,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = GDACSAlertsMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/geosphere-austria/geosphere_austria_mqtt/geosphere_austria_mqtt/app.py
+++ b/feeders/geosphere-austria/geosphere_austria_mqtt/geosphere_austria_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/german-waters/german_waters_mqtt/german_waters_mqtt/app.py
+++ b/feeders/german-waters/german_waters_mqtt/german_waters_mqtt/app.py
@@ -62,7 +62,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -71,7 +71,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -223,7 +229,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -234,9 +240,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -247,7 +253,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     provider_names = ", ".join(p.name for p in providers)
     logger.info("Publishing station info events for providers: [%s]", provider_names)

--- a/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
+++ b/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25'}, 'sample': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'fmisid': '1001', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Sensor', 'vars': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'sensor_id': '291'}, 'sample': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'sensor_id': '291', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'fmisid': '1001', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Measurement', 'vars': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'sensor_id': '291'}, 'sample': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'sensor_id': '291', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'fmisid': '1001', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'AirQualityIndex', 'vars': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25'}, 'sample': {'voivodeship': 'mazowieckie', 'station_id': 'station-1', 'pollutant': 'pm25', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'fmisid': '1001', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/gracedb/gracedb_mqtt/gracedb_mqtt/app.py
+++ b/feeders/gracedb/gracedb_mqtt/gracedb_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +117,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -119,12 +125,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = OrgLigoGracedbMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     adapter = _MqttProducerAdapter(mqtt_client)
     poller.event_producer = adapter
     try:

--- a/feeders/gtfs/gtfs_mqtt/gtfs_mqtt/app.py
+++ b/feeders/gtfs/gtfs_mqtt/gtfs_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "gtfs"
 XREG_FILE = "gtfs.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/hko-hong-kong/hko_hong_kong_mqtt/hko_hong_kong_mqtt/app.py
+++ b/feeders/hko-hong-kong/hko_hong_kong_mqtt/hko_hong_kong_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/hongkong-epd/hongkong_epd_mqtt/hongkong_epd_mqtt/app.py
+++ b/feeders/hongkong-epd/hongkong_epd_mqtt/hongkong_epd_mqtt/app.py
@@ -59,7 +59,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -68,7 +68,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +173,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -178,9 +184,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -191,7 +197,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     logger.info("Publishing station info events under air-quality/hk/epd/hongkong-epd/...")
     await _publish_stations(mqtt_client, api)

--- a/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt/hubeau_hydrometrie_mqtt/app.py
+++ b/feeders/hubeau-hydrometrie/hubeau_hydrometrie_mqtt/hubeau_hydrometrie_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, hubeau_hydrometrie_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/imgw-hydro/imgw_hydro_mqtt/imgw_hydro_mqtt/app.py
+++ b/feeders/imgw-hydro/imgw_hydro_mqtt/imgw_hydro_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -113,7 +119,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, imgw_hydro_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -121,12 +127,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/inpe-deter-brazil/inpe_deter_brazil_mqtt/inpe_deter_brazil_mqtt/app.py
+++ b/feeders/inpe-deter-brazil/inpe_deter_brazil_mqtt/inpe_deter_brazil_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +91,7 @@ async def feed(
     content_mode: str = "binary",
     poll_interval_minutes: int = 10,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -96,9 +102,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = BRINPEDETERMqttMqttClient(
@@ -110,7 +116,12 @@ async def feed(
     selected_biomes = _parse_biomes(biomes)
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             published = 0

--- a/feeders/irail/irail_mqtt/irail_mqtt/app.py
+++ b/feeders/irail/irail_mqtt/irail_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +86,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -91,9 +97,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = BeIrailMqttMqttClient(
@@ -102,7 +108,12 @@ async def feed(
         loop=asyncio.get_running_loop(),
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         filter_set = _parse_station_filter(station_filter)
         all_stations_raw = api.fetch_stations()

--- a/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
+++ b/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Timeseries', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Observation', 'vars': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1'}, 'sample': {'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'timeseries_id': 'ts-1', 'province': 'ON', 'community_name': 'ottawa', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel_mqtt/ireland_opw_waterlevel_mqtt/app.py
+++ b/feeders/ireland-opw-waterlevel/ireland_opw_waterlevel_mqtt/ireland_opw_waterlevel_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, ireland_opw_waterlevel_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
@@ -36,7 +36,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -45,7 +45,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 log=logging.getLogger(__name__)
 class MockAPI(JmaBosaiAmedasAPI):
@@ -67,7 +73,7 @@ async def cycle(api,client,state,state_file,refresh_hours):
             d=Observation(**obs.to_serializer_dict()); await client.publish_jp_jma_amedas_mqtt_observation(feedurl=api.observation_url(observed),prefecture=d.prefecture,station_code=d.station_code,event=d.event,data=d)
         state['last_snapshot_time']=observed.isoformat(); _save_state(state_file,state)
 async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hours,username=None,password=None,tls=False,client_id=None,content_mode='binary',once=False):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -75,7 +81,7 @@ async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hour
     )
 
     pc=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         pc.username_pw_set(resolved_username, resolved_password)
     if tls: pc.tls_set()
     client=JPJMAAmedasMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop()); await client.connect(host,port)

--- a/feeders/jma-bosai-quake/jma_bosai_quake_mqtt/jma_bosai_quake_mqtt/app.py
+++ b/feeders/jma-bosai-quake/jma_bosai_quake_mqtt/jma_bosai_quake_mqtt/app.py
@@ -53,7 +53,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -62,7 +62,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +121,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -123,12 +129,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = JPJMAQuakeMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 class MockAPI(JMABosaiVolcanoAPI):
     def fetch_volcano_catalog(self): return parse_volcano_catalog([{'code':'101','nameJp':'桜島','nameEn':'Sakurajima','lat':31.58,'lon':130.66,'elevation':1117,'levelOperation':True}])
@@ -61,7 +67,7 @@ async def run(api,c):
 def parse_url(u):
     p=urlparse(u if '://' in u else 'mqtt://'+u); t=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if t else 1883), t
 async def feed(api,h,p,tls=False,username=None,password=None,content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=None,
@@ -69,7 +75,7 @@ async def feed(api,h,p,tls=False,username=None,password=None,content_mode='binar
     )
 
     pc=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2,protocol=MQTTv5);
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         pc.username_pw_set(resolved_username, resolved_password)
     if tls: pc.tls_set()
     c=JPJMAVolcanoMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop()); await c.connect(h,p)

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/app.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt/jma_bosai_warning_mqtt/app.py
@@ -58,7 +58,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -67,7 +67,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -177,7 +183,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -185,12 +191,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = JPJMAWarningMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     state = BridgeState.from_dict(_load_state(state_file))
     metadata_interval = max(1, office_metadata_refresh_hours) * 3600
     try:

--- a/feeders/jma-japan/jma_japan_mqtt/jma_japan_mqtt/app.py
+++ b/feeders/jma-japan/jma_japan_mqtt/jma_japan_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/app.py
+++ b/feeders/king-county-marine/king_county_marine_mqtt/king_county_marine_mqtt/app.py
@@ -45,7 +45,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -54,7 +54,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +123,7 @@ async def feed(
     state_file: str = "",
     sample_mode: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -128,9 +134,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = USWAKingCountyMarineMqttMqttClient(
@@ -141,7 +147,12 @@ async def feed(
     bridge = KingCountyMarineBridge(state_file=state_file)
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             if sample_mode:

--- a/feeders/kmi-belgium/kmi_belgium_mqtt/kmi_belgium_mqtt/app.py
+++ b/feeders/kmi-belgium/kmi_belgium_mqtt/kmi_belgium_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/kystverket-ais/kystverket_ais_mqtt/kystverket_ais_mqtt/app.py
+++ b/feeders/kystverket-ais/kystverket_ais_mqtt/kystverket_ais_mqtt/app.py
@@ -86,7 +86,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -95,7 +95,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger("kystverket_ais_mqtt")
 
@@ -431,7 +437,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -442,9 +448,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -455,7 +461,12 @@ async def _run(args: argparse.Namespace) -> None:
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s); mid_iso_version=%s",
                 broker_host, broker_port, tls, MID_ISO_VERSION)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     bridge = KystverketAisMqttBridge(
         client,

--- a/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
+++ b/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Site', 'vars': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2'}, 'sample': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Measurement', 'vars': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2'}, 'sample': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'DailyIndex', 'vars': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2'}, 'sample': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Species', 'vars': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2'}, 'sample': {'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
+++ b/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2'}, 'sample': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Measurement', 'vars': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2'}, 'sample': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'LKI', 'vars': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2'}, 'sample': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Component', 'vars': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2'}, 'sample': {'region': 'central', 'station_number': 'NL001', 'formula': 'NO2', 'province': 'ON', 'community_name': 'ottawa', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/madrid-traffic/madrid_traffic_mqtt/madrid_traffic_mqtt/app.py
+++ b/feeders/madrid-traffic/madrid_traffic_mqtt/madrid_traffic_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "madrid-traffic"
 XREG_FILE = "madrid-traffic.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/meteoalarm/meteoalarm_mqtt/meteoalarm_mqtt/app.py
+++ b/feeders/meteoalarm/meteoalarm_mqtt/meteoalarm_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 USER_AGENT = os.environ.get("USER_AGENT") or (
@@ -114,7 +120,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -122,12 +128,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = MeteoalarmWarningsMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/mode-s/mode_s_mqtt/mode_s_mqtt/app.py
+++ b/feeders/mode-s/mode_s_mqtt/mode_s_mqtt/app.py
@@ -70,7 +70,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -79,7 +79,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger("mode_s_mqtt")
 
@@ -347,7 +353,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -358,9 +364,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -370,7 +376,12 @@ async def _run(args: argparse.Namespace) -> None:
         loop=loop,
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     feedurl = args.feedurl or (
         f"dump1090://{args.host}:{args.port}" if args.host and args.port

--- a/feeders/nasa-firms/nasa_firms_mqtt/nasa_firms_mqtt/app.py
+++ b/feeders/nasa-firms/nasa_firms_mqtt/nasa_firms_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +120,7 @@ async def feed(poller: FirmsPoller, broker_host: str, broker_port: int, *,
                username: Optional[str] = None, password: Optional[str] = None,
                tls: bool = False, client_id: Optional[str] = None,
                content_mode: str = "binary", once: bool = False) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -122,12 +128,17 @@ async def feed(poller: FirmsPoller, broker_host: str, broker_port: int, *,
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = NASAFIRMSMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     adapter = _MqttProducerAdapter(mqtt_client)
     poller.event_producer = adapter
     try:

--- a/feeders/ndw-road-traffic/ndw_road_traffic_mqtt/ndw_road_traffic_mqtt/app.py
+++ b/feeders/ndw-road-traffic/ndw_road_traffic_mqtt/ndw_road_traffic_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "ndw-road-traffic"
 XREG_FILE = "ndw-road-traffic.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology_mqtt/nepal_bipad_hydrology_mqtt/app.py
+++ b/feeders/nepal-bipad-hydrology/nepal_bipad_hydrology_mqtt/nepal_bipad_hydrology_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, nepal_bipad_hydrology_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/nextbus/nextbus_mqtt/nextbus_mqtt/app.py
+++ b/feeders/nextbus/nextbus_mqtt/nextbus_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "nextbus"
 XREG_FILE = "nextbus.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt/nifc_usa_wildfires_mqtt/app.py
+++ b/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt/nifc_usa_wildfires_mqtt/app.py
@@ -37,7 +37,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -46,7 +46,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger=logging.getLogger(__name__)
 def _parse(url):
@@ -55,7 +61,7 @@ def _sample():
  return [WildfireIncident(irwin_id='sample-irwin-001', state='ca', status='active', incident_name='Sample Fire', unique_fire_identifier='2026-CANIF-000001', incident_type_category='WF', incident_type_kind='FI', fire_discovery_datetime='2026-01-01T00:00:00+00:00', daily_acres=100.0, calculated_acres=None, discovery_acres=10.0, percent_contained=0.0, poo_state='US-CA', poo_county='Sample', latitude=38.5, longitude=-121.5, fire_cause='Undetermined', fire_cause_general=None, gacc='ONCC', total_incident_personnel=None, incident_management_organization=None, fire_mgmt_complexity=None, residences_destroyed=None, other_structures_destroyed=None, injuries=None, fatalities=None, containment_datetime=None, control_datetime=None, fire_out_datetime=None, final_acres=None, modified_on_datetime='2026-01-01T01:00:00+00:00')]
 def _to_mqtt(i): return WildfireIncident(**dataclasses.asdict(i))
 async def feed(host,port,*,username:Optional[str]=None,password:Optional[str]=None,tls=False,client_id:Optional[str]=None,once=False,content_mode='binary',polling_interval=300):
- resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+ resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
      username=username,
      password=password or '',
      client_id=client_id or '',
@@ -63,11 +69,16 @@ async def feed(host,port,*,username:Optional[str]=None,password:Optional[str]=No
  )
 
  paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
- if resolved_username or resolved_password:
+ if _entra_props is None and (resolved_username or resolved_password):
      paho.username_pw_set(resolved_username, resolved_password)
  if tls: paho.tls_set()
  client=GovNIFCWildfiresMqttMqttClient(client=paho, content_mode=content_mode, loop=asyncio.get_running_loop())
- await client.connect(host,port)
+ # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+ if _entra_props is not None:
+     paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+     paho.loop_start()
+ else:
+     await client.connect(host, port)
  try:
   while True:
    if os.getenv('NIFC_USA_WILDFIRES_SAMPLE_MODE','').lower() in ('1','true','yes'): incidents=_sample()

--- a/feeders/nina-bbk/nina_bbk_mqtt/nina_bbk_mqtt/app.py
+++ b/feeders/nina-bbk/nina_bbk_mqtt/nina_bbk_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +125,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -127,12 +133,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = NINAWarningsMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/noaa-goes/noaa_goes_mqtt/noaa_goes_mqtt/app.py
+++ b/feeders/noaa-goes/noaa_goes_mqtt/noaa_goes_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); return p.hostname or 'localhost', p.port or 1883
@@ -61,11 +67,17 @@ def main(argv=None):
     a=ap.parse_args(argv)
     if a.command!='feed': ap.print_help(); return
     async def run():
-        resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+        resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
             auth_mode=os.getenv("MQTT_AUTH_MODE"),
         )
         host,port=_parse(a.mqtt_broker_url); p=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-        if resolved_username or resolved_password: p.username_pw_set(resolved_username, resolved_password)
-        c=MicrosoftOpenDataUSNOAASWPCGOESMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop()); await c.connect(host,port); await _mock(c); await asyncio.sleep(1); await c.disconnect()
+        if _entra_props is None and (resolved_username or resolved_password): p.username_pw_set(resolved_username, resolved_password)
+        c=MicrosoftOpenDataUSNOAASWPCGOESMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop())
+        # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+        if _entra_props is not None:
+            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props); p.loop_start()
+        else:
+            await c.connect(host,port)
+        await _mock(c); await asyncio.sleep(1); await c.disconnect()
     asyncio.run(run())
 if __name__=='__main__': main()

--- a/feeders/noaa-ndbc/noaa_ndbc_mqtt/noaa_ndbc_mqtt/app.py
+++ b/feeders/noaa-ndbc/noaa_ndbc_mqtt/noaa_ndbc_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, noaa_ndbc_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/noaa-nws/noaa_nws_mqtt/noaa_nws_mqtt/app.py
+++ b/feeders/noaa-nws/noaa_nws_mqtt/noaa_nws_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -161,7 +167,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -169,7 +175,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/noaa/noaa_mqtt/noaa_mqtt/app.py
+++ b/feeders/noaa/noaa_mqtt/noaa_mqtt/app.py
@@ -55,7 +55,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -64,7 +64,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 
 def _slug(value):
@@ -234,7 +240,7 @@ async def feed(
     once=False,
     mock=False,
 ):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -246,13 +252,18 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     client_cls = next(obj for obj in globals().values() if isinstance(obj, type) and obj.__name__.endswith("MqttClient"))
     client = client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
 
     if mock:
         try:

--- a/feeders/nve-hydro/nve_hydro_mqtt/nve_hydro_mqtt/app.py
+++ b/feeders/nve-hydro/nve_hydro_mqtt/nve_hydro_mqtt/app.py
@@ -64,7 +64,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -73,7 +73,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -223,7 +229,7 @@ async def feed(
     content_mode: str = "binary",
 ) -> None:
     previous_readings = _load_state(state_file)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -234,9 +240,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -247,7 +253,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     stations = api.get_stations()
     logger.info("Publishing %d station info events under hydro/no/nve/nve-hydro/...", len(stations))

--- a/feeders/nws-forecasts/nws_forecasts_mqtt/nws_forecasts_mqtt/app.py
+++ b/feeders/nws-forecasts/nws_forecasts_mqtt/nws_forecasts_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); return p.hostname or 'localhost', p.port or 1883
@@ -60,12 +66,18 @@ def main(argv=None):
     args=ap.parse_args(argv)
     if args.command!='feed': ap.print_help(); return
     async def run():
-        resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+        resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
             auth_mode=os.getenv("MQTT_AUTH_MODE"),
         )
         host,port=_parse(args.mqtt_broker_url); p=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-        if resolved_username or resolved_password: p.username_pw_set(resolved_username, resolved_password)
-        c=MicrosoftOpenDataUSNOAANWSForecastsMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop()); await c.connect(host,port); await _mock(c); await asyncio.sleep(1); await c.disconnect()
+        if _entra_props is None and (resolved_username or resolved_password): p.username_pw_set(resolved_username, resolved_password)
+        c=MicrosoftOpenDataUSNOAANWSForecastsMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop())
+        # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+        if _entra_props is not None:
+            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props); p.loop_start()
+        else:
+            await c.connect(host,port)
+        await _mock(c); await asyncio.sleep(1); await c.disconnect()
     asyncio.run(run())
 if __name__=='__main__': main()
 

--- a/feeders/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/app.py
+++ b/feeders/paris-bicycle-counters/paris_bicycle_counters_mqtt/paris_bicycle_counters_mqtt/app.py
@@ -43,7 +43,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -52,7 +52,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +125,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -130,9 +136,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     mqtt_client = FRParisOpenDataVeloMqttMqttClient(
@@ -140,7 +146,12 @@ async def feed(
         content_mode=content_mode,  # type: ignore[arg-type]
         loop=asyncio.get_running_loop(),
     )
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         poller = ParisBicycleCounterMqttPoller(
             mqtt_client,

--- a/feeders/ptwc-tsunami/ptwc_tsunami_mqtt/ptwc_tsunami_mqtt/app.py
+++ b/feeders/ptwc-tsunami/ptwc_tsunami_mqtt/ptwc_tsunami_mqtt/app.py
@@ -44,7 +44,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -53,7 +53,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +121,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -123,12 +129,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = PTWCBulletinsMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             started = time.monotonic()

--- a/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
+++ b/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
@@ -40,7 +40,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -49,7 +49,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 try:
     from paho.mqtt.properties import Properties as MqttProperties
@@ -170,7 +176,7 @@ async def run() -> None:
     os.makedirs(args.state_dir, exist_ok=True)
 
     host, port, tls = _parse_broker_url(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or "",
         client_id=args.client_id,
@@ -178,9 +184,9 @@ async def run() -> None:
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     paho_client.connect(host, port)
     paho_client.loop_start()

--- a/feeders/rws-waterwebservices/rws_waterwebservices_mqtt/rws_waterwebservices_mqtt/app.py
+++ b/feeders/rws-waterwebservices/rws_waterwebservices_mqtt/rws_waterwebservices_mqtt/app.py
@@ -56,7 +56,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -65,7 +65,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +203,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -208,9 +214,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -221,7 +227,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     # Fetch station catalog and build station display-name map
     locations = api.get_water_level_stations()

--- a/feeders/seattle-911/seattle_911_mqtt/seattle_911_mqtt/app.py
+++ b/feeders/seattle-911/seattle_911_mqtt/seattle_911_mqtt/app.py
@@ -43,7 +43,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -52,7 +52,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +89,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -91,13 +97,18 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = USWASeattleFire911MqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     try:
         while True:
             if bridge.last_seen_datetime:

--- a/feeders/seattle-street-closures/seattle_street_closures_mqtt/seattle_street_closures_mqtt/app.py
+++ b/feeders/seattle-street-closures/seattle_street_closures_mqtt/seattle_street_closures_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "seattle-street-closures"
 XREG_FILE = "seattle-street-closures.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
+++ b/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'SensorInfo', 'vars': {'feedurl': 'https://data.sensor.community/airrohr/v1/sensor/291/', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291'}, 'sample': {'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'SensorReading', 'vars': {'feedurl': 'https://data.sensor.community/airrohr/v1/sensor/291/', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291'}, 'sample': {'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'station_id': 'station-1', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'bundesland': 'wien', 'component_id': '1', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/singapore-nea/singapore_nea_mqtt/singapore_nea_mqtt/app.py
+++ b/feeders/singapore-nea/singapore_nea_mqtt/singapore_nea_mqtt/app.py
@@ -35,7 +35,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -44,7 +44,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); return p.hostname or 'localhost', p.port or 1883
@@ -66,11 +72,17 @@ def main(argv=None):
     a=ap.parse_args(argv)
     if a.command!='feed': ap.print_help(); return
     async def run():
-        resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+        resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
             auth_mode=os.getenv("MQTT_AUTH_MODE"),
         )
         host,port=_parse(a.mqtt_broker_url); p=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-        if resolved_username or resolved_password: p.username_pw_set(resolved_username, resolved_password)
-        w=SGGovNEAWeatherMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop()); aq=SGGovNEAAirQualityMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop()); await w.connect(host,port); await _mock(w,aq); await asyncio.sleep(1); await w.disconnect()
+        if _entra_props is None and (resolved_username or resolved_password): p.username_pw_set(resolved_username, resolved_password)
+        w=SGGovNEAWeatherMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop()); aq=SGGovNEAAirQualityMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop())
+        # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+        if _entra_props is not None:
+            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props); p.loop_start()
+        else:
+            await w.connect(host,port)
+        await _mock(w,aq); await asyncio.sleep(1); await w.disconnect()
     asyncio.run(run())
 if __name__=='__main__': main()

--- a/feeders/smhi-hydro/smhi_hydro_mqtt/smhi_hydro_mqtt/app.py
+++ b/feeders/smhi-hydro/smhi_hydro_mqtt/smhi_hydro_mqtt/app.py
@@ -56,7 +56,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -65,7 +65,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +207,7 @@ async def feed(
 ) -> None:
     previous_readings = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -212,9 +218,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -225,7 +231,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     bulk_data = api.get_bulk_discharge_data()
     stations = bulk_data.get("station", [])

--- a/feeders/smhi-weather/smhi_weather_mqtt/smhi_weather_mqtt/app.py
+++ b/feeders/smhi-weather/smhi_weather_mqtt/smhi_weather_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 _TEMPLATE = re.compile(r"\{([^}]+)\}")
 
@@ -158,7 +164,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     from paho.mqtt.packettypes import PacketTypes
     from urllib.parse import urlparse
     parsed = urlparse(args.broker_url if "://" in args.broker_url else "mqtt://" + args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=parsed.username,
         password=parsed.password or "",
         client_id=None,
@@ -166,7 +172,7 @@ def publish_mqtt(args: argparse.Namespace) -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme in ("mqtts", "ssl", "tls") or args.tls: client.tls_set()
     client.connect(parsed.hostname or "localhost", parsed.port or (8883 if parsed.scheme == "mqtts" else 1883), 30)

--- a/feeders/snotel/snotel_mqtt/snotel_mqtt/app.py
+++ b/feeders/snotel/snotel_mqtt/snotel_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, snotel_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/syke-hydro/syke_hydro_mqtt/syke_hydro_mqtt/app.py
+++ b/feeders/syke-hydro/syke_hydro_mqtt/syke_hydro_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, syke_hydro_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
+++ b/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/tepco-denkiyoho.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
+++ b/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/ticketmaster.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()

--- a/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare_mqtt/tokyo_docomo_bikeshare_mqtt/app.py
+++ b/feeders/tokyo-docomo-bikeshare/tokyo_docomo_bikeshare_mqtt/tokyo_docomo_bikeshare_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "tokyo-docomo-bikeshare"
 XREG_FILE = "tokyo-docomo-bikeshare.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
+++ b/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
@@ -33,7 +33,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -42,7 +42,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 LOG=logging.getLogger(__name__)
 EVENT_SPECS = [{'class': 'Station', 'vars': {'feedurl': 'https://www.umweltbundesamt.at/airdata/v3/', 'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1'}, 'sample': {'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Measure', 'vars': {'feedurl': 'https://www.umweltbundesamt.at/airdata/v3/', 'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1'}, 'sample': {'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}, {'class': 'Component', 'vars': {'feedurl': 'https://www.umweltbundesamt.at/airdata/v3/', 'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1'}, 'sample': {'bundesland': 'wien', 'station_id': 'station-1', 'component_id': '1', 'province': 'ON', 'community_name': 'ottawa', 'region': 'central', 'pollutant': 'pm25', 'fmisid': '1001', 'voivodeship': 'mazowieckie', 'borough': 'camden', 'site_code': 'BL0', 'species_code': 'NO2', 'station_number': 'NL001', 'formula': 'NO2', 'country': 'nl', 'geohash5': 'u173z', 'sensor_id': '291', 'timeseries_id': 'ts-1', 'sensor_code': 'PM10', 'sensor_type_name': 'SDS011', 'component_code': 'NO2', 'parameter_formula': 'PM10', 'phenomenon_id': 'NO2', 'municipality': 'uusimaa', 'station_name': 'Sample Station', 'site_name': 'Sample Site', 'station_label': 'Sample Station', 'label': 'Sample'}}]
@@ -154,7 +160,7 @@ def _client_classes():
 async def main_async(args):
     host, port, tls, user, pwd = _parse_mqtt_url(args.broker_url or args.broker_host)
     user=args.username or user; pwd=args.password or pwd
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=user,
         password=pwd or '',
         client_id=args.client_id or '',
@@ -162,7 +168,7 @@ async def main_async(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]

--- a/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring_mqtt/uk_ea_flood_monitoring_mqtt/app.py
+++ b/feeders/uk-ea-flood-monitoring/uk_ea_flood_monitoring_mqtt/uk_ea_flood_monitoring_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, uk_ea_flood_monitoring_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/usgs-earthquakes/usgs_earthquakes_mqtt/usgs_earthquakes_mqtt/app.py
+++ b/feeders/usgs-earthquakes/usgs_earthquakes_mqtt/usgs_earthquakes_mqtt/app.py
@@ -42,7 +42,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -51,7 +51,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +100,7 @@ class _MqttProducerAdapter:
             raise RuntimeError("one or more MQTT publishes failed") from self._failures[0]
 
 async def feed(poller: USGSEarthquakePoller, broker_host: str, broker_port: int, *, username: Optional[str] = None, password: Optional[str] = None, tls: bool = False, client_id: Optional[str] = None, content_mode: str = "binary", once: bool = False) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -102,12 +108,17 @@ async def feed(poller: USGSEarthquakePoller, broker_host: str, broker_port: int,
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = USGSEarthquakesMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     adapter = _MqttProducerAdapter(mqtt_client)
     poller.event_producer = adapter
     try:

--- a/feeders/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/app.py
+++ b/feeders/usgs-geomag/usgs_geomag_mqtt/usgs_geomag_mqtt/app.py
@@ -43,7 +43,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -52,7 +52,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +137,7 @@ async def feed(
     once: bool = False,
     content_mode: str = "binary",
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -139,13 +145,18 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = GovUsgsGeomagMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     state = _load_state(state_file)
     try:
         await _publish_observatories(mqtt_client, observatories)

--- a/feeders/usgs-iv/usgs_iv_mqtt/usgs_iv_mqtt/app.py
+++ b/feeders/usgs-iv/usgs_iv_mqtt/usgs_iv_mqtt/app.py
@@ -45,7 +45,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -54,7 +54,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -117,13 +123,13 @@ async def feed(
 ) -> None:
     site_client_id = f"{client_id or 'usgs-iv'}-sites"
     values_client_id = f"{client_id or 'usgs-iv'}-values"
-    _, site_username, site_password = _resolve_mqtt_connection_settings(
+    _, site_username, site_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=site_client_id,
         auth_mode=os.getenv("MQTT_AUTH_MODE"),
     )
-    _, values_username, values_password = _resolve_mqtt_connection_settings(
+    _, values_username, values_password, _ = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=values_client_id,
@@ -132,17 +138,27 @@ async def feed(
 
     site_paho = mqtt.Client(client_id=site_client_id, callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     values_paho = mqtt.Client(client_id=values_client_id, callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if site_username or site_password:
+    if _entra_props is None and (site_username or site_password):
         site_paho.username_pw_set(site_username, site_password)
-    if values_username or values_password:
+    if _entra_props is None and (values_username or values_password):
         values_paho.username_pw_set(values_username, values_password)
-    if tls:
+    if tls or _entra_props is not None:
         site_paho.tls_set()
         values_paho.tls_set()
     site_client = USGSSitesMqttMqttClient(client=site_paho, content_mode=content_mode, loop=asyncio.get_running_loop())
     values_client = USGSInstantaneousValuesMqttMqttClient(client=values_paho, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await site_client.connect(broker_host, broker_port)
-    await values_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        import paho.mqtt.properties as _mqtt_props_mod
+        from paho.mqtt.properties import Properties as _EP
+        from paho.mqtt.packettypes import PacketTypes as _PKT
+        _site_props = _EP(_PKT.CONNECT); _site_props.AuthenticationMethod = "OAUTH2-JWT"; _site_props.AuthenticationData = _entra_props.AuthenticationData
+        _vals_props = _EP(_PKT.CONNECT); _vals_props.AuthenticationMethod = "OAUTH2-JWT"; _vals_props.AuthenticationData = _entra_props.AuthenticationData
+        site_paho.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_site_props); site_paho.loop_start()
+        values_paho.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_vals_props); values_paho.loop_start()
+    else:
+        await site_client.connect(broker_host, broker_port)
+        await values_client.connect(broker_host, broker_port)
     site_adapter = _MqttProducerAdapter(site_client, "usgs_sites_")
     values_adapter = _MqttProducerAdapter(values_client, "usgs_instantaneous_values_")
     poller.site_producer = site_adapter

--- a/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, usgs_nwis_wq_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,7 +125,7 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_classes=[obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient')]

--- a/feeders/vatsim/vatsim_mqtt/vatsim_mqtt/app.py
+++ b/feeders/vatsim/vatsim_mqtt/vatsim_mqtt/app.py
@@ -43,7 +43,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -52,7 +52,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +131,7 @@ async def feed(
     content_mode: str = "binary",
     once: bool = False,
 ) -> None:
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -133,12 +139,17 @@ async def feed(
     )
 
     paho_client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
     mqtt_client = NetVatsimMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
     state = _load_state(state_file)
     previous_pilots = state.get("pilots", {})
     previous_controllers = state.get("controllers", {})

--- a/feeders/wallonia-issep/wallonia_issep_mqtt/wallonia_issep_mqtt/app.py
+++ b/feeders/wallonia-issep/wallonia_issep_mqtt/wallonia_issep_mqtt/app.py
@@ -52,7 +52,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -61,7 +61,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger(__name__)
 
@@ -177,7 +183,7 @@ async def feed(
     """Run the MQTT feed loop."""
     state = _load_state(state_file)
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or "",
         client_id=client_id or "",
@@ -188,9 +194,9 @@ async def feed(
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -201,7 +207,12 @@ async def feed(
     )
 
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await mqtt_client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await mqtt_client.connect(broker_host, broker_port)
 
     # Initial full fetch: publish both reference data and observations
     all_records = api.fetch_all_records()

--- a/feeders/waterinfo-vmm/waterinfo_vmm_mqtt/waterinfo_vmm_mqtt/app.py
+++ b/feeders/waterinfo-vmm/waterinfo_vmm_mqtt/waterinfo_vmm_mqtt/app.py
@@ -29,7 +29,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -38,7 +38,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 def _slug(v):
     return str(v or 'unknown').replace('/', '-').replace(' ', '-').lower()
@@ -111,7 +117,7 @@ async def _publish_mock(client):
         await method(**_required_call_kwargs(method, waterinfo_vmm_mqtt_producer_data))
 
 async def feed(host, port, username=None, password=None, tls=False, client_id=None, once=False, content_mode='binary'):
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=username,
         password=password or '',
         client_id=client_id or '',
@@ -119,12 +125,17 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     )
 
     paho_client=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls: paho_client.tls_set()
     client_cls=next(obj for obj in globals().values() if isinstance(obj,type) and obj.__name__.endswith('MqttClient'))
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
-    await client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(host, port)
     try:
         await _publish_mock(client)
     finally:

--- a/feeders/wikimedia-eventstreams/wikimedia_eventstreams_mqtt/wikimedia_eventstreams_mqtt/app.py
+++ b/feeders/wikimedia-eventstreams/wikimedia_eventstreams_mqtt/wikimedia_eventstreams_mqtt/app.py
@@ -63,7 +63,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -72,7 +72,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger("wikimedia_eventstreams_mqtt")
 
@@ -330,7 +336,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -341,9 +347,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -353,7 +359,12 @@ async def _run(args: argparse.Namespace) -> None:
         loop=loop,
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     bridge = WikimediaMqttBridge(
         client,

--- a/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
+++ b/feeders/wikimedia-osm-diffs/wikimedia_osm_diffs_mqtt/wikimedia_osm_diffs_mqtt/app.py
@@ -72,7 +72,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -81,7 +81,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 logger = logging.getLogger("wikimedia_osm_diffs_mqtt")
 
@@ -416,7 +422,7 @@ async def _run(args: argparse.Namespace) -> None:
     broker_host, broker_port, tls = _parse_broker(args.mqtt_broker_url)
     tls = tls or args.mqtt_enable_tls
 
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.mqtt_username,
         password=args.mqtt_password or "",
         client_id=args.mqtt_client_id or "",
@@ -427,9 +433,9 @@ async def _run(args: argparse.Namespace) -> None:
         callback_api_version=CallbackAPIVersion.VERSION2,
         protocol=MQTTv5,
     )
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set()
 
     loop = asyncio.get_running_loop()
@@ -439,7 +445,12 @@ async def _run(args: argparse.Namespace) -> None:
         loop=loop,
     )
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
-    await client.connect(broker_host, broker_port)
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    if _entra_props is not None:
+        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho_client.loop_start()
+    else:
+        await client.connect(broker_host, broker_port)
 
     state_store = StateStore(args.state_file) if args.state_file else None
     bridge = OsmDiffsMqttBridge(

--- a/feeders/wsdot/wsdot_mqtt/wsdot_mqtt/app.py
+++ b/feeders/wsdot/wsdot_mqtt/wsdot_mqtt/app.py
@@ -32,7 +32,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -41,7 +41,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 PROJECT_DIR = "wsdot"
 XREG_FILE = "wsdot.xreg.json"
@@ -199,7 +205,7 @@ def mqtt_feed() -> None:
     url = os.getenv('MQTT_BROKER_URL') or f"mqtt://{os.getenv('MQTT_HOST','localhost')}:{os.getenv('MQTT_PORT','1883')}"
     parsed = urlparse(url if '://' in url else f'mqtt://{url}')
     host = parsed.hostname or 'localhost'; port = parsed.port or (8883 if parsed.scheme == 'mqtts' else 1883)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=os.getenv('MQTT_USERNAME'),
         password=os.getenv('MQTT_PASSWORD',''),
         client_id=None,
@@ -207,7 +213,7 @@ def mqtt_feed() -> None:
     )
 
     client = mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         client.username_pw_set(resolved_username, resolved_password)
     if parsed.scheme == 'mqtts' or os.getenv('MQTT_TLS','').lower() in ('1','true','yes'):
         client.tls_set()

--- a/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
+++ b/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
@@ -34,7 +34,7 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
     auth_mode = str(auth_mode or os.getenv("MQTT_AUTH_MODE", "password")).strip().lower() or "password"
 
     if auth_mode != "entra":
-        return resolved_client_id, str(username or ""), str(password or "")
+        return resolved_client_id, str(username or ""), str(password or ""), None
 
     audience = os.getenv("MQTT_ENTRA_AUDIENCE", "https://eventgrid.azure.net/")
     managed_identity_client_id = os.getenv("MQTT_ENTRA_CLIENT_ID") or None
@@ -43,7 +43,13 @@ def _resolve_mqtt_connection_settings(*, username=None, password=None, client_id
         raise ValueError("MQTT_CLIENT_ID (or --client-id) is required for MQTT_AUTH_MODE=entra")
 
     resolved_password = _fetch_entra_mqtt_token(audience, managed_identity_client_id)
-    return resolved_client_id, resolved_username, resolved_password
+    # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
+    from paho.mqtt.properties import Properties as _MqttConnProps
+    from paho.mqtt.packettypes import PacketTypes as _MqttPktTypes
+    _connect_props = _MqttConnProps(_MqttPktTypes.CONNECT)
+    _connect_props.AuthenticationMethod = "OAUTH2-JWT"
+    _connect_props.AuthenticationData = resolved_password.encode("utf-8")
+    return resolved_client_id, resolved_username, resolved_password, _connect_props
 
 MANIFEST = pathlib.Path(os.getenv('SOURCE_MANIFEST', '/app/xreg/xceed.xreg.json'))
 
@@ -125,7 +131,7 @@ def _parse(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 async def run(args):
     host,port,tls=_parse(args.broker_url)
-    resolved_client_id, resolved_username, resolved_password = _resolve_mqtt_connection_settings(
+    resolved_client_id, resolved_username, resolved_password, _entra_props = _resolve_mqtt_connection_settings(
         username=args.username,
         password=args.password or '',
         client_id=args.client_id or '',
@@ -133,7 +139,7 @@ async def run(args):
     )
 
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
-    if resolved_username or resolved_password:
+    if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls: paho.tls_set()
     loop=asyncio.get_running_loop()


### PR DESCRIPTION
## Problem

All 97 MQTT feeder app.py files were using paho.username_pw_set(client_id, token) to pass Entra JWT tokens to Azure Event Grid MQTT. This is silently wrong.

Azure Event Grid MQTT requires Entra JWT via MQTT v5 Extended Authentication:
- Authentication Method: OAUTH2-JWT
- Authentication Data: <token bytes>
in the CONNECT packet properties, not in the password field.

The result: paho silently retried the connection in a loop, publish() queued messages locally that were never delivered, and the feeder log reported "Published N events" even with 0 messages reaching the broker. Mqtt.SuccessfulPublishedMessages was always 0.

Tracked upstream as: xregistry/codegen#432

## Fix

- _resolve_mqtt_connection_settings() now returns a 4-tuple (client_id, username, password, connect_props) where connect_props is a paho Properties object for entra mode, None otherwise
- All callers updated to guard username_pw_set and tls_set, and use paho_client.connect() directly with properties= for Entra mode
- australia-wildfires: same fix applied to its _resolve_mqtt_auth() variant
- usgs-iv: special two-client handling (site_paho + values_paho)
- All fix sites marked: # WORKAROUND(xregistry/codegen#432)

## Scope

97 files changed. The 12 feeders already using OAUTH2-JWT (pegelonline, autobahn, digitraffic-road, dmi, entsoe, fdsn-seismology, gbfs-bikeshare, noaa-swpc-l1, nws-alerts, siri, tfl-road-traffic, uk-bods-siri) are NOT modified.
