### PR TITLE
fix: inject Entra JWT CONNECT properties into paho.connect() for 21 MQTT feeders

### DIFF
--- a/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
+++ b/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
+++ b/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
+++ b/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
+++ b/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
+++ b/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
+++ b/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
+++ b/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
+++ b/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
+++ b/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
+++ b/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
@@ -83,8 +83,14 @@ async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hour
     pc=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         pc.username_pw_set(resolved_username, resolved_password)
-    if tls: pc.tls_set()
-    client=JPJMAAmedasMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop()); await client.connect(host,port)
+    if tls or _entra_props is not None: pc.tls_set()
+    client=JPJMAAmedasMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop())
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        pc.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        pc.loop_start()
+    else:
+        await client.connect(host,port)
     state=_load_state(state_file)
     try:
         while True:

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
@@ -77,8 +77,14 @@ async def feed(api,h,p,tls=False,username=None,password=None,content_mode='binar
     pc=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2,protocol=MQTTv5);
     if _entra_props is None and (resolved_username or resolved_password):
         pc.username_pw_set(resolved_username, resolved_password)
-    if tls: pc.tls_set()
-    c=JPJMAVolcanoMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop()); await c.connect(h,p)
+    if tls or _entra_props is not None: pc.tls_set()
+    c=JPJMAVolcanoMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop())
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        pc.connect(h, p, keepalive=60, clean_start=True, properties=_entra_props)
+        pc.loop_start()
+    else:
+        await c.connect(h,p)
     try: await run(api,c)
     finally: await c.disconnect()
 def main():

--- a/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
+++ b/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
+++ b/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
+++ b/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
@@ -188,7 +188,11 @@ async def run() -> None:
         paho_client.username_pw_set(resolved_username, resolved_password)
     if tls or _entra_props is not None:
         paho_client.tls_set()
-    paho_client.connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+    else:
+        paho_client.connect(host, port)
     paho_client.loop_start()
     try:
         feed_urls = load_feedstore()

--- a/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
+++ b/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
+++ b/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
+++ b/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:

--- a/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
+++ b/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
@@ -172,7 +172,12 @@ async def main_async(args):
         paho.username_pw_set(resolved_username, resolved_password)
     if tls or args.tls: paho.tls_set()
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
-    await clients[0].connect(host, args.broker_port or port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
     finally: await clients[0].disconnect()
 

--- a/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
@@ -132,7 +132,12 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     if not client_classes:
         raise RuntimeError('No generated MQTT clients found')
     clients=[cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop()) for cls in client_classes]
-    await clients[0].connect(host, port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host, port)
     try:
         for client in clients:
             await _publish_mock(client)

--- a/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
+++ b/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
@@ -141,11 +141,16 @@ async def run(args):
     paho=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
     if _entra_props is None and (resolved_username or resolved_password):
         paho.username_pw_set(resolved_username, resolved_password)
-    if tls: paho.tls_set()
+    if tls or _entra_props is not None: paho.tls_set()
     loop=asyncio.get_running_loop()
     classes=[v for v in vars(client_mod).values() if isinstance(v,type) and v.__name__.endswith('MqttClient')]
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
-    await clients[0].connect(host,port)
+    # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
+    if _entra_props is not None:
+        paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+        paho.loop_start()
+    else:
+        await clients[0].connect(host,port)
     try:
         for sh,payload,_ in _iter_events(): await _publish_one(clients,sh,payload)
     finally:


### PR DESCRIPTION
## Root Cause

The fleet-wide MQTT OAUTH2-JWT fix in PR #961 built the \Properties(PacketTypes.CONNECT)\ object with \AuthenticationMethod=OAUTH2-JWT\ and \AuthenticationData=<token>\, but **never passed it to \paho.connect()\**. The generated async wrapper's \connect()\ calls \self.client.connect(host, port, keepalive)\ without a \properties\ kwarg, so Azure Event Grid MQTT rejected all connections with CONNACK rc=5.

Result: \Mqtt.Connections = 0\ for all 21 affected sources in the E2E validation run.

## Fix

When \_entra_props is not None\, bypass the async wrapper and call \paho_client.connect()\ directly with \properties=_entra_props, clean_start=True\ + \loop_start()\. Also ensures TLS is enabled whenever Entra auth is active (EG MQTT requires TLS).

This matches the working pattern already present in \isstream\, \pegelonline\, and other sources that were not affected.

## Affected Sources (21)
billetto, canada-aqhi, defra-aurn, elexon-bmrs, energidataservice-dk, energy-charts, fienta, fmi-finland, gios-poland, irceline-belgium, jma-bosai-amedas, jma-bosai-volcano, laqn-london, luchtmeetnet-nl, rss, sensor-community, tepco-denkiyoho, ticketmaster, uba-airdata, usgs-nwis-wq, xceed

Underlying generator bug tracked in xregistry/codegen#432.

## Related
- Follows PR #961 (fleet MQTT OAUTH2-JWT auth fix)
- Discovered during E2E validation session 2026-06-10