### PR TITLE
fix: add CONNACK wait for Entra JWT MQTT connections in 27 feeders

### DIFF
--- a/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
+++ b/feeders/billetto/billetto_mqtt/billetto_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
+++ b/feeders/canada-aqhi/canada_aqhi_mqtt/canada_aqhi_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
+++ b/feeders/defra-aurn/defra_aurn_mqtt/defra_aurn_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
+++ b/feeders/elexon-bmrs/elexon_bmrs_mqtt/elexon_bmrs_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
+++ b/feeders/energidataservice-dk/energidataservice_dk_mqtt/energidataservice_dk_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
+++ b/feeders/energy-charts/energy_charts_mqtt/energy_charts_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
+++ b/feeders/fienta/fienta_mqtt/fienta_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
+++ b/feeders/fmi-finland/fmi_finland_mqtt/fmi_finland_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
+++ b/feeders/gios-poland/gios_poland_mqtt/gios_poland_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
+++ b/feeders/irceline-belgium/irceline_belgium_mqtt/irceline_belgium_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
@@ -87,8 +87,16 @@ async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hour
     client=JPJMAAmedasMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop())
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         pc.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         pc.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await client.connect(host,port)
     state=_load_state(state_file)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt/jma_bosai_volcano_mqtt/app.py
@@ -81,8 +81,16 @@ async def feed(api,h,p,tls=False,username=None,password=None,content_mode='binar
     c=JPJMAVolcanoMqttMqttClient(client=pc,content_mode=content_mode,loop=asyncio.get_running_loop())
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         pc.connect(h, p, keepalive=60, clean_start=True, properties=_entra_props)
         pc.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await c.connect(h,p)
     try: await run(api,c)

--- a/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
+++ b/feeders/laqn-london/laqn_london_mqtt/laqn_london_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
+++ b/feeders/luchtmeetnet-nl/luchtmeetnet_nl_mqtt/luchtmeetnet_nl_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/mode-s/mode_s_mqtt/mode_s_mqtt/app.py
+++ b/feeders/mode-s/mode_s_mqtt/mode_s_mqtt/app.py
@@ -378,8 +378,16 @@ async def _run(args: argparse.Namespace) -> None:
     logger.info("Connecting to MQTT broker %s:%s (tls=%s)", broker_host, broker_port, tls)
     # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
         paho_client.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await client.connect(broker_host, broker_port)
 

--- a/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt/nifc_usa_wildfires_mqtt/app.py
+++ b/feeders/nifc-usa-wildfires/nifc_usa_wildfires_mqtt/nifc_usa_wildfires_mqtt/app.py
@@ -75,8 +75,16 @@ async def feed(host,port,*,username:Optional[str]=None,password:Optional[str]=No
  client=GovNIFCWildfiresMqttMqttClient(client=paho, content_mode=content_mode, loop=asyncio.get_running_loop())
  # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
  if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
      paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
      paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
  else:
      await client.connect(host, port)
  try:

--- a/feeders/noaa-goes/noaa_goes_mqtt/noaa_goes_mqtt/app.py
+++ b/feeders/noaa-goes/noaa_goes_mqtt/noaa_goes_mqtt/app.py
@@ -72,10 +72,20 @@ def main(argv=None):
         )
         host,port=_parse(a.mqtt_broker_url); p=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
         if _entra_props is None and (resolved_username or resolved_password): p.username_pw_set(resolved_username, resolved_password)
+        if _entra_props is not None or a.mqtt_broker_url.startswith(('mqtts://', 'ssl://')): p.tls_set()
         c=MicrosoftOpenDataUSNOAASWPCGOESMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop())
         # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
         if _entra_props is not None:
-            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props); p.loop_start()
+            import threading as _threading
+            _connected = _threading.Event()
+            def _on_connack(client, userdata, flags, reason_code, props=None):
+                if reason_code == 0:
+                    _connected.set()
+            p.on_connect = _on_connack
+            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+            p.loop_start()
+            if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+                raise RuntimeError('MQTT CONNACK timeout after 30s')
         else:
             await c.connect(host,port)
         await _mock(c); await asyncio.sleep(1); await c.disconnect()

--- a/feeders/noaa-ndbc/noaa_ndbc_mqtt/noaa_ndbc_mqtt/app.py
+++ b/feeders/noaa-ndbc/noaa_ndbc_mqtt/noaa_ndbc_mqtt/app.py
@@ -132,8 +132,16 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     client=client_cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
     # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho_client.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await client.connect(host, port)
     try:

--- a/feeders/nws-alerts/nws_alerts_mqtt/nws_alerts_mqtt/app.py
+++ b/feeders/nws-alerts/nws_alerts_mqtt/nws_alerts_mqtt/app.py
@@ -186,14 +186,22 @@ async def _connect_client(args: argparse.Namespace) -> NWSAlertsMqttMqttClient:
         from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
         from paho.mqtt.packettypes import PacketTypes
         from paho.mqtt.properties import Properties
+        import threading as _threading
 
         credential = ManagedIdentityCredential(client_id=args.mqtt_entra_client_id) if args.mqtt_entra_client_id else DefaultAzureCredential()
         token = credential.get_token(args.mqtt_entra_audience)
         props = Properties(PacketTypes.CONNECT)
         props.AuthenticationMethod = "OAUTH2-JWT"
         props.AuthenticationData = token.token.encode("utf-8")
+        _connected = _threading.Event()
+        def _on_connack(c, userdata, flags, reason_code, p=None):
+            if reason_code == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=props)
         paho_client.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await client.connect(broker_host, broker_port)
     return client

--- a/feeders/nws-forecasts/nws_forecasts_mqtt/nws_forecasts_mqtt/app.py
+++ b/feeders/nws-forecasts/nws_forecasts_mqtt/nws_forecasts_mqtt/app.py
@@ -71,10 +71,20 @@ def main(argv=None):
         )
         host,port=_parse(args.mqtt_broker_url); p=mqtt.Client(client_id=resolved_client_id or "", callback_api_version=CallbackAPIVersion.VERSION2, protocol=MQTTv5)
         if _entra_props is None and (resolved_username or resolved_password): p.username_pw_set(resolved_username, resolved_password)
+        if _entra_props is not None or args.mqtt_broker_url.startswith(('mqtts://', 'ssl://')): p.tls_set()
         c=MicrosoftOpenDataUSNOAANWSForecastsMqttMqttClient(client=p, content_mode='binary', loop=asyncio.get_running_loop())
         # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
         if _entra_props is not None:
-            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props); p.loop_start()
+            import threading as _threading
+            _connected = _threading.Event()
+            def _on_connack(client, userdata, flags, reason_code, props=None):
+                if reason_code == 0:
+                    _connected.set()
+            p.on_connect = _on_connack
+            p.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
+            p.loop_start()
+            if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+                raise RuntimeError('MQTT CONNACK timeout after 30s')
         else:
             await c.connect(host,port)
         await _mock(c); await asyncio.sleep(1); await c.disconnect()

--- a/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
+++ b/feeders/rss/rssbridge_mqtt/rssbridge_mqtt/app.py
@@ -190,10 +190,19 @@ async def run() -> None:
         paho_client.tls_set()
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
     else:
         paho_client.connect(host, port)
     paho_client.loop_start()
+    if _entra_props is not None:
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     try:
         feed_urls = load_feedstore()
         feed_urls.extend([url for url in args.urls if url])

--- a/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
+++ b/feeders/sensor-community/sensor_community_mqtt/sensor_community_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
+++ b/feeders/tepco-denkiyoho/tepco_denkiyoho_mqtt/tepco_denkiyoho_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
+++ b/feeders/ticketmaster/ticketmaster_mqtt/ticketmaster_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:

--- a/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
+++ b/feeders/uba-airdata/uba_airdata_mqtt/uba_airdata_mqtt/app.py
@@ -174,8 +174,16 @@ async def main_async(args):
     clients=[cls(client=paho, content_mode=args.content_mode, loop=asyncio.get_running_loop()) for cls in _client_classes()]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, args.broker_port or port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, args.broker_port or port)
     try: await _publish_all(clients)
@@ -199,4 +207,3 @@ def main():
     if args.command!='feed': ap.error("only 'feed' is supported")
     asyncio.run(main_async(args))
 if __name__=='__main__': main()
-

--- a/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
+++ b/feeders/usgs-nwis-wq/usgs_nwis_wq_mqtt/usgs_nwis_wq_mqtt/app.py
@@ -134,8 +134,16 @@ async def feed(host, port, username=None, password=None, tls=False, client_id=No
     clients=[cls(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop()) for cls in client_classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host, port)
     try:

--- a/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
+++ b/feeders/xceed/xceed_mqtt/xceed_mqtt/app.py
@@ -147,8 +147,16 @@ async def run(args):
     clients=[cls(client=paho, content_mode='binary', loop=loop) for cls in classes]
     # WORKAROUND(xregistry/codegen#432): pass Entra JWT CONNECT properties directly to paho
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if reason_code == 0:
+                _connected.set()
+        paho.on_connect = _on_connack
         paho.connect(host, port, keepalive=60, clean_start=True, properties=_entra_props)
         paho.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await clients[0].connect(host,port)
     try:


### PR DESCRIPTION
## Root Cause

Short-lived MQTT pollers (fetch-once, publish, disconnect) race with the TCP+TLS+JWT handshake when using OAUTH2-JWT extended auth against Event Grid MQTT. The code called \paho.connect()\ + \loop_start()\ then immediately tried to publish and disconnect before CONNACK arrived, resulting in \Mqtt.Connections=0\.

## Fix

Add a \	hreading.Event\ callback registered on \on_connect\ **before** \connect()\ is called, then \wait\ the event (30s timeout) before proceeding to publish.

Also fixes \
oaa-goes\ and \
ws-forecasts\ which were missing \	ls_set()\ for \mqtts://\ URLs (their \_parse()\ helper only returned host/port without a TLS flag).

**27 sources fixed:** billetto, canada-aqhi, defra-aurn, elexon-bmrs, energidataservice-dk, energy-charts, fienta, fmi-finland, gios-poland, irceline-belgium, jma-bosai-amedas, jma-bosai-volcano, laqn-london, luchtmeetnet-nl, mode-s, nifc-usa-wildfires, noaa-goes, noaa-ndbc, nws-alerts, nws-forecasts, rss, sensor-community, tepco-denkiyoho, ticketmaster, uba-airdata, usgs-nwis-wq, xceed

WORKAROUND(xregistry/codegen#432)