### PR TITLE
fix: add CONNACK wait for Entra JWT MQTT in digitraffic-maritime, tfl-road-traffic, usgs-earthquakes

### DIFF
--- a/feeders/digitraffic-maritime/digitraffic_maritime_mqtt/digitraffic_maritime_mqtt/app.py
+++ b/feeders/digitraffic-maritime/digitraffic_maritime_mqtt/digitraffic_maritime_mqtt/app.py
@@ -140,11 +140,19 @@ def _build_clients(args: argparse.Namespace):
         )
     if _entra_props is None and (resolved_username or resolved_password):
         paho_client.username_pw_set(resolved_username, resolved_password)
-    if tls:
+    if tls or _entra_props is not None:
         paho_client.tls_set(ca_certs=args.ca_file or None)
 
+    import threading as _threading
+    _connected = _threading.Event()
+    def _on_connack(client, userdata, flags, reason_code, props=None):
+        if (reason_code if isinstance(reason_code, int) else reason_code.value) == 0:
+            _connected.set()
+    paho_client.on_connect = _on_connack
     paho_client.connect(host, port, keepalive=60, properties=_entra_props)
     paho_client.loop_start()
+    if not _connected.wait(30):
+        raise RuntimeError('MQTT CONNACK timeout after 30s')
 
     ais_client = FiDigitrafficMarineAisMqttMqttClient(paho_client, content_mode=args.content_mode)
     port_call_client = FiDigitrafficMarinePortcallMqttMqttClient(paho_client, content_mode=args.content_mode)

--- a/feeders/tfl-road-traffic/tfl_road_traffic_mqtt/tfl_road_traffic_mqtt/app.py
+++ b/feeders/tfl-road-traffic/tfl_road_traffic_mqtt/tfl_road_traffic_mqtt/app.py
@@ -224,13 +224,21 @@ async def _connect_client(args: argparse.Namespace) -> UkGovTflRoadMqttMqttClien
         from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
         from paho.mqtt.packettypes import PacketTypes
         from paho.mqtt.properties import Properties
+        import threading as _threading
         credential = ManagedIdentityCredential(client_id=args.mqtt_entra_client_id) if args.mqtt_entra_client_id else DefaultAzureCredential()
         token = credential.get_token(args.mqtt_entra_audience)
         props = Properties(PacketTypes.CONNECT)
         props.AuthenticationMethod = "OAUTH2-JWT"
         props.AuthenticationData = token.token.encode("utf-8")
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, p=None):
+            if (reason_code if isinstance(reason_code, int) else reason_code.value) == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=props)
         paho_client.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await client.connect(broker_host, broker_port)
     return client

--- a/feeders/usgs-earthquakes/usgs_earthquakes_mqtt/usgs_earthquakes_mqtt/app.py
+++ b/feeders/usgs-earthquakes/usgs_earthquakes_mqtt/usgs_earthquakes_mqtt/app.py
@@ -115,8 +115,16 @@ async def feed(poller: USGSEarthquakePoller, broker_host: str, broker_port: int,
     mqtt_client = USGSEarthquakesMqttMqttClient(client=paho_client, content_mode=content_mode, loop=asyncio.get_running_loop())
     # WORKAROUND(xregistry/codegen#432): EG MQTT requires OAUTH2-JWT extended auth, not username/password
     if _entra_props is not None:
+        import threading as _threading
+        _connected = _threading.Event()
+        def _on_connack(client, userdata, flags, reason_code, props=None):
+            if (reason_code if isinstance(reason_code, int) else reason_code.value) == 0:
+                _connected.set()
+        paho_client.on_connect = _on_connack
         paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=_entra_props)
         paho_client.loop_start()
+        if not await asyncio.get_running_loop().run_in_executor(None, lambda: _connected.wait(30)):
+            raise RuntimeError('MQTT CONNACK timeout after 30s')
     else:
         await mqtt_client.connect(broker_host, broker_port)
     adapter = _MqttProducerAdapter(mqtt_client)


### PR DESCRIPTION
Same race-condition fix as PR #1169. These 3 sources had \MQTT_AUTH_MODE\ and \	ls_set()\ but were missing the \	hreading.Event\ + \on_connect\ + \_connected.wait(30)\ pattern to ensure TCP+TLS+CONNACK completes before publishing. All showed \Mqtt.Connections=0\ in E2E fleet validation.