### PR TITLE
fix(dwd): add Kafka producer backpressure to prevent BufferError

### DIFF
--- a/feeders/dwd/dwd/dwd.py
+++ b/feeders/dwd/dwd/dwd.py
@@ -258,14 +258,21 @@ def run_feed(kafka_config: Dict[str, str], kafka_topic: str,
                     events = []
 
                 for ev in events:
-                    _emit_event(
-                        cdc_event_producer,
-                        weather_event_producer,
-                        radar_event_producer,
-                        forecast_event_producer,
-                        ev,
-                    )
+                    while True:
+                        try:
+                            _emit_event(
+                                cdc_event_producer,
+                                weather_event_producer,
+                                radar_event_producer,
+                                forecast_event_producer,
+                                ev,
+                            )
+                            break
+                        except BufferError:
+                            kafka_producer.flush(5)
                     total_events += 1
+                    if total_events % 500 == 0:
+                        kafka_producer.poll(0)
 
                 if events:
                     kafka_producer.flush()


### PR DESCRIPTION
DWD emits 200K+ events on cold-start first poll. The Kafka producer buffer overflows → \BufferError: Local: Queue full\ → bridge crash.

**Fix:** Wrap \_emit_event\ in a \while True / except BufferError: flush(5)\ loop, plus \poll(0)\ every 500 events.

**Verified locally:** 226,798 events emitted, 0 BufferError occurrences.

Closes #1359