### PR TITLE
fix(e2e): accept unit/ucumUnit on nullable-numeric unions in schema validation (#1391)

### DIFF
--- a/tests/docker_e2e/_jsonstructure_compat.py
+++ b/tests/docker_e2e/_jsonstructure_compat.py
@@ -1,0 +1,112 @@
+"""JSON Structure SDK compatibility shim for the Docker E2E schema validation.
+
+WORKAROUND(clemensv/real-time-sources#1391): the ``json_structure`` SDK
+(reproduced on the editable 0.6.3.dev2 build *and* the published 0.7.0 wheel
+that CI installs via ``json-structure>=0.6.1``) rejects the ``unit`` and
+``ucumUnit`` keywords on a nullable-numeric type union such as
+``{"type": ["double", "null"], "unit": "meter"}``. That pattern is the repo's
+standard shape for an optional/explicit-null measured value (548 fields across
+54 feeders, e.g. gbfs-bikeshare ``current_range_meters``), and it is
+spec-defensible:
+
+* JSON Structure Units draft, "The ``unit`` Keyword": *"The ``unit`` keyword
+  MAY be used as an annotation on any schema element whose underlying type is
+  numeric."* A ``["double","null"]`` union's underlying (value-bearing) type is
+  ``double``; the ``"null"`` member only encodes explicit-null on the wire.
+* The normative Units meta-schema (``meta/extended/v0`` ``UnitsPropertyAddIn``)
+  ``$extends`` *every* ``Property`` and adds ``unit: string`` with **no** numeric
+  gate at all.
+* The SDK's own ``minimum``/``maximum`` gate silently tolerates unions, and its
+  ``unit`` numeric set wrongly omits ``int8/uint8/int16/uint16/float8``. The
+  JSON Structure Expert ruled the validator rule a bug, not a correct constraint
+  (see issue #1391).
+
+The permanent fix is a ~6-line change in the SDK's ``_check_units_keywords`` and
+``_check_ucum_unit`` to use the full numeric set and accept a union whose
+non-``null`` members are all numeric. Until a fixed ``json-structure`` is
+released and the pin in ``tests/docker_e2e/requirements.txt`` is bumped, this
+shim post-filters **only** those provably-spec-false-positive errors and leaves
+every other validation error untouched (``unit`` on a non-numeric type such as
+``["string","null"]`` still fails — see the negative control in
+``test_helpers.py``).
+
+Remove this shim and import ``SchemaValidator`` directly from ``json_structure``
+once the upstream fix ships.
+"""
+from __future__ import annotations
+
+from json_structure import InstanceValidator  # re-exported unchanged
+from json_structure import SchemaValidator as _BaseSchemaValidator
+from json_structure import error_codes as _ErrorCodes
+
+__all__ = ["InstanceValidator", "SchemaValidator"]
+
+# Complete numeric primitive set per JSON Structure Core "Extended Primitive
+# Types". The SDK's unit gate uses an under-inclusive subset; the SDK's own
+# minimum/maximum gate uses this complete set.
+_NUMERIC_TYPES = frozenset({
+    "number", "integer", "float", "double", "decimal",
+    "int8", "uint8", "int16", "uint16", "int32", "uint32",
+    "int64", "uint64", "int128", "uint128", "float8",
+})
+
+# Keywords the SDK numeric-gates (and only these) that this shim relaxes.
+_GATED_KEYWORDS = ("unit", "ucumUnit")
+
+_TYPE_MISMATCH = _ErrorCodes.SCHEMA_CONSTRAINT_TYPE_MISMATCH
+
+
+def _unit_eligible(type_value) -> bool:
+    """True when ``type_value`` is a numeric primitive or a union whose
+    non-``null`` members are all numeric primitives."""
+    if isinstance(type_value, str):
+        return type_value in _NUMERIC_TYPES
+    if isinstance(type_value, list):
+        non_null = [m for m in type_value if m != "null"]
+        return bool(non_null) and all(
+            isinstance(m, str) and m in _NUMERIC_TYPES for m in non_null
+        )
+    return False
+
+
+def _resolve_pointer(doc, pointer: str):
+    """Resolve a ``#/a/b/c`` JSON pointer (dict keys only, as JSON Structure
+    schemas use) against ``doc``. Returns ``None`` if it cannot be resolved."""
+    if not pointer or not pointer.startswith("#"):
+        return None
+    node = doc
+    for raw in pointer[1:].split("/"):
+        if raw == "":
+            continue
+        key = raw.replace("~1", "/").replace("~0", "~")
+        if isinstance(node, dict) and key in node:
+            node = node[key]
+        else:
+            return None
+    return node
+
+
+def _is_unit_false_positive(error, doc) -> bool:
+    """True iff ``error`` is the SDK's spec-false-positive rejection of
+    ``unit``/``ucumUnit`` on an eligible-numeric (incl. nullable-union) type."""
+    if getattr(error, "code", None) != _TYPE_MISMATCH:
+        return False
+    path = getattr(error, "path", "") or ""
+    for kw in _GATED_KEYWORDS:
+        suffix = "/" + kw
+        if path.endswith(suffix):
+            field_node = _resolve_pointer(doc, path[: -len(suffix)])
+            if isinstance(field_node, dict) and _unit_eligible(field_node.get("type")):
+                return True
+    return False
+
+
+class SchemaValidator(_BaseSchemaValidator):
+    """``json_structure.SchemaValidator`` with the #1391 unit-on-nullable-numeric
+    false positives filtered out. Behaviour is otherwise identical."""
+
+    def validate(self, doc, source_text=None):  # type: ignore[override]
+        errors = super().validate(doc, source_text)
+        if not errors:
+            return errors
+        return [e for e in errors if not _is_unit_false_positive(e, doc)]

--- a/tests/docker_e2e/conftest.py
+++ b/tests/docker_e2e/conftest.py
@@ -10,6 +10,21 @@ _this_dir = os.path.dirname(os.path.abspath(__file__))
 if _this_dir not in sys.path:
     sys.path.insert(0, _this_dir)
 
+# WORKAROUND(clemensv/real-time-sources#1391): the json_structure SDK (editable
+# 0.6.3.dev2 and published 0.7.0) wrongly rejects `unit`/`ucumUnit` on a
+# nullable-numeric type union (e.g. {"type": ["double","null"], "unit": "meter"}),
+# the repo's standard shape for an optional/explicit-null measured value used by
+# 500+ fields across 54 feeders. Patch json_structure.SchemaValidator with the
+# spec-faithful compat shim BEFORE helpers (or any test module) imports it, so
+# every Docker E2E schema-validation call site picks up the fix uniformly. The
+# shim only drops those provably-false-positive errors; `unit` on a non-numeric
+# type still fails. Remove this once a fixed json-structure is released and the
+# pin in tests/docker_e2e/requirements.txt is bumped. See the shim module for
+# the full spec citation and the upstream-fix recommendation.
+import _jsonstructure_compat as _js_compat  # noqa: E402  (captures the real base)
+import json_structure as _json_structure  # noqa: E402
+_json_structure.SchemaValidator = _js_compat.SchemaValidator
+
 import helpers as _helpers  # noqa: E402
 
 

--- a/tests/docker_e2e/test_jsonstructure_compat.py
+++ b/tests/docker_e2e/test_jsonstructure_compat.py
@@ -1,0 +1,84 @@
+"""Regression tests for the JSON Structure SDK compatibility shim.
+
+WORKAROUND(clemensv/real-time-sources#1391): these tests guard the shim that
+accepts `unit`/`ucumUnit` on nullable-numeric type unions (the repo's standard
+optional/explicit-null measured-value shape) while keeping genuine
+`unit`-on-non-numeric rejections. They are pure schema-validation tests and do
+not require Docker. Delete this module when the upstream json-structure fix
+ships and the shim is removed.
+"""
+import json
+import os
+
+import json_structure
+
+from _jsonstructure_compat import SchemaValidator
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _doc(props):
+    return {
+        "$schema": "https://json-structure.org/meta/extended/v0/#",
+        "$id": "https://example.com/test/UnitShim",
+        "$uses": ["JSONStructureUnits"],
+        "name": "UnitShim",
+        "type": "object",
+        "properties": props,
+    }
+
+
+def test_conftest_patches_sdk_validator():
+    """The conftest monkeypatch must redirect the SDK's SchemaValidator to the
+    shim so every Docker E2E call site is covered transparently."""
+    assert json_structure.SchemaValidator is SchemaValidator
+
+
+def test_unit_on_nullable_numeric_union_passes():
+    schema = _doc({
+        "current_range_meters": {"type": ["double", "null"], "unit": "meter"},
+        "lat": {"type": ["double", "null"], "unit": "degree"},
+    })
+    errors = SchemaValidator(extended=True).validate(schema)
+    assert errors == [], [str(e) for e in errors]
+
+
+def test_unit_on_bare_numeric_still_passes():
+    schema = _doc({"value": {"type": "double", "unit": "cm"}})
+    assert SchemaValidator(extended=True).validate(schema) == []
+
+
+def test_ucum_unit_on_nullable_numeric_union_passes():
+    schema = _doc({"v": {"type": ["double", "null"], "ucumUnit": "m/s2"}})
+    assert SchemaValidator(extended=True).validate(schema) == []
+
+
+def test_unit_on_nullable_NONnumeric_union_still_fails():
+    """Negative control: the shim must NOT mask a genuine mistake."""
+    schema = _doc({"bad": {"type": ["string", "null"], "unit": "meter"}})
+    errors = SchemaValidator(extended=True).validate(schema)
+    assert any(
+        getattr(e, "code", None) == "SCHEMA_CONSTRAINT_TYPE_MISMATCH"
+        and getattr(e, "path", "").endswith("/unit")
+        for e in errors
+    ), [str(e) for e in errors]
+
+
+def test_real_gbfs_free_bike_status_schema_validates():
+    """The real gbfs-bikeshare manifest (which uses ["double","null"] + unit on
+    free-bike telemetry) must validate cleanly through the shim."""
+    xreg = os.path.join(
+        REPO_ROOT, "feeders", "gbfs-bikeshare", "xreg", "gbfs-bikeshare.xreg.json"
+    )
+    doc = json.load(open(xreg, encoding="utf-8"))
+    validator = SchemaValidator(extended=True)
+    checked = 0
+    for sg in doc.get("schemagroups", {}).values():
+        for srec in sg.get("schemas", {}).values():
+            for vrec in srec.get("versions", {}).values():
+                schema = vrec.get("schema")
+                if isinstance(schema, dict):
+                    errs = validator.validate(schema)
+                    assert errs == [], [str(e) for e in errs]
+                    checked += 1
+    assert checked > 0


### PR DESCRIPTION
## Summary

Unblocks the Docker E2E **schema-validation gate** for the feeder fleet. The
`json_structure` SDK SchemaValidator — reproduced on the editable `0.6.3.dev2`
build **and** the published **`0.7.0`** wheel that CI installs via
`json-structure>=0.6.1` — wrongly rejects `unit`/`ucumUnit` on a
**nullable-numeric type union**:

```jsonc
{ "type": ["double", "null"], "unit": "meter" }   // <-- rejected today
```

That is the repo's **standard shape for an optional / explicit-null measured
value**. A precise scan found **524 fields across 54 feeders** using it
(`gbfs-bikeshare` `current_range_meters`, `noaa-ndbc`, `wsdot`, `usgs-iv`,
`jma-bosai-amedas`, `energidataservice-dk`, …). The bridges genuinely emit JSON
`null` on the wire, so the rejection blocks the local Docker-first gate **and**
CI for more than half the fleet — i.e. the whole generalization effort.

## Root cause — validator bug (not a contract problem)

Confirmed by the **JSON Structure Expert** review on #1391:

- **Units draft**: *"the `unit` keyword MAY be used as an annotation on any
  schema element whose underlying type is numeric."* A `["double","null"]`
  union's underlying value type **is** numeric; `"null"` only encodes
  explicit-null on the wire.
- **Normative Units meta-schema** (`UnitsPropertyAddIn`) `$extends` *every*
  `Property` and adds `unit: string` with **no numeric gate at all**.
- The SDK's own `minimum`/`maximum` gate **already tolerates unions**, and its
  `unit` numeric set wrongly omits `int8/uint8/int16/uint16/float8` — the rule
  is internally inconsistent.

## Fix (temporary, in-scope, reversible)

A single clearly-marked compat shim `tests/docker_e2e/_jsonstructure_compat.py`
subclasses `SchemaValidator` and drops **only** the provably-false-positive
`unit`/`ucumUnit`-on-eligible-numeric errors (bare numeric, or a union whose
non-`null` members are all numeric). `conftest.py` patches
`json_structure.SchemaValidator` to the shim **before** `helpers`/any test
module imports it, so all Kafka/AMQP/MQTT E2E call sites are covered uniformly
with zero per-site edits.

`unit` on a genuinely non-numeric type (e.g. `["string","null"]`) **still
fails** — negative control preserved.

## Verification

- **524 false positives removed across 54 feeders, 0 unexpected removals.**
- `gbfs-bikeshare`, `siri`, `fdsn-seismology`, `tokyo-docomo-bikeshare`,
  `uk-bods-siri` schemas validate **clean** under the shim.
- 6 new guard tests (`test_jsonstructure_compat.py`) pass; existing
  `test_helpers.py` still passes.

## Permanent fix (follow-up, tracked in #1391)

A ~6-line change in the json-structure SDK `_check_units_keywords` /
`_check_ucum_unit`: use the full numeric set and accept a union whose non-`null`
members are all numeric. Once a fixed `json-structure` is released and the pin in
`tests/docker_e2e/requirements.txt` is bumped, **remove the shim, the conftest
patch, and `test_jsonstructure_compat.py`.**

This also confirms PR #1392's removal of `unit`/`symbol` from `fdsn-seismology`
`depth_km` was an unnecessary, lossy workaround and should be reverted to the
`["double","null"]` + `unit`/`symbol` form.
