### PR TITLE
feat(gbfs-bikeshare): inject consumer key / template feed URLs at runtime

### DIFF
--- a/feeders/gbfs-bikeshare/CONTAINER.md
+++ b/feeders/gbfs-bikeshare/CONTAINER.md
@@ -16,9 +16,13 @@ This source ships three transport-specific images that all consume the same `GBF
 |---|---:|---:|---|
 | `GBFS_FEEDS` | ✅ | — | Comma-separated GBFS autodiscovery URLs, `@file`, or path to a file containing one URL per line. |
 | `GBFS_SYSTEM_IDS` | ❌ | — | Optional comma-separated system-id overrides aligned positionally with `GBFS_FEEDS`. |
+| `GBFS_API_KEY` | ❌ | — | Optional runtime upstream API key, or comma-separated keys aligned with `GBFS_FEEDS`. Keys are appended to autodiscovery URLs unless the URL template consumes `{GBFS_API_KEY}` / `${GBFS_API_KEY}` itself. |
+| `GBFS_API_KEY_PARAM` | ❌ | `acl:consumerKey` | Query-string parameter name used with `GBFS_API_KEY` (ODPT-compatible default). A comma-separated list may be aligned with multiple `GBFS_FEEDS`. |
 | `POLL_INTERVAL` | ❌ | `60` | Telemetry polling interval in seconds. |
 | `REFERENCE_REFRESH_INTERVAL` | ❌ | `3600` | Station and system reference-data refresh cadence in seconds. |
 | `STATE_FILE` | ❌ | image-specific home-file path | JSON dedupe state file. Mount persistent storage here for long-running deployments. |
+
+`GBFS_FEEDS` entries may also reference runtime environment variables as `{NAME}` or `${NAME}`. Use this for wrapper images that bake URL shapes but keep consumer keys and other secrets in runtime environment variables.
 | `ONCE_MODE` | ❌ | `false` | When `true`, run one polling cycle and exit. Required for Fabric notebook hosting and useful for smoke tests. |
 | `LOG_LEVEL` | ❌ | `INFO` | Standard Python logging level. |
 

--- a/feeders/gbfs-bikeshare/Dockerfile
+++ b/feeders/gbfs-bikeshare/Dockerfile
@@ -20,6 +20,8 @@ RUN pip install --no-cache-dir ./gbfs_bikeshare_producer/gbfs_bikeshare_producer
 
 ENV CONNECTION_STRING=""
 ENV GBFS_FEEDS=""
+ENV GBFS_API_KEY=""
+ENV GBFS_API_KEY_PARAM="acl:consumerKey"
 ENV POLL_INTERVAL="60"
 
 CMD ["python", "-m", "gbfs_bikeshare", "feed"]

--- a/feeders/gbfs-bikeshare/Dockerfile.amqp
+++ b/feeders/gbfs-bikeshare/Dockerfile.amqp
@@ -38,6 +38,8 @@ RUN pip install --no-cache-dir ./gbfs_bikeshare_amqp_producer/gbfs_bikeshare_amq
 ENV AMQP_BROKER_URL=""
 ENV AMQP_ADDRESS="gbfs-bikeshare"
 ENV GBFS_FEEDS=""
+ENV GBFS_API_KEY=""
+ENV GBFS_API_KEY_PARAM="acl:consumerKey"
 ENV POLL_INTERVAL="60"
 
 CMD ["python", "-m", "gbfs_bikeshare_amqp", "feed"]

--- a/feeders/gbfs-bikeshare/Dockerfile.mqtt
+++ b/feeders/gbfs-bikeshare/Dockerfile.mqtt
@@ -22,6 +22,8 @@ RUN pip install --no-cache-dir confluent-kafka \
 
 ENV MQTT_BROKER_URL=""
 ENV GBFS_FEEDS=""
+ENV GBFS_API_KEY=""
+ENV GBFS_API_KEY_PARAM="acl:consumerKey"
 ENV POLL_INTERVAL="60"
 
 CMD ["python", "-m", "gbfs_bikeshare_mqtt", "feed"]

--- a/feeders/gbfs-bikeshare/README.md
+++ b/feeders/gbfs-bikeshare/README.md
@@ -67,6 +67,9 @@ This source follows the GTFS-style deployment model: one container, user-configu
 
 - `GBFS_FEEDS` — **required**. Either a comma-separated list of GBFS autodiscovery URLs or a file path / `@file` reference containing one URL per line.
 - `GBFS_SYSTEM_IDS` — optional. Comma-separated override labels aligned positionally with `GBFS_FEEDS`. Use this when you want stable local system labels regardless of upstream `system_id` changes.
+- `GBFS_API_KEY` — optional. Runtime upstream API key, or comma-separated keys aligned with `GBFS_FEEDS`. Keys are appended as query parameters (default `acl:consumerKey`, override with `GBFS_API_KEY_PARAM`) unless the URL template consumes `{GBFS_API_KEY}` / `${GBFS_API_KEY}` itself.
+- `GBFS_API_KEY_PARAM` — optional. Query-parameter name for injected keys. Set a comma-separated list to align different parameter names with multiple `GBFS_FEEDS`.
+- URL templates — `GBFS_FEEDS` entries may reference runtime environment variables as `{NAME}` or `${NAME}`; this lets thin wrapper images bake non-secret URL shapes while secrets arrive only at runtime.
 - `POLL_INTERVAL` — optional. Default `60` seconds.
 - `ONCE_MODE=true` — run a single polling cycle. Required by the Fabric notebook hosting path.
 

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_amqp/gbfs_bikeshare_amqp/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_amqp/gbfs_bikeshare_amqp/app.py
@@ -137,7 +137,7 @@ def feed(args: argparse.Namespace) -> None:
         client, configured_feeds = build_offline_client_and_feeds()
         args.once = True
     else:
-        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids, args.gbfs_api_key, args.gbfs_api_key_param)
         client = GbfsSourceClient()
     sources = discover_sources(client, configured_feeds)
     if not sources:
@@ -197,6 +197,8 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser = subparsers.add_parser("feed", help="Poll GBFS feeds and publish CloudEvents to AMQP")
     feed_parser.add_argument("--gbfs-feeds", default=os.getenv("GBFS_FEEDS"))
     feed_parser.add_argument("--gbfs-system-ids", default=os.getenv("GBFS_SYSTEM_IDS"))
+    feed_parser.add_argument("--gbfs-api-key", default=os.getenv("GBFS_API_KEY"))
+    feed_parser.add_argument("--gbfs-api-key-param", default=os.getenv("GBFS_API_KEY_PARAM", "acl:consumerKey"))
     feed_parser.add_argument("--poll-interval", type=int, default=int(os.getenv("POLL_INTERVAL", "60")))
     feed_parser.add_argument("--reference-refresh-interval", type=int, default=int(os.getenv("REFERENCE_REFRESH_INTERVAL", "3600")))
     feed_parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE))

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/config.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_core/gbfs_bikeshare_core/config.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Mapping, Optional, Set, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 @dataclass(frozen=True)
@@ -13,6 +16,8 @@ class ConfiguredFeed:
 
 TRUE_VALUES = {"1", "true", "yes", "on"}
 FALSE_VALUES = {"0", "false", "no", "off"}
+DEFAULT_API_KEY_PARAM = "acl:consumerKey"
+_ENV_TEMPLATE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
 
 def parse_bool(value: object, default: bool = False) -> bool:
@@ -48,16 +53,68 @@ def _parse_feed_value(value: Optional[str]) -> List[str]:
     return [item.strip() for item in text.split(",") if item.strip()]
 
 
-def parse_feed_configuration(gbfs_feeds: Optional[str], gbfs_system_ids: Optional[str] = None) -> List[ConfiguredFeed]:
+def _expand_url_template(url: str, variables: Mapping[str, str]) -> Tuple[str, Set[str]]:
+    used: Set[str] = set()
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1) or match.group(2)
+        if name not in variables or variables[name] is None:
+            raise ValueError(f"GBFS feed URL template references unset environment variable {name}.")
+        used.add(name)
+        return str(variables[name])
+
+    return _ENV_TEMPLATE.sub(replace, url), used
+
+
+def _aligned_values(value: Optional[str], count: int, field_name: str) -> List[Optional[str]]:
+    values = _parse_feed_value(value)
+    if not values:
+        return [None] * count
+    if len(values) == 1:
+        return values * count
+    if len(values) != count:
+        raise ValueError(f"{field_name} must provide either one value or the same number of entries as GBFS_FEEDS.")
+    return values
+
+
+def _append_api_key(url: str, api_key: Optional[str], api_key_param: Optional[str]) -> str:
+    key = (api_key or "").strip()
+    param = (api_key_param or DEFAULT_API_KEY_PARAM).strip()
+    if not key or not param:
+        return url
+    parsed = urlsplit(url)
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    if any(name == param for name, _ in query_pairs):
+        return url
+    query_pairs.append((param, key))
+    query = urlencode(query_pairs, doseq=True, safe=":")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def parse_feed_configuration(
+    gbfs_feeds: Optional[str],
+    gbfs_system_ids: Optional[str] = None,
+    gbfs_api_key: Optional[str] = None,
+    gbfs_api_key_param: Optional[str] = DEFAULT_API_KEY_PARAM,
+) -> List[ConfiguredFeed]:
     feeds = _parse_feed_value(gbfs_feeds)
     if not feeds:
         raise ValueError("At least one GBFS auto-discovery URL must be provided via --gbfs-feeds or GBFS_FEEDS.")
     overrides = _parse_feed_value(gbfs_system_ids)
     if overrides and len(overrides) != len(feeds):
         raise ValueError("GBFS_SYSTEM_IDS must provide the same number of entries as GBFS_FEEDS when specified.")
+    api_keys = _aligned_values(gbfs_api_key, len(feeds), "GBFS_API_KEY")
+    api_key_params = _aligned_values(gbfs_api_key_param, len(feeds), "GBFS_API_KEY_PARAM")
     configured: List[ConfiguredFeed] = []
     for index, feed in enumerate(feeds):
-        configured.append(ConfiguredFeed(feed, overrides[index] if index < len(overrides) else None))
+        api_key = api_keys[index]
+        template_variables = dict(os.environ)
+        if api_key:
+            template_variables["GBFS_API_KEY"] = api_key
+        template_variables["GBFS_FEED_INDEX"] = str(index)
+        templated_feed, template_variables_used = _expand_url_template(feed, template_variables)
+        append_key = api_key if "GBFS_API_KEY" not in template_variables_used else None
+        configured.append(ConfiguredFeed(_append_api_key(templated_feed, append_key, api_key_params[index]), overrides[index] if index < len(overrides) else None))
     return configured
 
 

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_kafka/gbfs_bikeshare/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_kafka/gbfs_bikeshare/app.py
@@ -89,7 +89,7 @@ def _build_free_bike_status(record: FreeBikeStatusRecord) -> FreeBikeStatus:
 def feed(args: argparse.Namespace) -> None:
     mock_mode = getattr(args, "mock", False)
     configured_feeds = (
-        [] if mock_mode else parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+        [] if mock_mode else parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids, args.gbfs_api_key, args.gbfs_api_key_param)
     )
     if args.connection_string:
         cfg = parse_kafka_connection_string(args.connection_string)
@@ -206,6 +206,8 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser = subparsers.add_parser("feed", help="Poll GBFS feeds and publish CloudEvents to Kafka")
     feed_parser.add_argument("--gbfs-feeds", default=os.getenv("GBFS_FEEDS"), help="Comma-separated GBFS auto-discovery URLs, @file, or path to a file containing URLs")
     feed_parser.add_argument("--gbfs-system-ids", default=os.getenv("GBFS_SYSTEM_IDS"), help="Optional comma-separated system-id overrides aligned with GBFS_FEEDS")
+    feed_parser.add_argument("--gbfs-api-key", default=os.getenv("GBFS_API_KEY"), help="Optional upstream API key appended to configured GBFS auto-discovery URLs")
+    feed_parser.add_argument("--gbfs-api-key-param", default=os.getenv("GBFS_API_KEY_PARAM", "acl:consumerKey"), help="Query parameter name used with --gbfs-api-key")
     feed_parser.add_argument("--kafka-bootstrap-servers", default=os.getenv("KAFKA_BOOTSTRAP_SERVERS"), help="Kafka bootstrap servers")
     feed_parser.add_argument("--kafka-topic", default=os.getenv("KAFKA_TOPIC", "gbfs-bikeshare"), help="Kafka topic name")
     feed_parser.add_argument("--sasl-username", default=os.getenv("SASL_USERNAME"), help="SASL PLAIN username")

--- a/feeders/gbfs-bikeshare/gbfs_bikeshare_mqtt/gbfs_bikeshare_mqtt/app.py
+++ b/feeders/gbfs-bikeshare/gbfs_bikeshare_mqtt/gbfs_bikeshare_mqtt/app.py
@@ -139,7 +139,7 @@ async def feed(args: argparse.Namespace) -> None:
         client, configured_feeds = build_offline_client_and_feeds()
         args.once = True
     else:
-        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids)
+        configured_feeds = parse_feed_configuration(args.gbfs_feeds, args.gbfs_system_ids, args.gbfs_api_key, args.gbfs_api_key_param)
         client = GbfsSourceClient()
     sources = discover_sources(client, configured_feeds)
     if not sources:
@@ -159,6 +159,8 @@ async def feed(args: argparse.Namespace) -> None:
     system_client = OrgGbfsMqttSystemMqttClient(paho_client, content_mode="binary", loop=loop)
     stations_client = OrgGbfsMqttStationsMqttClient(paho_client, content_mode="binary", loop=loop)
     free_bikes_client = OrgGbfsMqttFreeBikesMqttClient(paho_client, content_mode="binary", loop=loop)
+    # Generated clients install callbacks on the shared Paho client; the last wrapper owns the connect waiter.
+    connection_client = free_bikes_client
 
     if auth_mode == "entra":
         token, expires_at = _acquire_entra_token(args.mqtt_entra_audience, args.mqtt_entra_client_id)
@@ -172,7 +174,7 @@ async def feed(args: argparse.Namespace) -> None:
         refresh_task = asyncio.create_task(_entra_token_refresh_loop(paho_client, host, port, args.mqtt_entra_audience, args.mqtt_entra_client_id, expires_at))
         logger.info("Using Entra ID MQTT auth (expires %s)", expires_at.isoformat())
     else:
-        await system_client.connect(host, port)
+        await connection_client.connect(host, port)
 
     last_reference_refresh = 0.0
     reference_refresh = max(300, args.reference_refresh_interval)
@@ -220,7 +222,7 @@ async def feed(args: argparse.Namespace) -> None:
         if refresh_task is not None:
             refresh_task.cancel()
         try:
-            await system_client.disconnect()
+            await connection_client.disconnect()
         except Exception:  # pragma: no cover
             pass
 
@@ -231,6 +233,8 @@ def build_parser() -> argparse.ArgumentParser:
     feed_parser = subparsers.add_parser("feed", help="Poll GBFS feeds and publish CloudEvents to MQTT")
     feed_parser.add_argument("--gbfs-feeds", default=os.getenv("GBFS_FEEDS"))
     feed_parser.add_argument("--gbfs-system-ids", default=os.getenv("GBFS_SYSTEM_IDS"))
+    feed_parser.add_argument("--gbfs-api-key", default=os.getenv("GBFS_API_KEY"))
+    feed_parser.add_argument("--gbfs-api-key-param", default=os.getenv("GBFS_API_KEY_PARAM", "acl:consumerKey"))
     feed_parser.add_argument("--poll-interval", type=int, default=int(os.getenv("POLL_INTERVAL", "60")))
     feed_parser.add_argument("--reference-refresh-interval", type=int, default=int(os.getenv("REFERENCE_REFRESH_INTERVAL", "3600")))
     feed_parser.add_argument("--state-file", default=os.getenv("STATE_FILE", DEFAULT_STATE_FILE))

--- a/feeders/gbfs-bikeshare/tests/test_gbfs_bikeshare_unit.py
+++ b/feeders/gbfs-bikeshare/tests/test_gbfs_bikeshare_unit.py
@@ -165,6 +165,69 @@ def test_parse_feed_configuration_with_overrides():
 
 
 @pytest.mark.unit
+def test_parse_feed_configuration_appends_runtime_api_key():
+    configured = parse_feed_configuration(
+        "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json",
+        gbfs_api_key="secret-key",
+    )
+    assert configured[0].autodiscovery_url == "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey=secret-key"
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_applies_per_feed_runtime_api_keys():
+    configured = parse_feed_configuration(
+        "https://a.example/gbfs.json,https://b.example/gbfs.json",
+        gbfs_api_key="key-a,key-b",
+    )
+    assert [item.autodiscovery_url for item in configured] == [
+        "https://a.example/gbfs.json?acl:consumerKey=key-a",
+        "https://b.example/gbfs.json?acl:consumerKey=key-b",
+    ]
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_templates_runtime_api_key_without_double_append():
+    configured = parse_feed_configuration(
+        "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey={GBFS_API_KEY}",
+        gbfs_api_key="secret-key",
+    )
+    assert configured[0].autodiscovery_url == "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey=secret-key"
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_expands_environment_url_templates(monkeypatch):
+    monkeypatch.setenv("GBFS_SYSTEM_SLUG", "docomo-cycle-tokyo")
+    configured = parse_feed_configuration(
+        "https://api-public.odpt.org/api/v4/gbfs/${GBFS_SYSTEM_SLUG}/gbfs.json",
+        gbfs_api_key="secret-key",
+    )
+    assert configured[0].autodiscovery_url == "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey=secret-key"
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_rejects_mismatched_per_feed_runtime_api_keys():
+    with pytest.raises(ValueError, match="GBFS_API_KEY"):
+        parse_feed_configuration("https://a.example/gbfs.json,https://b.example/gbfs.json", gbfs_api_key="only-a,only-b,extra")
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_does_not_double_append_existing_api_key():
+    configured = parse_feed_configuration(
+        "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey=existing",
+        gbfs_api_key="secret-key",
+    )
+    assert configured[0].autodiscovery_url == "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?acl:consumerKey=existing"
+
+
+@pytest.mark.unit
+def test_parse_feed_configuration_without_api_key_leaves_url_unchanged():
+    configured = parse_feed_configuration(
+        "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?system=docomo-cycle-tokyo"
+    )
+    assert configured[0].autodiscovery_url == "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json?system=docomo-cycle-tokyo"
+
+
+@pytest.mark.unit
 def test_discover_sources_uses_system_information_system_id():
     sources = discover_sources(_client(), [ConfiguredFeed(SAMPLE_DISCOVERY_URL)])
     assert len(sources) == 1


### PR DESCRIPTION
## Summary
- Adds runtime GBFS API-key injection in the shared gbfs-bikeshare core: a single key or comma-aligned per-feed keys can be appended with `GBFS_API_KEY_PARAM`.
- Adds `{NAME}` / `${NAME}` URL template expansion for `GBFS_FEEDS`, including `{GBFS_API_KEY}` without double-appending the key.
- Wires `GBFS_API_KEY` / `GBFS_API_KEY_PARAM` through Kafka, AMQP, and MQTT apps and docs.
- Fixes the MQTT app's shared-Paho connect wrapper selection so the Docker E2E MQTT flow exits cleanly.

## Contract
- `xreg/gbfs-bikeshare.xreg.json` is unchanged.
- Wire contract, event types, keys, subjects, and schemas are unchanged; no xRegistry / JSON Structure / Avro expert re-review required.

## Local validation
- Merge: fast-forwarded `origin/main` and verified `tests/docker_e2e/_jsonstructure_compat.py` is present.
- Unit: `python -m pytest tests/ -q` from `feeders/gbfs-bikeshare` => 15 passed.
- Kafka Docker E2E: `python -m pytest tests/docker_e2e/test_docker_kafka_flow.py -k Gbfs -v --timeout=900` => 1 passed, 107 deselected.
- AMQP Docker E2E: `python -m pytest tests/docker_e2e/test_docker_amqp_flow.py -k Gbfs -v --timeout=900` => 1 passed, 99 deselected.
- MQTT Docker E2E: `python -m pytest tests/docker_e2e/test_docker_mqtt_flow.py -k Gbfs -v --timeout=900` => 1 passed, 107 deselected.
- Generated/companion smoke: `compileall` over GBFS AMQP/MQTT producer packages and smoke import of `gbfs_bikeshare_amqp.app` + `gbfs_bikeshare_mqtt.app` => OK.