### PR TITLE
feat(siri): add Entur (Norway) SIRI-VM provider config

### DIFF
--- a/feeders/siri/CONTAINER.md
+++ b/feeders/siri/CONTAINER.md
@@ -20,15 +20,17 @@ This document covers the published OCI images for the generic `siri` feeder, the
 | Entry points | `python -m siri_kafka feed`, `python -m siri_mqtt feed`, `python -m siri_amqp feed` |
 | Persistent state | `STATE_FILE` |
 | Poll cadence | `POLLING_INTERVAL` seconds (default `30`) |
-| Shared source config | `SIRI_PROVIDER`, `SIRI_URL`, `SIRI_API_KEY`, `SIRI_OPERATORS`, `SIRI_DATA_TYPES` |
+| Shared source config | `SIRI_PROVIDER`, `SIRI_URL`, `SIRI_API_KEY`, `SIRI_HEADERS`, `SIRI_ET_CLIENT_NAME`, `SIRI_OPERATORS`, `SIRI_DATA_TYPES` |
 
 ## Shared source settings
 
 | Variable | Description |
 | --- | --- |
-| `SIRI_PROVIDER` | `bods`, `trafiklab`, or `custom` (default `bods`) |
-| `SIRI_URL` | Optional BODS override, Trafiklab URL template, or required direct custom URL |
+| `SIRI_PROVIDER` | `bods`, `trafiklab`, `entur`, or `custom` (default `bods`) |
+| `SIRI_URL` | Optional BODS override, Trafiklab/Entur URL template, or required direct custom URL |
 | `SIRI_API_KEY` | Provider API key |
+| `SIRI_HEADERS` | Optional semicolon-separated `Name=Value` request headers sent on every SIRI request |
+| `SIRI_ET_CLIENT_NAME` | Convenience value for Entur's `ET-Client-Name` request header; provider `entur` gets a default if unset |
 | `SIRI_OPERATORS` | Optional comma-separated operator filter / Trafiklab template expansion values |
 | `SIRI_DATA_TYPES` | Comma-separated `vm,et,sx`; default `vm` |
 | `POLLING_INTERVAL` | Poll interval in seconds |

--- a/feeders/siri/README.md
+++ b/feeders/siri/README.md
@@ -8,6 +8,7 @@ The `siri` feeder is a generic SIRI bridge that emits CloudEvents over **Kafka**
 
 - **`bods`** — UK Bus Open Data Service bulk ZIP download; API key sent as query parameter.
 - **`trafiklab`** — Sweden Trafiklab per-operator endpoints; API key sent as header and the URL template can expand `{operator}` and `{data_type}`.
+- **`entur`** — Norway Entur SIRI-Lite endpoints at `https://api.entur.io/realtime/v1/rest/{data_type}`; sends `ET-Client-Name`.
 - **`custom`** — direct SIRI endpoint URL supplied by the user; API key can be attached as headers and query parameters.
 
 ## What the feeder emits
@@ -34,9 +35,11 @@ Source configuration is shared across all three transports:
 
 | Setting | CLI | Environment | Notes |
 | --- | --- | --- | --- |
-| provider | `--provider` | `SIRI_PROVIDER` | `bods`, `trafiklab`, `custom` (default `bods`) |
+| provider | `--provider` | `SIRI_PROVIDER` | `bods`, `trafiklab`, `entur`, `custom` (default `bods`) |
 | source URL | `--siri-url` | `SIRI_URL` | Optional for `bods`; template/default for `trafiklab`; required for `custom` |
 | API key | `--api-key` | `SIRI_API_KEY` | Required for authenticated providers |
+| request headers | `--headers` | `SIRI_HEADERS` | Optional semicolon-separated `Name=Value` headers sent on every SIRI request |
+| Entur client name | `--et-client-name` | `SIRI_ET_CLIENT_NAME` | Convenience value for the `ET-Client-Name` header; defaults for provider `entur` |
 | operators | `--operators` | `SIRI_OPERATORS` | Optional comma-separated filter / URL-template expansion values |
 | data types | `--data-types` | `SIRI_DATA_TYPES` | Comma-separated `vm,et,sx`; default `vm` |
 | polling interval | `--polling-interval` | `POLLING_INTERVAL` | Default `30` seconds |
@@ -76,6 +79,17 @@ docker run --rm \
   -e SIRI_API_KEY="<api-key>" \
   -e AMQP_BROKER_URL="amqp://<user>:<password>@<broker-host>:5672/siri" \
   ghcr.io/clemensv/real-time-sources-siri-amqp:latest
+```
+
+### Entur
+
+```bash
+docker run --rm \
+  -e SIRI_PROVIDER=entur \
+  -e SIRI_DATA_TYPES=vm \
+  -e SIRI_ET_CLIENT_NAME="my-application-name" \
+  -e CONNECTION_STRING="<event-hubs-or-fabric-connection-string>" \
+  ghcr.io/clemensv/real-time-sources-siri-kafka:latest
 ```
 
 ## Fabric notebook hosting

--- a/feeders/siri/azure-template-mqtt.json
+++ b/feeders/siri/azure-template-mqtt.json
@@ -28,10 +28,10 @@
     },
     "siriApiKey": {
       "type": "securestring",
-      "minLength": 1,
       "metadata": {
-        "description": "API key used for the configured SIRI provider profile."
-      }
+        "description": "Optional API key used for provider profiles that require upstream authentication; leave empty for public BODS bulk archive or Entur."
+      },
+      "defaultValue": ""
     },
     "pollInterval": {
       "type": "int",
@@ -70,10 +70,32 @@
       "allowedValues": [
         "bods",
         "trafiklab",
+        "entur",
         "custom"
       ],
       "metadata": {
         "description": "SIRI provider profile to use."
+      }
+    },
+    "siriHeaders": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional semicolon-separated Name=Value request headers sent on every SIRI request; use for provider-specific client identification or custom upstream headers."
+      }
+    },
+    "siriEtClientName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Entur ET-Client-Name request header value. Leave empty to use the feeder's Entur default when SIRI_PROVIDER is entur."
+      }
+    },
+    "siriDataTypes": {
+      "type": "string",
+      "defaultValue": "vm",
+      "metadata": {
+        "description": "Comma-separated SIRI data types to fetch from provider URL templates, such as vm, et, or sx; VehicleMonitoring payloads emit the current contract."
       }
     },
     "siriUrl": {
@@ -191,6 +213,18 @@
                 {
                   "name": "SIRI_PROVIDER",
                   "value": "[parameters('siriProvider')]"
+                },
+                {
+                  "name": "SIRI_HEADERS",
+                  "secureValue": "[parameters('siriHeaders')]"
+                },
+                {
+                  "name": "SIRI_ET_CLIENT_NAME",
+                  "value": "[parameters('siriEtClientName')]"
+                },
+                {
+                  "name": "SIRI_DATA_TYPES",
+                  "value": "[parameters('siriDataTypes')]"
                 },
                 {
                   "name": "SIRI_URL",

--- a/feeders/siri/azure-template-with-eventgrid-mqtt.json
+++ b/feeders/siri/azure-template-with-eventgrid-mqtt.json
@@ -51,7 +51,7 @@
       "type": "securestring",
       "defaultValue": "",
       "metadata": {
-        "description": "API key used for the configured SIRI provider profile."
+        "description": "Optional API key used for provider profiles that require upstream authentication; leave empty for public BODS bulk archive or Entur."
       }
     },
     "pollInterval": {
@@ -82,10 +82,32 @@
       "allowedValues": [
         "bods",
         "trafiklab",
+        "entur",
         "custom"
       ],
       "metadata": {
         "description": "SIRI provider profile to use."
+      }
+    },
+    "siriHeaders": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional semicolon-separated Name=Value request headers sent on every SIRI request; use for provider-specific client identification or custom upstream headers."
+      }
+    },
+    "siriEtClientName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Entur ET-Client-Name request header value. Leave empty to use the feeder's Entur default when SIRI_PROVIDER is entur."
+      }
+    },
+    "siriDataTypes": {
+      "type": "string",
+      "defaultValue": "vm",
+      "metadata": {
+        "description": "Comma-separated SIRI data types to fetch from provider URL templates, such as vm, et, or sx; VehicleMonitoring payloads emit the current contract."
       }
     },
     "siriUrl": {
@@ -289,6 +311,18 @@
                 {
                   "name": "SIRI_PROVIDER",
                   "value": "[parameters('siriProvider')]"
+                },
+                {
+                  "name": "SIRI_HEADERS",
+                  "secureValue": "[parameters('siriHeaders')]"
+                },
+                {
+                  "name": "SIRI_ET_CLIENT_NAME",
+                  "value": "[parameters('siriEtClientName')]"
+                },
+                {
+                  "name": "SIRI_DATA_TYPES",
+                  "value": "[parameters('siriDataTypes')]"
                 },
                 {
                   "name": "SIRI_URL",

--- a/feeders/siri/azure-template-with-eventhub.json
+++ b/feeders/siri/azure-template-with-eventhub.json
@@ -9,7 +9,7 @@
       "type": "securestring",
       "defaultValue": "",
       "metadata": {
-        "description": "API key used for the configured SIRI provider profile."
+        "description": "Optional API key used for provider profiles that require upstream authentication; leave empty for public BODS bulk archive or Entur."
       }
     },
     "pollInterval": {
@@ -60,10 +60,32 @@
       "allowedValues": [
         "bods",
         "trafiklab",
+        "entur",
         "custom"
       ],
       "metadata": {
         "description": "SIRI provider profile to use."
+      }
+    },
+    "siriHeaders": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional semicolon-separated Name=Value request headers sent on every SIRI request; use for provider-specific client identification or custom upstream headers."
+      }
+    },
+    "siriEtClientName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Entur ET-Client-Name request header value. Leave empty to use the feeder's Entur default when SIRI_PROVIDER is entur."
+      }
+    },
+    "siriDataTypes": {
+      "type": "string",
+      "defaultValue": "vm",
+      "metadata": {
+        "description": "Comma-separated SIRI data types to fetch from provider URL templates, such as vm, et, or sx; VehicleMonitoring payloads emit the current contract."
       }
     },
     "siriUrl": {
@@ -220,6 +242,18 @@
                 {
                   "name": "SIRI_PROVIDER",
                   "value": "[parameters('siriProvider')]"
+                },
+                {
+                  "name": "SIRI_HEADERS",
+                  "secureValue": "[parameters('siriHeaders')]"
+                },
+                {
+                  "name": "SIRI_ET_CLIENT_NAME",
+                  "value": "[parameters('siriEtClientName')]"
+                },
+                {
+                  "name": "SIRI_DATA_TYPES",
+                  "value": "[parameters('siriDataTypes')]"
                 },
                 {
                   "name": "SIRI_URL",

--- a/feeders/siri/azure-template-with-servicebus.json
+++ b/feeders/siri/azure-template-with-servicebus.json
@@ -45,7 +45,7 @@
       "type": "securestring",
       "defaultValue": "",
       "metadata": {
-        "description": "API key used for the configured SIRI provider profile."
+        "description": "Optional API key used for provider profiles that require upstream authentication; leave empty for public BODS bulk archive or Entur."
       }
     },
     "pollInterval": {
@@ -76,10 +76,32 @@
       "allowedValues": [
         "bods",
         "trafiklab",
+        "entur",
         "custom"
       ],
       "metadata": {
         "description": "SIRI provider profile to use."
+      }
+    },
+    "siriHeaders": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional semicolon-separated Name=Value request headers sent on every SIRI request; use for provider-specific client identification or custom upstream headers."
+      }
+    },
+    "siriEtClientName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Entur ET-Client-Name request header value. Leave empty to use the feeder's Entur default when SIRI_PROVIDER is entur."
+      }
+    },
+    "siriDataTypes": {
+      "type": "string",
+      "defaultValue": "vm",
+      "metadata": {
+        "description": "Comma-separated SIRI data types to fetch from provider URL templates, such as vm, et, or sx; VehicleMonitoring payloads emit the current contract."
       }
     },
     "siriUrl": {
@@ -295,6 +317,18 @@
                 {
                   "name": "SIRI_PROVIDER",
                   "value": "[parameters('siriProvider')]"
+                },
+                {
+                  "name": "SIRI_HEADERS",
+                  "secureValue": "[parameters('siriHeaders')]"
+                },
+                {
+                  "name": "SIRI_ET_CLIENT_NAME",
+                  "value": "[parameters('siriEtClientName')]"
+                },
+                {
+                  "name": "SIRI_DATA_TYPES",
+                  "value": "[parameters('siriDataTypes')]"
                 },
                 {
                   "name": "SIRI_URL",

--- a/feeders/siri/azure-template.json
+++ b/feeders/siri/azure-template.json
@@ -9,15 +9,15 @@
       "type": "securestring",
       "minLength": 1,
       "metadata": {
-        "description": "Azure Event Hubs / Fabric Event Stream\u2013style connection string. Supersedes KAFKA_BOOTSTRAP_SERVERS, SASL_USERNAME, SASL_PASSWORD."
+        "description": "Azure Event Hubs / Fabric Event Stream–style connection string. Supersedes KAFKA_BOOTSTRAP_SERVERS, SASL_USERNAME, SASL_PASSWORD."
       }
     },
     "siriApiKey": {
       "type": "securestring",
-      "minLength": 1,
       "metadata": {
-        "description": "API key used for the configured SIRI provider profile."
-      }
+        "description": "Optional API key used for provider profiles that require upstream authentication; leave empty for public BODS bulk archive or Entur."
+      },
+      "defaultValue": ""
     },
     "pollInterval": {
       "type": "int",
@@ -56,10 +56,32 @@
       "allowedValues": [
         "bods",
         "trafiklab",
+        "entur",
         "custom"
       ],
       "metadata": {
         "description": "SIRI provider profile to use."
+      }
+    },
+    "siriHeaders": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional semicolon-separated Name=Value request headers sent on every SIRI request; use for provider-specific client identification or custom upstream headers."
+      }
+    },
+    "siriEtClientName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional Entur ET-Client-Name request header value. Leave empty to use the feeder's Entur default when SIRI_PROVIDER is entur."
+      }
+    },
+    "siriDataTypes": {
+      "type": "string",
+      "defaultValue": "vm",
+      "metadata": {
+        "description": "Comma-separated SIRI data types to fetch from provider URL templates, such as vm, et, or sx; VehicleMonitoring payloads emit the current contract."
       }
     },
     "siriUrl": {
@@ -169,6 +191,18 @@
                 {
                   "name": "SIRI_PROVIDER",
                   "value": "[parameters('siriProvider')]"
+                },
+                {
+                  "name": "SIRI_HEADERS",
+                  "secureValue": "[parameters('siriHeaders')]"
+                },
+                {
+                  "name": "SIRI_ET_CLIENT_NAME",
+                  "value": "[parameters('siriEtClientName')]"
+                },
+                {
+                  "name": "SIRI_DATA_TYPES",
+                  "value": "[parameters('siriDataTypes')]"
                 },
                 {
                   "name": "SIRI_URL",

--- a/feeders/siri/siri_amqp/siri_amqp/app.py
+++ b/feeders/siri/siri_amqp/siri_amqp/app.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from siri_amqp_producer_amqp_producer import OrgSiriAmqpProducer
 from siri_amqp_producer_data import Operator, VehiclePosition
-from siri_core import FeedConfig, SiriClient, load_state, parse_csv_tokens, parse_data_types, save_state
+from siri_core import SUPPORTED_PROVIDERS, FeedConfig, SiriClient, load_state, parse_csv_tokens, parse_data_types, save_state
 
 DEFAULT_ENTRA_AUDIENCE_SERVICEBUS = "https://servicebus.azure.net/.default"
 DEFAULT_ENTRA_AUDIENCE_EVENTHUBS = "https://eventhubs.azure.net/.default"
@@ -183,9 +183,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     feed_parser = subparsers.add_parser("feed", help="Feed operator metadata and vehicle positions as CloudEvents over AMQP 1.0")
-    feed_parser.add_argument("--provider", choices=["bods", "trafiklab", "custom"], default=os.getenv("SIRI_PROVIDER", "bods"))
+    feed_parser.add_argument("--provider", choices=SUPPORTED_PROVIDERS, default=os.getenv("SIRI_PROVIDER", "bods"))
     feed_parser.add_argument("--siri-url", type=str, default=os.getenv("SIRI_URL"))
     feed_parser.add_argument("--api-key", type=str, default=os.getenv("SIRI_API_KEY") or os.getenv("BODS_API_KEY"))
+    feed_parser.add_argument("--headers", type=str, default=os.getenv("SIRI_HEADERS"))
+    feed_parser.add_argument("--et-client-name", type=str, default=os.getenv("SIRI_ET_CLIENT_NAME"))
     feed_parser.add_argument("--operators", type=str, default=os.getenv("SIRI_OPERATORS") or os.getenv("OPERATORS"))
     feed_parser.add_argument("--data-types", type=str, default=os.getenv("SIRI_DATA_TYPES", "vm"))
     feed_parser.add_argument("--broker-url", type=str, default=os.getenv("AMQP_BROKER_URL"))
@@ -224,6 +226,8 @@ def main(argv: Optional[list] = None) -> None:
         polling_interval=args.polling_interval,
         state_file=args.state_file,
         once=args.once,
+        request_headers=args.headers,
+        et_client_name=args.et_client_name,
     )
 
     address = args.address
@@ -263,6 +267,7 @@ def main(argv: Optional[list] = None) -> None:
         api_key=config.api_key,
         operators=config.operators,
         data_types=config.data_types,
+        request_headers=config.request_headers,
     )
     feed(api, producer, config.polling_interval, state_file=config.state_file, once=config.once)
 

--- a/feeders/siri/siri_core/siri_core/__init__.py
+++ b/feeders/siri/siri_core/siri_core/__init__.py
@@ -1,5 +1,7 @@
 from .acquisition import (
     DEFAULT_BODS_URL,
+    DEFAULT_ENTUR_CLIENT_NAME,
+    DEFAULT_ENTUR_URL,
     DEFAULT_TRAFIKLAB_URL,
     FeedSnapshot,
     SiriClient,
@@ -14,11 +16,14 @@ from .config import (
     parse_csv_tokens,
     parse_data_types,
     parse_kafka_connection_string,
+    parse_request_headers,
 )
 from .state import load_state, save_state
 
 __all__ = [
     "DEFAULT_BODS_URL",
+    "DEFAULT_ENTUR_CLIENT_NAME",
+    "DEFAULT_ENTUR_URL",
     "DEFAULT_TRAFIKLAB_URL",
     "SUPPORTED_DATA_TYPES",
     "SUPPORTED_PROVIDERS",
@@ -32,5 +37,6 @@ __all__ = [
     "parse_csv_tokens",
     "parse_data_types",
     "parse_kafka_connection_string",
+    "parse_request_headers",
     "save_state",
 ]

--- a/feeders/siri/siri_core/siri_core/acquisition.py
+++ b/feeders/siri/siri_core/siri_core/acquisition.py
@@ -13,7 +13,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .config import DEFAULT_BODS_URL, DEFAULT_TRAFIKLAB_URL
+from .config import DEFAULT_BODS_URL, DEFAULT_ENTUR_CLIENT_NAME, DEFAULT_ENTUR_URL, DEFAULT_TRAFIKLAB_URL
 
 USER_AGENT = os.environ.get("USER_AGENT") or (
     "real-time-sources-siri/0.1.0 "
@@ -78,17 +78,21 @@ class SiriClient:
         api_key: str = "",
         operators: Optional[tuple[str, ...]] = None,
         data_types: tuple[str, ...] = ("vm",),
+        request_headers: Optional[dict[str, str]] = None,
         session: Optional[requests.Session] = None,
         request_timeout: float = 30.0,
         sample_mode: Optional[bool] = None,
         sample_path: Optional[str] = None,
     ) -> None:
         self._provider = provider
-        self._siri_url = siri_url.strip() if siri_url else (DEFAULT_BODS_URL if provider == "bods" else DEFAULT_TRAFIKLAB_URL)
+        self._siri_url = siri_url.strip() if siri_url else _default_url_for_provider(provider)
         self._api_key = api_key
         self._operators = tuple(value.strip() for value in operators or tuple() if value and value.strip()) or None
         self._operator_filter = set(self._operators or tuple()) or None
         self._data_types = tuple(data_types or ("vm",))
+        self._request_headers = dict(request_headers or {})
+        if self._provider == "entur" and not _has_header(self._request_headers, "ET-Client-Name"):
+            self._request_headers["ET-Client-Name"] = DEFAULT_ENTUR_CLIENT_NAME
         self._session = session or _build_retrying_session()
         self._session.headers.setdefault("User-Agent", USER_AGENT)
         self._request_timeout = request_timeout
@@ -137,7 +141,7 @@ class SiriClient:
                 RequestSpec(
                     request_url=bods_url,
                     source_url=bods_url,
-                    headers={},
+                    headers=dict(self._request_headers),
                     params={"api_key": self._api_key} if self._api_key else {},
                     is_zip=True,
                 )
@@ -146,12 +150,17 @@ class SiriClient:
         if self._provider == "trafiklab":
             base_url = self._siri_url or DEFAULT_TRAFIKLAB_URL
             headers = {"X-Api-Key": self._api_key} if self._api_key else {}
+            headers.update(self._request_headers)
             params: dict[str, str] = {}
             return self._expand_specs(base_url, headers=headers, params=params)
 
+        if self._provider == "entur":
+            base_url = self._siri_url or DEFAULT_ENTUR_URL
+            return self._expand_specs(base_url, headers=dict(self._request_headers), params={})
+
         if not self._siri_url:
             raise RuntimeError("SIRI_URL is required for provider=custom unless SIRI_SAMPLE_MODE=true.")
-        headers = {}
+        headers = dict(self._request_headers)
         params = {}
         if self._api_key:
             headers.update({"X-Api-Key": self._api_key, "Authorization": f"Bearer {self._api_key}"})
@@ -222,6 +231,20 @@ def _default_sample_path() -> Path:
         if candidate.exists():
             return candidate
     return candidates[0]
+
+
+def _default_url_for_provider(provider: str) -> str:
+    if provider == "bods":
+        return DEFAULT_BODS_URL
+    if provider == "trafiklab":
+        return DEFAULT_TRAFIKLAB_URL
+    if provider == "entur":
+        return DEFAULT_ENTUR_URL
+    return ""
+
+
+def _has_header(headers: dict[str, str], name: str) -> bool:
+    return any(header_name.lower() == name.lower() for header_name in headers)
 
 
 def _build_retrying_session() -> requests.Session:

--- a/feeders/siri/siri_core/siri_core/config.py
+++ b/feeders/siri/siri_core/siri_core/config.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, Optional
 
-SUPPORTED_PROVIDERS = ("bods", "trafiklab", "custom")
+SUPPORTED_PROVIDERS = ("bods", "trafiklab", "entur", "custom")
 SUPPORTED_DATA_TYPES = ("vm", "et", "sx")
 DEFAULT_BODS_URL = "https://data.bus-data.dft.gov.uk/avl/download/bulk_archive"
 DEFAULT_TRAFIKLAB_URL = "https://api.trafiklab.se/siri2.x/{data_type}/{operator}"
+DEFAULT_ENTUR_URL = "https://api.entur.io/realtime/v1/rest/{data_type}"
+DEFAULT_ENTUR_CLIENT_NAME = "clemensv-realtimesources"
 
 
 def parse_csv_tokens(value: Optional[str]) -> Optional[tuple[str, ...]]:
@@ -31,6 +33,29 @@ def parse_data_types(value: Optional[str]) -> tuple[str, ...]:
     return tuple(normalized)
 
 
+def parse_request_headers(value: Optional[str]) -> dict[str, str]:
+    if not value:
+        return {}
+    headers: dict[str, str] = {}
+    for part in value.replace("\n", ";").split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError(f"Invalid SIRI header '{part}'. Expected NAME=VALUE.")
+        name, header_value = part.split("=", 1)
+        name = name.strip()
+        header_value = header_value.strip()
+        if not name:
+            raise ValueError("Invalid SIRI header with empty name.")
+        headers[name] = header_value
+    return headers
+
+
+def _has_header(headers: Mapping[str, str], name: str) -> bool:
+    return any(header_name.lower() == name.lower() for header_name in headers)
+
+
 @dataclass
 class FeedConfig:
     provider: str = "bods"
@@ -41,6 +66,7 @@ class FeedConfig:
     polling_interval: int = 30
     state_file: str = ""
     once: bool = False
+    request_headers: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_env(
@@ -54,6 +80,8 @@ class FeedConfig:
         polling_interval: Optional[int] = None,
         state_file: Optional[str] = None,
         once: Optional[bool] = None,
+        request_headers: Optional[Mapping[str, str] | str] = None,
+        et_client_name: Optional[str] = None,
     ) -> "FeedConfig":
         if provider is None:
             provider = os.getenv("SIRI_PROVIDER", "bods")
@@ -65,7 +93,12 @@ class FeedConfig:
             siri_url = os.getenv("SIRI_URL", "")
         siri_url = (siri_url or "").strip()
         if not siri_url:
-            siri_url = DEFAULT_BODS_URL if provider == "bods" else (DEFAULT_TRAFIKLAB_URL if provider == "trafiklab" else "")
+            if provider == "bods":
+                siri_url = DEFAULT_BODS_URL
+            elif provider == "trafiklab":
+                siri_url = DEFAULT_TRAFIKLAB_URL
+            elif provider == "entur":
+                siri_url = DEFAULT_ENTUR_URL
 
         if api_key is None:
             api_key = os.getenv("SIRI_API_KEY") or os.getenv("BODS_API_KEY", "")
@@ -88,6 +121,18 @@ class FeedConfig:
             state_file = os.getenv("STATE_FILE", os.path.expanduser("~/.siri_state.json"))
         if once is None:
             once = os.getenv("ONCE_MODE", "").lower() in ("1", "true", "yes")
+        if request_headers is None:
+            resolved_headers = parse_request_headers(os.getenv("SIRI_HEADERS"))
+        elif isinstance(request_headers, str):
+            resolved_headers = parse_request_headers(request_headers)
+        else:
+            resolved_headers = {str(key).strip(): str(value).strip() for key, value in request_headers.items() if str(key).strip()}
+        if et_client_name is None:
+            et_client_name = os.getenv("SIRI_ET_CLIENT_NAME", "").strip()
+        if et_client_name:
+            resolved_headers["ET-Client-Name"] = et_client_name
+        elif provider == "entur" and not _has_header(resolved_headers, "ET-Client-Name"):
+            resolved_headers["ET-Client-Name"] = DEFAULT_ENTUR_CLIENT_NAME
         return cls(
             provider=provider,
             siri_url=siri_url,
@@ -97,6 +142,7 @@ class FeedConfig:
             polling_interval=polling_interval,
             state_file=state_file,
             once=once,
+            request_headers=resolved_headers,
         )
 
 

--- a/feeders/siri/siri_kafka/siri_kafka/app.py
+++ b/feeders/siri/siri_kafka/siri_kafka/app.py
@@ -10,7 +10,17 @@ from typing import Dict, Optional
 
 from confluent_kafka import Producer
 
-from siri_core import FeedConfig, SiriClient, build_kafka_config, load_state, parse_csv_tokens, parse_data_types, parse_kafka_connection_string, save_state
+from siri_core import (
+    SUPPORTED_PROVIDERS,
+    FeedConfig,
+    SiriClient,
+    build_kafka_config,
+    load_state,
+    parse_csv_tokens,
+    parse_data_types,
+    parse_kafka_connection_string,
+    save_state,
+)
 from siri_producer_data import Operator, VehiclePosition
 from siri_producer_kafka_producer.producer import OrgSiriKafkaEventProducer
 
@@ -137,9 +147,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     feed_parser = subparsers.add_parser("feed", help="Feed operator metadata and vehicle positions as CloudEvents to Kafka")
-    feed_parser.add_argument("--provider", choices=["bods", "trafiklab", "custom"], default=os.getenv("SIRI_PROVIDER", "bods"))
+    feed_parser.add_argument("--provider", choices=SUPPORTED_PROVIDERS, default=os.getenv("SIRI_PROVIDER", "bods"))
     feed_parser.add_argument("--siri-url", type=str, default=os.getenv("SIRI_URL"))
     feed_parser.add_argument("--api-key", type=str, default=os.getenv("SIRI_API_KEY") or os.getenv("BODS_API_KEY"))
+    feed_parser.add_argument("--headers", type=str, default=os.getenv("SIRI_HEADERS"))
+    feed_parser.add_argument("--et-client-name", type=str, default=os.getenv("SIRI_ET_CLIENT_NAME"))
     feed_parser.add_argument("--operators", type=str, default=os.getenv("SIRI_OPERATORS") or os.getenv("OPERATORS"))
     feed_parser.add_argument("--data-types", type=str, default=os.getenv("SIRI_DATA_TYPES", "vm"))
     feed_parser.add_argument("--kafka-bootstrap-servers", type=str, default=os.getenv("KAFKA_BOOTSTRAP_SERVERS"))
@@ -171,6 +183,8 @@ def main(argv: Optional[list] = None) -> None:
         polling_interval=args.polling_interval,
         state_file=args.state_file,
         once=args.once,
+        request_headers=args.headers,
+        et_client_name=args.et_client_name,
     )
 
     if args.connection_string:
@@ -204,6 +218,7 @@ def main(argv: Optional[list] = None) -> None:
         api_key=config.api_key,
         operators=config.operators,
         data_types=config.data_types,
+        request_headers=config.request_headers,
     )
     asyncio.run(
         feed(

--- a/feeders/siri/siri_mqtt/siri_mqtt/app.py
+++ b/feeders/siri/siri_mqtt/siri_mqtt/app.py
@@ -14,7 +14,7 @@ from paho.mqtt.client import CallbackAPIVersion, MQTTv5
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
 
-from siri_core import FeedConfig, SiriClient, load_state, parse_csv_tokens, parse_data_types, save_state
+from siri_core import SUPPORTED_PROVIDERS, FeedConfig, SiriClient, load_state, parse_csv_tokens, parse_data_types, save_state
 from siri_mqtt_producer_data import Operator, VehiclePosition
 from siri_mqtt_producer_mqtt_client.client import OrgSiriMqttMqttClient
 
@@ -119,13 +119,9 @@ async def feed(
     )
 
     refresh_task: Optional[asyncio.Task] = None
-    connect_properties: Optional[Properties] = None
     expires_at: Optional[datetime] = None
     if auth_mode == "entra":
         token, expires_at = _acquire_entra_token(entra_audience, entra_client_id)
-        connect_properties = Properties(PacketTypes.CONNECT)
-        connect_properties.AuthenticationMethod = ENTRA_MQTT_AUTH_METHOD
-        connect_properties.AuthenticationData = token.encode("utf-8")
     elif auth_mode == "userpass" and username:
         paho_client.username_pw_set(username, password or "")
 
@@ -136,8 +132,12 @@ async def feed(
     event_client = OrgSiriMqttMqttClient(client=paho_client, content_mode="binary", loop=loop)
 
     if auth_mode == "entra":
-        paho_client.connect(broker_host, broker_port, keepalive=60, clean_start=True, properties=connect_properties)
-        paho_client.loop_start()
+        await event_client.connect(
+            broker_host,
+            broker_port,
+            token=token,
+            authentication_method=ENTRA_MQTT_AUTH_METHOD,
+        )
         refresh_task = asyncio.create_task(
             _entra_token_refresh_loop(paho_client, broker_host, broker_port, 60, entra_audience, entra_client_id, expires_at)
         )
@@ -214,9 +214,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     feed_parser = subparsers.add_parser("feed", help="Feed operator metadata and vehicle positions as CloudEvents over MQTT")
-    feed_parser.add_argument("--provider", choices=["bods", "trafiklab", "custom"], default=os.getenv("SIRI_PROVIDER", "bods"))
+    feed_parser.add_argument("--provider", choices=SUPPORTED_PROVIDERS, default=os.getenv("SIRI_PROVIDER", "bods"))
     feed_parser.add_argument("--siri-url", type=str, default=os.getenv("SIRI_URL"))
     feed_parser.add_argument("--api-key", type=str, default=os.getenv("SIRI_API_KEY") or os.getenv("BODS_API_KEY"))
+    feed_parser.add_argument("--headers", type=str, default=os.getenv("SIRI_HEADERS"))
+    feed_parser.add_argument("--et-client-name", type=str, default=os.getenv("SIRI_ET_CLIENT_NAME"))
     feed_parser.add_argument("--operators", type=str, default=os.getenv("SIRI_OPERATORS") or os.getenv("OPERATORS"))
     feed_parser.add_argument("--data-types", type=str, default=os.getenv("SIRI_DATA_TYPES", "vm"))
     feed_parser.add_argument("--broker-url", type=str, default=os.getenv("MQTT_BROKER_URL"))
@@ -253,6 +255,8 @@ def main(argv: Optional[list] = None) -> None:
         polling_interval=args.polling_interval,
         state_file=args.state_file,
         once=args.once,
+        request_headers=args.headers,
+        et_client_name=args.et_client_name,
     )
 
     if args.broker_url:
@@ -276,6 +280,7 @@ def main(argv: Optional[list] = None) -> None:
         api_key=config.api_key,
         operators=config.operators,
         data_types=config.data_types,
+        request_headers=config.request_headers,
     )
     asyncio.run(
         feed(

--- a/feeders/siri/tests/test_siri_core.py
+++ b/feeders/siri/tests/test_siri_core.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from siri_core.acquisition import DEFAULT_BODS_URL, DEFAULT_TRAFIKLAB_URL, SiriClient, iter_vehicle_positions
+from siri_core.acquisition import DEFAULT_BODS_URL, DEFAULT_ENTUR_URL, DEFAULT_TRAFIKLAB_URL, SiriClient, iter_vehicle_positions
+from siri_core.config import DEFAULT_ENTUR_CLIENT_NAME, FeedConfig, parse_request_headers
 
 
 def test_iter_vehicle_positions_parses_sample_xml():
@@ -103,3 +104,81 @@ def test_bods_datafeed_requires_api_key():
 
     with pytest.raises(RuntimeError):
         client._build_request_specs()
+
+
+def test_entur_provider_defaults_to_siri_lite_paths_and_client_header():
+    config = FeedConfig.from_env(provider="entur", data_types="et,vm,sx")
+    client = SiriClient(
+        provider=config.provider,
+        siri_url=config.siri_url,
+        data_types=config.data_types,
+        request_headers=config.request_headers,
+    )
+
+    specs = client._build_request_specs()
+
+    assert config.siri_url == DEFAULT_ENTUR_URL
+    assert [spec.request_url for spec in specs] == [
+        "https://api.entur.io/realtime/v1/rest/et",
+        "https://api.entur.io/realtime/v1/rest/vm",
+        "https://api.entur.io/realtime/v1/rest/sx",
+    ]
+    assert all(spec.headers == {"ET-Client-Name": DEFAULT_ENTUR_CLIENT_NAME} for spec in specs)
+    assert all(spec.params == {} for spec in specs)
+
+
+def test_parse_request_headers_accepts_semicolon_separated_values():
+    assert parse_request_headers("ET-Client-Name=my-client;X-Trace = abc=123") == {
+        "ET-Client-Name": "my-client",
+        "X-Trace": "abc=123",
+    }
+
+
+def test_custom_headers_are_sent_with_request():
+    class FakeResponse:
+        content = b"<Siri xmlns=\"http://www.siri.org.uk/siri\"><ServiceDelivery /></Siri>"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.headers = {}
+            self.calls = []
+
+        def get(self, url, *, headers, params, timeout):
+            self.calls.append({"url": url, "headers": headers, "params": params, "timeout": timeout})
+            return FakeResponse()
+
+    session = FakeSession()
+    client = SiriClient(
+        provider="custom",
+        siri_url="https://example.test/siri",
+        request_headers={"ET-Client-Name": "unit-test", "X-Extra": "yes"},
+        session=session,
+    )
+
+    client.load_snapshot()
+
+    assert session.calls == [
+        {
+            "url": "https://example.test/siri",
+            "headers": {"ET-Client-Name": "unit-test", "X-Extra": "yes"},
+            "params": {},
+            "timeout": 30.0,
+        }
+    ]
+
+
+def test_existing_provider_headers_are_unchanged_when_no_custom_headers():
+    client = SiriClient(
+        provider="trafiklab",
+        siri_url=DEFAULT_TRAFIKLAB_URL,
+        api_key="secret",
+        operators=("skane/skanetrafiken",),
+        data_types=("vm",),
+    )
+
+    specs = client._build_request_specs()
+
+    assert specs[0].headers == {"X-Api-Key": "secret"}


### PR DESCRIPTION
## Summary
- Adds Entur (`SIRI_PROVIDER=entur`) to the generalized `siri` feeder core with default `https://api.entur.io/realtime/v1/rest/{data_type}` SIRI-Lite URL expansion and automatic `ET-Client-Name` request header support.
- Wires the shared provider/config surface (`SIRI_PROVIDER`, `SIRI_URL`, `SIRI_HEADERS`, `SIRI_ET_CLIENT_NAME`, `SIRI_DATA_TYPES`) through Kafka, AMQP, and MQTT apps and all five Azure templates.
- Uses the shared MQTT generated client connect wrapper for Entra MQTT initial connect, so Paho v5 CONNACK/auth failures are surfaced before publishing.

## Contract / review scope
- `feeders/siri/xreg/siri.xreg.json` is unchanged; this is code/config/deployment/docs only.
- Existing consolidated event contract remains `org.siri.VehiclePosition` and `org.siri.Operator`.
- xRegistry / JSON Structure / Avro expert reviews are N/A because the wire contract did not change.

## ARM template validation
- `pwsh tools\\validate-arm-templates.ps1 -RepoRoot . -FeederSlug siri`
- Result: `PASS: all 5 templates pass static audit.` (0 blockers, 0 warnings)
- Fleet run also completed with 0 blockers: `pwsh tools\\validate-arm-templates.ps1 -RepoRoot .` -> `PASS (with 112 warning(s))`; warnings are pre-existing outside `siri`.

## Local validation evidence
- Merge: `origin/main` fast-forwarded to `09f71cfbe`; `tests\\docker_e2e\\_jsonstructure_compat.py` present.
- Unit tests: from `feeders\\siri`, `python -m pytest tests\\ -q` -> `16 passed in 1.83s`.
- Kafka Docker E2E: `python -m pytest tests\\docker_e2e\\test_docker_kafka_flow.py::TestSiriKafkaDockerFlow -v --timeout=1200` -> `1 passed, 1 warning in 68.51s`.
- AMQP Docker E2E: `python -m pytest tests\\docker_e2e\\test_docker_amqp_flow.py::TestSiriAmqpDockerFlow -v --timeout=1200` -> `1 passed, 2 warnings in 177.58s`.
- MQTT Docker E2E: `python -m pytest tests\\docker_e2e\\test_docker_mqtt_flow.py::TestSiriMqttDockerFlow -v --timeout=1200` -> `1 passed, 1 warning in 126.52s`.
- Companion app smoke imports from repo root with installed Siri packages:
  - `python -c "import siri_amqp.app"` -> OK
  - `python -c "import siri_mqtt.app"` -> OK

## Release checklist status
- Transport scope declared: ✅ Kafka, AMQP, MQTT all in scope.
- Change scope declared: ✅ env-var/config/runtime/deploy-template/docs change; no contract/schema change.
- xRegistry contract quality: N/A — `feeders/siri/xreg/siri.xreg.json` unchanged.
- Upstream API re-audit: N/A — provider config only; existing schema remains SIRI VehicleMonitoring.
- Producer regeneration: N/A — no contract change and no generated producer changes.
- Runtime bridge: ✅ Entur provider selection, request headers, data-type URL expansion, state/dedupe, and explicit key/subject placeholder calls verified by unit and Docker E2E.
- Tests: ✅ unit + Kafka/AMQP/MQTT Docker E2E passed locally as listed above.
- Container packaging: ✅ Docker E2E built and ran all three image variants.
- Azure deployment templates: ✅ Siri-specific static audit passed all 5 templates with 0 blockers / 0 warnings.
- Documentation: ✅ README.md and CONTAINER.md document Entur provider and new env vars.
- Pre-merge: ✅ no secrets committed; xreg unchanged; branch pushed with Co-authored-by trailer.
