### PR TITLE
Add shared ArcGIS and GeoJSON poller core

### DIFF
--- a/feeders/_poller_core/README.md
+++ b/feeders/_poller_core/README.md
@@ -1,0 +1,82 @@
+# Shared poller core
+
+`feeders/_poller_core` is the first shared cross-feeder Python package in this repository. It is **not** a feeder/source: it has no xRegistry contract, generated producer, transport app, container, or Events document. Bespoke feeders import it for reusable fetch plumbing and still define their own event contracts and mapping code.
+
+Future feeders wire it as a path dependency:
+
+```toml
+[tool.poetry.dependencies]
+poller_core = { path = "../_poller_core" }
+```
+
+## ArcGIS FeatureServer usage
+
+```python
+from poller_core import ArcGisFeatureServerPoller, DeltaDetector, JsonFileStateStore
+
+poller = ArcGisFeatureServerPoller(
+    "https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer",
+    layer_id=0,
+    unique_field="IrwinID",
+    order_by_fields="OBJECTID ASC",
+    headers={"User-Agent": USER_AGENT},
+)
+state_store = JsonFileStateStore(last_polled_file)
+state = state_store.load_namespace("wildfire-delta")
+delta = DeltaDetector(timestamp_field="ModifiedOnDateTime")
+
+for feature in delta.changed_features(poller.fetch().features, state):
+    attrs = feature["attributes"]
+    geometry = feature["geometry"]
+    incident = WildfireIncident(
+        irwin_id=feature["id"],
+        incident_name=attrs.get("IncidentName", ""),
+        # map the rest of this feeder's schema here
+    )
+    producer.send_wildfire_incident(incident, _subject_id=feature["id"])
+
+state_store.save_namespace("wildfire-delta", state)
+```
+
+The ArcGIS poller normalizes service-root, layer, and `/query` URLs; discovers `objectIdField` and `maxRecordCount` from layer metadata; requests `f=geojson` first; falls back to `f=json`; and pages with `resultOffset`/`resultRecordCount` until all features are fetched.
+
+## GeoJSON FeatureCollection usage
+
+```python
+from poller_core import DeltaDetector, GeoJsonFeatureCollectionPoller, OffsetLimitPagination
+
+poller = GeoJsonFeatureCollectionPoller(
+    "https://api.weather.gc.ca/collections/swob-stations/items",
+    params={"f": "json"},
+    id_path="properties.id",
+    pagination=OffsetLimitPagination(limit=500),
+    headers={"User-Agent": USER_AGENT},
+)
+delta = DeltaDetector()  # falls back to a stable attributes+geometry hash
+state = state_store.load_namespace("stations")
+
+for feature in delta.changed_features(poller.fetch().features, state):
+    props = feature["attributes"]
+    station = Station(
+        station_id=feature["id"],
+        name=props.get("name", ""),
+        # map the rest of this feeder's schema here
+    )
+    producer.send_station(station, _subject_id=feature["id"])
+```
+
+The GeoJSON poller handles gzip payloads, conditional GET with ETag/Last-Modified, offset/limit pagination, and RFC 5988 `Link: rel="next"` pagination. It returns normalized `{id, attributes, geometry}` dictionaries so each feeder remains responsible for its own schema-specific parsing.
+
+## Generalized existing patterns
+
+This package extracts the shared fetch skeleton already present in bespoke feeders:
+
+- `nifc-usa-wildfires`: ArcGIS FeatureServer `f=geojson`, `resultOffset`, `resultRecordCount`, and `exceededTransferLimit` paging.
+- `german-waters`: ArcGIS/MapServer query parameters, `outFields`, `outSR`, and attribute/geometry parsing.
+- `australia-wildfires`: GeoJSON FeatureCollection polling from multiple emergency feeds and per-feature id extraction.
+- `environment-canada`: OGC API FeatureCollection offset/limit paging.
+- `eurdep-radiation` and `inpe-deter-brazil`: FeatureCollection/WFS-style page loops and stable feature extraction.
+- `noaa-nws`: FeatureCollection pagination using a next-page URL.
+- `bfs-odl`, `ireland-opw-waterlevel`, and `usgs-geomag`: simple GeoJSON fetch-then-map patterns and file-backed state/dedupe analogs.
+
+Current feeders do not import this package yet. It lands ahead of consumers so future ArcGIS and GeoJSON sources can depend on one reviewed polling implementation.

--- a/feeders/_poller_core/pyproject.toml
+++ b/feeders/_poller_core/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "poller-core"
+version = "0.1.0"
+description = "Shared ArcGIS FeatureServer and GeoJSON FeatureCollection polling helpers for bespoke real-time-sources feeders"
+authors = ["Clemens Vasters <clemensv@microsoft.com>"]
+license = "MIT"
+packages = [{ include = "poller_core", from = "src" }]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4.0"
+requests = ">=2.32.3"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=8.0"

--- a/feeders/_poller_core/pytest.ini
+++ b/feeders/_poller_core/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    live: live smoke tests against public upstream endpoints; skipped automatically when unavailable

--- a/feeders/_poller_core/src/poller_core/__init__.py
+++ b/feeders/_poller_core/src/poller_core/__init__.py
@@ -1,0 +1,28 @@
+"""Shared polling primitives for bespoke real-time-sources feeders.
+
+The package intentionally contains no source contract, CloudEvents producer, or
+transport application. Feeders import these helpers to fetch ArcGIS
+FeatureServer or GeoJSON FeatureCollection payloads, then map the returned
+normalized features into their own generated data classes.
+"""
+
+from poller_core.arcgis import ArcGisFeatureServerPoller
+from poller_core.delta import DeltaDetector, FeatureState, stable_feature_hash
+from poller_core.geojson import GeoJsonFeatureCollectionPoller, OffsetLimitPagination
+from poller_core.http import create_retrying_session
+from poller_core.models import NormalizedFeature, PollMetadata, PollResult
+from poller_core.state import JsonFileStateStore
+
+__all__ = [
+    "ArcGisFeatureServerPoller",
+    "DeltaDetector",
+    "FeatureState",
+    "GeoJsonFeatureCollectionPoller",
+    "JsonFileStateStore",
+    "NormalizedFeature",
+    "OffsetLimitPagination",
+    "PollMetadata",
+    "PollResult",
+    "create_retrying_session",
+    "stable_feature_hash",
+]

--- a/feeders/_poller_core/src/poller_core/arcgis.py
+++ b/feeders/_poller_core/src/poller_core/arcgis.py
@@ -1,0 +1,212 @@
+"""ArcGIS FeatureServer layer poller."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from poller_core.http import create_retrying_session, response_json
+from poller_core.models import NormalizedFeature, PollMetadata, PollResult
+
+DEFAULT_PAGE_SIZE = 2000
+
+
+class ArcGisFeatureServerPoller:
+    """Poll an ArcGIS FeatureServer or MapServer layer query endpoint.
+
+    Args:
+        base_url: Service URL ending at FeatureServer, MapServer, a layer id, or
+            a layer query endpoint. All forms used by existing bespoke feeders
+            are normalized internally.
+        layer_id: Layer id to query when base_url is the service root. Ignored
+            when base_url already ends with a numeric layer id or /query.
+        where: ArcGIS where clause, defaulting to all features.
+        out_fields: ArcGIS outFields value, defaulting to all fields.
+        out_sr: Optional output spatial reference, for example "4326".
+        unique_field: Optional stable id field. When omitted, layer metadata is
+            queried and objectIdField is used.
+        order_by_fields: Optional stable orderByFields value for paging.
+        page_size: resultRecordCount per request. Metadata maxRecordCount lowers
+            this value when available.
+        token: Optional ArcGIS token sent as a query parameter.
+        headers: Optional request headers, such as Authorization or User-Agent.
+        session: Optional requests session. A retrying session is created when
+            omitted.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        layer_id: int = 0,
+        *,
+        where: str = "1=1",
+        out_fields: str = "*",
+        out_sr: Optional[str] = None,
+        unique_field: Optional[str] = None,
+        order_by_fields: Optional[str] = None,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        token: Optional[str] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.layer_url, self.query_url = _layer_and_query_urls(base_url, layer_id)
+        self.where = where
+        self.out_fields = out_fields
+        self.out_sr = out_sr
+        self.unique_field = unique_field
+        self.order_by_fields = order_by_fields
+        self.page_size = page_size
+        self.token = token
+        self.session = session or create_retrying_session(headers=headers)
+        if headers and session is not None:
+            self.session.headers.update(dict(headers))
+        self._object_id_field: Optional[str] = None
+        self._max_record_count: Optional[int] = None
+
+    def fetch(self) -> PollResult:
+        """Fetch all pages and return normalized features keyed by stable id."""
+        metadata = self.layer_metadata()
+        object_id_field = self.unique_field or _string_or_none(metadata.get("objectIdField")) or "OBJECTID"
+        max_record_count = _int_or_none(metadata.get("maxRecordCount")) or self.page_size
+        page_size = max(1, min(self.page_size, max_record_count))
+        all_features: List[NormalizedFeature] = []
+        offset = 0
+        page_count = 0
+        status_code = 0
+        while True:
+            data, status_code = self._query_page(offset, page_size, preferred_format="geojson")
+            page_count += 1
+            features = data.get("features", [])
+            if not isinstance(features, list):
+                features = []
+            all_features.extend(
+                self._normalize_feature(feature, object_id_field) for feature in features if isinstance(feature, dict)
+            )
+            exceeded = _exceeded_transfer_limit(data)
+            if not features:
+                break
+            if not exceeded and len(features) < page_size:
+                break
+            offset += len(features)
+        return PollResult(
+            features=all_features,
+            metadata=PollMetadata(
+                status_code=status_code,
+                page_count=page_count,
+                source_url=self.query_url,
+            ),
+        )
+
+    def layer_metadata(self) -> Dict[str, Any]:
+        """Return and cache ArcGIS layer metadata discovered via ?f=json."""
+        if self._object_id_field is not None:
+            return {"objectIdField": self._object_id_field, "maxRecordCount": self._max_record_count}
+        params: Dict[str, Any] = {"f": "json"}
+        if self.token:
+            params["token"] = self.token
+        response = self.session.get(self.layer_url, params=params)
+        response.raise_for_status()
+        data = response_json(response)
+        self._object_id_field = _string_or_none(data.get("objectIdField")) or "OBJECTID"
+        self._max_record_count = _int_or_none(data.get("maxRecordCount"))
+        return data
+
+    def _query_page(self, offset: int, page_size: int, *, preferred_format: str) -> tuple[Dict[str, Any], int]:
+        params = self._query_params(offset, page_size, preferred_format)
+        try:
+            response = self.session.get(self.query_url, params=params)
+            response.raise_for_status()
+            data = response_json(response)
+            if isinstance(data.get("error"), dict):
+                raise ValueError(str(data["error"]))
+            return data, response.status_code
+        except (requests.RequestException, ValueError):
+            if preferred_format == "json":
+                raise
+        params = self._query_params(offset, page_size, "json")
+        response = self.session.get(self.query_url, params=params)
+        response.raise_for_status()
+        data = response_json(response)
+        if isinstance(data.get("error"), dict):
+            raise ValueError(str(data["error"]))
+        return data, response.status_code
+
+    def _query_params(self, offset: int, page_size: int, output_format: str) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "f": output_format,
+            "where": self.where,
+            "outFields": self.out_fields,
+            "resultRecordCount": str(page_size),
+            "resultOffset": str(offset),
+        }
+        if self.out_sr:
+            params["outSR"] = self.out_sr
+        if self.order_by_fields:
+            params["orderByFields"] = self.order_by_fields
+        if self.token:
+            params["token"] = self.token
+        return params
+
+    def _normalize_feature(self, feature: Dict[str, Any], object_id_field: str) -> NormalizedFeature:
+        attributes = feature.get("attributes")
+        if not isinstance(attributes, dict):
+            props = feature.get("properties")
+            attributes = props if isinstance(props, dict) else {}
+        geometry = feature.get("geometry") if isinstance(feature.get("geometry"), dict) else None
+        raw_id = _first_present(
+            attributes.get(object_id_field),
+            feature.get("id"),
+            attributes.get("OBJECTID"),
+            attributes.get("FID"),
+        )
+        if raw_id is None:
+            raw_id = stable_repr({"attributes": attributes, "geometry": geometry})
+        return {"id": str(raw_id), "attributes": dict(attributes), "geometry": geometry}
+
+
+def _layer_and_query_urls(base_url: str, layer_id: int) -> tuple[str, str]:
+    trimmed = base_url.rstrip("/")
+    if trimmed.lower().endswith("/query"):
+        layer_url = trimmed.rsplit("/", 1)[0]
+        return layer_url, trimmed
+    last_segment = urlparse(trimmed).path.rstrip("/").rsplit("/", 1)[-1]
+    if last_segment.isdigit():
+        return trimmed, f"{trimmed}/query"
+    layer_url = f"{trimmed}/{layer_id}"
+    return layer_url, f"{layer_url}/query"
+
+
+def _exceeded_transfer_limit(data: Dict[str, Any]) -> bool:
+    props = data.get("properties")
+    if isinstance(props, dict) and bool(props.get("exceededTransferLimit")):
+        return True
+    return bool(data.get("exceededTransferLimit"))
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def stable_repr(value: Any) -> str:
+    """Return a deterministic fallback id for malformed upstream features."""
+    import json
+    import hashlib
+
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None

--- a/feeders/_poller_core/src/poller_core/delta.py
+++ b/feeders/_poller_core/src/poller_core/delta.py
@@ -1,0 +1,111 @@
+"""Delta-detection helpers for normalized features."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional
+
+from poller_core.models import NormalizedFeature
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def stable_feature_hash(feature: NormalizedFeature) -> str:
+    """Return a stable SHA-256 hash of a feature's attributes and geometry.
+
+    Args:
+        feature: Normalized feature whose id is excluded from the hash. Excluding
+            id means the digest reflects payload changes only.
+    """
+
+    payload = {"attributes": feature.get("attributes", {}), "geometry": feature.get("geometry")}
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class FeatureState:
+    """Persisted delta marker for one feature id.
+
+    Args:
+        version: Edit timestamp or stable hash used for change detection.
+        mode: Detection mode that produced version, either "timestamp" or
+            "hash".
+    """
+
+    version: str
+    mode: str
+
+
+class DeltaDetector:
+    """Detect new or changed normalized features against persisted state.
+
+    Args:
+        timestamp_field: Optional field name or dotted path inside feature
+            attributes. When it resolves to a non-empty value for a feature, that
+            value is used as the version. Otherwise the detector falls back to a
+            stable attributes+geometry hash.
+    """
+
+    def __init__(self, timestamp_field: Optional[str] = None) -> None:
+        self.timestamp_field = timestamp_field
+
+    def feature_state(self, feature: NormalizedFeature) -> FeatureState:
+        """Return the current delta marker for a normalized feature."""
+        timestamp = _get_path(feature.get("attributes", {}), self.timestamp_field)
+        if timestamp not in (None, ""):
+            return FeatureState(version=str(timestamp), mode="timestamp")
+        return FeatureState(version=stable_feature_hash(feature), mode="hash")
+
+    def is_changed(self, feature: NormalizedFeature, state: MutableMapping[str, Any]) -> bool:
+        """Return True when a feature is new or has a different persisted marker."""
+        feature_id = feature["id"]
+        current = self.feature_state(feature)
+        previous = state.get(feature_id)
+        previous_version: Optional[str]
+        previous_mode: Optional[str]
+        if isinstance(previous, dict):
+            previous_version = str(previous.get("version", ""))
+            previous_mode = str(previous.get("mode", ""))
+        elif previous is not None:
+            previous_version = str(previous)
+            previous_mode = None
+        else:
+            previous_version = None
+            previous_mode = None
+        return previous_version != current.version or (previous_mode not in (None, current.mode))
+
+    def mark_seen(self, feature: NormalizedFeature, state: MutableMapping[str, Any]) -> None:
+        """Update state with the current marker for one feature."""
+        current = self.feature_state(feature)
+        state[feature["id"]] = {"version": current.version, "mode": current.mode}
+
+    def changed_features(
+        self,
+        features: Iterable[NormalizedFeature],
+        state: MutableMapping[str, Any],
+        *,
+        mark_seen: bool = True,
+    ) -> List[NormalizedFeature]:
+        """Return features that are new or changed and optionally update state."""
+        changed: List[NormalizedFeature] = []
+        for feature in features:
+            if self.is_changed(feature, state):
+                changed.append(feature)
+                if mark_seen:
+                    self.mark_seen(feature, state)
+        return changed
+
+
+def _get_path(mapping: Dict[str, Any], path: Optional[str]) -> Any:
+    if not path:
+        return None
+    current: Any = mapping
+    for part in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current

--- a/feeders/_poller_core/src/poller_core/geojson.py
+++ b/feeders/_poller_core/src/poller_core/geojson.py
@@ -1,0 +1,218 @@
+"""GeoJSON FeatureCollection poller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from poller_core.http import create_retrying_session, response_json
+from poller_core.models import NormalizedFeature, PollMetadata, PollResult
+from poller_core.state import JsonFileStateStore
+
+
+@dataclass(frozen=True)
+class OffsetLimitPagination:
+    """Offset/limit pagination settings for GeoJSON APIs.
+
+    Args:
+        offset_param: Query parameter carrying the current offset.
+        limit_param: Query parameter carrying the page size.
+        limit: Page size requested from the upstream.
+        start_offset: Initial offset value. Existing feeders use both 0-based
+            offset and WFS-style startIndex conventions; callers configure the
+            exact parameter names here.
+    """
+
+    offset_param: str = "offset"
+    limit_param: str = "limit"
+    limit: int = 500
+    start_offset: int = 0
+
+
+class GeoJsonFeatureCollectionPoller:
+    """Poll a GeoJSON FeatureCollection endpoint.
+
+    Args:
+        url: Endpoint URL returning a GeoJSON FeatureCollection.
+        params: Optional query parameters sent with the first request.
+        id_path: Dotted path used as the stable feature id. Defaults to
+            feature.id. Examples: "properties.guid", "properties.station.id".
+        fallback_property: Optional properties field used when id_path is empty.
+        pagination: Optional offset/limit pagination settings.
+        follow_link_next: Whether to follow RFC 5988 Link headers with
+            rel="next". Enabled by default.
+        body_next_path: Optional dotted response-body path carrying a next-page
+            URL, defaulting to NOAA NWS-style "pagination.next".
+        terminal_status_codes: Optional statuses that end pagination after at
+            least one page has been fetched, for WFS endpoints that return a
+            terminal 400 when startIndex exceeds the result set.
+        use_conditional_get: Whether to send saved ETag/Last-Modified values as
+            If-None-Match/If-Modified-Since headers.
+        state_store: Optional JSON state store for conditional-GET metadata.
+        headers: Optional request headers, such as Authorization or User-Agent.
+        session: Optional requests session. A retrying session is created when
+            omitted.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        id_path: str = "id",
+        fallback_property: Optional[str] = None,
+        pagination: Optional[OffsetLimitPagination] = None,
+        follow_link_next: bool = True,
+        body_next_path: Optional[str] = "pagination.next",
+        terminal_status_codes: tuple[int, ...] = (),
+        use_conditional_get: bool = True,
+        state_store: Optional[JsonFileStateStore] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.url = url
+        self.params = dict(params or {})
+        self.id_path = id_path
+        self.fallback_property = fallback_property
+        self.pagination = pagination
+        self.follow_link_next = follow_link_next
+        self.body_next_path = body_next_path
+        self.terminal_status_codes = terminal_status_codes
+        self.use_conditional_get = use_conditional_get
+        self.state_store = state_store
+        self.session = session or create_retrying_session(headers=headers)
+        if headers and session is not None:
+            self.session.headers.update(dict(headers))
+        self._etag: Optional[str] = None
+        self._last_modified: Optional[str] = None
+
+    def fetch(self) -> PollResult:
+        """Fetch one or more pages and return normalized features.
+
+        Returns an empty feature list with metadata.not_modified=True when the
+        first request receives HTTP 304.
+        """
+        features: List[NormalizedFeature] = []
+        page_count = 0
+        status_code = 0
+        next_url: Optional[str] = self.url
+        offset = self.pagination.start_offset if self.pagination else 0
+        first_page = True
+        latest_etag: Optional[str] = None
+        latest_last_modified: Optional[str] = None
+        while next_url:
+            request_params: Optional[Dict[str, Any]] = dict(self.params) if first_page or next_url == self.url else None
+            if self.pagination and next_url == self.url:
+                assert request_params is not None
+                request_params[self.pagination.offset_param] = str(offset)
+                request_params[self.pagination.limit_param] = str(self.pagination.limit)
+            headers = self._conditional_headers() if first_page else {}
+            response = self.session.get(next_url, params=request_params, headers=headers or None)
+            status_code = response.status_code
+            if page_count > 0 and status_code in self.terminal_status_codes:
+                break
+            if status_code == 304:
+                metadata = PollMetadata(
+                    status_code=status_code,
+                    not_modified=True,
+                    etag=self._etag,
+                    last_modified=self._last_modified,
+                    page_count=page_count + 1,
+                    source_url=self.url,
+                )
+                return PollResult(features=[], metadata=metadata)
+            response.raise_for_status()
+            latest_etag = response.headers.get("ETag") or latest_etag
+            latest_last_modified = response.headers.get("Last-Modified") or latest_last_modified
+            data = response_json(response)
+            raw_features = data.get("features", [])
+            if not isinstance(raw_features, list):
+                raw_features = []
+            features.extend(self._normalize_feature(feature) for feature in raw_features if isinstance(feature, dict))
+            page_count += 1
+            link_next = _next_link(response.headers.get("Link"), response.url or next_url) if self.follow_link_next else None
+            body_next = _get_path(data, self.body_next_path) if self.body_next_path else None
+            if link_next:
+                next_url = link_next
+                first_page = False
+                continue
+            if isinstance(body_next, str) and body_next:
+                next_url = body_next
+                first_page = False
+                continue
+            if self.pagination and len(raw_features) >= self.pagination.limit:
+                offset += len(raw_features)
+                next_url = self.url
+                first_page = False
+                continue
+            break
+        self._remember_http_metadata(latest_etag, latest_last_modified)
+        return PollResult(
+            features=features,
+            metadata=PollMetadata(
+                status_code=status_code,
+                etag=self._etag,
+                last_modified=self._last_modified,
+                page_count=page_count,
+                source_url=self.url,
+            ),
+        )
+
+    def _conditional_headers(self) -> Dict[str, str]:
+        if not self.use_conditional_get:
+            return {}
+        if self.state_store:
+            headers = self.state_store.conditional_headers()
+            self._etag = headers.get("If-None-Match") or self._etag
+            self._last_modified = headers.get("If-Modified-Since") or self._last_modified
+            return headers
+        headers: Dict[str, str] = {}
+        if self._etag:
+            headers["If-None-Match"] = self._etag
+        if self._last_modified:
+            headers["If-Modified-Since"] = self._last_modified
+        return headers
+
+    def _remember_http_metadata(self, etag: Optional[str], last_modified: Optional[str]) -> None:
+        if etag:
+            self._etag = etag
+        if last_modified:
+            self._last_modified = last_modified
+        if self.state_store and (etag or last_modified):
+            self.state_store.save_http_metadata(etag=etag, last_modified=last_modified)
+
+    def _normalize_feature(self, feature: Dict[str, Any]) -> NormalizedFeature:
+        props = feature.get("properties")
+        attributes: Dict[str, Any] = dict(props) if isinstance(props, dict) else {}
+        raw_id = _get_path(feature, self.id_path)
+        if raw_id in (None, "") and self.fallback_property:
+            raw_id = attributes.get(self.fallback_property)
+        if raw_id in (None, ""):
+            raise ValueError(f"Feature from {self.url} has no id at {self.id_path!r}")
+        geometry = feature.get("geometry") if isinstance(feature.get("geometry"), dict) else None
+        return {"id": str(raw_id), "attributes": attributes, "geometry": geometry}
+
+
+def _get_path(mapping: Dict[str, Any], path: str) -> Any:
+    current: Any = mapping
+    for part in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _next_link(link_header: Optional[str], base_url: str) -> Optional[str]:
+    if not link_header:
+        return None
+    for entry in link_header.split(","):
+        sections = [section.strip() for section in entry.split(";")]
+        if not sections or not sections[0].startswith("<") or not sections[0].endswith(">"):
+            continue
+        rels = [section for section in sections[1:] if section.lower().replace(" ", "") == 'rel="next"']
+        if rels:
+            return urljoin(base_url, sections[0][1:-1])
+    return None

--- a/feeders/_poller_core/src/poller_core/http.py
+++ b/feeders/_poller_core/src/poller_core/http.py
@@ -1,0 +1,95 @@
+"""HTTP helpers shared by poller implementations."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from typing import Any, Dict, Mapping, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+DEFAULT_TIMEOUT_SECONDS = 60.0
+
+
+class TimeoutSession(requests.Session):
+    """Requests session that applies a default timeout to every request.
+
+    Args:
+        default_timeout: Timeout in seconds used when callers do not pass a
+            per-request timeout.
+    """
+
+    def __init__(self, default_timeout: float = DEFAULT_TIMEOUT_SECONDS) -> None:
+        super().__init__()
+        self.default_timeout = default_timeout
+
+    def request(self, method: Any, url: Any, **kwargs: Any) -> requests.Response:  # type: ignore[override]
+        """Send an HTTP request, inserting the configured default timeout."""
+        kwargs.setdefault("timeout", self.default_timeout)
+        return super().request(method, url, **kwargs)
+
+
+def create_retrying_session(
+    *,
+    user_agent: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    total_retries: int = 3,
+    backoff_factor: float = 0.5,
+    status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
+    headers: Optional[Mapping[str, str]] = None,
+) -> requests.Session:
+    """Create a requests session with timeout and exponential-backoff retries.
+
+    Args:
+        user_agent: Optional User-Agent header to set on the session.
+        timeout: Default timeout in seconds for requests made through the
+            returned session.
+        total_retries: Maximum retry count for connect/read/status failures.
+        backoff_factor: urllib3 retry backoff factor; sleep grows
+            exponentially between attempts.
+        status_forcelist: HTTP status codes retried for idempotent GET calls.
+        headers: Additional headers, for example Authorization tokens.
+    """
+
+    session = TimeoutSession(default_timeout=timeout)
+    if user_agent:
+        session.headers["User-Agent"] = user_agent
+    if headers:
+        session.headers.update(dict(headers))
+    retry = Retry(
+        total=total_retries,
+        connect=total_retries,
+        read=total_retries,
+        status=total_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=frozenset({"GET", "HEAD"}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def response_json(response: requests.Response) -> Dict[str, Any]:
+    """Decode a JSON response, including manually supplied gzip fixtures.
+
+    Requests normally decompresses gzip/deflate before exposing content. Tests
+    and some bespoke callers may construct Response objects directly, so this
+    helper also honors Content-Encoding: gzip when raw compressed bytes remain.
+    """
+
+    content = response.content
+    if response.headers.get("Content-Encoding", "").lower() == "gzip" and content[:2] == b"\x1f\x8b":
+        content = gzip.decompress(content)
+    if not content:
+        return {}
+    parsed = json.loads(content.decode(response.encoding or "utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError("Expected a JSON object response")
+    return parsed

--- a/feeders/_poller_core/src/poller_core/models.py
+++ b/feeders/_poller_core/src/poller_core/models.py
@@ -1,0 +1,50 @@
+"""Typed data shapes shared by the ArcGIS and GeoJSON pollers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TypedDict
+
+
+class NormalizedFeature(TypedDict):
+    """A source-neutral feature shape returned by the shared pollers."""
+
+    id: str
+    attributes: Dict[str, Any]
+    geometry: Optional[Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PollMetadata:
+    """Metadata describing one polling pass.
+
+    Args:
+        status_code: HTTP status from the first response, or 0 when no request
+            was issued.
+        not_modified: True when conditional GET returned HTTP 304.
+        etag: Latest ETag value returned by the upstream, if any.
+        last_modified: Latest Last-Modified value returned by the upstream, if
+            any.
+        page_count: Number of HTTP pages fetched.
+        source_url: First URL requested for this poll.
+    """
+
+    status_code: int
+    not_modified: bool = False
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+    page_count: int = 0
+    source_url: str = ""
+
+
+@dataclass(frozen=True)
+class PollResult:
+    """Result returned by poller fetch methods.
+
+    Args:
+        features: Normalized features keyed by the configured stable id.
+        metadata: Poll metadata, including conditional-GET and paging details.
+    """
+
+    features: List[NormalizedFeature] = field(default_factory=list)
+    metadata: PollMetadata = field(default_factory=lambda: PollMetadata(status_code=0))

--- a/feeders/_poller_core/src/poller_core/state.py
+++ b/feeders/_poller_core/src/poller_core/state.py
@@ -1,0 +1,67 @@
+"""File-backed JSON state storage for dedupe and conditional-GET metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, MutableMapping, Optional
+
+
+class JsonFileStateStore:
+    """Load and save small JSON state documents used by pollers.
+
+    Args:
+        path: State file path. Parent directories are created on save. A missing
+            or invalid file is treated as an empty state, matching existing
+            feeder dedupe-state behavior in this repository.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> Dict[str, Any]:
+        """Return the stored JSON object, or an empty dict when unavailable."""
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def save(self, state: MutableMapping[str, Any]) -> None:
+        """Persist a JSON-serializable state object to disk atomically enough for pollers."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as handle:
+            json.dump(dict(state), handle, indent=2, sort_keys=True)
+
+    def load_namespace(self, name: str) -> Dict[str, Any]:
+        """Return one named sub-dictionary from the state document."""
+        value = self.load().get(name, {})
+        return value if isinstance(value, dict) else {}
+
+    def save_namespace(self, name: str, value: MutableMapping[str, Any]) -> None:
+        """Update one named sub-dictionary in the state document."""
+        state = self.load()
+        state[name] = dict(value)
+        self.save(state)
+
+    def conditional_headers(self) -> Dict[str, str]:
+        """Return If-None-Match/If-Modified-Since headers from saved metadata."""
+        headers: Dict[str, str] = {}
+        metadata = self.load_namespace("http")
+        etag = metadata.get("etag")
+        last_modified = metadata.get("last_modified")
+        if isinstance(etag, str) and etag:
+            headers["If-None-Match"] = etag
+        if isinstance(last_modified, str) and last_modified:
+            headers["If-Modified-Since"] = last_modified
+        return headers
+
+    def save_http_metadata(self, *, etag: Optional[str], last_modified: Optional[str]) -> None:
+        """Persist ETag and Last-Modified values returned by an upstream."""
+        existing = self.load_namespace("http")
+        if etag:
+            existing["etag"] = etag
+        if last_modified:
+            existing["last_modified"] = last_modified
+        self.save_namespace("http", existing)

--- a/feeders/_poller_core/tests/test_poller_core.py
+++ b/feeders/_poller_core/tests/test_poller_core.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from poller_core import (  # noqa: E402
+    ArcGisFeatureServerPoller,
+    DeltaDetector,
+    GeoJsonFeatureCollectionPoller,
+    JsonFileStateStore,
+    OffsetLimitPagination,
+    create_retrying_session,
+)
+
+
+class FakeSession(requests.Session):
+    def __init__(self, responses: List[requests.Response]) -> None:
+        super().__init__()
+        self.responses = responses
+        self.calls: List[Dict[str, Any]] = []
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:  # type: ignore[override]
+        self.calls.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError(f"Unexpected GET {url} {kwargs}")
+        response = self.responses.pop(0)
+        response.url = url
+        return response
+
+
+def make_response(
+    payload: Optional[Dict[str, Any]],
+    *,
+    status: int = 200,
+    headers: Optional[Dict[str, str]] = None,
+    gzip_body: bool = False,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response.headers.update(headers or {})
+    response.encoding = "utf-8"
+    if payload is None:
+        response._content = b""
+    else:
+        raw = json.dumps(payload).encode("utf-8")
+        if gzip_body:
+            raw = gzip.compress(raw)
+            response.headers["Content-Encoding"] = "gzip"
+        response._content = raw
+    return response
+
+
+def arcgis_feature(object_id: int, name: str, *, edited: int = 100) -> Dict[str, Any]:
+    return {
+        "type": "Feature",
+        "properties": {"OBJECTID": object_id, "name": name, "last_edited_date": edited},
+        "geometry": {"type": "Point", "coordinates": [10.0 + object_id, 50.0]},
+    }
+
+
+def test_arcgis_pages_all_features_and_keys_by_metadata_object_id() -> None:
+    session = FakeSession([
+        make_response({"objectIdField": "OBJECTID", "maxRecordCount": 2}),
+        make_response({"type": "FeatureCollection", "properties": {"exceededTransferLimit": True}, "features": [arcgis_feature(1, "a"), arcgis_feature(2, "b")]}),
+        make_response({"type": "FeatureCollection", "properties": {"exceededTransferLimit": False}, "features": [arcgis_feature(3, "c")]}),
+    ])
+    poller = ArcGisFeatureServerPoller(
+        "https://example.test/arcgis/rest/services/Fires/FeatureServer",
+        layer_id=0,
+        order_by_fields="OBJECTID ASC",
+        page_size=10,
+        session=session,
+    )
+
+    result = poller.fetch()
+
+    assert [feature["id"] for feature in result.features] == ["1", "2", "3"]
+    assert result.features[0]["attributes"]["name"] == "a"
+    assert result.features[0]["geometry"] == {"type": "Point", "coordinates": [11.0, 50.0]}
+    assert result.metadata.page_count == 2
+    assert session.calls[1]["params"]["f"] == "geojson"
+    assert session.calls[1]["params"]["resultOffset"] == "0"
+    assert session.calls[1]["params"]["resultRecordCount"] == "2"
+    assert session.calls[2]["params"]["resultOffset"] == "2"
+    assert session.calls[2]["params"]["orderByFields"] == "OBJECTID ASC"
+
+
+def test_arcgis_preserves_zero_object_id() -> None:
+    session = FakeSession([
+        make_response({"objectIdField": "OBJECTID", "maxRecordCount": 500}),
+        make_response({"type": "FeatureCollection", "features": [arcgis_feature(0, "zero")]}, status=200),
+    ])
+    poller = ArcGisFeatureServerPoller("https://example.test/FeatureServer/0", session=session)
+
+    result = poller.fetch()
+
+    assert result.features[0]["id"] == "0"
+
+
+def test_arcgis_falls_back_to_json_and_uses_caller_unique_field() -> None:
+    session = FakeSession([
+        make_response({"objectIdField": "OBJECTID", "maxRecordCount": 500}),
+        make_response({"error": {"message": "geojson not supported"}}),
+        make_response({
+            "features": [{"attributes": {"station_no": "SN-1", "value": 42}, "geometry": {"x": 13.0, "y": 51.0}}],
+            "exceededTransferLimit": False,
+        }),
+    ])
+    poller = ArcGisFeatureServerPoller(
+        "https://example.test/arcgis/rest/services/wasser/pegelnetz/MapServer/1/query",
+        unique_field="station_no",
+        session=session,
+    )
+
+    result = poller.fetch()
+
+    assert result.features == [{"id": "SN-1", "attributes": {"station_no": "SN-1", "value": 42}, "geometry": {"x": 13.0, "y": 51.0}}]
+    assert session.calls[1]["params"]["f"] == "geojson"
+    assert session.calls[2]["params"]["f"] == "json"
+
+
+def test_arcgis_fallback_json_error_raises() -> None:
+    session = FakeSession([
+        make_response({"objectIdField": "OBJECTID", "maxRecordCount": 500}),
+        make_response({"error": {"message": "geojson not supported"}}),
+        make_response({"error": {"message": "bad where"}}),
+    ])
+    poller = ArcGisFeatureServerPoller("https://example.test/FeatureServer/0", session=session)
+
+    with pytest.raises(ValueError, match="bad where"):
+        poller.fetch()
+
+
+def test_geojson_gzip_offset_pagination_and_id_path() -> None:
+    session = FakeSession([
+        make_response({"type": "FeatureCollection", "features": [geo_feature("n1"), geo_feature("n2")]}, gzip_body=True),
+        make_response({"type": "FeatureCollection", "features": [geo_feature("n3")]}, gzip_body=True),
+    ])
+    poller = GeoJsonFeatureCollectionPoller(
+        "https://example.test/feed.geojson",
+        params={"status": "active"},
+        id_path="properties.guid",
+        pagination=OffsetLimitPagination(offset_param="startIndex", limit_param="count", limit=2),
+        session=session,
+    )
+
+    result = poller.fetch()
+
+    assert [feature["id"] for feature in result.features] == ["n1", "n2", "n3"]
+    assert session.calls[0]["params"] == {"status": "active", "startIndex": "0", "count": "2"}
+    assert session.calls[1]["params"]["startIndex"] == "2"
+    assert result.metadata.page_count == 2
+
+
+def test_geojson_link_pagination() -> None:
+    session = FakeSession([
+        make_response(
+            {"type": "FeatureCollection", "features": [geo_feature("a")]},
+            headers={"Link": '<https://example.test/feed.geojson?page=2>; rel="next"'},
+        ),
+        make_response({"type": "FeatureCollection", "features": [geo_feature("b")]}),
+    ])
+    poller = GeoJsonFeatureCollectionPoller("https://example.test/feed.geojson", id_path="properties.guid", session=session)
+
+    result = poller.fetch()
+
+    assert [feature["id"] for feature in result.features] == ["a", "b"]
+    assert session.calls[1]["url"] == "https://example.test/feed.geojson?page=2"
+
+
+def test_geojson_body_pagination_next_url() -> None:
+    session = FakeSession([
+        make_response({"type": "FeatureCollection", "features": [geo_feature("a")], "pagination": {"next": "https://example.test/feed.geojson?page=2"}}),
+        make_response({"type": "FeatureCollection", "features": [geo_feature("b")]}),
+    ])
+    poller = GeoJsonFeatureCollectionPoller("https://example.test/feed.geojson", id_path="properties.guid", session=session)
+
+    result = poller.fetch()
+
+    assert [feature["id"] for feature in result.features] == ["a", "b"]
+    assert session.calls[1]["url"] == "https://example.test/feed.geojson?page=2"
+
+
+def test_geojson_terminal_status_after_accumulated_pages() -> None:
+    response = make_response(None, status=400)
+    response.url = "https://example.test/wfs?startIndex=2"
+    session = FakeSession([
+        make_response({"type": "FeatureCollection", "features": [geo_feature("a"), geo_feature("b")]}),
+        response,
+    ])
+    poller = GeoJsonFeatureCollectionPoller(
+        "https://example.test/wfs",
+        id_path="properties.guid",
+        pagination=OffsetLimitPagination(offset_param="startIndex", limit_param="count", limit=2),
+        terminal_status_codes=(400,),
+        session=session,
+    )
+
+    result = poller.fetch()
+
+    assert [feature["id"] for feature in result.features] == ["a", "b"]
+    assert result.metadata.page_count == 1
+
+
+def test_geojson_conditional_get_304_uses_state_store(tmp_path: Path) -> None:
+    store = JsonFileStateStore(tmp_path / "state.json")
+    store.save_http_metadata(etag='"abc"', last_modified="Wed, 01 Jan 2025 00:00:00 GMT")
+    session = FakeSession([make_response(None, status=304)])
+    poller = GeoJsonFeatureCollectionPoller("https://example.test/feed.geojson", state_store=store, session=session)
+
+    result = poller.fetch()
+
+    assert result.features == []
+    assert result.metadata.not_modified is True
+    assert session.calls[0]["headers"] == {
+        "If-None-Match": '"abc"',
+        "If-Modified-Since": "Wed, 01 Jan 2025 00:00:00 GMT",
+    }
+
+
+def test_delta_detects_new_unchanged_and_changed_features() -> None:
+    detector = DeltaDetector(timestamp_field="last_edited_date")
+    state: Dict[str, Any] = {}
+    first = {"id": "1", "attributes": {"last_edited_date": 100, "name": "a"}, "geometry": None}
+    same = {"id": "1", "attributes": {"last_edited_date": 100, "name": "changed but timestamp wins"}, "geometry": None}
+    changed = {"id": "1", "attributes": {"last_edited_date": 101, "name": "a"}, "geometry": None}
+    hashed = {"id": "2", "attributes": {"name": "hash-me"}, "geometry": {"type": "Point", "coordinates": [1, 2]}}
+    hashed_changed = {"id": "2", "attributes": {"name": "hash-me-too"}, "geometry": {"type": "Point", "coordinates": [1, 2]}}
+
+    assert detector.changed_features([first], state) == [first]
+    assert detector.changed_features([same], state) == []
+    assert detector.changed_features([changed], state) == [changed]
+    assert detector.changed_features([hashed], state) == [hashed]
+    assert detector.changed_features([hashed_changed], state) == [hashed_changed]
+
+
+def test_retrying_session_configures_timeout_and_backoff() -> None:
+    session = create_retrying_session(user_agent="poller-core-test/1", timeout=12.5, total_retries=4, backoff_factor=0.25)
+    adapter = session.get_adapter("https://")
+    retries = adapter.max_retries
+    assert session.headers["User-Agent"] == "poller-core-test/1"
+    assert getattr(session, "default_timeout") == 12.5
+    assert retries.total == 4
+    assert retries.backoff_factor == 0.25
+    assert 429 in retries.status_forcelist
+
+
+def geo_feature(identifier: str) -> Dict[str, Any]:
+    return {
+        "type": "Feature",
+        "id": f"feature-{identifier}",
+        "properties": {"guid": identifier, "value": identifier.upper()},
+        "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+    }
+
+
+@pytest.mark.live
+def test_live_arcgis_nifc_smoke() -> None:
+    poller = ArcGisFeatureServerPoller(
+        "https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer",
+        layer_id=0,
+        unique_field="IrwinID",
+        order_by_fields="OBJECTID ASC",
+        page_size=200,
+        headers={"User-Agent": "real-time-sources-poller-core-smoke/0.1"},
+    )
+    try:
+        result = poller.fetch()
+    except requests.RequestException as exc:
+        pytest.skip(f"ArcGIS live endpoint unavailable: {exc}")
+    keyed = [feature for feature in result.features if feature["id"]]
+    print(f"LIVE_ARCGIS_NIFC_FEATURE_COUNT={len(keyed)}")
+    assert keyed
+
+
+@pytest.mark.live
+def test_live_geojson_usgs_earthquakes_smoke() -> None:
+    poller = GeoJsonFeatureCollectionPoller(
+        "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson",
+        id_path="id",
+        headers={"User-Agent": "real-time-sources-poller-core-smoke/0.1"},
+    )
+    try:
+        result = poller.fetch()
+    except requests.RequestException as exc:
+        pytest.skip(f"GeoJSON live endpoint unavailable: {exc}")
+    print(f"LIVE_GEOJSON_USGS_EARTHQUAKES_FEATURE_COUNT={len(result.features)}")
+    assert result.features
+    assert all(feature["id"] for feature in result.features)


### PR DESCRIPTION
## Summary

This PR adds `feeders/_poller_core`, the first shared cross-feeder Python package in this repo. This is a structural code-reuse decision for reviewer attention: future bespoke feeders can import ArcGIS FeatureServer and GeoJSON FeatureCollection polling plumbing while keeping their own source folders, xRegistry contracts, schemas, and producers.

No current feeder imports it yet. It lands ahead of consumers per the approved B-structural plan. Intended first consumers are `nifc-usa-wildfires` and `german-waters` for ArcGIS, plus GeoJSON candidates such as USGS earthquakes / NASA EONET-style FeatureCollection sources.

## What it generalizes

Existing fetch code studied/generalized:

- `feeders/nifc-usa-wildfires`: ArcGIS FeatureServer `f=geojson`, `resultOffset`, `resultRecordCount`, `exceededTransferLimit` paging.
- `feeders/german-waters`: ArcGIS/MapServer query parameters, `outFields`, `outSR`, attributes/geometry parsing.
- `feeders/australia-wildfires`: GeoJSON FeatureCollection polling and source-specific id extraction.
- `feeders/environment-canada`: OGC API FeatureCollection offset/limit pagination.
- `feeders/eurdep-radiation`: FeatureCollection/WFS-style paging and terminal 400 pagination behavior.
- `feeders/inpe-deter-brazil`: WFS-style `startIndex`/`count` FeatureCollection paging.
- `feeders/noaa-nws`: FeatureCollection pagination through body `pagination.next` URLs.
- `feeders/bfs-odl`, `feeders/ireland-opw-waterlevel`, `feeders/usgs-geomag`: simple GeoJSON fetch-then-map and file-backed state/dedupe patterns.

## Added API

- `ArcGisFeatureServerPoller`: service/layer/query URL normalization, metadata discovery, `f=geojson` preferred with `f=json` fallback, stable id normalization, full ArcGIS paging.
- `GeoJsonFeatureCollectionPoller`: gzip JSON handling, conditional GET, offset/limit pagination, RFC 5988 `Link: rel="next"`, body next-link pagination.
- Shared helpers: retrying requests session, JSON file state store, stable feature hashing, timestamp/hash-based delta detection.

## Live smoke results

- ArcGIS: NIFC USA Wildfires FeatureServer (`https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer/0`) — 388 keyed features.
- GeoJSON: USGS all-day earthquakes (`https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson`) — 199 keyed features.

## Validation

- `python -m py_compile feeders\_poller_core\src\poller_core\__init__.py feeders\_poller_core\src\poller_core\arcgis.py feeders\_poller_core\src\poller_core\delta.py feeders\_poller_core\src\poller_core\geojson.py feeders\_poller_core\src\poller_core\http.py feeders\_poller_core\src\poller_core\models.py feeders\_poller_core\src\poller_core\state.py` — passed.
- `python -m pytest feeders\_poller_core -q` — 13 passed.
- `python -m mypy feeders --config-file mypy.ini --exclude /build/` — success, 0 errors across 1104 source files.
- `python -m pytest feeders\_poller_core -q -m live -s` — 2 passed, live counts above.
- `code-review` agent final pass — no substantive findings.

## Intentionally skipped source gates

This is a shared library, not a feeder/source. Therefore the normal source definition-of-done gates do not apply here: no xRegistry manifest, no generated producers, no Kafka/MQTT/AMQP transport apps, no Docker E2E, no `EVENTS.md`, and no xRegistry/JSON Structure/Avro expert reviews.
