### PR TITLE
ci: mirror CI base+broker images to GHCR to dodge Docker Hub rate limits

### DIFF
--- a/.github/actions/seed-images/action.yml
+++ b/.github/actions/seed-images/action.yml
@@ -1,0 +1,49 @@
+name: Seed CI images from GHCR mirror
+description: >
+  Pulls the requested third-party images from this repo's GHCR mirror and
+  retags them to their canonical Docker Hub names, so subsequent
+  `docker build` (FROM ...) and `containers.run(...)` calls resolve them from
+  the local daemon cache instead of contacting Docker Hub. Best-effort: a
+  mirror miss is logged and left to fall back to Docker Hub, so the action
+  never hard-fails CI.
+
+inputs:
+  categories:
+    description: Space-separated categories to seed (any of base mqtt amqp kafka).
+    required: true
+  token:
+    description: GITHUB_TOKEN used to authenticate to GHCR.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR (read-only)
+      shell: bash
+      run: |
+        echo "${{ inputs.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin \
+          || echo "::warning::GHCR login failed; image seeding will fall back to Docker Hub"
+
+    - name: Seed images from GHCR mirror
+      shell: bash
+      env:
+        OWNER_REPO: ${{ github.repository }}
+        WANT: ${{ inputs.categories }}
+      run: |
+        set -uo pipefail
+        list="${GITHUB_ACTION_PATH}/../../mirror-images.txt"
+        dest_prefix="ghcr.io/$(echo "$OWNER_REPO" | tr '[:upper:]' '[:lower:]')/mirror"
+        while read -r ref category _rest; do
+          case "$ref" in ''|\#*) continue ;; esac
+          case " $WANT " in *" $category "*) ;; *) continue ;; esac
+          src="${dest_prefix}/${ref}"
+          echo "::group::seed ${ref} (${category})"
+          if docker pull -q "$src" 2>/dev/null; then
+            docker tag "$src" "$ref"
+            echo "seeded ${ref} <- ${src}"
+          else
+            echo "::warning::mirror miss for ${ref}; will fall back to Docker Hub"
+          fi
+          echo "::endgroup::"
+        done < "$list"
+        exit 0

--- a/.github/mirror-images.txt
+++ b/.github/mirror-images.txt
@@ -1,0 +1,23 @@
+# Third-party container images mirrored into GHCR to insulate CI from Docker
+# Hub rate limits (100 anonymous pulls / 6h / shared runner egress IP) and
+# transient pull timeouts (registry-1.docker.io Client.Timeout).
+#
+# The "Mirror upstream images to GHCR" workflow (.github/workflows/mirror-images.yml)
+# copies each image below to:
+#     ghcr.io/<owner>/<repo>/mirror/<image>:<tag>
+# weekly. The Docker E2E shards consume the mirror via the
+# .github/actions/seed-images composite action, which retags the GHCR copy back
+# to the canonical name so `docker build` (FROM ...) and `containers.run(...)`
+# resolve it from the local daemon cache without contacting Docker Hub. The
+# Kafka broker is seeded the same way; testcontainers' KafkaFixture defaults to
+# the same canonical tag (overridable via KAFKA_TEST_IMAGE).
+#
+# Format (whitespace-separated):  <canonical-image-ref>  <category>
+# Categories: base | mqtt | amqp | kafka
+# Blank lines and lines starting with '#' are ignored.
+python:3.10-slim                       base
+python:3.11-slim                       base
+python:3.12-slim                       base
+eclipse-mosquitto:2                    mqtt
+apache/activemq-artemis:latest-alpine  amqp
+confluentinc/cp-kafka:7.6.0            kafka

--- a/.github/workflows/_docker-build-shard.yml
+++ b/.github/workflows/_docker-build-shard.yml
@@ -18,6 +18,9 @@ jobs:
     name: Docker Build & Import
     if: ${{ inputs.matrix != '' && fromJson(inputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       max-parallel: 20
@@ -25,6 +28,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Seed base images from GHCR mirror
+        uses: ./.github/actions/seed-images
+        with:
+          categories: base
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/_docker-flow-shard.yml
+++ b/.github/workflows/_docker-flow-shard.yml
@@ -21,6 +21,9 @@ jobs:
     name: Docker Kafka Flow
     if: ${{ inputs.matrix != '' && fromJson(inputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       max-parallel: 20
@@ -28,6 +31,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Seed broker + base images from GHCR mirror
+        uses: ./.github/actions/seed-images
+        with:
+          # Seed the base images every job needs plus only this job's broker
+          # (kafka for the default/Kafka flow, otherwise mqtt or amqp).
+          categories: base ${{ contains(matrix.test_file, 'mqtt') && 'mqtt' || contains(matrix.test_file, 'amqp') && 'amqp' || 'kafka' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -55,3 +66,8 @@ jobs:
         timeout-minutes: 45
         env:
           WSDOT_ACCESS_CODE: ${{ secrets.WSDOT_ACCESS_CODE }}
+          # CI containers are ephemeral; skip the Ryuk reaper and its Hub pull.
+          # The Kafka broker itself is seeded from the GHCR mirror above and
+          # retagged to its canonical name, so testcontainers resolves it from
+          # the local cache; a mirror miss falls back to Docker Hub.
+          TESTCONTAINERS_RYUK_DISABLED: "true"

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -131,6 +131,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+        with:
+          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
@@ -234,6 +239,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+        with:
+          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,61 @@
+name: Mirror upstream images to GHCR
+
+# Periodically copies the third-party images CI depends on (Python base images
+# and the Kafka / MQTT / AMQP test brokers) from Docker Hub into this repo's
+# GHCR namespace, so the Docker E2E build/flow shards never hit Docker Hub rate
+# limits or transient pull timeouts. The image list lives in
+# .github/mirror-images.txt -- the single source of truth shared with the
+# .github/actions/seed-images composite action that consumes the mirror.
+
+on:
+  schedule:
+    # Weekly, Mondays 05:00 UTC -- an hour before the weekly full Docker E2E run.
+    - cron: '0 5 * * 1'
+  workflow_dispatch: {}
+
+concurrency:
+  group: mirror-images
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    name: Copy images to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Copy each image to the GHCR mirror
+        env:
+          OWNER_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          dest_prefix="ghcr.io/$(echo "$OWNER_REPO" | tr '[:upper:]' '[:lower:]')/mirror"
+          fail=0
+          while read -r ref category _rest; do
+            case "$ref" in ''|\#*) continue ;; esac
+            dst="${dest_prefix}/${ref}"
+            echo "::group::mirror ${ref} (${category}) -> ${dst}"
+            if docker buildx imagetools create --tag "$dst" "$ref"; then
+              echo "OK  ${ref} -> ${dst}"
+            else
+              echo "::error::failed to mirror ${ref}"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done < .github/mirror-images.txt
+          exit $fail

--- a/tests/docker_e2e/helpers.py
+++ b/tests/docker_e2e/helpers.py
@@ -29,6 +29,11 @@ from testcontainers.kafka import KafkaContainer
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 FEEDERS_ROOT = os.path.join(REPO_ROOT, 'feeders')
 
+# Kafka broker image for the test container. Overridable via KAFKA_TEST_IMAGE so
+# CI can point testcontainers at the GHCR mirror (avoiding Docker Hub rate
+# limits); local runs fall back to the canonical Docker Hub tag.
+KAFKA_TEST_IMAGE = os.environ.get('KAFKA_TEST_IMAGE', 'confluentinc/cp-kafka:7.6.0')
+
 
 def _resolve_project_dir(project_dir: str) -> str:
     """Resolve a project directory name to an absolute path.
@@ -181,7 +186,7 @@ class KafkaFixture:
         self._kafka_ip: Optional[str] = None
 
     def start(self) -> 'KafkaFixture':
-        self._kafka = KafkaContainer()
+        self._kafka = KafkaContainer(KAFKA_TEST_IMAGE)
         self._kafka.start()
         wrapped = self._kafka.get_wrapped_container()
         wrapped.reload()

--- a/tests/docker_e2e/requirements.txt
+++ b/tests/docker_e2e/requirements.txt
@@ -1,6 +1,6 @@
 docker
 confluent-kafka
-testcontainers[kafka]
+testcontainers[kafka]>=4.7,<5
 json-structure>=0.6.1
 paho-mqtt>=2.1.0
 python-qpid-proton>=0.40.0


### PR DESCRIPTION
## Why

The Docker E2E **build** and **flow** shards pull `python:*-slim` base images
plus the Kafka / MQTT / AMQP test brokers from Docker Hub on every job. Across
the fleet-scale matrix (100+ feeders, sharded, highly parallel) these anonymous
pulls share GitHub's runner egress IPs and routinely hit Docker Hub's
**100-pull / 6h rate limit** and transient `registry-1.docker.io` timeouts —
the `C-DOCKER-FLAKE` base-image pull failures seen on the fleet run.

## What

Mirror the handful of third-party images CI depends on into **GHCR** weekly and
consume them from there.

| Image | Category | Consumed by |
|-------|----------|-------------|
| `python:3.10-slim`, `python:3.11-slim`, `python:3.12-slim` | `base` | `docker build` (FROM) in both shards |
| `eclipse-mosquitto:2` | `mqtt` | MQTT flow tests (`containers.run`) |
| `apache/activemq-artemis:latest-alpine` | `amqp` | AMQP flow tests (`containers.run`) |
| `confluentinc/cp-kafka:7.6.0` | `kafka` | testcontainers `KafkaFixture` |

- **`.github/mirror-images.txt`** — single source of truth (image + category),
  shared by the mirror workflow and the seed action.
- **`.github/workflows/mirror-images.yml`** — weekly (Mon 05:00 UTC) + manual;
  copies each image to `ghcr.io/<owner>/<repo>/mirror/<img>` via
  `docker buildx imagetools create` (registry-to-registry, multi-arch, no local
  pull).
- **`.github/actions/seed-images`** — composite action that pulls the mirror
  copy and **retags it to the canonical Hub name**, so `docker build` and
  `containers.run` resolve it from the local daemon cache without touching Hub.
  Best-effort with graceful Hub fallback — **never hard-fails CI**.
- **`_docker-build-shard.yml`** seeds `base`; **`_docker-flow-shard.yml`** seeds
  `base` plus only the job's own broker (`kafka`/`mqtt`/`amqp`) and disables the
  Ryuk reaper (and its Hub pull). Every image — Kafka included — is retagged to
  its canonical name, so a mirror miss falls back to Docker Hub.
- **`helpers.py`** — `KafkaFixture` reads `KAFKA_TEST_IMAGE` (default: canonical
  Hub tag for local runs).
- **`requirements.txt`** — pin `testcontainers[kafka] >=4.7,<5`, closing the
  unpinned-dependency drift that made the implicit Kafka tag non-reproducible.
- **`build_containers.yml`** — pin the buildx **buildkit bootstrap** image to the
  GCR pull-through mirror via
  `driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1` on both *Set
  up Docker Buildx* steps. The `docker-container` driver boots `moby/buildkit`
  from `registry-1.docker.io` **before any build step runs**, so the daemon
  registry-mirror doesn't cover it — that bootstrap pull was timing out on the
  `build-base` shards (e.g. `hko-hong-kong`). `mirror.gcr.io` serves the image
  anonymously with no rate limit; validated end-to-end locally. **Also** set
  `buildkitd-config-inline` on both *Set up Docker Buildx* steps so BuildKit
  itself mirrors `docker.io` → `mirror.gcr.io` (`[registry."docker.io"]
  mirrors`). (The pinned `setup-buildx-action` renamed `config-inline` →
  `buildkitd-config-inline`; the old name is silently ignored.)
  The `/etc/docker/daemon.json` registry-mirror only affects the host dockerd,
  **not** buildx's `docker-container` driver, so `FROM python:3.10-slim` was
  still resolved against `registry-1.docker.io` and timed out **at build time**
  (observed on `vatsim` + `irceline-belgium` base shards and `tfl-road-traffic`
  + `syke-hydro` AMQP transport shards). With the BuildKit registry mirror the
  base-image manifest comes from the GCR pull-through cache — no build step
  touches Docker Hub.

## Rollout is order-independent

Until the mirror workflow first populates GHCR, the seed steps log a miss and
fall back to Docker Hub (today's behavior). After the first mirror run, CI stops
touching Docker Hub for these images. To activate immediately after merge:
**Actions → "Mirror upstream images to GHCR" → Run workflow**.

## Notes

- GHCR packages are created **private**; the seed action authenticates with the
  default `GITHUB_TOKEN` (`packages: read`). Optionally flip the `mirror/*`
  packages to public to drop even that login.
- Orthogonal to #1463 (CI enforcement gates) — zero file overlap.
