### PR TITLE
fix(jma-bosai-amedas): distinct names for Station/Observation event enums (codegen collision + routing fix)

### DIFF
--- a/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
@@ -246,8 +246,8 @@ def parse_observation(station_code: str, payload: dict[str, Any], observed_at_lo
         prefecture=prefecture_for_station(station_code),
         event=ObservationEventEnum.observation,
         station_code=station_code,
-        observed_at=datetime.fromisoformat(utc.isoformat().replace("+00:00", "Z")),
-        observed_at_local=datetime.fromisoformat(observed_at_local.isoformat()),
+        observed_at=utc,
+        observed_at_local=observed_at_local,
         **values,
     )
 
@@ -318,7 +318,7 @@ class JmaBosaiAmedasAPI:
         if not text:
             return None
         try:
-            return datetime.fromisoformat(text)
+            return datetime.fromisoformat(text.strip().replace("Z", "+00:00"))
         except ValueError as exc:
             logging.warning("Could not parse latest_time.txt value %r: %s", text, exc)
             return None

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas/jma_bosai_amedas.py
@@ -19,7 +19,8 @@ from confluent_kafka import Producer
 
 from jma_bosai_amedas_producer_data.jp.jma.amedas.observation import Observation
 from jma_bosai_amedas_producer_data.jp.jma.amedas.station import Station
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 try:
     from jma_bosai_amedas_producer_kafka_producer.producer import JPJMAAmedasEventProducer
 except ModuleNotFoundError:
@@ -183,7 +184,7 @@ def _measurement_kwargs() -> dict[str, Any]:
 def parse_station(station_code: str, payload: dict[str, Any]) -> Station:
     return Station(
         prefecture=prefecture_for_station(station_code),
-        event=EventEnum("info"),
+        event=StationEventEnum.info,
         station_code=station_code,
         kj_name=payload.get("kjName", ""),
         kana=payload.get("kana") or payload.get("knName", ""),
@@ -243,7 +244,7 @@ def parse_observation(station_code: str, payload: dict[str, Any], observed_at_lo
     utc = observed_at_local.astimezone(timezone.utc)
     return Observation(
         prefecture=prefecture_for_station(station_code),
-        event=EventEnum("info"),
+        event=ObservationEventEnum.observation,
         station_code=station_code,
         observed_at=datetime.fromisoformat(utc.isoformat().replace("+00:00", "Z")),
         observed_at_local=datetime.fromisoformat(observed_at_local.isoformat()),

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .jp import EventEnum, Observation, StationTypeenum, Station
+from .jp import StationTypeenum, StationEventEnum, Station, ObservationEventEnum, Observation
 
-__all__ = ["EventEnum", "Observation", "StationTypeenum", "Station"]
+__all__ = ["StationTypeenum", "StationEventEnum", "Station", "ObservationEventEnum", "Observation"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/__init__.py
@@ -1,3 +1,3 @@
-from .jma import EventEnum, Observation, StationTypeenum, Station
+from .jma import StationTypeenum, StationEventEnum, Station, ObservationEventEnum, Observation
 
-__all__ = ["EventEnum", "Observation", "StationTypeenum", "Station"]
+__all__ = ["StationTypeenum", "StationEventEnum", "Station", "ObservationEventEnum", "Observation"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/__init__.py
@@ -1,3 +1,3 @@
-from .amedas import EventEnum, Observation, StationTypeenum, Station
+from .amedas import StationTypeenum, StationEventEnum, Station, ObservationEventEnum, Observation
 
-__all__ = ["EventEnum", "Observation", "StationTypeenum", "Station"]
+__all__ = ["StationTypeenum", "StationEventEnum", "Station", "ObservationEventEnum", "Observation"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/__init__.py
@@ -1,6 +1,7 @@
-from .eventenum import EventEnum
-from .observation import Observation
 from .stationtypeenum import StationTypeenum
+from .stationeventenum import StationEventEnum
 from .station import Station
+from .observationeventenum import ObservationEventEnum
+from .observation import Observation
 
-__all__ = ["EventEnum", "Observation", "StationTypeenum", "Station"]
+__all__ = ["StationTypeenum", "StationEventEnum", "Station", "ObservationEventEnum", "Observation"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/observation.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -75,7 +75,7 @@ class Observation:
         weather (typing.Optional[float])
         weather_qc_flag (typing.Optional[int])
         prefecture (str)
-        event (EventEnum)
+        event (ObservationEventEnum)
     """
     
     
@@ -131,7 +131,7 @@ class Observation:
     weather: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather"))
     weather_qc_flag: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather_qc_flag"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: ObservationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Observation':
@@ -260,57 +260,57 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='thsiecgpvpkjflrhgyxj',
+            station_code='dyzwxdqfyxchfuplxzqz',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(42.27657990761908),
-            temp_qc_flag=int(92),
-            humidity=float(29.786285655412993),
-            humidity_qc_flag=int(91),
-            pressure=float(43.88308316303253),
-            pressure_qc_flag=int(0),
-            normal_pressure=float(36.06101429537374),
-            normal_pressure_qc_flag=int(86),
-            wind_speed=float(76.19619847511721),
-            wind_speed_qc_flag=int(51),
-            wind_direction=float(14.931818292305564),
-            wind_direction_qc_flag=int(54),
-            wind_gust=float(27.45661497985361),
-            wind_gust_qc_flag=int(16),
-            wind_gust_direction=float(55.480236932212875),
+            temp=float(26.120468748978876),
+            temp_qc_flag=int(38),
+            humidity=float(84.16824925759275),
+            humidity_qc_flag=int(28),
+            pressure=float(3.286051109640775),
+            pressure_qc_flag=int(55),
+            normal_pressure=float(7.872044872880579),
+            normal_pressure_qc_flag=int(2),
+            wind_speed=float(72.3617312864713),
+            wind_speed_qc_flag=int(49),
+            wind_direction=float(65.78773443732919),
+            wind_direction_qc_flag=int(80),
+            wind_gust=float(76.47197236636293),
+            wind_gust_qc_flag=int(100),
+            wind_gust_direction=float(60.86237199503736),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(37.476860385682556),
+            max_temp=float(73.44595475574788),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(80.0181504859434),
+            min_temp=float(80.32624047620158),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(73.3786400815131),
-            precipitation10m_qc_flag=int(66),
-            precipitation1h=float(43.719338236506466),
-            precipitation1h_qc_flag=int(96),
-            precipitation3h=float(12.0447676798623),
-            precipitation3h_qc_flag=int(12),
-            precipitation24h=float(1.8569469505839598),
-            precipitation24h_qc_flag=int(71),
-            sun10m=float(49.0700282507682),
-            sun10m_qc_flag=int(0),
-            sun1h=float(13.54277815371363),
-            sun1h_qc_flag=int(48),
-            snow=float(98.42043431737146),
-            snow_qc_flag=int(53),
-            snow1h=float(67.31999832023011),
-            snow1h_qc_flag=int(18),
-            snow6h=float(2.4574009341924663),
-            snow6h_qc_flag=int(31),
-            snow12h=float(33.99724173763119),
-            snow12h_qc_flag=int(20),
-            snow24h=float(10.948427640864633),
-            snow24h_qc_flag=int(57),
-            visibility=float(52.19764763725249),
-            visibility_qc_flag=int(77),
-            cloud=float(54.61594693004472),
-            cloud_qc_flag=int(2),
-            weather=float(40.5860763376991),
-            weather_qc_flag=int(6),
-            prefecture='bxorpqipzjqrruxnegmi',
-            event=EventEnum.observation
+            precipitation10m=float(90.90829072732306),
+            precipitation10m_qc_flag=int(82),
+            precipitation1h=float(57.524985152182495),
+            precipitation1h_qc_flag=int(79),
+            precipitation3h=float(88.88439441799942),
+            precipitation3h_qc_flag=int(21),
+            precipitation24h=float(27.70874100120013),
+            precipitation24h_qc_flag=int(78),
+            sun10m=float(12.224805196580634),
+            sun10m_qc_flag=int(9),
+            sun1h=float(57.74262415650844),
+            sun1h_qc_flag=int(32),
+            snow=float(84.8252167750316),
+            snow_qc_flag=int(66),
+            snow1h=float(73.34151298650671),
+            snow1h_qc_flag=int(89),
+            snow6h=float(48.02134457930271),
+            snow6h_qc_flag=int(24),
+            snow12h=float(56.49469592744355),
+            snow12h_qc_flag=int(84),
+            snow24h=float(12.805664620263336),
+            snow24h_qc_flag=int(94),
+            visibility=float(10.654270615760863),
+            visibility_qc_flag=int(8),
+            cloud=float(53.168051314754806),
+            cloud_qc_flag=int(50),
+            weather=float(53.70579634378151),
+            weather_qc_flag=int(2),
+            prefecture='fmkufclxmnqvwdfoivzq',
+            event=ObservationEventEnum.observation
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/observationeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class ObservationEventEnum(Enum):
     """
     Fixed topic event segment for Observation messages.
     """
     observation = 'observation'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'ObservationEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'ObservationEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (ObservationEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/station.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
-from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.eventenum import EventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -33,7 +33,7 @@ class Station:
         elems_bitmask (str)
         enabled_measurements (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (StationEventEnum)
     """
     
     
@@ -48,7 +48,7 @@ class Station:
     elems_bitmask: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elems_bitmask"))
     enabled_measurements: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="enabled_measurements"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: StationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Station':
@@ -177,16 +177,16 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_code='sjesrgkldxmklhwtnkcv',
-            kj_name='jnjqhtjoujqpkmlewbow',
-            kana='ygxfxbybpzmzficgpsqf',
-            en_name='yubzcbiztdqsxmimejag',
-            latitude=float(4.601361908298795),
-            longitude=float(7.287959458320392),
-            altitude_m=float(78.83118013298038),
+            station_code='dkpjeldkbgwekvgjntdl',
+            kj_name='ewhndkscsvakxpeyznul',
+            kana='hcluqeejxxmatnhwzcvf',
+            en_name='hukmrpmiyjqgifpudhbi',
+            latitude=float(44.32343959279335),
+            longitude=float(29.24034534772275),
+            altitude_m=float(12.55328726680698),
             station_type=StationTypeenum.A,
-            elems_bitmask='uibuouoqxvicbtyhtyzj',
-            enabled_measurements=['dnxidbzspjhuanxxihmm', 'bhpoqqfcwehrdwudeydg', 'gcgonbuqfrjjdodmrakn', 'suiyozzwvqhuceqsgvlw'],
-            prefecture='nlqwavkfzocgfoztevzo',
-            event=EventEnum.observation
+            elems_bitmask='qpqlumxbbifghjppwcgq',
+            enabled_measurements=['kprevcwgkyneqphwomki', 'tdbifbhkewilambnjhdl', 'jwthfwdcqshgqpbgpjrw', 'cfmplnqtpkxvskzsavxl'],
+            prefecture='nimkzkdqcjfsylqdywjf',
+            event=StationEventEnum.info
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/src/jma_bosai_amedas_amqp_producer_data/jp/jma/amedas/stationeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class StationEventEnum(Enum):
+    """
+    Fixed topic event segment for Station messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StationEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StationEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StationEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_observation.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.observation import Observation
-from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -30,59 +30,59 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            station_code='thsiecgpvpkjflrhgyxj',
+            station_code='dyzwxdqfyxchfuplxzqz',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(42.27657990761908),
-            temp_qc_flag=int(92),
-            humidity=float(29.786285655412993),
-            humidity_qc_flag=int(91),
-            pressure=float(43.88308316303253),
-            pressure_qc_flag=int(0),
-            normal_pressure=float(36.06101429537374),
-            normal_pressure_qc_flag=int(86),
-            wind_speed=float(76.19619847511721),
-            wind_speed_qc_flag=int(51),
-            wind_direction=float(14.931818292305564),
-            wind_direction_qc_flag=int(54),
-            wind_gust=float(27.45661497985361),
-            wind_gust_qc_flag=int(16),
-            wind_gust_direction=float(55.480236932212875),
+            temp=float(26.120468748978876),
+            temp_qc_flag=int(38),
+            humidity=float(84.16824925759275),
+            humidity_qc_flag=int(28),
+            pressure=float(3.286051109640775),
+            pressure_qc_flag=int(55),
+            normal_pressure=float(7.872044872880579),
+            normal_pressure_qc_flag=int(2),
+            wind_speed=float(72.3617312864713),
+            wind_speed_qc_flag=int(49),
+            wind_direction=float(65.78773443732919),
+            wind_direction_qc_flag=int(80),
+            wind_gust=float(76.47197236636293),
+            wind_gust_qc_flag=int(100),
+            wind_gust_direction=float(60.86237199503736),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(37.476860385682556),
+            max_temp=float(73.44595475574788),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(80.0181504859434),
+            min_temp=float(80.32624047620158),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(73.3786400815131),
-            precipitation10m_qc_flag=int(66),
-            precipitation1h=float(43.719338236506466),
-            precipitation1h_qc_flag=int(96),
-            precipitation3h=float(12.0447676798623),
-            precipitation3h_qc_flag=int(12),
-            precipitation24h=float(1.8569469505839598),
-            precipitation24h_qc_flag=int(71),
-            sun10m=float(49.0700282507682),
-            sun10m_qc_flag=int(0),
-            sun1h=float(13.54277815371363),
-            sun1h_qc_flag=int(48),
-            snow=float(98.42043431737146),
-            snow_qc_flag=int(53),
-            snow1h=float(67.31999832023011),
-            snow1h_qc_flag=int(18),
-            snow6h=float(2.4574009341924663),
-            snow6h_qc_flag=int(31),
-            snow12h=float(33.99724173763119),
-            snow12h_qc_flag=int(20),
-            snow24h=float(10.948427640864633),
-            snow24h_qc_flag=int(57),
-            visibility=float(52.19764763725249),
-            visibility_qc_flag=int(77),
-            cloud=float(54.61594693004472),
-            cloud_qc_flag=int(2),
-            weather=float(40.5860763376991),
-            weather_qc_flag=int(6),
-            prefecture='bxorpqipzjqrruxnegmi',
-            event=EventEnum.observation
+            precipitation10m=float(90.90829072732306),
+            precipitation10m_qc_flag=int(82),
+            precipitation1h=float(57.524985152182495),
+            precipitation1h_qc_flag=int(79),
+            precipitation3h=float(88.88439441799942),
+            precipitation3h_qc_flag=int(21),
+            precipitation24h=float(27.70874100120013),
+            precipitation24h_qc_flag=int(78),
+            sun10m=float(12.224805196580634),
+            sun10m_qc_flag=int(9),
+            sun1h=float(57.74262415650844),
+            sun1h_qc_flag=int(32),
+            snow=float(84.8252167750316),
+            snow_qc_flag=int(66),
+            snow1h=float(73.34151298650671),
+            snow1h_qc_flag=int(89),
+            snow6h=float(48.02134457930271),
+            snow6h_qc_flag=int(24),
+            snow12h=float(56.49469592744355),
+            snow12h_qc_flag=int(84),
+            snow24h=float(12.805664620263336),
+            snow24h_qc_flag=int(94),
+            visibility=float(10.654270615760863),
+            visibility_qc_flag=int(8),
+            cloud=float(53.168051314754806),
+            cloud_qc_flag=int(50),
+            weather=float(53.70579634378151),
+            weather_qc_flag=int(2),
+            prefecture='fmkufclxmnqvwdfoivzq',
+            event=ObservationEventEnum.observation
         )
         return instance
 
@@ -91,7 +91,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'thsiecgpvpkjflrhgyxj'
+        test_value = 'dyzwxdqfyxchfuplxzqz'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp property
         """
-        test_value = float(42.27657990761908)
+        test_value = float(26.120468748978876)
         self.instance.temp = test_value
         self.assertEqual(self.instance.temp, test_value)
     
@@ -123,7 +123,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp_qc_flag property
         """
-        test_value = int(92)
+        test_value = int(38)
         self.instance.temp_qc_flag = test_value
         self.assertEqual(self.instance.temp_qc_flag, test_value)
     
@@ -131,7 +131,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(29.786285655412993)
+        test_value = float(84.16824925759275)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -139,7 +139,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity_qc_flag property
         """
-        test_value = int(91)
+        test_value = int(28)
         self.instance.humidity_qc_flag = test_value
         self.assertEqual(self.instance.humidity_qc_flag, test_value)
     
@@ -147,7 +147,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(43.88308316303253)
+        test_value = float(3.286051109640775)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -155,7 +155,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure_qc_flag property
         """
-        test_value = int(0)
+        test_value = int(55)
         self.instance.pressure_qc_flag = test_value
         self.assertEqual(self.instance.pressure_qc_flag, test_value)
     
@@ -163,7 +163,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure property
         """
-        test_value = float(36.06101429537374)
+        test_value = float(7.872044872880579)
         self.instance.normal_pressure = test_value
         self.assertEqual(self.instance.normal_pressure, test_value)
     
@@ -171,7 +171,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure_qc_flag property
         """
-        test_value = int(86)
+        test_value = int(2)
         self.instance.normal_pressure_qc_flag = test_value
         self.assertEqual(self.instance.normal_pressure_qc_flag, test_value)
     
@@ -179,7 +179,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(76.19619847511721)
+        test_value = float(72.3617312864713)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -187,7 +187,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed_qc_flag property
         """
-        test_value = int(51)
+        test_value = int(49)
         self.instance.wind_speed_qc_flag = test_value
         self.assertEqual(self.instance.wind_speed_qc_flag, test_value)
     
@@ -195,7 +195,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(14.931818292305564)
+        test_value = float(65.78773443732919)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -203,7 +203,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction_qc_flag property
         """
-        test_value = int(54)
+        test_value = int(80)
         self.instance.wind_direction_qc_flag = test_value
         self.assertEqual(self.instance.wind_direction_qc_flag, test_value)
     
@@ -211,7 +211,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust property
         """
-        test_value = float(27.45661497985361)
+        test_value = float(76.47197236636293)
         self.instance.wind_gust = test_value
         self.assertEqual(self.instance.wind_gust, test_value)
     
@@ -219,7 +219,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_qc_flag property
         """
-        test_value = int(16)
+        test_value = int(100)
         self.instance.wind_gust_qc_flag = test_value
         self.assertEqual(self.instance.wind_gust_qc_flag, test_value)
     
@@ -227,7 +227,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_direction property
         """
-        test_value = float(55.480236932212875)
+        test_value = float(60.86237199503736)
         self.instance.wind_gust_direction = test_value
         self.assertEqual(self.instance.wind_gust_direction, test_value)
     
@@ -243,7 +243,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test max_temp property
         """
-        test_value = float(37.476860385682556)
+        test_value = float(73.44595475574788)
         self.instance.max_temp = test_value
         self.assertEqual(self.instance.max_temp, test_value)
     
@@ -259,7 +259,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test min_temp property
         """
-        test_value = float(80.0181504859434)
+        test_value = float(80.32624047620158)
         self.instance.min_temp = test_value
         self.assertEqual(self.instance.min_temp, test_value)
     
@@ -275,7 +275,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m property
         """
-        test_value = float(73.3786400815131)
+        test_value = float(90.90829072732306)
         self.instance.precipitation10m = test_value
         self.assertEqual(self.instance.precipitation10m, test_value)
     
@@ -283,7 +283,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m_qc_flag property
         """
-        test_value = int(66)
+        test_value = int(82)
         self.instance.precipitation10m_qc_flag = test_value
         self.assertEqual(self.instance.precipitation10m_qc_flag, test_value)
     
@@ -291,7 +291,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h property
         """
-        test_value = float(43.719338236506466)
+        test_value = float(57.524985152182495)
         self.instance.precipitation1h = test_value
         self.assertEqual(self.instance.precipitation1h, test_value)
     
@@ -299,7 +299,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h_qc_flag property
         """
-        test_value = int(96)
+        test_value = int(79)
         self.instance.precipitation1h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation1h_qc_flag, test_value)
     
@@ -307,7 +307,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h property
         """
-        test_value = float(12.0447676798623)
+        test_value = float(88.88439441799942)
         self.instance.precipitation3h = test_value
         self.assertEqual(self.instance.precipitation3h, test_value)
     
@@ -315,7 +315,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h_qc_flag property
         """
-        test_value = int(12)
+        test_value = int(21)
         self.instance.precipitation3h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation3h_qc_flag, test_value)
     
@@ -323,7 +323,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h property
         """
-        test_value = float(1.8569469505839598)
+        test_value = float(27.70874100120013)
         self.instance.precipitation24h = test_value
         self.assertEqual(self.instance.precipitation24h, test_value)
     
@@ -331,7 +331,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h_qc_flag property
         """
-        test_value = int(71)
+        test_value = int(78)
         self.instance.precipitation24h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation24h_qc_flag, test_value)
     
@@ -339,7 +339,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun10m property
         """
-        test_value = float(49.0700282507682)
+        test_value = float(12.224805196580634)
         self.instance.sun10m = test_value
         self.assertEqual(self.instance.sun10m, test_value)
     
@@ -347,7 +347,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun10m_qc_flag property
         """
-        test_value = int(0)
+        test_value = int(9)
         self.instance.sun10m_qc_flag = test_value
         self.assertEqual(self.instance.sun10m_qc_flag, test_value)
     
@@ -355,7 +355,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h property
         """
-        test_value = float(13.54277815371363)
+        test_value = float(57.74262415650844)
         self.instance.sun1h = test_value
         self.assertEqual(self.instance.sun1h, test_value)
     
@@ -363,7 +363,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h_qc_flag property
         """
-        test_value = int(48)
+        test_value = int(32)
         self.instance.sun1h_qc_flag = test_value
         self.assertEqual(self.instance.sun1h_qc_flag, test_value)
     
@@ -371,7 +371,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow property
         """
-        test_value = float(98.42043431737146)
+        test_value = float(84.8252167750316)
         self.instance.snow = test_value
         self.assertEqual(self.instance.snow, test_value)
     
@@ -379,7 +379,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow_qc_flag property
         """
-        test_value = int(53)
+        test_value = int(66)
         self.instance.snow_qc_flag = test_value
         self.assertEqual(self.instance.snow_qc_flag, test_value)
     
@@ -387,7 +387,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h property
         """
-        test_value = float(67.31999832023011)
+        test_value = float(73.34151298650671)
         self.instance.snow1h = test_value
         self.assertEqual(self.instance.snow1h, test_value)
     
@@ -395,7 +395,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h_qc_flag property
         """
-        test_value = int(18)
+        test_value = int(89)
         self.instance.snow1h_qc_flag = test_value
         self.assertEqual(self.instance.snow1h_qc_flag, test_value)
     
@@ -403,7 +403,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h property
         """
-        test_value = float(2.4574009341924663)
+        test_value = float(48.02134457930271)
         self.instance.snow6h = test_value
         self.assertEqual(self.instance.snow6h, test_value)
     
@@ -411,7 +411,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h_qc_flag property
         """
-        test_value = int(31)
+        test_value = int(24)
         self.instance.snow6h_qc_flag = test_value
         self.assertEqual(self.instance.snow6h_qc_flag, test_value)
     
@@ -419,7 +419,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h property
         """
-        test_value = float(33.99724173763119)
+        test_value = float(56.49469592744355)
         self.instance.snow12h = test_value
         self.assertEqual(self.instance.snow12h, test_value)
     
@@ -427,7 +427,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h_qc_flag property
         """
-        test_value = int(20)
+        test_value = int(84)
         self.instance.snow12h_qc_flag = test_value
         self.assertEqual(self.instance.snow12h_qc_flag, test_value)
     
@@ -435,7 +435,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h property
         """
-        test_value = float(10.948427640864633)
+        test_value = float(12.805664620263336)
         self.instance.snow24h = test_value
         self.assertEqual(self.instance.snow24h, test_value)
     
@@ -443,7 +443,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h_qc_flag property
         """
-        test_value = int(57)
+        test_value = int(94)
         self.instance.snow24h_qc_flag = test_value
         self.assertEqual(self.instance.snow24h_qc_flag, test_value)
     
@@ -451,7 +451,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility property
         """
-        test_value = float(52.19764763725249)
+        test_value = float(10.654270615760863)
         self.instance.visibility = test_value
         self.assertEqual(self.instance.visibility, test_value)
     
@@ -459,7 +459,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility_qc_flag property
         """
-        test_value = int(77)
+        test_value = int(8)
         self.instance.visibility_qc_flag = test_value
         self.assertEqual(self.instance.visibility_qc_flag, test_value)
     
@@ -467,7 +467,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud property
         """
-        test_value = float(54.61594693004472)
+        test_value = float(53.168051314754806)
         self.instance.cloud = test_value
         self.assertEqual(self.instance.cloud, test_value)
     
@@ -475,7 +475,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud_qc_flag property
         """
-        test_value = int(2)
+        test_value = int(50)
         self.instance.cloud_qc_flag = test_value
         self.assertEqual(self.instance.cloud_qc_flag, test_value)
     
@@ -483,7 +483,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather property
         """
-        test_value = float(40.5860763376991)
+        test_value = float(53.70579634378151)
         self.instance.weather = test_value
         self.assertEqual(self.instance.weather, test_value)
     
@@ -491,7 +491,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather_qc_flag property
         """
-        test_value = int(6)
+        test_value = int(2)
         self.instance.weather_qc_flag = test_value
         self.assertEqual(self.instance.weather_qc_flag, test_value)
     
@@ -499,7 +499,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'bxorpqipzjqrruxnegmi'
+        test_value = 'fmkufclxmnqvwdfoivzq'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -507,7 +507,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.observation
+        test_value = ObservationEventEnum.observation
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_observationeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
+
+
+class Test_ObservationEventEnum(unittest.TestCase):
+    """
+    Test case for ObservationEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = ObservationEventEnum.observation
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of ObservationEventEnum
+        """
+        return ObservationEventEnum.observation
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(ObservationEventEnum.observation.value, 'observation')

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_station.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.station import Station
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
-from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.eventenum import EventEnum
 
 
 class Test_Station(unittest.TestCase):
@@ -30,18 +30,18 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_code='sjesrgkldxmklhwtnkcv',
-            kj_name='jnjqhtjoujqpkmlewbow',
-            kana='ygxfxbybpzmzficgpsqf',
-            en_name='yubzcbiztdqsxmimejag',
-            latitude=float(4.601361908298795),
-            longitude=float(7.287959458320392),
-            altitude_m=float(78.83118013298038),
+            station_code='dkpjeldkbgwekvgjntdl',
+            kj_name='ewhndkscsvakxpeyznul',
+            kana='hcluqeejxxmatnhwzcvf',
+            en_name='hukmrpmiyjqgifpudhbi',
+            latitude=float(44.32343959279335),
+            longitude=float(29.24034534772275),
+            altitude_m=float(12.55328726680698),
             station_type=StationTypeenum.A,
-            elems_bitmask='uibuouoqxvicbtyhtyzj',
-            enabled_measurements=['dnxidbzspjhuanxxihmm', 'bhpoqqfcwehrdwudeydg', 'gcgonbuqfrjjdodmrakn', 'suiyozzwvqhuceqsgvlw'],
-            prefecture='nlqwavkfzocgfoztevzo',
-            event=EventEnum.observation
+            elems_bitmask='qpqlumxbbifghjppwcgq',
+            enabled_measurements=['kprevcwgkyneqphwomki', 'tdbifbhkewilambnjhdl', 'jwthfwdcqshgqpbgpjrw', 'cfmplnqtpkxvskzsavxl'],
+            prefecture='nimkzkdqcjfsylqdywjf',
+            event=StationEventEnum.info
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'sjesrgkldxmklhwtnkcv'
+        test_value = 'dkpjeldkbgwekvgjntdl'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -58,7 +58,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kj_name property
         """
-        test_value = 'jnjqhtjoujqpkmlewbow'
+        test_value = 'ewhndkscsvakxpeyznul'
         self.instance.kj_name = test_value
         self.assertEqual(self.instance.kj_name, test_value)
     
@@ -66,7 +66,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kana property
         """
-        test_value = 'ygxfxbybpzmzficgpsqf'
+        test_value = 'hcluqeejxxmatnhwzcvf'
         self.instance.kana = test_value
         self.assertEqual(self.instance.kana, test_value)
     
@@ -74,7 +74,7 @@ class Test_Station(unittest.TestCase):
         """
         Test en_name property
         """
-        test_value = 'yubzcbiztdqsxmimejag'
+        test_value = 'hukmrpmiyjqgifpudhbi'
         self.instance.en_name = test_value
         self.assertEqual(self.instance.en_name, test_value)
     
@@ -82,7 +82,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(4.601361908298795)
+        test_value = float(44.32343959279335)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -90,7 +90,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(7.287959458320392)
+        test_value = float(29.24034534772275)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -98,7 +98,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude_m property
         """
-        test_value = float(78.83118013298038)
+        test_value = float(12.55328726680698)
         self.instance.altitude_m = test_value
         self.assertEqual(self.instance.altitude_m, test_value)
     
@@ -114,7 +114,7 @@ class Test_Station(unittest.TestCase):
         """
         Test elems_bitmask property
         """
-        test_value = 'uibuouoqxvicbtyhtyzj'
+        test_value = 'qpqlumxbbifghjppwcgq'
         self.instance.elems_bitmask = test_value
         self.assertEqual(self.instance.elems_bitmask, test_value)
     
@@ -122,7 +122,7 @@ class Test_Station(unittest.TestCase):
         """
         Test enabled_measurements property
         """
-        test_value = ['dnxidbzspjhuanxxihmm', 'bhpoqqfcwehrdwudeydg', 'gcgonbuqfrjjdodmrakn', 'suiyozzwvqhuceqsgvlw']
+        test_value = ['kprevcwgkyneqphwomki', 'tdbifbhkewilambnjhdl', 'jwthfwdcqshgqpbgpjrw', 'cfmplnqtpkxvskzsavxl']
         self.instance.enabled_measurements = test_value
         self.assertEqual(self.instance.enabled_measurements, test_value)
     
@@ -130,7 +130,7 @@ class Test_Station(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'nlqwavkfzocgfoztevzo'
+        test_value = 'nimkzkdqcjfsylqdywjf'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -138,7 +138,7 @@ class Test_Station(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.observation
+        test_value = StationEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_amqp_producer/jma_bosai_amedas_amqp_producer_data/tests/test_stationeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_StationEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for StationEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.info
+        self.instance = StationEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of StationEventEnum
         """
-        return EventEnum.info
+        return StationEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.info.value, 'info')
+        self.assertEqual(StationEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
@@ -105,7 +105,20 @@ async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hour
             start=time.monotonic(); await cycle(api,client,state,state_file,metadata_refresh_hours)
             if once: break
             await asyncio.sleep(max(0,polling_interval-(time.monotonic()-start)))
-    finally: await client.disconnect()
+    finally:
+        # WORKAROUND(xregistry/codegen#486): the generated MqttClient.disconnect()
+        # calls loop_stop() before disconnect(), which tears down paho's network
+        # loop while QoS-1 PUBLISH packets are still queued. In --once mode the
+        # last-published message (the Observation telemetry) is dropped before it
+        # reaches the broker, so only the Station reference event survives. Drain
+        # paho's outbound queue (bounded, best-effort) before the broken disconnect.
+        try:
+            _drain_deadline = time.monotonic() + 10.0
+            while (getattr(pc, "_out_messages", None) or getattr(pc, "_out_packet", None)) and time.monotonic() < _drain_deadline:
+                await asyncio.sleep(0.1)
+        except Exception:  # pragma: no cover - drain is best-effort
+            pass
+        await client.disconnect()
 def parse_url(url):
     p=urlparse(url if '://' in url else 'mqtt://'+url); tls=(p.scheme or 'mqtt').lower() in ('mqtts','ssl','tls'); return p.hostname or 'localhost', p.port or (8883 if tls else 1883), tls
 def main():

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt/jma_bosai_amedas_mqtt/app.py
@@ -107,11 +107,11 @@ async def feed(api,host,port,*,state_file,polling_interval,metadata_refresh_hour
             await asyncio.sleep(max(0,polling_interval-(time.monotonic()-start)))
     finally:
         # WORKAROUND(xregistry/codegen#486): the generated MqttClient.disconnect()
-        # calls loop_stop() before disconnect(), which tears down paho's network
-        # loop while QoS-1 PUBLISH packets are still queued. In --once mode the
-        # last-published message (the Observation telemetry) is dropped before it
-        # reaches the broker, so only the Station reference event survives. Drain
-        # paho's outbound queue (bounded, best-effort) before the broken disconnect.
+        # calls loop_stop() before disconnect(), tearing down paho's network loop
+        # while fire-and-forget QoS-1 PUBLISH packets may still be queued (the
+        # generated publish_* methods discard the MQTTMessageInfo and never await
+        # PUBACK). Drain paho's outbound queue (bounded, best-effort) so the last
+        # telemetry PUBLISH reaches the broker before the disconnect ordering bug.
         try:
             _drain_deadline = time.monotonic() + 10.0
             while (getattr(pc, "_out_messages", None) or getattr(pc, "_out_packet", None)) and time.monotonic() < _drain_deadline:

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .jp import StationTypeenum, EventEnum, Station, Observation
+from .jp import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/__init__.py
@@ -1,3 +1,3 @@
-from .jma import StationTypeenum, EventEnum, Station, Observation
+from .jma import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/__init__.py
@@ -1,3 +1,3 @@
-from .amedas import StationTypeenum, EventEnum, Station, Observation
+from .amedas import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/__init__.py
@@ -1,6 +1,7 @@
-from .stationtypeenum import StationTypeenum
-from .eventenum import EventEnum
-from .station import Station
+from .observationeventenum import ObservationEventEnum
 from .observation import Observation
+from .stationtypeenum import StationTypeenum
+from .stationeventenum import StationEventEnum
+from .station import Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/observation.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -75,7 +75,7 @@ class Observation:
         weather (typing.Optional[float])
         weather_qc_flag (typing.Optional[int])
         prefecture (str)
-        event (EventEnum)
+        event (ObservationEventEnum)
     """
     
     
@@ -131,7 +131,7 @@ class Observation:
     weather: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather"))
     weather_qc_flag: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather_qc_flag"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: ObservationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Observation':
@@ -260,57 +260,57 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='tqlwoeoivrpzhhayxdnp',
+            station_code='upbdzcwehyoomyudlnra',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(41.08538657532582),
-            temp_qc_flag=int(62),
-            humidity=float(60.771537467673376),
-            humidity_qc_flag=int(18),
-            pressure=float(86.76545601890328),
-            pressure_qc_flag=int(20),
-            normal_pressure=float(69.6910774185313),
-            normal_pressure_qc_flag=int(99),
-            wind_speed=float(51.071892769057484),
-            wind_speed_qc_flag=int(38),
-            wind_direction=float(58.30854372203119),
-            wind_direction_qc_flag=int(92),
-            wind_gust=float(76.94762775506338),
-            wind_gust_qc_flag=int(44),
-            wind_gust_direction=float(54.450928588488814),
+            temp=float(68.0627430153537),
+            temp_qc_flag=int(5),
+            humidity=float(15.087123721470885),
+            humidity_qc_flag=int(79),
+            pressure=float(27.470588919034967),
+            pressure_qc_flag=int(81),
+            normal_pressure=float(12.895615583171205),
+            normal_pressure_qc_flag=int(77),
+            wind_speed=float(96.45188834113459),
+            wind_speed_qc_flag=int(82),
+            wind_direction=float(93.0944064209247),
+            wind_direction_qc_flag=int(39),
+            wind_gust=float(67.90141181180616),
+            wind_gust_qc_flag=int(92),
+            wind_gust_direction=float(21.610504882875283),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(91.07809214420068),
+            max_temp=float(47.17259321015518),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(1.2871954827694543),
+            min_temp=float(89.1409846138587),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(23.217712216998322),
-            precipitation10m_qc_flag=int(94),
-            precipitation1h=float(22.613473312964416),
-            precipitation1h_qc_flag=int(5),
-            precipitation3h=float(79.09480224667973),
-            precipitation3h_qc_flag=int(50),
-            precipitation24h=float(71.51910142328036),
-            precipitation24h_qc_flag=int(61),
-            sun10m=float(7.694738443758986),
+            precipitation10m=float(22.2351241664827),
+            precipitation10m_qc_flag=int(71),
+            precipitation1h=float(57.49557604338222),
+            precipitation1h_qc_flag=int(22),
+            precipitation3h=float(40.1474619587925),
+            precipitation3h_qc_flag=int(28),
+            precipitation24h=float(37.134568737648756),
+            precipitation24h_qc_flag=int(57),
+            sun10m=float(26.642754516474966),
             sun10m_qc_flag=int(76),
-            sun1h=float(11.062150222933587),
-            sun1h_qc_flag=int(43),
-            snow=float(41.86972414278398),
-            snow_qc_flag=int(59),
-            snow1h=float(78.69760627226444),
-            snow1h_qc_flag=int(27),
-            snow6h=float(33.65254411645279),
-            snow6h_qc_flag=int(67),
-            snow12h=float(71.90718865670401),
-            snow12h_qc_flag=int(58),
-            snow24h=float(29.333712037403693),
-            snow24h_qc_flag=int(48),
-            visibility=float(68.44408688478774),
-            visibility_qc_flag=int(86),
-            cloud=float(2.018613271180558),
-            cloud_qc_flag=int(0),
-            weather=float(42.49395729435413),
-            weather_qc_flag=int(47),
-            prefecture='hjqeqqltmwoexacwgcgk',
-            event=EventEnum.info
+            sun1h=float(88.42742935778645),
+            sun1h_qc_flag=int(0),
+            snow=float(87.07000487462055),
+            snow_qc_flag=int(81),
+            snow1h=float(91.00533157948702),
+            snow1h_qc_flag=int(49),
+            snow6h=float(88.28643335201511),
+            snow6h_qc_flag=int(63),
+            snow12h=float(29.090829135107697),
+            snow12h_qc_flag=int(65),
+            snow24h=float(58.878460370255766),
+            snow24h_qc_flag=int(77),
+            visibility=float(16.743612479898328),
+            visibility_qc_flag=int(85),
+            cloud=float(22.704240262005303),
+            cloud_qc_flag=int(16),
+            weather=float(15.376174800836884),
+            weather_qc_flag=int(93),
+            prefecture='zbwcpzycwwwdlrivdmeq',
+            event=ObservationEventEnum.observation
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/observationeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class ObservationEventEnum(Enum):
     """
-    Fixed topic event segment for Station messages.
+    Fixed topic event segment for Observation messages.
     """
-    info = 'info'
+    observation = 'observation'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'ObservationEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'ObservationEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (ObservationEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/station.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
 
 
@@ -33,7 +33,7 @@ class Station:
         elems_bitmask (str)
         enabled_measurements (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (StationEventEnum)
     """
     
     
@@ -48,7 +48,7 @@ class Station:
     elems_bitmask: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elems_bitmask"))
     enabled_measurements: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="enabled_measurements"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: StationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Station':
@@ -177,16 +177,16 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_code='hhnsgbdppxdrednqaqij',
-            kj_name='ahervrrmjkgwdezujrmg',
-            kana='wpdbimaqsiakwdwjrtmp',
-            en_name='axbyityypqeekrpxvxnj',
-            latitude=float(19.999313878779233),
-            longitude=float(21.378388150266016),
-            altitude_m=float(80.42746727922479),
+            station_code='uwwcklrczrikudvacaus',
+            kj_name='sbqcovvyjioedbegamee',
+            kana='owaswasymryhtdkijetg',
+            en_name='albjdoroqalgvgdwlnde',
+            latitude=float(2.9081348740074398),
+            longitude=float(87.62608614863498),
+            altitude_m=float(75.85360056095784),
             station_type=StationTypeenum.A,
-            elems_bitmask='oeyntiigdhltryiyoksc',
-            enabled_measurements=['plipctimoidyaybzrthl', 'hsjaoybplhecnclmnsfp', 'bntgtyegnvvmglmsozbp'],
-            prefecture='dqguwlfduxpzpoywifhl',
-            event=EventEnum.info
+            elems_bitmask='wnwvatbgjpghzhuxxkdp',
+            enabled_measurements=['ztfbvkrhgmsxwykldpdm'],
+            prefecture='cnxhrmzztnbawcqapwpf',
+            event=StationEventEnum.info
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/src/jma_bosai_amedas_mqtt_producer_data/jp/jma/amedas/stationeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class StationEventEnum(Enum):
+    """
+    Fixed topic event segment for Station messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StationEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StationEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StationEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_observation.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.observation import Observation
-from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -30,59 +30,59 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            station_code='tqlwoeoivrpzhhayxdnp',
+            station_code='upbdzcwehyoomyudlnra',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(41.08538657532582),
-            temp_qc_flag=int(62),
-            humidity=float(60.771537467673376),
-            humidity_qc_flag=int(18),
-            pressure=float(86.76545601890328),
-            pressure_qc_flag=int(20),
-            normal_pressure=float(69.6910774185313),
-            normal_pressure_qc_flag=int(99),
-            wind_speed=float(51.071892769057484),
-            wind_speed_qc_flag=int(38),
-            wind_direction=float(58.30854372203119),
-            wind_direction_qc_flag=int(92),
-            wind_gust=float(76.94762775506338),
-            wind_gust_qc_flag=int(44),
-            wind_gust_direction=float(54.450928588488814),
+            temp=float(68.0627430153537),
+            temp_qc_flag=int(5),
+            humidity=float(15.087123721470885),
+            humidity_qc_flag=int(79),
+            pressure=float(27.470588919034967),
+            pressure_qc_flag=int(81),
+            normal_pressure=float(12.895615583171205),
+            normal_pressure_qc_flag=int(77),
+            wind_speed=float(96.45188834113459),
+            wind_speed_qc_flag=int(82),
+            wind_direction=float(93.0944064209247),
+            wind_direction_qc_flag=int(39),
+            wind_gust=float(67.90141181180616),
+            wind_gust_qc_flag=int(92),
+            wind_gust_direction=float(21.610504882875283),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(91.07809214420068),
+            max_temp=float(47.17259321015518),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(1.2871954827694543),
+            min_temp=float(89.1409846138587),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(23.217712216998322),
-            precipitation10m_qc_flag=int(94),
-            precipitation1h=float(22.613473312964416),
-            precipitation1h_qc_flag=int(5),
-            precipitation3h=float(79.09480224667973),
-            precipitation3h_qc_flag=int(50),
-            precipitation24h=float(71.51910142328036),
-            precipitation24h_qc_flag=int(61),
-            sun10m=float(7.694738443758986),
+            precipitation10m=float(22.2351241664827),
+            precipitation10m_qc_flag=int(71),
+            precipitation1h=float(57.49557604338222),
+            precipitation1h_qc_flag=int(22),
+            precipitation3h=float(40.1474619587925),
+            precipitation3h_qc_flag=int(28),
+            precipitation24h=float(37.134568737648756),
+            precipitation24h_qc_flag=int(57),
+            sun10m=float(26.642754516474966),
             sun10m_qc_flag=int(76),
-            sun1h=float(11.062150222933587),
-            sun1h_qc_flag=int(43),
-            snow=float(41.86972414278398),
-            snow_qc_flag=int(59),
-            snow1h=float(78.69760627226444),
-            snow1h_qc_flag=int(27),
-            snow6h=float(33.65254411645279),
-            snow6h_qc_flag=int(67),
-            snow12h=float(71.90718865670401),
-            snow12h_qc_flag=int(58),
-            snow24h=float(29.333712037403693),
-            snow24h_qc_flag=int(48),
-            visibility=float(68.44408688478774),
-            visibility_qc_flag=int(86),
-            cloud=float(2.018613271180558),
-            cloud_qc_flag=int(0),
-            weather=float(42.49395729435413),
-            weather_qc_flag=int(47),
-            prefecture='hjqeqqltmwoexacwgcgk',
-            event=EventEnum.info
+            sun1h=float(88.42742935778645),
+            sun1h_qc_flag=int(0),
+            snow=float(87.07000487462055),
+            snow_qc_flag=int(81),
+            snow1h=float(91.00533157948702),
+            snow1h_qc_flag=int(49),
+            snow6h=float(88.28643335201511),
+            snow6h_qc_flag=int(63),
+            snow12h=float(29.090829135107697),
+            snow12h_qc_flag=int(65),
+            snow24h=float(58.878460370255766),
+            snow24h_qc_flag=int(77),
+            visibility=float(16.743612479898328),
+            visibility_qc_flag=int(85),
+            cloud=float(22.704240262005303),
+            cloud_qc_flag=int(16),
+            weather=float(15.376174800836884),
+            weather_qc_flag=int(93),
+            prefecture='zbwcpzycwwwdlrivdmeq',
+            event=ObservationEventEnum.observation
         )
         return instance
 
@@ -91,7 +91,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'tqlwoeoivrpzhhayxdnp'
+        test_value = 'upbdzcwehyoomyudlnra'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp property
         """
-        test_value = float(41.08538657532582)
+        test_value = float(68.0627430153537)
         self.instance.temp = test_value
         self.assertEqual(self.instance.temp, test_value)
     
@@ -123,7 +123,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp_qc_flag property
         """
-        test_value = int(62)
+        test_value = int(5)
         self.instance.temp_qc_flag = test_value
         self.assertEqual(self.instance.temp_qc_flag, test_value)
     
@@ -131,7 +131,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(60.771537467673376)
+        test_value = float(15.087123721470885)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -139,7 +139,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity_qc_flag property
         """
-        test_value = int(18)
+        test_value = int(79)
         self.instance.humidity_qc_flag = test_value
         self.assertEqual(self.instance.humidity_qc_flag, test_value)
     
@@ -147,7 +147,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(86.76545601890328)
+        test_value = float(27.470588919034967)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -155,7 +155,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure_qc_flag property
         """
-        test_value = int(20)
+        test_value = int(81)
         self.instance.pressure_qc_flag = test_value
         self.assertEqual(self.instance.pressure_qc_flag, test_value)
     
@@ -163,7 +163,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure property
         """
-        test_value = float(69.6910774185313)
+        test_value = float(12.895615583171205)
         self.instance.normal_pressure = test_value
         self.assertEqual(self.instance.normal_pressure, test_value)
     
@@ -171,7 +171,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure_qc_flag property
         """
-        test_value = int(99)
+        test_value = int(77)
         self.instance.normal_pressure_qc_flag = test_value
         self.assertEqual(self.instance.normal_pressure_qc_flag, test_value)
     
@@ -179,7 +179,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(51.071892769057484)
+        test_value = float(96.45188834113459)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -187,7 +187,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed_qc_flag property
         """
-        test_value = int(38)
+        test_value = int(82)
         self.instance.wind_speed_qc_flag = test_value
         self.assertEqual(self.instance.wind_speed_qc_flag, test_value)
     
@@ -195,7 +195,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(58.30854372203119)
+        test_value = float(93.0944064209247)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -203,7 +203,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction_qc_flag property
         """
-        test_value = int(92)
+        test_value = int(39)
         self.instance.wind_direction_qc_flag = test_value
         self.assertEqual(self.instance.wind_direction_qc_flag, test_value)
     
@@ -211,7 +211,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust property
         """
-        test_value = float(76.94762775506338)
+        test_value = float(67.90141181180616)
         self.instance.wind_gust = test_value
         self.assertEqual(self.instance.wind_gust, test_value)
     
@@ -219,7 +219,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_qc_flag property
         """
-        test_value = int(44)
+        test_value = int(92)
         self.instance.wind_gust_qc_flag = test_value
         self.assertEqual(self.instance.wind_gust_qc_flag, test_value)
     
@@ -227,7 +227,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_direction property
         """
-        test_value = float(54.450928588488814)
+        test_value = float(21.610504882875283)
         self.instance.wind_gust_direction = test_value
         self.assertEqual(self.instance.wind_gust_direction, test_value)
     
@@ -243,7 +243,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test max_temp property
         """
-        test_value = float(91.07809214420068)
+        test_value = float(47.17259321015518)
         self.instance.max_temp = test_value
         self.assertEqual(self.instance.max_temp, test_value)
     
@@ -259,7 +259,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test min_temp property
         """
-        test_value = float(1.2871954827694543)
+        test_value = float(89.1409846138587)
         self.instance.min_temp = test_value
         self.assertEqual(self.instance.min_temp, test_value)
     
@@ -275,7 +275,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m property
         """
-        test_value = float(23.217712216998322)
+        test_value = float(22.2351241664827)
         self.instance.precipitation10m = test_value
         self.assertEqual(self.instance.precipitation10m, test_value)
     
@@ -283,7 +283,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m_qc_flag property
         """
-        test_value = int(94)
+        test_value = int(71)
         self.instance.precipitation10m_qc_flag = test_value
         self.assertEqual(self.instance.precipitation10m_qc_flag, test_value)
     
@@ -291,7 +291,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h property
         """
-        test_value = float(22.613473312964416)
+        test_value = float(57.49557604338222)
         self.instance.precipitation1h = test_value
         self.assertEqual(self.instance.precipitation1h, test_value)
     
@@ -299,7 +299,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h_qc_flag property
         """
-        test_value = int(5)
+        test_value = int(22)
         self.instance.precipitation1h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation1h_qc_flag, test_value)
     
@@ -307,7 +307,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h property
         """
-        test_value = float(79.09480224667973)
+        test_value = float(40.1474619587925)
         self.instance.precipitation3h = test_value
         self.assertEqual(self.instance.precipitation3h, test_value)
     
@@ -315,7 +315,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h_qc_flag property
         """
-        test_value = int(50)
+        test_value = int(28)
         self.instance.precipitation3h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation3h_qc_flag, test_value)
     
@@ -323,7 +323,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h property
         """
-        test_value = float(71.51910142328036)
+        test_value = float(37.134568737648756)
         self.instance.precipitation24h = test_value
         self.assertEqual(self.instance.precipitation24h, test_value)
     
@@ -331,7 +331,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h_qc_flag property
         """
-        test_value = int(61)
+        test_value = int(57)
         self.instance.precipitation24h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation24h_qc_flag, test_value)
     
@@ -339,7 +339,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun10m property
         """
-        test_value = float(7.694738443758986)
+        test_value = float(26.642754516474966)
         self.instance.sun10m = test_value
         self.assertEqual(self.instance.sun10m, test_value)
     
@@ -355,7 +355,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h property
         """
-        test_value = float(11.062150222933587)
+        test_value = float(88.42742935778645)
         self.instance.sun1h = test_value
         self.assertEqual(self.instance.sun1h, test_value)
     
@@ -363,7 +363,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h_qc_flag property
         """
-        test_value = int(43)
+        test_value = int(0)
         self.instance.sun1h_qc_flag = test_value
         self.assertEqual(self.instance.sun1h_qc_flag, test_value)
     
@@ -371,7 +371,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow property
         """
-        test_value = float(41.86972414278398)
+        test_value = float(87.07000487462055)
         self.instance.snow = test_value
         self.assertEqual(self.instance.snow, test_value)
     
@@ -379,7 +379,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow_qc_flag property
         """
-        test_value = int(59)
+        test_value = int(81)
         self.instance.snow_qc_flag = test_value
         self.assertEqual(self.instance.snow_qc_flag, test_value)
     
@@ -387,7 +387,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h property
         """
-        test_value = float(78.69760627226444)
+        test_value = float(91.00533157948702)
         self.instance.snow1h = test_value
         self.assertEqual(self.instance.snow1h, test_value)
     
@@ -395,7 +395,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h_qc_flag property
         """
-        test_value = int(27)
+        test_value = int(49)
         self.instance.snow1h_qc_flag = test_value
         self.assertEqual(self.instance.snow1h_qc_flag, test_value)
     
@@ -403,7 +403,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h property
         """
-        test_value = float(33.65254411645279)
+        test_value = float(88.28643335201511)
         self.instance.snow6h = test_value
         self.assertEqual(self.instance.snow6h, test_value)
     
@@ -411,7 +411,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h_qc_flag property
         """
-        test_value = int(67)
+        test_value = int(63)
         self.instance.snow6h_qc_flag = test_value
         self.assertEqual(self.instance.snow6h_qc_flag, test_value)
     
@@ -419,7 +419,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h property
         """
-        test_value = float(71.90718865670401)
+        test_value = float(29.090829135107697)
         self.instance.snow12h = test_value
         self.assertEqual(self.instance.snow12h, test_value)
     
@@ -427,7 +427,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h_qc_flag property
         """
-        test_value = int(58)
+        test_value = int(65)
         self.instance.snow12h_qc_flag = test_value
         self.assertEqual(self.instance.snow12h_qc_flag, test_value)
     
@@ -435,7 +435,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h property
         """
-        test_value = float(29.333712037403693)
+        test_value = float(58.878460370255766)
         self.instance.snow24h = test_value
         self.assertEqual(self.instance.snow24h, test_value)
     
@@ -443,7 +443,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h_qc_flag property
         """
-        test_value = int(48)
+        test_value = int(77)
         self.instance.snow24h_qc_flag = test_value
         self.assertEqual(self.instance.snow24h_qc_flag, test_value)
     
@@ -451,7 +451,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility property
         """
-        test_value = float(68.44408688478774)
+        test_value = float(16.743612479898328)
         self.instance.visibility = test_value
         self.assertEqual(self.instance.visibility, test_value)
     
@@ -459,7 +459,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility_qc_flag property
         """
-        test_value = int(86)
+        test_value = int(85)
         self.instance.visibility_qc_flag = test_value
         self.assertEqual(self.instance.visibility_qc_flag, test_value)
     
@@ -467,7 +467,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud property
         """
-        test_value = float(2.018613271180558)
+        test_value = float(22.704240262005303)
         self.instance.cloud = test_value
         self.assertEqual(self.instance.cloud, test_value)
     
@@ -475,7 +475,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud_qc_flag property
         """
-        test_value = int(0)
+        test_value = int(16)
         self.instance.cloud_qc_flag = test_value
         self.assertEqual(self.instance.cloud_qc_flag, test_value)
     
@@ -483,7 +483,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather property
         """
-        test_value = float(42.49395729435413)
+        test_value = float(15.376174800836884)
         self.instance.weather = test_value
         self.assertEqual(self.instance.weather, test_value)
     
@@ -491,7 +491,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather_qc_flag property
         """
-        test_value = int(47)
+        test_value = int(93)
         self.instance.weather_qc_flag = test_value
         self.assertEqual(self.instance.weather_qc_flag, test_value)
     
@@ -499,7 +499,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'hjqeqqltmwoexacwgcgk'
+        test_value = 'zbwcpzycwwwdlrivdmeq'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -507,7 +507,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = ObservationEventEnum.observation
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_observationeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
+
+
+class Test_ObservationEventEnum(unittest.TestCase):
+    """
+    Test case for ObservationEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = ObservationEventEnum.observation
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of ObservationEventEnum
+        """
+        return ObservationEventEnum.observation
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(ObservationEventEnum.observation.value, 'observation')

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_station.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.station import Station
-from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
 
 
@@ -30,18 +30,18 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_code='hhnsgbdppxdrednqaqij',
-            kj_name='ahervrrmjkgwdezujrmg',
-            kana='wpdbimaqsiakwdwjrtmp',
-            en_name='axbyityypqeekrpxvxnj',
-            latitude=float(19.999313878779233),
-            longitude=float(21.378388150266016),
-            altitude_m=float(80.42746727922479),
+            station_code='uwwcklrczrikudvacaus',
+            kj_name='sbqcovvyjioedbegamee',
+            kana='owaswasymryhtdkijetg',
+            en_name='albjdoroqalgvgdwlnde',
+            latitude=float(2.9081348740074398),
+            longitude=float(87.62608614863498),
+            altitude_m=float(75.85360056095784),
             station_type=StationTypeenum.A,
-            elems_bitmask='oeyntiigdhltryiyoksc',
-            enabled_measurements=['plipctimoidyaybzrthl', 'hsjaoybplhecnclmnsfp', 'bntgtyegnvvmglmsozbp'],
-            prefecture='dqguwlfduxpzpoywifhl',
-            event=EventEnum.info
+            elems_bitmask='wnwvatbgjpghzhuxxkdp',
+            enabled_measurements=['ztfbvkrhgmsxwykldpdm'],
+            prefecture='cnxhrmzztnbawcqapwpf',
+            event=StationEventEnum.info
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'hhnsgbdppxdrednqaqij'
+        test_value = 'uwwcklrczrikudvacaus'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -58,7 +58,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kj_name property
         """
-        test_value = 'ahervrrmjkgwdezujrmg'
+        test_value = 'sbqcovvyjioedbegamee'
         self.instance.kj_name = test_value
         self.assertEqual(self.instance.kj_name, test_value)
     
@@ -66,7 +66,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kana property
         """
-        test_value = 'wpdbimaqsiakwdwjrtmp'
+        test_value = 'owaswasymryhtdkijetg'
         self.instance.kana = test_value
         self.assertEqual(self.instance.kana, test_value)
     
@@ -74,7 +74,7 @@ class Test_Station(unittest.TestCase):
         """
         Test en_name property
         """
-        test_value = 'axbyityypqeekrpxvxnj'
+        test_value = 'albjdoroqalgvgdwlnde'
         self.instance.en_name = test_value
         self.assertEqual(self.instance.en_name, test_value)
     
@@ -82,7 +82,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(19.999313878779233)
+        test_value = float(2.9081348740074398)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -90,7 +90,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(21.378388150266016)
+        test_value = float(87.62608614863498)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -98,7 +98,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude_m property
         """
-        test_value = float(80.42746727922479)
+        test_value = float(75.85360056095784)
         self.instance.altitude_m = test_value
         self.assertEqual(self.instance.altitude_m, test_value)
     
@@ -114,7 +114,7 @@ class Test_Station(unittest.TestCase):
         """
         Test elems_bitmask property
         """
-        test_value = 'oeyntiigdhltryiyoksc'
+        test_value = 'wnwvatbgjpghzhuxxkdp'
         self.instance.elems_bitmask = test_value
         self.assertEqual(self.instance.elems_bitmask, test_value)
     
@@ -122,7 +122,7 @@ class Test_Station(unittest.TestCase):
         """
         Test enabled_measurements property
         """
-        test_value = ['plipctimoidyaybzrthl', 'hsjaoybplhecnclmnsfp', 'bntgtyegnvvmglmsozbp']
+        test_value = ['ztfbvkrhgmsxwykldpdm']
         self.instance.enabled_measurements = test_value
         self.assertEqual(self.instance.enabled_measurements, test_value)
     
@@ -130,7 +130,7 @@ class Test_Station(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'dqguwlfduxpzpoywifhl'
+        test_value = 'cnxhrmzztnbawcqapwpf'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -138,7 +138,7 @@ class Test_Station(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = StationEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_mqtt_producer/jma_bosai_amedas_mqtt_producer_data/tests/test_stationeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_amedas_amqp_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_StationEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for StationEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.observation
+        self.instance = StationEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of StationEventEnum
         """
-        return EventEnum.observation
+        return StationEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.observation.value, 'observation')
+        self.assertEqual(StationEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .jp import StationTypeenum, EventEnum, Station, Observation
+from .jp import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/__init__.py
@@ -1,3 +1,3 @@
-from .jma import StationTypeenum, EventEnum, Station, Observation
+from .jma import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/__init__.py
@@ -1,3 +1,3 @@
-from .amedas import StationTypeenum, EventEnum, Station, Observation
+from .amedas import ObservationEventEnum, Observation, StationTypeenum, StationEventEnum, Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/__init__.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/__init__.py
@@ -1,6 +1,7 @@
-from .stationtypeenum import StationTypeenum
-from .eventenum import EventEnum
-from .station import Station
+from .observationeventenum import ObservationEventEnum
 from .observation import Observation
+from .stationtypeenum import StationTypeenum
+from .stationeventenum import StationEventEnum
+from .station import Station
 
-__all__ = ["StationTypeenum", "EventEnum", "Station", "Observation"]
+__all__ = ["ObservationEventEnum", "Observation", "StationTypeenum", "StationEventEnum", "Station"]

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/observation.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -75,7 +75,7 @@ class Observation:
         weather (typing.Optional[float])
         weather_qc_flag (typing.Optional[int])
         prefecture (str)
-        event (EventEnum)
+        event (ObservationEventEnum)
     """
     
     
@@ -131,7 +131,7 @@ class Observation:
     weather: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather"))
     weather_qc_flag: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="weather_qc_flag"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: ObservationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Observation':
@@ -260,57 +260,57 @@ class Observation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='nijuffqvfcyrqfyddqlk',
+            station_code='vairtbctpjzvkcbvruuk',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(84.42113254095929),
-            temp_qc_flag=int(22),
-            humidity=float(72.65975392017363),
-            humidity_qc_flag=int(18),
-            pressure=float(38.962098100811396),
-            pressure_qc_flag=int(85),
-            normal_pressure=float(61.597540310502055),
-            normal_pressure_qc_flag=int(25),
-            wind_speed=float(59.16405373546525),
-            wind_speed_qc_flag=int(82),
-            wind_direction=float(43.48210582856606),
-            wind_direction_qc_flag=int(42),
-            wind_gust=float(59.89760271919033),
-            wind_gust_qc_flag=int(3),
-            wind_gust_direction=float(17.638913892428597),
+            temp=float(54.17276332377574),
+            temp_qc_flag=int(3),
+            humidity=float(97.02598126342016),
+            humidity_qc_flag=int(0),
+            pressure=float(37.73785241925373),
+            pressure_qc_flag=int(25),
+            normal_pressure=float(41.71585320377319),
+            normal_pressure_qc_flag=int(54),
+            wind_speed=float(58.199990472418015),
+            wind_speed_qc_flag=int(96),
+            wind_direction=float(22.739027890897745),
+            wind_direction_qc_flag=int(74),
+            wind_gust=float(26.11570081655786),
+            wind_gust_qc_flag=int(58),
+            wind_gust_direction=float(19.63783707843675),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(48.70628960929528),
+            max_temp=float(76.02766949591081),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(6.992368246439506),
+            min_temp=float(20.098143761898836),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(13.324006506643226),
-            precipitation10m_qc_flag=int(67),
-            precipitation1h=float(93.83156200338144),
-            precipitation1h_qc_flag=int(32),
-            precipitation3h=float(65.12741918339606),
-            precipitation3h_qc_flag=int(29),
-            precipitation24h=float(96.85411597447265),
-            precipitation24h_qc_flag=int(52),
-            sun10m=float(68.86629395007301),
-            sun10m_qc_flag=int(31),
-            sun1h=float(30.708907167721698),
-            sun1h_qc_flag=int(33),
-            snow=float(17.323064133876088),
-            snow_qc_flag=int(79),
-            snow1h=float(71.27634973352674),
-            snow1h_qc_flag=int(9),
-            snow6h=float(21.462287655299196),
-            snow6h_qc_flag=int(71),
-            snow12h=float(46.422932421026566),
-            snow12h_qc_flag=int(45),
-            snow24h=float(69.01230216311401),
-            snow24h_qc_flag=int(25),
-            visibility=float(87.74490769094744),
-            visibility_qc_flag=int(92),
-            cloud=float(68.41367475814002),
-            cloud_qc_flag=int(80),
-            weather=float(99.13870639899551),
-            weather_qc_flag=int(9),
-            prefecture='oehtknxpomsmvdtwlwjm',
-            event=EventEnum.info
+            precipitation10m=float(68.13465301661573),
+            precipitation10m_qc_flag=int(63),
+            precipitation1h=float(84.15334961296527),
+            precipitation1h_qc_flag=int(17),
+            precipitation3h=float(26.956377027769708),
+            precipitation3h_qc_flag=int(3),
+            precipitation24h=float(64.95824714073702),
+            precipitation24h_qc_flag=int(39),
+            sun10m=float(46.00823323426408),
+            sun10m_qc_flag=int(46),
+            sun1h=float(32.61236807662824),
+            sun1h_qc_flag=int(91),
+            snow=float(90.63692370556893),
+            snow_qc_flag=int(25),
+            snow1h=float(56.342785658782915),
+            snow1h_qc_flag=int(58),
+            snow6h=float(24.075898905563385),
+            snow6h_qc_flag=int(77),
+            snow12h=float(64.4953750772281),
+            snow12h_qc_flag=int(56),
+            snow24h=float(4.137427914824954),
+            snow24h_qc_flag=int(38),
+            visibility=float(69.45466187009619),
+            visibility_qc_flag=int(72),
+            cloud=float(59.98047346338944),
+            cloud_qc_flag=int(16),
+            weather=float(88.9804418282978),
+            weather_qc_flag=int(69),
+            prefecture='amxzxutodtqspyzyqxhx',
+            event=ObservationEventEnum.observation
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/observationeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class ObservationEventEnum(Enum):
     """
-    Fixed topic event segment for Station messages.
+    Fixed topic event segment for Observation messages.
     """
-    info = 'info'
+    observation = 'observation'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'ObservationEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'ObservationEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (ObservationEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/station.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
 
 
@@ -33,7 +33,7 @@ class Station:
         elems_bitmask (str)
         enabled_measurements (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (StationEventEnum)
     """
     
     
@@ -48,7 +48,7 @@ class Station:
     elems_bitmask: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elems_bitmask"))
     enabled_measurements: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="enabled_measurements"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: StationEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Station':
@@ -177,16 +177,16 @@ class Station:
             An instance of the dataclass.
         """
         return cls(
-            station_code='dcyqztuhkdeycsxrgwpv',
-            kj_name='ejjjrnrmsiczglehckta',
-            kana='crkmgwpzytdetqthmzoh',
-            en_name='kiozqpxgmnqnzhikbcay',
-            latitude=float(82.69727195439002),
-            longitude=float(77.54832701802569),
-            altitude_m=float(16.449210712686057),
+            station_code='pwlpvitrildrhdnmmoru',
+            kj_name='vnheiiisuskpleqyqhqf',
+            kana='coduwiwohgypwvzcegox',
+            en_name='thlzgnvqhnfsdkxtnxbo',
+            latitude=float(2.9543478099315346),
+            longitude=float(48.135648033601186),
+            altitude_m=float(43.915468970217574),
             station_type=StationTypeenum.A,
-            elems_bitmask='nlgohofuecdbyrqqfogy',
-            enabled_measurements=['sqrxhiioilzgnlpmitaf'],
-            prefecture='mwwcozogbiqkakahxncr',
-            event=EventEnum.info
+            elems_bitmask='uerdngjmdyfvcqlxndsq',
+            enabled_measurements=['rjsgtghkakwvcruemkka', 'ecegvhgkbatdfjuzyxjp', 'fcpklqkzinodwsozmydn', 'pnipyttfpagxuskropeu'],
+            prefecture='palgwwrvokxyjuqrbezf',
+            event=StationEventEnum.info
         )

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/src/jma_bosai_amedas_producer_data/jp/jma/amedas/stationeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class StationEventEnum(Enum):
+    """
+    Fixed topic event segment for Station messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'StationEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'StationEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (StationEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_observation.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_observation.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_producer_data.jp.jma.amedas.observation import Observation
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 import datetime
 
 
@@ -30,59 +30,59 @@ class Test_Observation(unittest.TestCase):
         Create instance of Observation for testing
         """
         instance = Observation(
-            station_code='nijuffqvfcyrqfyddqlk',
+            station_code='vairtbctpjzvkcbvruuk',
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
-            temp=float(84.42113254095929),
-            temp_qc_flag=int(22),
-            humidity=float(72.65975392017363),
-            humidity_qc_flag=int(18),
-            pressure=float(38.962098100811396),
-            pressure_qc_flag=int(85),
-            normal_pressure=float(61.597540310502055),
-            normal_pressure_qc_flag=int(25),
-            wind_speed=float(59.16405373546525),
-            wind_speed_qc_flag=int(82),
-            wind_direction=float(43.48210582856606),
-            wind_direction_qc_flag=int(42),
-            wind_gust=float(59.89760271919033),
-            wind_gust_qc_flag=int(3),
-            wind_gust_direction=float(17.638913892428597),
+            temp=float(54.17276332377574),
+            temp_qc_flag=int(3),
+            humidity=float(97.02598126342016),
+            humidity_qc_flag=int(0),
+            pressure=float(37.73785241925373),
+            pressure_qc_flag=int(25),
+            normal_pressure=float(41.71585320377319),
+            normal_pressure_qc_flag=int(54),
+            wind_speed=float(58.199990472418015),
+            wind_speed_qc_flag=int(96),
+            wind_direction=float(22.739027890897745),
+            wind_direction_qc_flag=int(74),
+            wind_gust=float(26.11570081655786),
+            wind_gust_qc_flag=int(58),
+            wind_gust_direction=float(19.63783707843675),
             wind_gust_time=datetime.datetime.now(datetime.timezone.utc),
-            max_temp=float(48.70628960929528),
+            max_temp=float(76.02766949591081),
             max_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            min_temp=float(6.992368246439506),
+            min_temp=float(20.098143761898836),
             min_temp_time=datetime.datetime.now(datetime.timezone.utc),
-            precipitation10m=float(13.324006506643226),
-            precipitation10m_qc_flag=int(67),
-            precipitation1h=float(93.83156200338144),
-            precipitation1h_qc_flag=int(32),
-            precipitation3h=float(65.12741918339606),
-            precipitation3h_qc_flag=int(29),
-            precipitation24h=float(96.85411597447265),
-            precipitation24h_qc_flag=int(52),
-            sun10m=float(68.86629395007301),
-            sun10m_qc_flag=int(31),
-            sun1h=float(30.708907167721698),
-            sun1h_qc_flag=int(33),
-            snow=float(17.323064133876088),
-            snow_qc_flag=int(79),
-            snow1h=float(71.27634973352674),
-            snow1h_qc_flag=int(9),
-            snow6h=float(21.462287655299196),
-            snow6h_qc_flag=int(71),
-            snow12h=float(46.422932421026566),
-            snow12h_qc_flag=int(45),
-            snow24h=float(69.01230216311401),
-            snow24h_qc_flag=int(25),
-            visibility=float(87.74490769094744),
-            visibility_qc_flag=int(92),
-            cloud=float(68.41367475814002),
-            cloud_qc_flag=int(80),
-            weather=float(99.13870639899551),
-            weather_qc_flag=int(9),
-            prefecture='oehtknxpomsmvdtwlwjm',
-            event=EventEnum.info
+            precipitation10m=float(68.13465301661573),
+            precipitation10m_qc_flag=int(63),
+            precipitation1h=float(84.15334961296527),
+            precipitation1h_qc_flag=int(17),
+            precipitation3h=float(26.956377027769708),
+            precipitation3h_qc_flag=int(3),
+            precipitation24h=float(64.95824714073702),
+            precipitation24h_qc_flag=int(39),
+            sun10m=float(46.00823323426408),
+            sun10m_qc_flag=int(46),
+            sun1h=float(32.61236807662824),
+            sun1h_qc_flag=int(91),
+            snow=float(90.63692370556893),
+            snow_qc_flag=int(25),
+            snow1h=float(56.342785658782915),
+            snow1h_qc_flag=int(58),
+            snow6h=float(24.075898905563385),
+            snow6h_qc_flag=int(77),
+            snow12h=float(64.4953750772281),
+            snow12h_qc_flag=int(56),
+            snow24h=float(4.137427914824954),
+            snow24h_qc_flag=int(38),
+            visibility=float(69.45466187009619),
+            visibility_qc_flag=int(72),
+            cloud=float(59.98047346338944),
+            cloud_qc_flag=int(16),
+            weather=float(88.9804418282978),
+            weather_qc_flag=int(69),
+            prefecture='amxzxutodtqspyzyqxhx',
+            event=ObservationEventEnum.observation
         )
         return instance
 
@@ -91,7 +91,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'nijuffqvfcyrqfyddqlk'
+        test_value = 'vairtbctpjzvkcbvruuk'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp property
         """
-        test_value = float(84.42113254095929)
+        test_value = float(54.17276332377574)
         self.instance.temp = test_value
         self.assertEqual(self.instance.temp, test_value)
     
@@ -123,7 +123,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test temp_qc_flag property
         """
-        test_value = int(22)
+        test_value = int(3)
         self.instance.temp_qc_flag = test_value
         self.assertEqual(self.instance.temp_qc_flag, test_value)
     
@@ -131,7 +131,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity property
         """
-        test_value = float(72.65975392017363)
+        test_value = float(97.02598126342016)
         self.instance.humidity = test_value
         self.assertEqual(self.instance.humidity, test_value)
     
@@ -139,7 +139,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test humidity_qc_flag property
         """
-        test_value = int(18)
+        test_value = int(0)
         self.instance.humidity_qc_flag = test_value
         self.assertEqual(self.instance.humidity_qc_flag, test_value)
     
@@ -147,7 +147,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure property
         """
-        test_value = float(38.962098100811396)
+        test_value = float(37.73785241925373)
         self.instance.pressure = test_value
         self.assertEqual(self.instance.pressure, test_value)
     
@@ -155,7 +155,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test pressure_qc_flag property
         """
-        test_value = int(85)
+        test_value = int(25)
         self.instance.pressure_qc_flag = test_value
         self.assertEqual(self.instance.pressure_qc_flag, test_value)
     
@@ -163,7 +163,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure property
         """
-        test_value = float(61.597540310502055)
+        test_value = float(41.71585320377319)
         self.instance.normal_pressure = test_value
         self.assertEqual(self.instance.normal_pressure, test_value)
     
@@ -171,7 +171,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test normal_pressure_qc_flag property
         """
-        test_value = int(25)
+        test_value = int(54)
         self.instance.normal_pressure_qc_flag = test_value
         self.assertEqual(self.instance.normal_pressure_qc_flag, test_value)
     
@@ -179,7 +179,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed property
         """
-        test_value = float(59.16405373546525)
+        test_value = float(58.199990472418015)
         self.instance.wind_speed = test_value
         self.assertEqual(self.instance.wind_speed, test_value)
     
@@ -187,7 +187,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_speed_qc_flag property
         """
-        test_value = int(82)
+        test_value = int(96)
         self.instance.wind_speed_qc_flag = test_value
         self.assertEqual(self.instance.wind_speed_qc_flag, test_value)
     
@@ -195,7 +195,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction property
         """
-        test_value = float(43.48210582856606)
+        test_value = float(22.739027890897745)
         self.instance.wind_direction = test_value
         self.assertEqual(self.instance.wind_direction, test_value)
     
@@ -203,7 +203,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_direction_qc_flag property
         """
-        test_value = int(42)
+        test_value = int(74)
         self.instance.wind_direction_qc_flag = test_value
         self.assertEqual(self.instance.wind_direction_qc_flag, test_value)
     
@@ -211,7 +211,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust property
         """
-        test_value = float(59.89760271919033)
+        test_value = float(26.11570081655786)
         self.instance.wind_gust = test_value
         self.assertEqual(self.instance.wind_gust, test_value)
     
@@ -219,7 +219,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_qc_flag property
         """
-        test_value = int(3)
+        test_value = int(58)
         self.instance.wind_gust_qc_flag = test_value
         self.assertEqual(self.instance.wind_gust_qc_flag, test_value)
     
@@ -227,7 +227,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test wind_gust_direction property
         """
-        test_value = float(17.638913892428597)
+        test_value = float(19.63783707843675)
         self.instance.wind_gust_direction = test_value
         self.assertEqual(self.instance.wind_gust_direction, test_value)
     
@@ -243,7 +243,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test max_temp property
         """
-        test_value = float(48.70628960929528)
+        test_value = float(76.02766949591081)
         self.instance.max_temp = test_value
         self.assertEqual(self.instance.max_temp, test_value)
     
@@ -259,7 +259,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test min_temp property
         """
-        test_value = float(6.992368246439506)
+        test_value = float(20.098143761898836)
         self.instance.min_temp = test_value
         self.assertEqual(self.instance.min_temp, test_value)
     
@@ -275,7 +275,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m property
         """
-        test_value = float(13.324006506643226)
+        test_value = float(68.13465301661573)
         self.instance.precipitation10m = test_value
         self.assertEqual(self.instance.precipitation10m, test_value)
     
@@ -283,7 +283,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation10m_qc_flag property
         """
-        test_value = int(67)
+        test_value = int(63)
         self.instance.precipitation10m_qc_flag = test_value
         self.assertEqual(self.instance.precipitation10m_qc_flag, test_value)
     
@@ -291,7 +291,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h property
         """
-        test_value = float(93.83156200338144)
+        test_value = float(84.15334961296527)
         self.instance.precipitation1h = test_value
         self.assertEqual(self.instance.precipitation1h, test_value)
     
@@ -299,7 +299,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation1h_qc_flag property
         """
-        test_value = int(32)
+        test_value = int(17)
         self.instance.precipitation1h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation1h_qc_flag, test_value)
     
@@ -307,7 +307,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h property
         """
-        test_value = float(65.12741918339606)
+        test_value = float(26.956377027769708)
         self.instance.precipitation3h = test_value
         self.assertEqual(self.instance.precipitation3h, test_value)
     
@@ -315,7 +315,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation3h_qc_flag property
         """
-        test_value = int(29)
+        test_value = int(3)
         self.instance.precipitation3h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation3h_qc_flag, test_value)
     
@@ -323,7 +323,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h property
         """
-        test_value = float(96.85411597447265)
+        test_value = float(64.95824714073702)
         self.instance.precipitation24h = test_value
         self.assertEqual(self.instance.precipitation24h, test_value)
     
@@ -331,7 +331,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test precipitation24h_qc_flag property
         """
-        test_value = int(52)
+        test_value = int(39)
         self.instance.precipitation24h_qc_flag = test_value
         self.assertEqual(self.instance.precipitation24h_qc_flag, test_value)
     
@@ -339,7 +339,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun10m property
         """
-        test_value = float(68.86629395007301)
+        test_value = float(46.00823323426408)
         self.instance.sun10m = test_value
         self.assertEqual(self.instance.sun10m, test_value)
     
@@ -347,7 +347,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun10m_qc_flag property
         """
-        test_value = int(31)
+        test_value = int(46)
         self.instance.sun10m_qc_flag = test_value
         self.assertEqual(self.instance.sun10m_qc_flag, test_value)
     
@@ -355,7 +355,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h property
         """
-        test_value = float(30.708907167721698)
+        test_value = float(32.61236807662824)
         self.instance.sun1h = test_value
         self.assertEqual(self.instance.sun1h, test_value)
     
@@ -363,7 +363,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test sun1h_qc_flag property
         """
-        test_value = int(33)
+        test_value = int(91)
         self.instance.sun1h_qc_flag = test_value
         self.assertEqual(self.instance.sun1h_qc_flag, test_value)
     
@@ -371,7 +371,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow property
         """
-        test_value = float(17.323064133876088)
+        test_value = float(90.63692370556893)
         self.instance.snow = test_value
         self.assertEqual(self.instance.snow, test_value)
     
@@ -379,7 +379,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow_qc_flag property
         """
-        test_value = int(79)
+        test_value = int(25)
         self.instance.snow_qc_flag = test_value
         self.assertEqual(self.instance.snow_qc_flag, test_value)
     
@@ -387,7 +387,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h property
         """
-        test_value = float(71.27634973352674)
+        test_value = float(56.342785658782915)
         self.instance.snow1h = test_value
         self.assertEqual(self.instance.snow1h, test_value)
     
@@ -395,7 +395,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow1h_qc_flag property
         """
-        test_value = int(9)
+        test_value = int(58)
         self.instance.snow1h_qc_flag = test_value
         self.assertEqual(self.instance.snow1h_qc_flag, test_value)
     
@@ -403,7 +403,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h property
         """
-        test_value = float(21.462287655299196)
+        test_value = float(24.075898905563385)
         self.instance.snow6h = test_value
         self.assertEqual(self.instance.snow6h, test_value)
     
@@ -411,7 +411,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow6h_qc_flag property
         """
-        test_value = int(71)
+        test_value = int(77)
         self.instance.snow6h_qc_flag = test_value
         self.assertEqual(self.instance.snow6h_qc_flag, test_value)
     
@@ -419,7 +419,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h property
         """
-        test_value = float(46.422932421026566)
+        test_value = float(64.4953750772281)
         self.instance.snow12h = test_value
         self.assertEqual(self.instance.snow12h, test_value)
     
@@ -427,7 +427,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow12h_qc_flag property
         """
-        test_value = int(45)
+        test_value = int(56)
         self.instance.snow12h_qc_flag = test_value
         self.assertEqual(self.instance.snow12h_qc_flag, test_value)
     
@@ -435,7 +435,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h property
         """
-        test_value = float(69.01230216311401)
+        test_value = float(4.137427914824954)
         self.instance.snow24h = test_value
         self.assertEqual(self.instance.snow24h, test_value)
     
@@ -443,7 +443,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test snow24h_qc_flag property
         """
-        test_value = int(25)
+        test_value = int(38)
         self.instance.snow24h_qc_flag = test_value
         self.assertEqual(self.instance.snow24h_qc_flag, test_value)
     
@@ -451,7 +451,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility property
         """
-        test_value = float(87.74490769094744)
+        test_value = float(69.45466187009619)
         self.instance.visibility = test_value
         self.assertEqual(self.instance.visibility, test_value)
     
@@ -459,7 +459,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test visibility_qc_flag property
         """
-        test_value = int(92)
+        test_value = int(72)
         self.instance.visibility_qc_flag = test_value
         self.assertEqual(self.instance.visibility_qc_flag, test_value)
     
@@ -467,7 +467,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud property
         """
-        test_value = float(68.41367475814002)
+        test_value = float(59.98047346338944)
         self.instance.cloud = test_value
         self.assertEqual(self.instance.cloud, test_value)
     
@@ -475,7 +475,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test cloud_qc_flag property
         """
-        test_value = int(80)
+        test_value = int(16)
         self.instance.cloud_qc_flag = test_value
         self.assertEqual(self.instance.cloud_qc_flag, test_value)
     
@@ -483,7 +483,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather property
         """
-        test_value = float(99.13870639899551)
+        test_value = float(88.9804418282978)
         self.instance.weather = test_value
         self.assertEqual(self.instance.weather, test_value)
     
@@ -491,7 +491,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test weather_qc_flag property
         """
-        test_value = int(9)
+        test_value = int(69)
         self.instance.weather_qc_flag = test_value
         self.assertEqual(self.instance.weather_qc_flag, test_value)
     
@@ -499,7 +499,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'oehtknxpomsmvdtwlwjm'
+        test_value = 'amxzxutodtqspyzyqxhx'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -507,7 +507,7 @@ class Test_Observation(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = ObservationEventEnum.observation
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_observationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_observationeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_amedas_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
+
+
+class Test_ObservationEventEnum(unittest.TestCase):
+    """
+    Test case for ObservationEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = ObservationEventEnum.observation
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of ObservationEventEnum
+        """
+        return ObservationEventEnum.observation
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(ObservationEventEnum.observation.value, 'observation')

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_station.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_station.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_amedas_producer_data.jp.jma.amedas.station import Station
-from jma_bosai_amedas_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 from jma_bosai_amedas_producer_data.jp.jma.amedas.stationtypeenum import StationTypeenum
 
 
@@ -30,18 +30,18 @@ class Test_Station(unittest.TestCase):
         Create instance of Station for testing
         """
         instance = Station(
-            station_code='dcyqztuhkdeycsxrgwpv',
-            kj_name='ejjjrnrmsiczglehckta',
-            kana='crkmgwpzytdetqthmzoh',
-            en_name='kiozqpxgmnqnzhikbcay',
-            latitude=float(82.69727195439002),
-            longitude=float(77.54832701802569),
-            altitude_m=float(16.449210712686057),
+            station_code='pwlpvitrildrhdnmmoru',
+            kj_name='vnheiiisuskpleqyqhqf',
+            kana='coduwiwohgypwvzcegox',
+            en_name='thlzgnvqhnfsdkxtnxbo',
+            latitude=float(2.9543478099315346),
+            longitude=float(48.135648033601186),
+            altitude_m=float(43.915468970217574),
             station_type=StationTypeenum.A,
-            elems_bitmask='nlgohofuecdbyrqqfogy',
-            enabled_measurements=['sqrxhiioilzgnlpmitaf'],
-            prefecture='mwwcozogbiqkakahxncr',
-            event=EventEnum.info
+            elems_bitmask='uerdngjmdyfvcqlxndsq',
+            enabled_measurements=['rjsgtghkakwvcruemkka', 'ecegvhgkbatdfjuzyxjp', 'fcpklqkzinodwsozmydn', 'pnipyttfpagxuskropeu'],
+            prefecture='palgwwrvokxyjuqrbezf',
+            event=StationEventEnum.info
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Station(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'dcyqztuhkdeycsxrgwpv'
+        test_value = 'pwlpvitrildrhdnmmoru'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -58,7 +58,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kj_name property
         """
-        test_value = 'ejjjrnrmsiczglehckta'
+        test_value = 'vnheiiisuskpleqyqhqf'
         self.instance.kj_name = test_value
         self.assertEqual(self.instance.kj_name, test_value)
     
@@ -66,7 +66,7 @@ class Test_Station(unittest.TestCase):
         """
         Test kana property
         """
-        test_value = 'crkmgwpzytdetqthmzoh'
+        test_value = 'coduwiwohgypwvzcegox'
         self.instance.kana = test_value
         self.assertEqual(self.instance.kana, test_value)
     
@@ -74,7 +74,7 @@ class Test_Station(unittest.TestCase):
         """
         Test en_name property
         """
-        test_value = 'kiozqpxgmnqnzhikbcay'
+        test_value = 'thlzgnvqhnfsdkxtnxbo'
         self.instance.en_name = test_value
         self.assertEqual(self.instance.en_name, test_value)
     
@@ -82,7 +82,7 @@ class Test_Station(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(82.69727195439002)
+        test_value = float(2.9543478099315346)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -90,7 +90,7 @@ class Test_Station(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(77.54832701802569)
+        test_value = float(48.135648033601186)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -98,7 +98,7 @@ class Test_Station(unittest.TestCase):
         """
         Test altitude_m property
         """
-        test_value = float(16.449210712686057)
+        test_value = float(43.915468970217574)
         self.instance.altitude_m = test_value
         self.assertEqual(self.instance.altitude_m, test_value)
     
@@ -114,7 +114,7 @@ class Test_Station(unittest.TestCase):
         """
         Test elems_bitmask property
         """
-        test_value = 'nlgohofuecdbyrqqfogy'
+        test_value = 'uerdngjmdyfvcqlxndsq'
         self.instance.elems_bitmask = test_value
         self.assertEqual(self.instance.elems_bitmask, test_value)
     
@@ -122,7 +122,7 @@ class Test_Station(unittest.TestCase):
         """
         Test enabled_measurements property
         """
-        test_value = ['sqrxhiioilzgnlpmitaf']
+        test_value = ['rjsgtghkakwvcruemkka', 'ecegvhgkbatdfjuzyxjp', 'fcpklqkzinodwsozmydn', 'pnipyttfpagxuskropeu']
         self.instance.enabled_measurements = test_value
         self.assertEqual(self.instance.enabled_measurements, test_value)
     
@@ -130,7 +130,7 @@ class Test_Station(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'mwwcozogbiqkakahxncr'
+        test_value = 'palgwwrvokxyjuqrbezf'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -138,7 +138,7 @@ class Test_Station(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = StationEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_stationeventenum.py
+++ b/feeders/jma-bosai-amedas/jma_bosai_amedas_producer/jma_bosai_amedas_producer_data/tests/test_stationeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_amedas_mqtt_producer_data.jp.jma.amedas.eventenum import EventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_StationEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for StationEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.info
+        self.instance = StationEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of StationEventEnum
         """
-        return EventEnum.info
+        return StationEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.info.value, 'info')
+        self.assertEqual(StationEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-amedas/tests/test_unit.py
+++ b/feeders/jma-bosai-amedas/tests/test_unit.py
@@ -17,6 +17,8 @@ from jma_bosai_amedas.jma_bosai_amedas import (
     point_detail_time_to_utc,
     point_file_time,
 )
+from jma_bosai_amedas_producer_data.jp.jma.amedas.stationeventenum import StationEventEnum
+from jma_bosai_amedas_producer_data.jp.jma.amedas.observationeventenum import ObservationEventEnum
 
 
 class FakeResponse:
@@ -124,6 +126,33 @@ class TestParsingHelpers:
         assert station.altitude_m == 3.0
         assert station.station_type == "A"
         assert "humidity" in station.enabled_measurements
+
+    def test_station_and_observation_carry_distinct_event_segments(self):
+        # Regression: the Station and Observation inline `event` enums used to
+        # collide into a single generated EventEnum (last-writer-wins, keeping
+        # only Station's "info"), which forced Observation messages onto the
+        # wrong `/info` topic segment. Each message type must now carry its own
+        # distinctly-named enum with the correct fixed value.
+        station = parse_station(
+            "44132",
+            {
+                "kjName": "東京",
+                "knName": "トウキョウ",
+                "enName": "Tokyo",
+                "lat": [35, 41.4],
+                "lon": [139, 45.6],
+                "alt": 25,
+                "type": "A",
+                "elems": "11111111",
+            },
+        )
+        observed_at = datetime(2026, 5, 21, 5, 50, tzinfo=timezone(timedelta(hours=9)))
+        observation = parse_observation("11016", {"temp": [14.5, 0]}, observed_at)
+        assert station.event is StationEventEnum.info
+        assert station.event.value == "info"
+        assert observation is not None
+        assert observation.event is ObservationEventEnum.observation
+        assert observation.event.value == "observation"
 
     def test_observation_parsing_from_fixture(self):
         observed_at = datetime(2026, 5, 21, 5, 50, tzinfo=timezone(timedelta(hours=9)))

--- a/feeders/jma-bosai-amedas/xreg/jma-bosai-amedas.xreg.json
+++ b/feeders/jma-bosai-amedas/xreg/jma-bosai-amedas.xreg.json
@@ -315,6 +315,7 @@
                               "pattern": "^[a-z0-9][a-z0-9-]*$"
                             },
                             "event": {
+                              "name": "StationEventEnum",
                               "type": "string",
                               "enum": [
                                 "info"
@@ -834,6 +835,7 @@
                               "pattern": "^[a-z0-9][a-z0-9-]*$"
                             },
                             "event": {
+                              "name": "ObservationEventEnum",
                               "type": "string",
                               "enum": [
                                 "observation"


### PR DESCRIPTION
## What

Give the two inline `event` enums in the **jma-bosai-amedas** contract
distinct JsonStructure `name`s (`StationEventEnum`, `ObservationEventEnum`)
so codegen stops collapsing them into one module.

## Why — codegen collision + wire-level mis-routing

Both inline `event` enums had **no** JsonStructure `name`, so xrcg/avrotize
0.10.15 derived both generated type names from the property (`event` →
`EventEnum`) and wrote both to the **same module path** `eventenum.py` with
**last-writer-wins**. Station's enum (value `info`) won; Observation's enum
(value `observation`) was silently overwritten. The bridge was then forced
to emit `EventEnum("info")` for Observation too — **mis-routing Observation
telemetry** onto `…/{station_code}/info` instead of
`…/{station_code}/observation` on **all three transports** (the MQTT topic
`…/{station_code}/{event}` and the AMQP `event` application-property both
bind the `event` value).

So this is **both** a codegen-collision fix **and** a wire-level routing
fix: Observation events now correctly carry `event=observation`.

## Change

- **Manifest** (`xreg/jma-bosai-amedas.xreg.json`): two one-line additions —
  `"name": "StationEventEnum"` and `"name": "ObservationEventEnum"` on the
  respective inline `event` enums. Values (`info`/`observation`), `required`,
  and descriptions unchanged.
- **Regenerated** Kafka + MQTT + AMQP producer packages (xrcg 0.10.15):
  new `stationeventenum.py` / `observationeventenum.py`; the orphaned
  `eventenum.py` (and its `test_eventenum.py`) **removed** from all three
  data packages (xrcg adds the new modules but does not prune the renamed
  one — removed by hand as regeneration hygiene).
- **Bridge** (`jma_bosai_amedas/jma_bosai_amedas.py`): import both enums;
  emit `StationEventEnum.info` / `ObservationEventEnum.observation` at the
  two call sites. MQTT/AMQP apps reuse `parse_station`/`parse_observation`
  via the `to_serializer_dict()` round-trip, so the routing correction
  propagates to all three transports with **no app-code change**.
- **Test** (`tests/test_unit.py`): regression test
  `test_station_and_observation_carry_distinct_event_segments` asserting the
  two messages carry distinct, correct event segments.

## Validation gates

| Gate | Result |
|------|--------|
| 1 import smoke | ✅ `Station.event = StationEventEnum.info` |
| 2 py_compile | ✅ generated + hand-written, 0 errors |
| 4 unit tests | ✅ 17 passed (incl. new regression) |
| 6 mypy (`feeders/jma-bosai-amedas`, MYPYPATH=producer src) | ✅ no issues, 9 files |
| Avro neutrality | ✅ **0** avro/avsc files changed; `JP.JMA.Amedas.avro` group does not model `event` |
| 5 Docker E2E | ⏸ **deferred to CI** — local Docker Desktop Linux engine was wedged (500 Internal Server Error, `docker ps` hung). The `TestJmaBosaiAmedasDockerFlow` E2E runs in CI on this PR. |

## Mandatory expert reviews

- **xRegistry Expert — ✅ APPROVE (0 blockers).** Confirmed adding a
  JsonStructure `name` to an inline enum is valid + idiomatic (touches zero
  xRegistry core attributes, instance validation unchanged, wire shape
  byte-identical); subject ↔ Kafka-key alignment preserved (both embed only
  `{station_code}`, which did not change); no messagegroup/endpoint
  structural regression. Non-blocking notes: the `Enum` suffix in the type
  name is stylistic; the unused `JP.JMA.Amedas.avro` mirror group omits the
  `event` segment field (pre-existing, does not affect these `.jstruct`-bound
  producers).
- **JSON Structure Expert — ✅ APPROVE-WITH-NITS.** SDK core validator
  returns 0 errors; diff is exactly the two additive `name` lines; no
  description/validation-keyword loss; `event` correctly stays `required`
  for a fixed routing discriminator. **Actionable nit (now fixed in this
  PR):** the orphaned `eventenum.py` + `test_eventenum.py` had not been
  pruned by regeneration — **deleted all six** so the worktree matches the
  intended state. **Pre-existing FYI (tracked, not in scope):** meta-schema
  flags 22 `unit` keywords on nullable-union (`["double","null"]`)
  properties in the Observation schema ("`unit` can only appear in numeric
  schemas"); present on `origin/main`, untouched here, orthogonal to this
  fix.
- **Avro Schema Expert — verified directly (no agent registered).** The
  regeneration changed **0** Avro schema files and the `JP.JMA.Amedas.avro`
  schemagroup does not model an `event` field, so the change is provably
  Avro-neutral.

## Out-of-scope follow-ups discovered

1. **Upstream codegen bug** (xrcg/avrotize): an inline enum with no `name`
   is named from its property and hoisted into the parent namespace at a
   shared module path → last-writer-wins collision, and the renamed-away
   module is not pruned on regeneration. Reproducer = this PR's before-state.
   To be filed upstream.
2. **Sibling feeders** `jma-bosai-volcano` and `jma-bosai-warning` also ship
   `eventenum.py` modules and may carry the same latent collision — to be
   investigated separately (not modified here).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
