### PR TITLE
fix(jma-bosai-volcano): distinct names for Volcano/Warning/Eruption event enums (codegen collision)

### DIFF
--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/__init__.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/__init__.py
@@ -1,8 +1,10 @@
+from .volcanoeventenum import VolcanoEventEnum
+from .volcano import Volcano
 from .conditionenum import ConditionEnum
-from .eventenum import EventEnum
+from .volcanicwarningeventenum import VolcanicWarningEventEnum
 from .volcanicwarning import VolcanicWarning
 from .eruptiontypeenum import EruptionTypeenum
+from .volcaniceruptioneventenum import VolcanicEruptionEventEnum
 from .volcaniceruption import VolcanicEruption
-from .volcano import Volcano
 
-__all__ = ["ConditionEnum", "EventEnum", "VolcanicWarning", "EruptionTypeenum", "VolcanicEruption", "Volcano"]
+__all__ = ["VolcanoEventEnum", "Volcano", "ConditionEnum", "VolcanicWarningEventEnum", "VolcanicWarning", "EruptionTypeenum", "VolcanicEruptionEventEnum", "VolcanicEruption"]

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcaniceruption.py
@@ -13,7 +13,7 @@ from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
 from jma_bosai_volcano_amqp_producer_data.eruptiontypeenum import EruptionTypeenum
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 import datetime
 
 
@@ -43,7 +43,7 @@ class VolcanicEruption:
         info_type_jp (typing.Optional[str])
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicEruptionEventEnum)
     """
     
     
@@ -66,7 +66,7 @@ class VolcanicEruption:
     info_type_jp: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicEruptionEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicEruption':
@@ -195,24 +195,24 @@ class VolcanicEruption:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='jyabuibenjaitrnbblst',
-            event_id='mcrjrkplwsmutaxbhssm',
+            volcano_code='oggrvzidbmmbbwxrnuxr',
+            event_id='uffpipkynsubfvuaevqz',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='nowidyesnxwyuuueophd',
-            colored_plume_height_m=float(88.14556340282216),
-            white_plume_height_m=float(36.42096783915717),
-            maximum_plume_height_since_start_m=float(53.02785173146892),
-            plume_direction='wnuofbitromkhpdhzdpf',
-            ash_dispersal_direction='xkiyobbnaiyvvdrwdojx',
+            crater_name='bjdnidgejdukkshjyjlm',
+            colored_plume_height_m=float(34.0690344125205),
+            white_plume_height_m=float(43.76409200152316),
+            maximum_plume_height_since_start_m=float(11.50591634202176),
+            plume_direction='twjqjrvxqqzvsuocymru',
+            ash_dispersal_direction='stgnxgarsbhhazfxdzvl',
             pyroclastic_flow_observed=True,
-            plume_amount_jp='hkyygegmulmifawpwolu',
-            description='iwvpjzxuyerhkucumczg',
-            info_type_jp='rulrqblsuopuqeyuhsit',
-            area_codes=['kvyydwgqftskjxlstypl'],
-            prefecture='lueupckqhojokcmqrwwz',
-            event=EventEnum.warning
+            plume_amount_jp='ishaomjkygiwwpkbzhol',
+            description='euvgssycgapissxeakdx',
+            info_type_jp='tvfenkhulukjyrdaubix',
+            area_codes=['tcjkwkyytkjetxxpfdxm', 'fzncmxfgvtqrvckzpbtj', 'lfcaqbkwgmznqgejdnqt'],
+            prefecture='mpowbhosoxxrsldzktci',
+            event=VolcanicEruptionEventEnum.eruption
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcaniceruptioneventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanicEruptionEventEnum(Enum):
+    """
+    Fixed topic event segment for VolcanicEruption messages.
+    """
+    eruption = 'eruption'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicEruptionEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanicEruptionEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanicEruptionEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanicwarning.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_amqp_producer_data.conditionenum import ConditionEnum
 import datetime
 
@@ -35,7 +35,7 @@ class VolcanicWarning:
         info_type_jp (str)
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicWarningEventEnum)
     """
     
     
@@ -50,7 +50,7 @@ class VolcanicWarning:
     info_type_jp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicWarning':
@@ -179,16 +179,16 @@ class VolcanicWarning:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='hajinzntzsbrnvgnvbny',
-            event_id='ogoorhcdhznewdkruaxy',
+            volcano_code='jzawrzivshlpvwnwbbxb',
+            event_id='fexftznnicqnrpyjlvdd',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='cpxbwodpkbpxgtzvrxjj',
-            alert_level_name='ssalitcbxzkxaiqrakjf',
-            previous_level_code='dzljzkbcfmamrhiuaevg',
+            alert_level_code='kyomzkpjxhpnezvlizhd',
+            alert_level_name='pqfrssxuwklctfpevhup',
+            previous_level_code='eizdwjmkvktxfaghukgs',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='yiczowvefkljxocyuwrb',
-            area_codes=['iljhbrbvtujaqkfdotcu'],
-            prefecture='npggtdcnmbdvvfwlxczb',
-            event=EventEnum.warning
+            info_type_jp='thnyrbegnxeiilosxmry',
+            area_codes=['rugqamexvkqmhuwfmwre', 'gtwuhpylyjgbylmgthsi'],
+            prefecture='xsswsxrczjdydnlwlxzd',
+            event=VolcanicWarningEventEnum.warning
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanicwarningeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class VolcanicWarningEventEnum(Enum):
     """
     Fixed topic event segment for VolcanicWarning messages.
     """
     warning = 'warning'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'VolcanicWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (VolcanicWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcano.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -29,7 +29,7 @@ class Volcano:
         elevation_m (typing.Optional[float])
         level_operation (bool)
         prefecture (str)
-        event (EventEnum)
+        event (VolcanoEventEnum)
     """
     
     
@@ -41,7 +41,7 @@ class Volcano:
     elevation_m: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation_m"))
     level_operation: bool=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_operation"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanoEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Volcano':
@@ -170,13 +170,13 @@ class Volcano:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='whzpljwlewipwxzrqfle',
-            name_jp='vtckvbtbombsfdtmhfoy',
-            name_en='coblfhiadodlafdmymtk',
-            latitude=float(24.584250332572477),
-            longitude=float(79.2196014535121),
-            elevation_m=float(10.528756284438867),
-            level_operation=True,
-            prefecture='smnofumzqiyuvjldxssq',
-            event=EventEnum.warning
+            volcano_code='soxxjzfeowkdxlahkycz',
+            name_jp='aglrhiekizkqezkgouux',
+            name_en='jrxsourxbvrkmvvtyvpe',
+            latitude=float(7.289520054950271),
+            longitude=float(98.5271819831292),
+            elevation_m=float(56.87570722765872),
+            level_operation=False,
+            prefecture='zivftphtmdqmmtzzhsqb',
+            event=VolcanoEventEnum.info
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/src/jma_bosai_volcano_amqp_producer_data/volcanoeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanoEventEnum(Enum):
+    """
+    Fixed topic event segment for Volcano messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanoEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanoEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanoEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcaniceruption.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_volcano_amqp_producer_data.volcaniceruption import VolcanicEruption
 from jma_bosai_volcano_amqp_producer_data.eruptiontypeenum import EruptionTypeenum
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 import datetime
 
 
@@ -31,26 +31,26 @@ class Test_VolcanicEruption(unittest.TestCase):
         Create instance of VolcanicEruption for testing
         """
         instance = VolcanicEruption(
-            volcano_code='jyabuibenjaitrnbblst',
-            event_id='mcrjrkplwsmutaxbhssm',
+            volcano_code='oggrvzidbmmbbwxrnuxr',
+            event_id='uffpipkynsubfvuaevqz',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='nowidyesnxwyuuueophd',
-            colored_plume_height_m=float(88.14556340282216),
-            white_plume_height_m=float(36.42096783915717),
-            maximum_plume_height_since_start_m=float(53.02785173146892),
-            plume_direction='wnuofbitromkhpdhzdpf',
-            ash_dispersal_direction='xkiyobbnaiyvvdrwdojx',
+            crater_name='bjdnidgejdukkshjyjlm',
+            colored_plume_height_m=float(34.0690344125205),
+            white_plume_height_m=float(43.76409200152316),
+            maximum_plume_height_since_start_m=float(11.50591634202176),
+            plume_direction='twjqjrvxqqzvsuocymru',
+            ash_dispersal_direction='stgnxgarsbhhazfxdzvl',
             pyroclastic_flow_observed=True,
-            plume_amount_jp='hkyygegmulmifawpwolu',
-            description='iwvpjzxuyerhkucumczg',
-            info_type_jp='rulrqblsuopuqeyuhsit',
-            area_codes=['kvyydwgqftskjxlstypl'],
-            prefecture='lueupckqhojokcmqrwwz',
-            event=EventEnum.warning
+            plume_amount_jp='ishaomjkygiwwpkbzhol',
+            description='euvgssycgapissxeakdx',
+            info_type_jp='tvfenkhulukjyrdaubix',
+            area_codes=['tcjkwkyytkjetxxpfdxm', 'fzncmxfgvtqrvckzpbtj', 'lfcaqbkwgmznqgejdnqt'],
+            prefecture='mpowbhosoxxrsldzktci',
+            event=VolcanicEruptionEventEnum.eruption
         )
         return instance
 
@@ -59,7 +59,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'jyabuibenjaitrnbblst'
+        test_value = 'oggrvzidbmmbbwxrnuxr'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -67,7 +67,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'mcrjrkplwsmutaxbhssm'
+        test_value = 'uffpipkynsubfvuaevqz'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test crater_name property
         """
-        test_value = 'nowidyesnxwyuuueophd'
+        test_value = 'bjdnidgejdukkshjyjlm'
         self.instance.crater_name = test_value
         self.assertEqual(self.instance.crater_name, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test colored_plume_height_m property
         """
-        test_value = float(88.14556340282216)
+        test_value = float(34.0690344125205)
         self.instance.colored_plume_height_m = test_value
         self.assertEqual(self.instance.colored_plume_height_m, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test white_plume_height_m property
         """
-        test_value = float(36.42096783915717)
+        test_value = float(43.76409200152316)
         self.instance.white_plume_height_m = test_value
         self.assertEqual(self.instance.white_plume_height_m, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test maximum_plume_height_since_start_m property
         """
-        test_value = float(53.02785173146892)
+        test_value = float(11.50591634202176)
         self.instance.maximum_plume_height_since_start_m = test_value
         self.assertEqual(self.instance.maximum_plume_height_since_start_m, test_value)
     
@@ -147,7 +147,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_direction property
         """
-        test_value = 'wnuofbitromkhpdhzdpf'
+        test_value = 'twjqjrvxqqzvsuocymru'
         self.instance.plume_direction = test_value
         self.assertEqual(self.instance.plume_direction, test_value)
     
@@ -155,7 +155,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test ash_dispersal_direction property
         """
-        test_value = 'xkiyobbnaiyvvdrwdojx'
+        test_value = 'stgnxgarsbhhazfxdzvl'
         self.instance.ash_dispersal_direction = test_value
         self.assertEqual(self.instance.ash_dispersal_direction, test_value)
     
@@ -171,7 +171,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_amount_jp property
         """
-        test_value = 'hkyygegmulmifawpwolu'
+        test_value = 'ishaomjkygiwwpkbzhol'
         self.instance.plume_amount_jp = test_value
         self.assertEqual(self.instance.plume_amount_jp, test_value)
     
@@ -179,7 +179,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'iwvpjzxuyerhkucumczg'
+        test_value = 'euvgssycgapissxeakdx'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -187,7 +187,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'rulrqblsuopuqeyuhsit'
+        test_value = 'tvfenkhulukjyrdaubix'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -195,7 +195,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['kvyydwgqftskjxlstypl']
+        test_value = ['tcjkwkyytkjetxxpfdxm', 'fzncmxfgvtqrvckzpbtj', 'lfcaqbkwgmznqgejdnqt']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -203,7 +203,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'lueupckqhojokcmqrwwz'
+        test_value = 'mpowbhosoxxrsldzktci'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -211,7 +211,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.warning
+        test_value = VolcanicEruptionEventEnum.eruption
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcaniceruptioneventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_amqp_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
+
+
+class Test_VolcanicEruptionEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicEruptionEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicEruptionEventEnum.eruption
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicEruptionEventEnum
+        """
+        return VolcanicEruptionEventEnum.eruption
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicEruptionEventEnum.eruption.value, 'eruption')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanicwarning.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_amqp_producer_data.volcanicwarning import VolcanicWarning
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_amqp_producer_data.conditionenum import ConditionEnum
 import datetime
 
@@ -31,18 +31,18 @@ class Test_VolcanicWarning(unittest.TestCase):
         Create instance of VolcanicWarning for testing
         """
         instance = VolcanicWarning(
-            volcano_code='hajinzntzsbrnvgnvbny',
-            event_id='ogoorhcdhznewdkruaxy',
+            volcano_code='jzawrzivshlpvwnwbbxb',
+            event_id='fexftznnicqnrpyjlvdd',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='cpxbwodpkbpxgtzvrxjj',
-            alert_level_name='ssalitcbxzkxaiqrakjf',
-            previous_level_code='dzljzkbcfmamrhiuaevg',
+            alert_level_code='kyomzkpjxhpnezvlizhd',
+            alert_level_name='pqfrssxuwklctfpevhup',
+            previous_level_code='eizdwjmkvktxfaghukgs',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='yiczowvefkljxocyuwrb',
-            area_codes=['iljhbrbvtujaqkfdotcu'],
-            prefecture='npggtdcnmbdvvfwlxczb',
-            event=EventEnum.warning
+            info_type_jp='thnyrbegnxeiilosxmry',
+            area_codes=['rugqamexvkqmhuwfmwre', 'gtwuhpylyjgbylmgthsi'],
+            prefecture='xsswsxrczjdydnlwlxzd',
+            event=VolcanicWarningEventEnum.warning
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'hajinzntzsbrnvgnvbny'
+        test_value = 'jzawrzivshlpvwnwbbxb'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -59,7 +59,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'ogoorhcdhznewdkruaxy'
+        test_value = 'fexftznnicqnrpyjlvdd'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -83,7 +83,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_code property
         """
-        test_value = 'cpxbwodpkbpxgtzvrxjj'
+        test_value = 'kyomzkpjxhpnezvlizhd'
         self.instance.alert_level_code = test_value
         self.assertEqual(self.instance.alert_level_code, test_value)
     
@@ -91,7 +91,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_name property
         """
-        test_value = 'ssalitcbxzkxaiqrakjf'
+        test_value = 'pqfrssxuwklctfpevhup'
         self.instance.alert_level_name = test_value
         self.assertEqual(self.instance.alert_level_name, test_value)
     
@@ -99,7 +99,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test previous_level_code property
         """
-        test_value = 'dzljzkbcfmamrhiuaevg'
+        test_value = 'eizdwjmkvktxfaghukgs'
         self.instance.previous_level_code = test_value
         self.assertEqual(self.instance.previous_level_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'yiczowvefkljxocyuwrb'
+        test_value = 'thnyrbegnxeiilosxmry'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['iljhbrbvtujaqkfdotcu']
+        test_value = ['rugqamexvkqmhuwfmwre', 'gtwuhpylyjgbylmgthsi']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'npggtdcnmbdvvfwlxczb'
+        test_value = 'xsswsxrczjdydnlwlxzd'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.warning
+        test_value = VolcanicWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanicwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_amqp_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
+
+
+class Test_VolcanicWarningEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicWarningEventEnum
+        """
+        return VolcanicWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcano.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_amqp_producer_data.volcano import Volcano
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 class Test_Volcano(unittest.TestCase):
@@ -29,15 +29,15 @@ class Test_Volcano(unittest.TestCase):
         Create instance of Volcano for testing
         """
         instance = Volcano(
-            volcano_code='whzpljwlewipwxzrqfle',
-            name_jp='vtckvbtbombsfdtmhfoy',
-            name_en='coblfhiadodlafdmymtk',
-            latitude=float(24.584250332572477),
-            longitude=float(79.2196014535121),
-            elevation_m=float(10.528756284438867),
-            level_operation=True,
-            prefecture='smnofumzqiyuvjldxssq',
-            event=EventEnum.warning
+            volcano_code='soxxjzfeowkdxlahkycz',
+            name_jp='aglrhiekizkqezkgouux',
+            name_en='jrxsourxbvrkmvvtyvpe',
+            latitude=float(7.289520054950271),
+            longitude=float(98.5271819831292),
+            elevation_m=float(56.87570722765872),
+            level_operation=False,
+            prefecture='zivftphtmdqmmtzzhsqb',
+            event=VolcanoEventEnum.info
         )
         return instance
 
@@ -46,7 +46,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'whzpljwlewipwxzrqfle'
+        test_value = 'soxxjzfeowkdxlahkycz'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -54,7 +54,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'vtckvbtbombsfdtmhfoy'
+        test_value = 'aglrhiekizkqezkgouux'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -62,7 +62,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'coblfhiadodlafdmymtk'
+        test_value = 'jrxsourxbvrkmvvtyvpe'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -70,7 +70,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(24.584250332572477)
+        test_value = float(7.289520054950271)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -78,7 +78,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(79.2196014535121)
+        test_value = float(98.5271819831292)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -86,7 +86,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test elevation_m property
         """
-        test_value = float(10.528756284438867)
+        test_value = float(56.87570722765872)
         self.instance.elevation_m = test_value
         self.assertEqual(self.instance.elevation_m, test_value)
     
@@ -94,7 +94,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test level_operation property
         """
-        test_value = True
+        test_value = False
         self.instance.level_operation = test_value
         self.assertEqual(self.instance.level_operation, test_value)
     
@@ -102,7 +102,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'smnofumzqiyuvjldxssq'
+        test_value = 'zivftphtmdqmmtzzhsqb'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -110,7 +110,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.warning
+        test_value = VolcanoEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_amqp_producer/jma_bosai_volcano_amqp_producer_data/tests/test_volcanoeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_volcano_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_amqp_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_VolcanoEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for VolcanoEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.warning
+        self.instance = VolcanoEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of VolcanoEventEnum
         """
-        return EventEnum.warning
+        return VolcanoEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.warning.value, 'warning')
+        self.assertEqual(VolcanoEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/__init__.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/__init__.py
@@ -1,8 +1,10 @@
-from .eruptiontypeenum import EruptionTypeenum
-from .eventenum import EventEnum
-from .volcaniceruption import VolcanicEruption
+from .volcanoeventenum import VolcanoEventEnum
 from .volcano import Volcano
 from .conditionenum import ConditionEnum
+from .volcanicwarningeventenum import VolcanicWarningEventEnum
 from .volcanicwarning import VolcanicWarning
+from .eruptiontypeenum import EruptionTypeenum
+from .volcaniceruptioneventenum import VolcanicEruptionEventEnum
+from .volcaniceruption import VolcanicEruption
 
-__all__ = ["EruptionTypeenum", "EventEnum", "VolcanicEruption", "Volcano", "ConditionEnum", "VolcanicWarning"]
+__all__ = ["VolcanoEventEnum", "Volcano", "ConditionEnum", "VolcanicWarningEventEnum", "VolcanicWarning", "EruptionTypeenum", "VolcanicEruptionEventEnum", "VolcanicEruption"]

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcaniceruption.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 from jma_bosai_volcano_mqtt_producer_data.eruptiontypeenum import EruptionTypeenum
 import datetime
 
@@ -43,7 +43,7 @@ class VolcanicEruption:
         info_type_jp (typing.Optional[str])
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicEruptionEventEnum)
     """
     
     
@@ -66,7 +66,7 @@ class VolcanicEruption:
     info_type_jp: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicEruptionEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicEruption':
@@ -195,24 +195,24 @@ class VolcanicEruption:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='qfhbaynwlctqgffjzlao',
-            event_id='dvwzevrupkeslalsuwyu',
+            volcano_code='yfjnhtxbhhqlxrmverhd',
+            event_id='ojvrjwdklboubpydycsu',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='xywnnipsujwouckjwidc',
-            colored_plume_height_m=float(3.4291487104233354),
-            white_plume_height_m=float(25.765045403741716),
-            maximum_plume_height_since_start_m=float(12.219610749322051),
-            plume_direction='myeftrcrxvhxcxqwltze',
-            ash_dispersal_direction='gtchnpbiswttuuoxrsky',
+            crater_name='yycfgpknklubfwvhzjeh',
+            colored_plume_height_m=float(73.01170383892484),
+            white_plume_height_m=float(39.24171468115457),
+            maximum_plume_height_since_start_m=float(10.053745138583881),
+            plume_direction='ynmoeziwfhegrbbzlckn',
+            ash_dispersal_direction='wtasfnrlipxboxrqqxxh',
             pyroclastic_flow_observed=False,
-            plume_amount_jp='zajqwqmziatdvwnkgnry',
-            description='aieimurlvtbtsowrorww',
-            info_type_jp='luomrkutmraranrzuoul',
-            area_codes=['kvvkuriluumuhpdilquf', 'rlqrnuxunnakbjmaomnf', 'wzwmarjvrjdmbxmdkgjq', 'ypojabvhuncawaoywvts', 'hdfvtbksmeylolivmcsc'],
-            prefecture='vmwryduxkmakzgstjsve',
-            event=EventEnum.eruption
+            plume_amount_jp='mxsdyfxfxssqurttkfoo',
+            description='stejcblzusubrwzvvpkf',
+            info_type_jp='nrctbscczztxdmjqgbdr',
+            area_codes=['pzxujxahzyalmfnusgii'],
+            prefecture='xsuaqolplzuobdeoidgw',
+            event=VolcanicEruptionEventEnum.eruption
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcaniceruptioneventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanicEruptionEventEnum(Enum):
+    """
+    Fixed topic event segment for VolcanicEruption messages.
+    """
+    eruption = 'eruption'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicEruptionEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanicEruptionEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanicEruptionEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanicwarning.py
@@ -12,7 +12,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_mqtt_producer_data.conditionenum import ConditionEnum
 import datetime
 
@@ -35,7 +35,7 @@ class VolcanicWarning:
         info_type_jp (str)
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicWarningEventEnum)
     """
     
     
@@ -50,7 +50,7 @@ class VolcanicWarning:
     info_type_jp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicWarning':
@@ -179,16 +179,16 @@ class VolcanicWarning:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='vefqnflhpqyaktvxasmv',
-            event_id='euiehibsvontbglycrpw',
+            volcano_code='cyyzkwmcvxmzzrvgzrpv',
+            event_id='gtkhxeiahaqioptvsxbf',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='yrmjlogcblbmhxqrbqqr',
-            alert_level_name='gcxwfutbbcjxgjgzmwjs',
-            previous_level_code='zpvpdsiyrackloirqqzh',
+            alert_level_code='oycuxefivhapcnbpmzyw',
+            alert_level_name='wdxfqglxxkymvmomzqgv',
+            previous_level_code='wbanvisslgqtkfnsigyx',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='ceqckdbsjruxmgpsoveg',
-            area_codes=['imbajmonwoylmjheymmx', 'uerhwewdeherfaxnwtyl', 'stxoihwpvzqeslilnvzd', 'sbtyrldnpfizlmrbztis'],
-            prefecture='vyzoxthuuepqunnpfiwb',
-            event=EventEnum.eruption
+            info_type_jp='nvqsluqmkrazjnwymptn',
+            area_codes=['xftlrstwxpvmdyrtetvv', 'jpppbgcxgvlfqkeafvdp', 'txbnbarpnrckfsqzdikr'],
+            prefecture='jpghtvosxitpionvshid',
+            event=VolcanicWarningEventEnum.warning
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanicwarningeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class VolcanicWarningEventEnum(Enum):
     """
-    Fixed topic event segment for VolcanicEruption messages.
+    Fixed topic event segment for VolcanicWarning messages.
     """
-    eruption = 'eruption'
+    warning = 'warning'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'VolcanicWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (VolcanicWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcano.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -29,7 +29,7 @@ class Volcano:
         elevation_m (typing.Optional[float])
         level_operation (bool)
         prefecture (str)
-        event (EventEnum)
+        event (VolcanoEventEnum)
     """
     
     
@@ -41,7 +41,7 @@ class Volcano:
     elevation_m: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation_m"))
     level_operation: bool=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_operation"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanoEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Volcano':
@@ -170,13 +170,13 @@ class Volcano:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='mvyrarvjirnszequhtle',
-            name_jp='yrktkeguuqyigqnnnyyq',
-            name_en='sahfmiqbjzhxssrgfsgd',
-            latitude=float(82.22054932012946),
-            longitude=float(79.68018424622372),
-            elevation_m=float(71.401683819042),
+            volcano_code='plfziigujkjszbhhgqmi',
+            name_jp='oggxxathcqksircgmxnu',
+            name_en='ojuckpjrgakywbighgdr',
+            latitude=float(91.81731369906664),
+            longitude=float(5.061855898952317),
+            elevation_m=float(8.099434509988978),
             level_operation=False,
-            prefecture='atjiuwdjezrdywtatjpx',
-            event=EventEnum.eruption
+            prefecture='avuqodhyxpsfwzhxzusi',
+            event=VolcanoEventEnum.info
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/src/jma_bosai_volcano_mqtt_producer_data/volcanoeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanoEventEnum(Enum):
+    """
+    Fixed topic event segment for Volcano messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanoEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanoEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanoEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcaniceruption.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_mqtt_producer_data.volcaniceruption import VolcanicEruption
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 from jma_bosai_volcano_mqtt_producer_data.eruptiontypeenum import EruptionTypeenum
 import datetime
 
@@ -31,26 +31,26 @@ class Test_VolcanicEruption(unittest.TestCase):
         Create instance of VolcanicEruption for testing
         """
         instance = VolcanicEruption(
-            volcano_code='qfhbaynwlctqgffjzlao',
-            event_id='dvwzevrupkeslalsuwyu',
+            volcano_code='yfjnhtxbhhqlxrmverhd',
+            event_id='ojvrjwdklboubpydycsu',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='xywnnipsujwouckjwidc',
-            colored_plume_height_m=float(3.4291487104233354),
-            white_plume_height_m=float(25.765045403741716),
-            maximum_plume_height_since_start_m=float(12.219610749322051),
-            plume_direction='myeftrcrxvhxcxqwltze',
-            ash_dispersal_direction='gtchnpbiswttuuoxrsky',
+            crater_name='yycfgpknklubfwvhzjeh',
+            colored_plume_height_m=float(73.01170383892484),
+            white_plume_height_m=float(39.24171468115457),
+            maximum_plume_height_since_start_m=float(10.053745138583881),
+            plume_direction='ynmoeziwfhegrbbzlckn',
+            ash_dispersal_direction='wtasfnrlipxboxrqqxxh',
             pyroclastic_flow_observed=False,
-            plume_amount_jp='zajqwqmziatdvwnkgnry',
-            description='aieimurlvtbtsowrorww',
-            info_type_jp='luomrkutmraranrzuoul',
-            area_codes=['kvvkuriluumuhpdilquf', 'rlqrnuxunnakbjmaomnf', 'wzwmarjvrjdmbxmdkgjq', 'ypojabvhuncawaoywvts', 'hdfvtbksmeylolivmcsc'],
-            prefecture='vmwryduxkmakzgstjsve',
-            event=EventEnum.eruption
+            plume_amount_jp='mxsdyfxfxssqurttkfoo',
+            description='stejcblzusubrwzvvpkf',
+            info_type_jp='nrctbscczztxdmjqgbdr',
+            area_codes=['pzxujxahzyalmfnusgii'],
+            prefecture='xsuaqolplzuobdeoidgw',
+            event=VolcanicEruptionEventEnum.eruption
         )
         return instance
 
@@ -59,7 +59,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'qfhbaynwlctqgffjzlao'
+        test_value = 'yfjnhtxbhhqlxrmverhd'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -67,7 +67,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'dvwzevrupkeslalsuwyu'
+        test_value = 'ojvrjwdklboubpydycsu'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test crater_name property
         """
-        test_value = 'xywnnipsujwouckjwidc'
+        test_value = 'yycfgpknklubfwvhzjeh'
         self.instance.crater_name = test_value
         self.assertEqual(self.instance.crater_name, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test colored_plume_height_m property
         """
-        test_value = float(3.4291487104233354)
+        test_value = float(73.01170383892484)
         self.instance.colored_plume_height_m = test_value
         self.assertEqual(self.instance.colored_plume_height_m, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test white_plume_height_m property
         """
-        test_value = float(25.765045403741716)
+        test_value = float(39.24171468115457)
         self.instance.white_plume_height_m = test_value
         self.assertEqual(self.instance.white_plume_height_m, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test maximum_plume_height_since_start_m property
         """
-        test_value = float(12.219610749322051)
+        test_value = float(10.053745138583881)
         self.instance.maximum_plume_height_since_start_m = test_value
         self.assertEqual(self.instance.maximum_plume_height_since_start_m, test_value)
     
@@ -147,7 +147,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_direction property
         """
-        test_value = 'myeftrcrxvhxcxqwltze'
+        test_value = 'ynmoeziwfhegrbbzlckn'
         self.instance.plume_direction = test_value
         self.assertEqual(self.instance.plume_direction, test_value)
     
@@ -155,7 +155,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test ash_dispersal_direction property
         """
-        test_value = 'gtchnpbiswttuuoxrsky'
+        test_value = 'wtasfnrlipxboxrqqxxh'
         self.instance.ash_dispersal_direction = test_value
         self.assertEqual(self.instance.ash_dispersal_direction, test_value)
     
@@ -171,7 +171,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_amount_jp property
         """
-        test_value = 'zajqwqmziatdvwnkgnry'
+        test_value = 'mxsdyfxfxssqurttkfoo'
         self.instance.plume_amount_jp = test_value
         self.assertEqual(self.instance.plume_amount_jp, test_value)
     
@@ -179,7 +179,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'aieimurlvtbtsowrorww'
+        test_value = 'stejcblzusubrwzvvpkf'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -187,7 +187,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'luomrkutmraranrzuoul'
+        test_value = 'nrctbscczztxdmjqgbdr'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -195,7 +195,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['kvvkuriluumuhpdilquf', 'rlqrnuxunnakbjmaomnf', 'wzwmarjvrjdmbxmdkgjq', 'ypojabvhuncawaoywvts', 'hdfvtbksmeylolivmcsc']
+        test_value = ['pzxujxahzyalmfnusgii']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -203,7 +203,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'vmwryduxkmakzgstjsve'
+        test_value = 'xsuaqolplzuobdeoidgw'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -211,7 +211,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.eruption
+        test_value = VolcanicEruptionEventEnum.eruption
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcaniceruptioneventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_mqtt_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
+
+
+class Test_VolcanicEruptionEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicEruptionEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicEruptionEventEnum.eruption
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicEruptionEventEnum
+        """
+        return VolcanicEruptionEventEnum.eruption
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicEruptionEventEnum.eruption.value, 'eruption')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanicwarning.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_mqtt_producer_data.volcanicwarning import VolcanicWarning
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_mqtt_producer_data.conditionenum import ConditionEnum
 import datetime
 
@@ -31,18 +31,18 @@ class Test_VolcanicWarning(unittest.TestCase):
         Create instance of VolcanicWarning for testing
         """
         instance = VolcanicWarning(
-            volcano_code='vefqnflhpqyaktvxasmv',
-            event_id='euiehibsvontbglycrpw',
+            volcano_code='cyyzkwmcvxmzzrvgzrpv',
+            event_id='gtkhxeiahaqioptvsxbf',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='yrmjlogcblbmhxqrbqqr',
-            alert_level_name='gcxwfutbbcjxgjgzmwjs',
-            previous_level_code='zpvpdsiyrackloirqqzh',
+            alert_level_code='oycuxefivhapcnbpmzyw',
+            alert_level_name='wdxfqglxxkymvmomzqgv',
+            previous_level_code='wbanvisslgqtkfnsigyx',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='ceqckdbsjruxmgpsoveg',
-            area_codes=['imbajmonwoylmjheymmx', 'uerhwewdeherfaxnwtyl', 'stxoihwpvzqeslilnvzd', 'sbtyrldnpfizlmrbztis'],
-            prefecture='vyzoxthuuepqunnpfiwb',
-            event=EventEnum.eruption
+            info_type_jp='nvqsluqmkrazjnwymptn',
+            area_codes=['xftlrstwxpvmdyrtetvv', 'jpppbgcxgvlfqkeafvdp', 'txbnbarpnrckfsqzdikr'],
+            prefecture='jpghtvosxitpionvshid',
+            event=VolcanicWarningEventEnum.warning
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'vefqnflhpqyaktvxasmv'
+        test_value = 'cyyzkwmcvxmzzrvgzrpv'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -59,7 +59,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'euiehibsvontbglycrpw'
+        test_value = 'gtkhxeiahaqioptvsxbf'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -83,7 +83,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_code property
         """
-        test_value = 'yrmjlogcblbmhxqrbqqr'
+        test_value = 'oycuxefivhapcnbpmzyw'
         self.instance.alert_level_code = test_value
         self.assertEqual(self.instance.alert_level_code, test_value)
     
@@ -91,7 +91,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_name property
         """
-        test_value = 'gcxwfutbbcjxgjgzmwjs'
+        test_value = 'wdxfqglxxkymvmomzqgv'
         self.instance.alert_level_name = test_value
         self.assertEqual(self.instance.alert_level_name, test_value)
     
@@ -99,7 +99,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test previous_level_code property
         """
-        test_value = 'zpvpdsiyrackloirqqzh'
+        test_value = 'wbanvisslgqtkfnsigyx'
         self.instance.previous_level_code = test_value
         self.assertEqual(self.instance.previous_level_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'ceqckdbsjruxmgpsoveg'
+        test_value = 'nvqsluqmkrazjnwymptn'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['imbajmonwoylmjheymmx', 'uerhwewdeherfaxnwtyl', 'stxoihwpvzqeslilnvzd', 'sbtyrldnpfizlmrbztis']
+        test_value = ['xftlrstwxpvmdyrtetvv', 'jpppbgcxgvlfqkeafvdp', 'txbnbarpnrckfsqzdikr']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'vyzoxthuuepqunnpfiwb'
+        test_value = 'jpghtvosxitpionvshid'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.eruption
+        test_value = VolcanicWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanicwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_mqtt_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
+
+
+class Test_VolcanicWarningEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicWarningEventEnum
+        """
+        return VolcanicWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcano.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_mqtt_producer_data.volcano import Volcano
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 class Test_Volcano(unittest.TestCase):
@@ -29,15 +29,15 @@ class Test_Volcano(unittest.TestCase):
         Create instance of Volcano for testing
         """
         instance = Volcano(
-            volcano_code='mvyrarvjirnszequhtle',
-            name_jp='yrktkeguuqyigqnnnyyq',
-            name_en='sahfmiqbjzhxssrgfsgd',
-            latitude=float(82.22054932012946),
-            longitude=float(79.68018424622372),
-            elevation_m=float(71.401683819042),
+            volcano_code='plfziigujkjszbhhgqmi',
+            name_jp='oggxxathcqksircgmxnu',
+            name_en='ojuckpjrgakywbighgdr',
+            latitude=float(91.81731369906664),
+            longitude=float(5.061855898952317),
+            elevation_m=float(8.099434509988978),
             level_operation=False,
-            prefecture='atjiuwdjezrdywtatjpx',
-            event=EventEnum.eruption
+            prefecture='avuqodhyxpsfwzhxzusi',
+            event=VolcanoEventEnum.info
         )
         return instance
 
@@ -46,7 +46,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'mvyrarvjirnszequhtle'
+        test_value = 'plfziigujkjszbhhgqmi'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -54,7 +54,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'yrktkeguuqyigqnnnyyq'
+        test_value = 'oggxxathcqksircgmxnu'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -62,7 +62,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'sahfmiqbjzhxssrgfsgd'
+        test_value = 'ojuckpjrgakywbighgdr'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -70,7 +70,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(82.22054932012946)
+        test_value = float(91.81731369906664)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -78,7 +78,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(79.68018424622372)
+        test_value = float(5.061855898952317)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -86,7 +86,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test elevation_m property
         """
-        test_value = float(71.401683819042)
+        test_value = float(8.099434509988978)
         self.instance.elevation_m = test_value
         self.assertEqual(self.instance.elevation_m, test_value)
     
@@ -102,7 +102,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'atjiuwdjezrdywtatjpx'
+        test_value = 'avuqodhyxpsfwzhxzusi'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -110,7 +110,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.eruption
+        test_value = VolcanoEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_mqtt_producer/jma_bosai_volcano_mqtt_producer_data/tests/test_volcanoeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_mqtt_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_VolcanoEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for VolcanoEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.info
+        self.instance = VolcanoEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of VolcanoEventEnum
         """
-        return EventEnum.info
+        return VolcanoEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.info.value, 'info')
+        self.assertEqual(VolcanoEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/__init__.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/__init__.py
@@ -1,8 +1,10 @@
-from .eventenum import EventEnum
-from .volcano import Volcano
 from .eruptiontypeenum import EruptionTypeenum
+from .volcaniceruptioneventenum import VolcanicEruptionEventEnum
 from .volcaniceruption import VolcanicEruption
 from .conditionenum import ConditionEnum
+from .volcanicwarningeventenum import VolcanicWarningEventEnum
 from .volcanicwarning import VolcanicWarning
+from .volcanoeventenum import VolcanoEventEnum
+from .volcano import Volcano
 
-__all__ = ["EventEnum", "Volcano", "EruptionTypeenum", "VolcanicEruption", "ConditionEnum", "VolcanicWarning"]
+__all__ = ["EruptionTypeenum", "VolcanicEruptionEventEnum", "VolcanicEruption", "ConditionEnum", "VolcanicWarningEventEnum", "VolcanicWarning", "VolcanoEventEnum", "Volcano"]

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcaniceruption.py
@@ -13,7 +13,7 @@ from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
 from jma_bosai_volcano_producer_data.eruptiontypeenum import EruptionTypeenum
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 import datetime
 
 
@@ -43,7 +43,7 @@ class VolcanicEruption:
         info_type_jp (typing.Optional[str])
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicEruptionEventEnum)
     """
     
     
@@ -66,7 +66,7 @@ class VolcanicEruption:
     info_type_jp: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicEruptionEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicEruption':
@@ -195,24 +195,24 @@ class VolcanicEruption:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='sqxrtpqrzhlcijoarxrg',
-            event_id='vesudwcaegppzvbbbrvl',
+            volcano_code='eofaajtmzqygwxbmgzym',
+            event_id='hmglidqgdvneiftdutre',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='hfowftknjdymvucxmcpz',
-            colored_plume_height_m=float(57.43519963754912),
-            white_plume_height_m=float(66.50214115783206),
-            maximum_plume_height_since_start_m=float(76.63259165055047),
-            plume_direction='oafmemxtldbwsvyvwhix',
-            ash_dispersal_direction='jcrrphstflbnoqkqbfak',
-            pyroclastic_flow_observed=True,
-            plume_amount_jp='zbpxiermoooespezlbgo',
-            description='ngwhdfvmiszkqconhlep',
-            info_type_jp='dfoabopkunqdgoamrscq',
-            area_codes=['mugxaihwmxbqnjyktfni', 'monxaxsavclzwfgvegfv'],
-            prefecture='fzojgzigsoxgointkitu',
-            event=EventEnum.info
+            crater_name='bscyggcyaslifjqoczyo',
+            colored_plume_height_m=float(57.411747471047455),
+            white_plume_height_m=float(46.10950315589314),
+            maximum_plume_height_since_start_m=float(58.51429253710554),
+            plume_direction='nkxetglbidpjpgudehao',
+            ash_dispersal_direction='vfopegpoklbuxuqmjugf',
+            pyroclastic_flow_observed=False,
+            plume_amount_jp='wdmfwzbuxkkhcpvfvcfh',
+            description='mrjpzjwxwqmwpdixskzu',
+            info_type_jp='uaxdtmahalgcyydpvobm',
+            area_codes=['gaitacpaogcmlcnaoyag', 'jiaucmewnopvvzybpnkt', 'dajdxohyuitbgsrpapab', 'ifmqtzpvdkcgxwggxzqi', 'jzrlcgbqidlkkohosqdu'],
+            prefecture='bejxxxrqcxnaapcokvhi',
+            event=VolcanicEruptionEventEnum.eruption
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcaniceruptioneventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanicEruptionEventEnum(Enum):
+    """
+    Fixed topic event segment for VolcanicEruption messages.
+    """
+    eruption = 'eruption'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicEruptionEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanicEruptionEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanicEruptionEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanicwarning.py
@@ -12,8 +12,8 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
+from jma_bosai_volcano_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_producer_data.conditionenum import ConditionEnum
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
 import datetime
 
 
@@ -35,7 +35,7 @@ class VolcanicWarning:
         info_type_jp (str)
         area_codes (typing.List[str])
         prefecture (str)
-        event (EventEnum)
+        event (VolcanicWarningEventEnum)
     """
     
     
@@ -50,7 +50,7 @@ class VolcanicWarning:
     info_type_jp: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="info_type_jp"))
     area_codes: typing.List[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_codes"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanicWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'VolcanicWarning':
@@ -179,16 +179,16 @@ class VolcanicWarning:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='odrwiiecbeoncuycyxpe',
-            event_id='vnjhsoiqashzmyjzkral',
+            volcano_code='hkeedajppaocowalrbie',
+            event_id='plxbrciygnggplugmvmt',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='pvwsfuilefbuujfxzgds',
-            alert_level_name='liahglddsoxaljmqztux',
-            previous_level_code='ctjjiyxyavsphewnhbzh',
+            alert_level_code='jjfgjnjhempivhnxxvvz',
+            alert_level_name='qsiyoowlgdsnoppzodyf',
+            previous_level_code='knxorcjjwlsxfvovxdfz',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='vbbjalrmirajuquqtvor',
-            area_codes=['yhjwaqtjhtsfstnblxbw', 'zzpxvmakouekxltskbrz', 'cxuchekryxaqlomyxmhs'],
-            prefecture='jigkfvfiitmjldnuszey',
-            event=EventEnum.info
+            info_type_jp='bzkntmoviofbdgbngrvl',
+            area_codes=['hdoagcgfqcivmhoxzzyh', 'itwpoysiqwxtphhusdkq'],
+            prefecture='jhgnqmplnupwlpsberxs',
+            event=VolcanicWarningEventEnum.warning
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanicwarningeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class VolcanicWarningEventEnum(Enum):
     """
-    Fixed topic event segment for Volcano messages.
+    Fixed topic event segment for VolcanicWarning messages.
     """
-    info = 'info'
+    warning = 'warning'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanicWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'VolcanicWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (VolcanicWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcano.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -29,7 +29,7 @@ class Volcano:
         elevation_m (typing.Optional[float])
         level_operation (bool)
         prefecture (str)
-        event (EventEnum)
+        event (VolcanoEventEnum)
     """
     
     
@@ -41,7 +41,7 @@ class Volcano:
     elevation_m: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="elevation_m"))
     level_operation: bool=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="level_operation"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: VolcanoEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Volcano':
@@ -170,13 +170,13 @@ class Volcano:
             An instance of the dataclass.
         """
         return cls(
-            volcano_code='biqbwxqhupvvdgmkjzgv',
-            name_jp='bfgmwupiqrcofrzfxddl',
-            name_en='wukhcbmphdlemexepuew',
-            latitude=float(23.5819475489331),
-            longitude=float(76.99826376158799),
-            elevation_m=float(52.2475435573893),
-            level_operation=False,
-            prefecture='bsblkqduxxcqybizrxoj',
-            event=EventEnum.info
+            volcano_code='qcohxjiizgojienxhsfa',
+            name_jp='cosuyrapvtwxntubxrfq',
+            name_en='iioljkimoxgsqhnohnss',
+            latitude=float(85.18622989046791),
+            longitude=float(25.625840277936184),
+            elevation_m=float(74.80512298523027),
+            level_operation=True,
+            prefecture='epwujyilhheppkgvcvhc',
+            event=VolcanoEventEnum.info
         )

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/src/jma_bosai_volcano_producer_data/volcanoeventenum.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class VolcanoEventEnum(Enum):
+    """
+    Fixed topic event segment for Volcano messages.
+    """
+    info = 'info'
+
+    @classmethod
+    def from_ordinal(cls, ordinal: int | str) -> 'VolcanoEventEnum':
+        """
+        Get enum member by ordinal
+
+        Args:
+            ordinal (int | str): The ordinal of the enum member. This can be an integer or a string representation of an integer.
+
+        Returns:
+            The enum member corresponding to the ordinal.
+        """
+        if ordinal is None:
+            raise ValueError("ordinal must not be None")
+        if isinstance(ordinal, str) and ordinal.isdigit():
+            ordinal = int(ordinal)
+        members = list(cls)
+        if 0 <= int(ordinal) < len(members):
+            return members[ordinal]
+        else:
+            raise IndexError("Ordinal out of range for enum")
+
+    @classmethod
+    def to_ordinal(cls, member: 'VolcanoEventEnum') -> int:
+        """
+        Get enum ordinal
+
+        Args:
+            member (VolcanoEventEnum): The enum member to get the ordinal of.
+
+        Returns:
+            The ordinal of the enum member.
+        """
+        members = list(cls)
+        return members.index(member)

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcaniceruption.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcaniceruption.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_volcano_producer_data.volcaniceruption import VolcanicEruption
 from jma_bosai_volcano_producer_data.eruptiontypeenum import EruptionTypeenum
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
 import datetime
 
 
@@ -31,26 +31,26 @@ class Test_VolcanicEruption(unittest.TestCase):
         Create instance of VolcanicEruption for testing
         """
         instance = VolcanicEruption(
-            volcano_code='sqxrtpqrzhlcijoarxrg',
-            event_id='vesudwcaegppzvbbbrvl',
+            volcano_code='eofaajtmzqygwxbmgzym',
+            event_id='hmglidqgdvneiftdutre',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime=datetime.datetime.now(datetime.timezone.utc),
             eruption_datetime_local=datetime.datetime.now(datetime.timezone.utc),
             eruption_type=EruptionTypeenum.ERUPTION,
-            crater_name='hfowftknjdymvucxmcpz',
-            colored_plume_height_m=float(57.43519963754912),
-            white_plume_height_m=float(66.50214115783206),
-            maximum_plume_height_since_start_m=float(76.63259165055047),
-            plume_direction='oafmemxtldbwsvyvwhix',
-            ash_dispersal_direction='jcrrphstflbnoqkqbfak',
-            pyroclastic_flow_observed=True,
-            plume_amount_jp='zbpxiermoooespezlbgo',
-            description='ngwhdfvmiszkqconhlep',
-            info_type_jp='dfoabopkunqdgoamrscq',
-            area_codes=['mugxaihwmxbqnjyktfni', 'monxaxsavclzwfgvegfv'],
-            prefecture='fzojgzigsoxgointkitu',
-            event=EventEnum.info
+            crater_name='bscyggcyaslifjqoczyo',
+            colored_plume_height_m=float(57.411747471047455),
+            white_plume_height_m=float(46.10950315589314),
+            maximum_plume_height_since_start_m=float(58.51429253710554),
+            plume_direction='nkxetglbidpjpgudehao',
+            ash_dispersal_direction='vfopegpoklbuxuqmjugf',
+            pyroclastic_flow_observed=False,
+            plume_amount_jp='wdmfwzbuxkkhcpvfvcfh',
+            description='mrjpzjwxwqmwpdixskzu',
+            info_type_jp='uaxdtmahalgcyydpvobm',
+            area_codes=['gaitacpaogcmlcnaoyag', 'jiaucmewnopvvzybpnkt', 'dajdxohyuitbgsrpapab', 'ifmqtzpvdkcgxwggxzqi', 'jzrlcgbqidlkkohosqdu'],
+            prefecture='bejxxxrqcxnaapcokvhi',
+            event=VolcanicEruptionEventEnum.eruption
         )
         return instance
 
@@ -59,7 +59,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'sqxrtpqrzhlcijoarxrg'
+        test_value = 'eofaajtmzqygwxbmgzym'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -67,7 +67,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'vesudwcaegppzvbbbrvl'
+        test_value = 'hmglidqgdvneiftdutre'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test crater_name property
         """
-        test_value = 'hfowftknjdymvucxmcpz'
+        test_value = 'bscyggcyaslifjqoczyo'
         self.instance.crater_name = test_value
         self.assertEqual(self.instance.crater_name, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test colored_plume_height_m property
         """
-        test_value = float(57.43519963754912)
+        test_value = float(57.411747471047455)
         self.instance.colored_plume_height_m = test_value
         self.assertEqual(self.instance.colored_plume_height_m, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test white_plume_height_m property
         """
-        test_value = float(66.50214115783206)
+        test_value = float(46.10950315589314)
         self.instance.white_plume_height_m = test_value
         self.assertEqual(self.instance.white_plume_height_m, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test maximum_plume_height_since_start_m property
         """
-        test_value = float(76.63259165055047)
+        test_value = float(58.51429253710554)
         self.instance.maximum_plume_height_since_start_m = test_value
         self.assertEqual(self.instance.maximum_plume_height_since_start_m, test_value)
     
@@ -147,7 +147,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_direction property
         """
-        test_value = 'oafmemxtldbwsvyvwhix'
+        test_value = 'nkxetglbidpjpgudehao'
         self.instance.plume_direction = test_value
         self.assertEqual(self.instance.plume_direction, test_value)
     
@@ -155,7 +155,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test ash_dispersal_direction property
         """
-        test_value = 'jcrrphstflbnoqkqbfak'
+        test_value = 'vfopegpoklbuxuqmjugf'
         self.instance.ash_dispersal_direction = test_value
         self.assertEqual(self.instance.ash_dispersal_direction, test_value)
     
@@ -163,7 +163,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test pyroclastic_flow_observed property
         """
-        test_value = True
+        test_value = False
         self.instance.pyroclastic_flow_observed = test_value
         self.assertEqual(self.instance.pyroclastic_flow_observed, test_value)
     
@@ -171,7 +171,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test plume_amount_jp property
         """
-        test_value = 'zbpxiermoooespezlbgo'
+        test_value = 'wdmfwzbuxkkhcpvfvcfh'
         self.instance.plume_amount_jp = test_value
         self.assertEqual(self.instance.plume_amount_jp, test_value)
     
@@ -179,7 +179,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test description property
         """
-        test_value = 'ngwhdfvmiszkqconhlep'
+        test_value = 'mrjpzjwxwqmwpdixskzu'
         self.instance.description = test_value
         self.assertEqual(self.instance.description, test_value)
     
@@ -187,7 +187,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'dfoabopkunqdgoamrscq'
+        test_value = 'uaxdtmahalgcyydpvobm'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -195,7 +195,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['mugxaihwmxbqnjyktfni', 'monxaxsavclzwfgvegfv']
+        test_value = ['gaitacpaogcmlcnaoyag', 'jiaucmewnopvvzybpnkt', 'dajdxohyuitbgsrpapab', 'ifmqtzpvdkcgxwggxzqi', 'jzrlcgbqidlkkohosqdu']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -203,7 +203,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'fzojgzigsoxgointkitu'
+        test_value = 'bejxxxrqcxnaapcokvhi'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -211,7 +211,7 @@ class Test_VolcanicEruption(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = VolcanicEruptionEventEnum.eruption
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcaniceruptioneventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcaniceruptioneventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_producer_data.volcaniceruptioneventenum import VolcanicEruptionEventEnum
+
+
+class Test_VolcanicEruptionEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicEruptionEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicEruptionEventEnum.eruption
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicEruptionEventEnum
+        """
+        return VolcanicEruptionEventEnum.eruption
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicEruptionEventEnum.eruption.value, 'eruption')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanicwarning.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanicwarning.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_producer_data.volcanicwarning import VolcanicWarning
+from jma_bosai_volcano_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
 from jma_bosai_volcano_producer_data.conditionenum import ConditionEnum
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
 import datetime
 
 
@@ -31,18 +31,18 @@ class Test_VolcanicWarning(unittest.TestCase):
         Create instance of VolcanicWarning for testing
         """
         instance = VolcanicWarning(
-            volcano_code='odrwiiecbeoncuycyxpe',
-            event_id='vnjhsoiqashzmyjzkral',
+            volcano_code='hkeedajppaocowalrbie',
+            event_id='plxbrciygnggplugmvmt',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            alert_level_code='pvwsfuilefbuujfxzgds',
-            alert_level_name='liahglddsoxaljmqztux',
-            previous_level_code='ctjjiyxyavsphewnhbzh',
+            alert_level_code='jjfgjnjhempivhnxxvvz',
+            alert_level_name='qsiyoowlgdsnoppzodyf',
+            previous_level_code='knxorcjjwlsxfvovxdfz',
             condition=ConditionEnum.ISSUED,
-            info_type_jp='vbbjalrmirajuquqtvor',
-            area_codes=['yhjwaqtjhtsfstnblxbw', 'zzpxvmakouekxltskbrz', 'cxuchekryxaqlomyxmhs'],
-            prefecture='jigkfvfiitmjldnuszey',
-            event=EventEnum.info
+            info_type_jp='bzkntmoviofbdgbngrvl',
+            area_codes=['hdoagcgfqcivmhoxzzyh', 'itwpoysiqwxtphhusdkq'],
+            prefecture='jhgnqmplnupwlpsberxs',
+            event=VolcanicWarningEventEnum.warning
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'odrwiiecbeoncuycyxpe'
+        test_value = 'hkeedajppaocowalrbie'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -59,7 +59,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'vnjhsoiqashzmyjzkral'
+        test_value = 'plxbrciygnggplugmvmt'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -83,7 +83,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_code property
         """
-        test_value = 'pvwsfuilefbuujfxzgds'
+        test_value = 'jjfgjnjhempivhnxxvvz'
         self.instance.alert_level_code = test_value
         self.assertEqual(self.instance.alert_level_code, test_value)
     
@@ -91,7 +91,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test alert_level_name property
         """
-        test_value = 'liahglddsoxaljmqztux'
+        test_value = 'qsiyoowlgdsnoppzodyf'
         self.instance.alert_level_name = test_value
         self.assertEqual(self.instance.alert_level_name, test_value)
     
@@ -99,7 +99,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test previous_level_code property
         """
-        test_value = 'ctjjiyxyavsphewnhbzh'
+        test_value = 'knxorcjjwlsxfvovxdfz'
         self.instance.previous_level_code = test_value
         self.assertEqual(self.instance.previous_level_code, test_value)
     
@@ -115,7 +115,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test info_type_jp property
         """
-        test_value = 'vbbjalrmirajuquqtvor'
+        test_value = 'bzkntmoviofbdgbngrvl'
         self.instance.info_type_jp = test_value
         self.assertEqual(self.instance.info_type_jp, test_value)
     
@@ -123,7 +123,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test area_codes property
         """
-        test_value = ['yhjwaqtjhtsfstnblxbw', 'zzpxvmakouekxltskbrz', 'cxuchekryxaqlomyxmhs']
+        test_value = ['hdoagcgfqcivmhoxzzyh', 'itwpoysiqwxtphhusdkq']
         self.instance.area_codes = test_value
         self.assertEqual(self.instance.area_codes, test_value)
     
@@ -131,7 +131,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'jigkfvfiitmjldnuszey'
+        test_value = 'jhgnqmplnupwlpsberxs'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -139,7 +139,7 @@ class Test_VolcanicWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = VolcanicWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanicwarningeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanicwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_volcano_producer_data.volcanicwarningeventenum import VolcanicWarningEventEnum
+
+
+class Test_VolcanicWarningEventEnum(unittest.TestCase):
+    """
+    Test case for VolcanicWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = VolcanicWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of VolcanicWarningEventEnum
+        """
+        return VolcanicWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(VolcanicWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcano.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcano.py
@@ -9,7 +9,7 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_volcano_producer_data.volcano import Volcano
-from jma_bosai_volcano_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
 class Test_Volcano(unittest.TestCase):
@@ -29,15 +29,15 @@ class Test_Volcano(unittest.TestCase):
         Create instance of Volcano for testing
         """
         instance = Volcano(
-            volcano_code='biqbwxqhupvvdgmkjzgv',
-            name_jp='bfgmwupiqrcofrzfxddl',
-            name_en='wukhcbmphdlemexepuew',
-            latitude=float(23.5819475489331),
-            longitude=float(76.99826376158799),
-            elevation_m=float(52.2475435573893),
-            level_operation=False,
-            prefecture='bsblkqduxxcqybizrxoj',
-            event=EventEnum.info
+            volcano_code='qcohxjiizgojienxhsfa',
+            name_jp='cosuyrapvtwxntubxrfq',
+            name_en='iioljkimoxgsqhnohnss',
+            latitude=float(85.18622989046791),
+            longitude=float(25.625840277936184),
+            elevation_m=float(74.80512298523027),
+            level_operation=True,
+            prefecture='epwujyilhheppkgvcvhc',
+            event=VolcanoEventEnum.info
         )
         return instance
 
@@ -46,7 +46,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test volcano_code property
         """
-        test_value = 'biqbwxqhupvvdgmkjzgv'
+        test_value = 'qcohxjiizgojienxhsfa'
         self.instance.volcano_code = test_value
         self.assertEqual(self.instance.volcano_code, test_value)
     
@@ -54,7 +54,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'bfgmwupiqrcofrzfxddl'
+        test_value = 'cosuyrapvtwxntubxrfq'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -62,7 +62,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'wukhcbmphdlemexepuew'
+        test_value = 'iioljkimoxgsqhnohnss'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -70,7 +70,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test latitude property
         """
-        test_value = float(23.5819475489331)
+        test_value = float(85.18622989046791)
         self.instance.latitude = test_value
         self.assertEqual(self.instance.latitude, test_value)
     
@@ -78,7 +78,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test longitude property
         """
-        test_value = float(76.99826376158799)
+        test_value = float(25.625840277936184)
         self.instance.longitude = test_value
         self.assertEqual(self.instance.longitude, test_value)
     
@@ -86,7 +86,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test elevation_m property
         """
-        test_value = float(52.2475435573893)
+        test_value = float(74.80512298523027)
         self.instance.elevation_m = test_value
         self.assertEqual(self.instance.elevation_m, test_value)
     
@@ -94,7 +94,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test level_operation property
         """
-        test_value = False
+        test_value = True
         self.instance.level_operation = test_value
         self.assertEqual(self.instance.level_operation, test_value)
     
@@ -102,7 +102,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'bsblkqduxxcqybizrxoj'
+        test_value = 'epwujyilhheppkgvcvhc'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -110,7 +110,7 @@ class Test_Volcano(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = VolcanoEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanoeventenum.py
+++ b/feeders/jma-bosai-volcano/jma_bosai_volcano_producer/jma_bosai_volcano_producer_data/tests/test_volcanoeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_volcano_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_volcano_producer_data.volcanoeventenum import VolcanoEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_VolcanoEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for VolcanoEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.eruption
+        self.instance = VolcanoEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of VolcanoEventEnum
         """
-        return EventEnum.eruption
+        return VolcanoEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.eruption.value, 'eruption')
+        self.assertEqual(VolcanoEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-volcano/xreg/jma-bosai-volcano.xreg.json
+++ b/feeders/jma-bosai-volcano/xreg/jma-bosai-volcano.xreg.json
@@ -319,6 +319,7 @@
                     "pattern": "^[a-z0-9][a-z0-9-]*$"
                   },
                   "event": {
+                    "name": "VolcanoEventEnum",
                     "type": "string",
                     "enum": [
                       "info"
@@ -459,6 +460,7 @@
                     "pattern": "^[a-z0-9][a-z0-9-]*$"
                   },
                   "event": {
+                    "name": "VolcanicWarningEventEnum",
                     "type": "string",
                     "enum": [
                       "warning"
@@ -657,6 +659,7 @@
                     "pattern": "^[a-z0-9][a-z0-9-]*$"
                   },
                   "event": {
+                    "name": "VolcanicEruptionEventEnum",
                     "type": "string",
                     "enum": [
                       "eruption"


### PR DESCRIPTION
## What

Give the inline `event` enums in the **jma-bosai-volcano** contract distinct
JsonStructure `name`s (`VolcanoEventEnum`, `VolcanicWarningEventEnum`,
`VolcanicEruptionEventEnum`) so codegen stops collapsing them into one module.

## Why — codegen collision (latent, not a live wire bug)

The three inline `event` enums (Volcano `info`, VolcanicWarning `warning`,
VolcanicEruption `eruption`) had **no** JsonStructure `name`, so xrcg/avrotize
derived all three generated type names from the property (`event` →
`EventEnum`) and wrote them to the **same module** `eventenum.py` with
last-writer-wins. Only `info` survived; `warning` and `eruption` were dropped
from the generated enum.

**Blast radius — important nuance vs jma-bosai-amedas (#1466):** amedas was a
genuine *wire* bug because its bridge constructs `EventEnum(...)` **instances**
and Observation was forced to `info`. This feeder is **different**: its core
builds payloads with `event` as a plain **string** (`"info"`/`"warning"`/
`"eruption"`) and the generated serializer passes strings through unchanged,
so **the wire output was already correct** (verified empirically). The
collision here is a **latent defect**:

- the generated `event` field was typed `EventEnum` (missing two members),
- `create_instance()` test data used `EventEnum.info` for **all three**
  classes,
- any future enum-coercing consumer would break on `warning`/`eruption`.

## Change

- **Manifest**: three additive `name` lines on the inline `event` enums.
  Values, `required`, descriptions unchanged.
- **Regenerated** Kafka + MQTT + AMQP producer packages (xrcg 0.10.15): new
  `volcanoeventenum.py` / `volcanicwarningeventenum.py` /
  `volcaniceruptioneventenum.py`; the orphaned `eventenum.py` (+
  `test_eventenum.py`) **removed** from all three data packages. Generated
  dataclasses now carry the correct per-message enum type and correct
  `create_instance()` test values.
- **No bridge/app change** — the bridge never references the enum type (it
  spreads string dicts via `**payload`).

## Validation gates

| Gate | Result |
|------|--------|
| 1 import smoke | ✅ `VolcanicWarning.create_instance().event == VolcanicWarningEventEnum.warning` |
| 2 py_compile | ✅ 0 errors |
| 4 unit tests | ✅ 19 passed |
| 6 mypy (MYPYPATH=producer src) | ✅ no issues, 11 files |
| Avro neutrality | ✅ 0 avro/avsc files changed |
| 5 Docker E2E | ⏸ deferred to CI (local Docker Desktop engine wedged, 500s) — runs on this PR |

## Mandatory expert reviews

xRegistry Expert and JSON Structure Expert reviews are running against this
exact final state (same reviewers that approved the identical amedas pattern
in #1466). Verdicts will be posted as a comment on this PR. The one actionable
nit from the amedas review — orphaned `eventenum.py` not pruned by
regeneration — has already been handled here (all orphans `git rm`'d).
Avro Schema Expert: no such agent is registered; verified directly that the
change is Avro-neutral (0 avro files changed).

## Related

Part of a three-feeder sweep of the same xrcg/avrotize inline-enum name
collision: jma-bosai-amedas (#1466, genuine wire fix), jma-bosai-volcano
(this PR), jma-bosai-warning. Upstream xrcg/avrotize codegen bug to be filed
separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
