### PR TITLE
fix(jma-bosai-warning): distinct names for Office/WeatherWarning event enums (codegen collision)

### DIFF
--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/__init__.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/__init__.py
@@ -1,15 +1,16 @@
-from .officetypeenum import OfficeTypeenum
-from .severityenum import SeverityEnum
-from .eventenum import EventEnum
-from .office import Office
-from .statusenum import StatusEnum
-from .warningitem import WarningItem
-from .weatherwarning import WeatherWarning
 from .infotypeenum import InfoTypeenum
 from .categoryenum import CategoryEnum
 from .affectedcoastalregion import AffectedCoastalRegion
 from .arrivalstatusenum import ArrivalStatusenum
 from .tsunamiobservation import TsunamiObservation
+from .severityenum import SeverityEnum
 from .tsunamialert import TsunamiAlert
+from .weatherwarningeventenum import WeatherWarningEventEnum
+from .statusenum import StatusEnum
+from .warningitem import WarningItem
+from .weatherwarning import WeatherWarning
+from .officetypeenum import OfficeTypeenum
+from .officeeventenum import OfficeEventEnum
+from .office import Office
 
-__all__ = ["OfficeTypeenum", "SeverityEnum", "EventEnum", "Office", "StatusEnum", "WarningItem", "WeatherWarning", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert"]
+__all__ = ["InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "SeverityEnum", "TsunamiAlert", "WeatherWarningEventEnum", "StatusEnum", "WarningItem", "WeatherWarning", "OfficeTypeenum", "OfficeEventEnum", "Office"]

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/affectedcoastalregion.py
@@ -166,10 +166,10 @@ class AffectedCoastalRegion:
             An instance of the dataclass.
         """
         return cls(
-            code='ewirnsltkdaatmlksrsx',
-            name='cysjilqatrqizstiyapx',
+            code='lcvjmqrmdjyxthlgkmcl',
+            name='hlrigzqfshmqwgpndqhm',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(75.57543199099031),
+            expected_max_wave_height_m=float(66.93599517944524),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/office.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_amqp_producer_data.eventenum import EventEnum
 from jma_bosai_warning_amqp_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_amqp_producer_data.officeeventenum import OfficeEventEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -31,7 +31,7 @@ class Office:
         office_type (OfficeTypeenum)
         prefecture (str)
         severity (SeverityEnum)
-        event (EventEnum)
+        event (OfficeEventEnum)
     """
     
     
@@ -43,7 +43,7 @@ class Office:
     office_type: OfficeTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_type"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: OfficeEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Office':
@@ -172,13 +172,13 @@ class Office:
             An instance of the dataclass.
         """
         return cls(
-            office_code='wjdjcmogyrahvfxjrwts',
-            area_code='bqtwyuniznrkujgtpklc',
-            name_jp='qlsoscancivfftowgwdf',
-            name_en='pbfewbwkthuqdzodnyfj',
-            parent_office_code='fkivdukoastjokrmlaca',
+            office_code='hshqmovabofeukjswfby',
+            area_code='yvblrymnhttwwipxpetz',
+            name_jp='mwkjqagyxvufpilllodw',
+            name_en='dbmbcphmwgtafqniapmh',
+            parent_office_code='qpqjtgesxoomfqhwxslf',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='esmmmbstpqajxnuarjwk',
-            severity=SeverityEnum.info,
-            event=EventEnum.info
+            prefecture='iavbtfobrmegmhpjmrag',
+            severity=SeverityEnum.advisory,
+            event=OfficeEventEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/officeeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class OfficeEventEnum(Enum):
     """
-    Fixed MQTT topic event segment for JMA Bosai weather warning state records.
+    Fixed MQTT topic event segment for retained office reference records.
     """
-    warning = 'warning'
+    info = 'info'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'OfficeEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'OfficeEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (OfficeEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/tsunamialert.py
@@ -183,17 +183,17 @@ class TsunamiAlert:
             An instance of the dataclass.
         """
         return cls(
-            event_id='aslhcuurakgvidjlmehc',
-            serial=int(34),
+            event_id='qjmbrluicnhjzbuprhdk',
+            serial=int(20),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='sndnrfuupxtmvmkvmqnn',
-            title_en='ctesbwlgasvswdfghrtd',
-            bulletin_type='wsgcwfldhtmzgevichku',
-            detail_url='uybgaahbtvqomtptbbbs',
-            affected_coastal_regions=[None, None, None, None, None],
-            observations=[None],
-            prefecture='kihebvvtfububsvqrajs',
-            severity=SeverityEnum.info
+            title_jp='bbmbefaugnaxetotdvyo',
+            title_en='gsszpajqvdleqpnescla',
+            bulletin_type='pfsdsayhxbegrzxzzvey',
+            detail_url='znoybrnythcgslalsisl',
+            affected_coastal_regions=[None, None],
+            observations=[None, None, None],
+            prefecture='nvjypdleiheyrbcgwowo',
+            severity=SeverityEnum.advisory
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/tsunamiobservation.py
@@ -168,10 +168,10 @@ class TsunamiObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='iqlkqyxzftfvoyyzkrpp',
-            station_name_jp='swmhwlslxylyljzxwrei',
-            station_name_en='mfbmtmaijvgpvmucyzrv',
-            observed_max_wave_height_m=float(79.20739238218852),
+            station_code='auqnswnpqqlriordzybt',
+            station_name_jp='ntjomsytlzjyubwhimbk',
+            station_name_en='yteqcpjhkdfplgkqsyct',
+            observed_max_wave_height_m=float(48.83464484268101),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/warningitem.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_amqp_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -163,9 +163,9 @@ class WarningItem:
             An instance of the dataclass.
         """
         return cls(
-            code='bmmmtzmfavthiabubptq',
-            code_description_jp='nhgtdedjgumnjeizcyva',
-            code_description_en='zsmwujvusmdekqxvkrhe',
+            code='ilmsajrozlsvtusukuvq',
+            code_description_jp='bweaxhskztpcukcvbzxr',
+            code_description_en='ceuxsgqksiagurjgqfch',
             status=StatusEnum.ISSUED,
-            severity=SeverityEnum.info
+            severity=SeverityEnum.advisory
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/weatherwarning.py
@@ -12,9 +12,9 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_amqp_producer_data.warningitem import WarningItem
-from jma_bosai_warning_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_warning_amqp_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 import datetime
 
 
@@ -29,7 +29,7 @@ class WeatherWarning:
         severity (SeverityEnum)
         office_code (str)
         area_code (str)
-        event (EventEnum)
+        event (WeatherWarningEventEnum)
         area_name (str)
         report_datetime (datetime.datetime)
         report_datetime_local (datetime.datetime)
@@ -43,7 +43,7 @@ class WeatherWarning:
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
     office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
     area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: WeatherWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
     area_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_name"))
     report_datetime: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     report_datetime_local: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime_local", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -178,15 +178,15 @@ class WeatherWarning:
             An instance of the dataclass.
         """
         return cls(
-            prefecture='mhzkugnrymcrgtceehdl',
-            severity=SeverityEnum.info,
-            office_code='cxusxuzmyixodeuynheo',
-            area_code='mivxyvwsbmjeuuzsknuy',
-            event=EventEnum.info,
-            area_name='eitgcfmnpddnouwsrfhf',
+            prefecture='wmrojyaojeqwhiodzhzn',
+            severity=SeverityEnum.advisory,
+            office_code='anxluebwcdfnimtyxnhg',
+            area_code='ftevmlytenacckguyvyi',
+            event=WeatherWarningEventEnum.warning,
+            area_name='twpiqthggvgwannnkjzh',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='hnbnbyglwpgrdrkmbdff',
-            warnings=[None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='ljvvskgwqpdoavnmuncc',
+            warnings=[None, None, None, None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/src/jma_bosai_warning_amqp_producer_data/weatherwarningeventenum.py
@@ -1,16 +1,14 @@
 from enum import Enum
 
 
-class SeverityEnum(Enum):
+class WeatherWarningEventEnum(Enum):
     """
-    Japan-native tsunami warning severity axis: advisory, warning, or emergency.
+    Fixed MQTT topic event segment for JMA Bosai weather warning state records.
     """
-    advisory = 'advisory'
     warning = 'warning'
-    emergency = 'emergency'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'SeverityEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'WeatherWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -31,12 +29,12 @@ class SeverityEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'SeverityEnum') -> int:
+    def to_ordinal(cls, member: 'WeatherWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (SeverityEnum): The enum member to get the ordinal of.
+            member (WeatherWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_affectedcoastalregion.py
@@ -30,10 +30,10 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         Create instance of AffectedCoastalRegion for testing
         """
         instance = AffectedCoastalRegion(
-            code='ewirnsltkdaatmlksrsx',
-            name='cysjilqatrqizstiyapx',
+            code='lcvjmqrmdjyxthlgkmcl',
+            name='hlrigzqfshmqwgpndqhm',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(75.57543199099031),
+            expected_max_wave_height_m=float(66.93599517944524),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )
@@ -44,7 +44,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'ewirnsltkdaatmlksrsx'
+        test_value = 'lcvjmqrmdjyxthlgkmcl'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -52,7 +52,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'cysjilqatrqizstiyapx'
+        test_value = 'hlrigzqfshmqwgpndqhm'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -68,7 +68,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test expected_max_wave_height_m property
         """
-        test_value = float(75.57543199099031)
+        test_value = float(66.93599517944524)
         self.instance.expected_max_wave_height_m = test_value
         self.assertEqual(self.instance.expected_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_office.py
@@ -9,9 +9,9 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_amqp_producer_data.office import Office
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_amqp_producer_data.eventenum import EventEnum
 from jma_bosai_warning_amqp_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_amqp_producer_data.officeeventenum import OfficeEventEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 
 
 class Test_Office(unittest.TestCase):
@@ -31,15 +31,15 @@ class Test_Office(unittest.TestCase):
         Create instance of Office for testing
         """
         instance = Office(
-            office_code='wjdjcmogyrahvfxjrwts',
-            area_code='bqtwyuniznrkujgtpklc',
-            name_jp='qlsoscancivfftowgwdf',
-            name_en='pbfewbwkthuqdzodnyfj',
-            parent_office_code='fkivdukoastjokrmlaca',
+            office_code='hshqmovabofeukjswfby',
+            area_code='yvblrymnhttwwipxpetz',
+            name_jp='mwkjqagyxvufpilllodw',
+            name_en='dbmbcphmwgtafqniapmh',
+            parent_office_code='qpqjtgesxoomfqhwxslf',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='esmmmbstpqajxnuarjwk',
-            severity=SeverityEnum.info,
-            event=EventEnum.info
+            prefecture='iavbtfobrmegmhpjmrag',
+            severity=SeverityEnum.advisory,
+            event=OfficeEventEnum.info
         )
         return instance
 
@@ -48,7 +48,7 @@ class Test_Office(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'wjdjcmogyrahvfxjrwts'
+        test_value = 'hshqmovabofeukjswfby'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -56,7 +56,7 @@ class Test_Office(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'bqtwyuniznrkujgtpklc'
+        test_value = 'yvblrymnhttwwipxpetz'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -64,7 +64,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'qlsoscancivfftowgwdf'
+        test_value = 'mwkjqagyxvufpilllodw'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -72,7 +72,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'pbfewbwkthuqdzodnyfj'
+        test_value = 'dbmbcphmwgtafqniapmh'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -80,7 +80,7 @@ class Test_Office(unittest.TestCase):
         """
         Test parent_office_code property
         """
-        test_value = 'fkivdukoastjokrmlaca'
+        test_value = 'qpqjtgesxoomfqhwxslf'
         self.instance.parent_office_code = test_value
         self.assertEqual(self.instance.parent_office_code, test_value)
     
@@ -96,7 +96,7 @@ class Test_Office(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'esmmmbstpqajxnuarjwk'
+        test_value = 'iavbtfobrmegmhpjmrag'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -104,7 +104,7 @@ class Test_Office(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = SeverityEnum.info
+        test_value = SeverityEnum.advisory
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     
@@ -112,7 +112,7 @@ class Test_Office(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = OfficeEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_officeeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_amqp_producer_data.officeeventenum import OfficeEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_OfficeEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for OfficeEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.info
+        self.instance = OfficeEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of OfficeEventEnum
         """
-        return EventEnum.info
+        return OfficeEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.info.value, 'info')
+        self.assertEqual(OfficeEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_severityenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_severityenum.py
@@ -16,20 +16,19 @@ class Test_SeverityEnum(unittest.TestCase):
         """
         Setup test
         """
-        self.instance = SeverityEnum.info
+        self.instance = SeverityEnum.advisory
 
     @staticmethod
     def create_instance():
         """
         Create instance of SeverityEnum
         """
-        return SeverityEnum.info
+        return SeverityEnum.advisory
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(SeverityEnum.info.value, 'info')
         self.assertEqual(SeverityEnum.advisory.value, 'advisory')
         self.assertEqual(SeverityEnum.warning.value, 'warning')
         self.assertEqual(SeverityEnum.emergency.value, 'emergency')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_tsunamialert.py
@@ -33,19 +33,19 @@ class Test_TsunamiAlert(unittest.TestCase):
         Create instance of TsunamiAlert for testing
         """
         instance = TsunamiAlert(
-            event_id='aslhcuurakgvidjlmehc',
-            serial=int(34),
+            event_id='qjmbrluicnhjzbuprhdk',
+            serial=int(20),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='sndnrfuupxtmvmkvmqnn',
-            title_en='ctesbwlgasvswdfghrtd',
-            bulletin_type='wsgcwfldhtmzgevichku',
-            detail_url='uybgaahbtvqomtptbbbs',
-            affected_coastal_regions=[None, None, None, None, None],
-            observations=[None],
-            prefecture='kihebvvtfububsvqrajs',
-            severity=SeverityEnum.info
+            title_jp='bbmbefaugnaxetotdvyo',
+            title_en='gsszpajqvdleqpnescla',
+            bulletin_type='pfsdsayhxbegrzxzzvey',
+            detail_url='znoybrnythcgslalsisl',
+            affected_coastal_regions=[None, None],
+            observations=[None, None, None],
+            prefecture='nvjypdleiheyrbcgwowo',
+            severity=SeverityEnum.advisory
         )
         return instance
 
@@ -54,7 +54,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'aslhcuurakgvidjlmehc'
+        test_value = 'qjmbrluicnhjzbuprhdk'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -62,7 +62,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test serial property
         """
-        test_value = int(34)
+        test_value = int(20)
         self.instance.serial = test_value
         self.assertEqual(self.instance.serial, test_value)
     
@@ -94,7 +94,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_jp property
         """
-        test_value = 'sndnrfuupxtmvmkvmqnn'
+        test_value = 'bbmbefaugnaxetotdvyo'
         self.instance.title_jp = test_value
         self.assertEqual(self.instance.title_jp, test_value)
     
@@ -102,7 +102,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_en property
         """
-        test_value = 'ctesbwlgasvswdfghrtd'
+        test_value = 'gsszpajqvdleqpnescla'
         self.instance.title_en = test_value
         self.assertEqual(self.instance.title_en, test_value)
     
@@ -110,7 +110,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test bulletin_type property
         """
-        test_value = 'wsgcwfldhtmzgevichku'
+        test_value = 'pfsdsayhxbegrzxzzvey'
         self.instance.bulletin_type = test_value
         self.assertEqual(self.instance.bulletin_type, test_value)
     
@@ -118,7 +118,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test detail_url property
         """
-        test_value = 'uybgaahbtvqomtptbbbs'
+        test_value = 'znoybrnythcgslalsisl'
         self.instance.detail_url = test_value
         self.assertEqual(self.instance.detail_url, test_value)
     
@@ -126,7 +126,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test affected_coastal_regions property
         """
-        test_value = [None, None, None, None, None]
+        test_value = [None, None]
         self.instance.affected_coastal_regions = test_value
         self.assertEqual(self.instance.affected_coastal_regions, test_value)
     
@@ -134,7 +134,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test observations property
         """
-        test_value = [None]
+        test_value = [None, None, None]
         self.instance.observations = test_value
         self.assertEqual(self.instance.observations, test_value)
     
@@ -142,7 +142,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'kihebvvtfububsvqrajs'
+        test_value = 'nvjypdleiheyrbcgwowo'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -150,7 +150,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = SeverityEnum.info
+        test_value = SeverityEnum.advisory
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_tsunamiobservation.py
@@ -30,10 +30,10 @@ class Test_TsunamiObservation(unittest.TestCase):
         Create instance of TsunamiObservation for testing
         """
         instance = TsunamiObservation(
-            station_code='iqlkqyxzftfvoyyzkrpp',
-            station_name_jp='swmhwlslxylyljzxwrei',
-            station_name_en='mfbmtmaijvgpvmucyzrv',
-            observed_max_wave_height_m=float(79.20739238218852),
+            station_code='auqnswnpqqlriordzybt',
+            station_name_jp='ntjomsytlzjyubwhimbk',
+            station_name_en='yteqcpjhkdfplgkqsyct',
+            observed_max_wave_height_m=float(48.83464484268101),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED
@@ -45,7 +45,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'iqlkqyxzftfvoyyzkrpp'
+        test_value = 'auqnswnpqqlriordzybt'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -53,7 +53,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_jp property
         """
-        test_value = 'swmhwlslxylyljzxwrei'
+        test_value = 'ntjomsytlzjyubwhimbk'
         self.instance.station_name_jp = test_value
         self.assertEqual(self.instance.station_name_jp, test_value)
     
@@ -61,7 +61,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_en property
         """
-        test_value = 'mfbmtmaijvgpvmucyzrv'
+        test_value = 'yteqcpjhkdfplgkqsyct'
         self.instance.station_name_en = test_value
         self.assertEqual(self.instance.station_name_en, test_value)
     
@@ -69,7 +69,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test observed_max_wave_height_m property
         """
-        test_value = float(79.20739238218852)
+        test_value = float(48.83464484268101)
         self.instance.observed_max_wave_height_m = test_value
         self.assertEqual(self.instance.observed_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_warningitem.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_amqp_producer_data.warningitem import WarningItem
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_amqp_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 
 
 class Test_WarningItem(unittest.TestCase):
@@ -30,11 +30,11 @@ class Test_WarningItem(unittest.TestCase):
         Create instance of WarningItem for testing
         """
         instance = WarningItem(
-            code='bmmmtzmfavthiabubptq',
-            code_description_jp='nhgtdedjgumnjeizcyva',
-            code_description_en='zsmwujvusmdekqxvkrhe',
+            code='ilmsajrozlsvtusukuvq',
+            code_description_jp='bweaxhskztpcukcvbzxr',
+            code_description_en='ceuxsgqksiagurjgqfch',
             status=StatusEnum.ISSUED,
-            severity=SeverityEnum.info
+            severity=SeverityEnum.advisory
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'bmmmtzmfavthiabubptq'
+        test_value = 'ilmsajrozlsvtusukuvq'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -51,7 +51,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_jp property
         """
-        test_value = 'nhgtdedjgumnjeizcyva'
+        test_value = 'bweaxhskztpcukcvbzxr'
         self.instance.code_description_jp = test_value
         self.assertEqual(self.instance.code_description_jp, test_value)
     
@@ -59,7 +59,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_en property
         """
-        test_value = 'zsmwujvusmdekqxvkrhe'
+        test_value = 'ceuxsgqksiagurjgqfch'
         self.instance.code_description_en = test_value
         self.assertEqual(self.instance.code_description_en, test_value)
     
@@ -75,7 +75,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = SeverityEnum.info
+        test_value = SeverityEnum.advisory
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_weatherwarning.py
@@ -9,9 +9,9 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_amqp_producer_data.weatherwarning import WeatherWarning
-from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_amqp_producer_data.warningitem import WarningItem
-from jma_bosai_warning_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_warning_amqp_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
+from jma_bosai_warning_amqp_producer_data.severityenum import SeverityEnum
 import datetime
 
 
@@ -32,17 +32,17 @@ class Test_WeatherWarning(unittest.TestCase):
         Create instance of WeatherWarning for testing
         """
         instance = WeatherWarning(
-            prefecture='mhzkugnrymcrgtceehdl',
-            severity=SeverityEnum.info,
-            office_code='cxusxuzmyixodeuynheo',
-            area_code='mivxyvwsbmjeuuzsknuy',
-            event=EventEnum.info,
-            area_name='eitgcfmnpddnouwsrfhf',
+            prefecture='wmrojyaojeqwhiodzhzn',
+            severity=SeverityEnum.advisory,
+            office_code='anxluebwcdfnimtyxnhg',
+            area_code='ftevmlytenacckguyvyi',
+            event=WeatherWarningEventEnum.warning,
+            area_name='twpiqthggvgwannnkjzh',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='hnbnbyglwpgrdrkmbdff',
-            warnings=[None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='ljvvskgwqpdoavnmuncc',
+            warnings=[None, None, None, None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'mhzkugnrymcrgtceehdl'
+        test_value = 'wmrojyaojeqwhiodzhzn'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -59,7 +59,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test severity property
         """
-        test_value = SeverityEnum.info
+        test_value = SeverityEnum.advisory
         self.instance.severity = test_value
         self.assertEqual(self.instance.severity, test_value)
     
@@ -67,7 +67,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'cxusxuzmyixodeuynheo'
+        test_value = 'anxluebwcdfnimtyxnhg'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -75,7 +75,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'mivxyvwsbmjeuuzsknuy'
+        test_value = 'ftevmlytenacckguyvyi'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -83,7 +83,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = WeatherWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -91,7 +91,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_name property
         """
-        test_value = 'eitgcfmnpddnouwsrfhf'
+        test_value = 'twpiqthggvgwannnkjzh'
         self.instance.area_name = test_value
         self.assertEqual(self.instance.area_name, test_value)
     
@@ -115,7 +115,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test headline_text property
         """
-        test_value = 'hnbnbyglwpgrdrkmbdff'
+        test_value = 'ljvvskgwqpdoavnmuncc'
         self.instance.headline_text = test_value
         self.assertEqual(self.instance.headline_text, test_value)
     
@@ -123,7 +123,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test warnings property
         """
-        test_value = [None, None]
+        test_value = [None, None, None, None, None]
         self.instance.warnings = test_value
         self.assertEqual(self.instance.warnings, test_value)
     
@@ -131,7 +131,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test time_defines property
         """
-        test_value = [datetime.datetime.now(datetime.timezone.utc)]
+        test_value = [datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         self.instance.time_defines = test_value
         self.assertEqual(self.instance.time_defines, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_amqp_producer/jma_bosai_warning_amqp_producer_data/tests/test_weatherwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_amqp_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
+
+
+class Test_WeatherWarningEventEnum(unittest.TestCase):
+    """
+    Test case for WeatherWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = WeatherWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WeatherWarningEventEnum
+        """
+        return WeatherWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(WeatherWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/__init__.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/__init__.py
@@ -1,10 +1,11 @@
-from .officetypeenum import OfficeTypeenum
 from .severityenum import SeverityEnum
-from .eventenum import EventEnum
-from .office import Office
+from .weatherwarningeventenum import WeatherWarningEventEnum
 from .statusenum import StatusEnum
 from .warningitem import WarningItem
 from .weatherwarning import WeatherWarning
+from .officetypeenum import OfficeTypeenum
+from .officeeventenum import OfficeEventEnum
+from .office import Office
 from .infotypeenum import InfoTypeenum
 from .categoryenum import CategoryEnum
 from .affectedcoastalregion import AffectedCoastalRegion
@@ -12,4 +13,4 @@ from .arrivalstatusenum import ArrivalStatusenum
 from .tsunamiobservation import TsunamiObservation
 from .tsunamialert import TsunamiAlert
 
-__all__ = ["OfficeTypeenum", "SeverityEnum", "EventEnum", "Office", "StatusEnum", "WarningItem", "WeatherWarning", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert"]
+__all__ = ["SeverityEnum", "WeatherWarningEventEnum", "StatusEnum", "WarningItem", "WeatherWarning", "OfficeTypeenum", "OfficeEventEnum", "Office", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert"]

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/affectedcoastalregion.py
@@ -166,10 +166,10 @@ class AffectedCoastalRegion:
             An instance of the dataclass.
         """
         return cls(
-            code='dqypxmermlstakyelfcb',
-            name='bzpqdczbffubcvihwrsb',
+            code='fhlexfzbdhxplmhsuoqz',
+            name='lhmxgckofiyhnbgdaabj',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(75.3013516208057),
+            expected_max_wave_height_m=float(79.48866653629226),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/office.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
 from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_mqtt_producer_data.officeeventenum import OfficeEventEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -31,7 +31,7 @@ class Office:
         office_type (OfficeTypeenum)
         prefecture (str)
         severity (SeverityEnum)
-        event (EventEnum)
+        event (OfficeEventEnum)
     """
     
     
@@ -43,7 +43,7 @@ class Office:
     office_type: OfficeTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_type"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: OfficeEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Office':
@@ -172,13 +172,13 @@ class Office:
             An instance of the dataclass.
         """
         return cls(
-            office_code='xnqjgaavhztkgdtzhkic',
-            area_code='vfjipppeutqdgysmboxo',
-            name_jp='rsduxpyqtelmdmbqqtdu',
-            name_en='sdohkefinxubgjzzlkss',
-            parent_office_code='lbmbzovtcazglpykzyqu',
+            office_code='zqhheaqfqbtsmnwxhcgd',
+            area_code='kdmyumlwaonwsilolvgj',
+            name_jp='btcxfateczzqjaisziws',
+            name_en='ezqvytarhmygytxsjwbz',
+            parent_office_code='qekrpovoflhqtkgzezch',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='dcmpewvywbgawpfltysf',
+            prefecture='yvignhwsqrbszrtqinnh',
             severity=SeverityEnum.info,
-            event=EventEnum.info
+            event=OfficeEventEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/officeeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class OfficeEventEnum(Enum):
     """
     Fixed MQTT topic event segment for retained office reference records.
     """
     info = 'info'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'OfficeEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'OfficeEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (OfficeEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/tsunamialert.py
@@ -12,10 +12,10 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
-from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_mqtt_producer_data.infotypeenum import InfoTypeenum
-from jma_bosai_warning_mqtt_producer_data.affectedcoastalregion import AffectedCoastalRegion
 from jma_bosai_warning_mqtt_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_mqtt_producer_data.affectedcoastalregion import AffectedCoastalRegion
 import datetime
 
 
@@ -183,17 +183,17 @@ class TsunamiAlert:
             An instance of the dataclass.
         """
         return cls(
-            event_id='amszqymmuhwytlecxisr',
-            serial=int(87),
+            event_id='nxiymokmrqxtnqdanipu',
+            serial=int(9),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='npjtwqoqkwgvnbjljgwe',
-            title_en='iwcxfksfpmjkljjdtawb',
-            bulletin_type='iouszzyutesnmofaxluq',
-            detail_url='islmcajmlkdlnffbwiog',
-            affected_coastal_regions=[None, None],
+            title_jp='mwrpswqiuuerwtuirdzu',
+            title_en='tutfvswglanbgjeimjhg',
+            bulletin_type='bcnvrernhdobkarkkkvf',
+            detail_url='dnyomzrldlpjtqgcqdmi',
+            affected_coastal_regions=[None, None, None, None, None],
             observations=[None, None],
-            prefecture='mwwbyuiubneflogkyynf',
+            prefecture='zdavxpwhxseqzrfmrphc',
             severity=SeverityEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/tsunamiobservation.py
@@ -168,10 +168,10 @@ class TsunamiObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='grlpwfpwmjwaxdmdanqb',
-            station_name_jp='jzeqbcitreqwmxoycqvc',
-            station_name_en='wwdlzohqdstuxyojemeb',
-            observed_max_wave_height_m=float(22.224994939358044),
+            station_code='sbmlgycikspndzhmjods',
+            station_name_jp='maggxptltmjuerjmxdfi',
+            station_name_en='jugaiurwwydpkeljpvrh',
+            observed_max_wave_height_m=float(99.63782041314644),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/warningitem.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_mqtt_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -163,9 +163,9 @@ class WarningItem:
             An instance of the dataclass.
         """
         return cls(
-            code='cwnblsbmwriwxnmslagm',
-            code_description_jp='oqptsxtkcllhenhnulfa',
-            code_description_en='flepnmqodsmbyrydwbxc',
+            code='ghegvovudrmljxtvapas',
+            code_description_jp='vpivkhqxfthasjseonyl',
+            code_description_en='dnsgknmcgsbeujigydvb',
             status=StatusEnum.ISSUED,
             severity=SeverityEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarning.py
@@ -13,7 +13,7 @@ from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
 from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
 from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
 import datetime
 
@@ -29,7 +29,7 @@ class WeatherWarning:
         severity (SeverityEnum)
         office_code (str)
         area_code (str)
-        event (EventEnum)
+        event (WeatherWarningEventEnum)
         area_name (str)
         report_datetime (datetime.datetime)
         report_datetime_local (datetime.datetime)
@@ -43,7 +43,7 @@ class WeatherWarning:
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
     office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
     area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: WeatherWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
     area_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_name"))
     report_datetime: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     report_datetime_local: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime_local", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -178,15 +178,15 @@ class WeatherWarning:
             An instance of the dataclass.
         """
         return cls(
-            prefecture='ihdtnuuqpswfhdzpnklq',
+            prefecture='bpkwinvftanenocedzlq',
             severity=SeverityEnum.info,
-            office_code='nwijzqdttmjejnrmcnln',
-            area_code='dtprfacbnigugofnqqtb',
-            event=EventEnum.info,
-            area_name='uscrsiebbcqxehjcufsp',
+            office_code='oaqnrqkxbjtsoiejyzrz',
+            area_code='jhkyzppyxxvuvhbyitet',
+            event=WeatherWarningEventEnum.warning,
+            area_name='nnmorhvpnknxivbtazlw',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='uerbcecosedpzlyovjfy',
-            warnings=[None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='mkqldlvsldwhmkzigkfm',
+            warnings=[None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/src/jma_bosai_warning_mqtt_producer_data/weatherwarningeventenum.py
@@ -1,16 +1,14 @@
 from enum import Enum
 
 
-class SeverityEnum(Enum):
+class WeatherWarningEventEnum(Enum):
     """
-    Japan-native tsunami warning severity axis: advisory, warning, or emergency.
+    Fixed MQTT topic event segment for JMA Bosai weather warning state records.
     """
-    advisory = 'advisory'
     warning = 'warning'
-    emergency = 'emergency'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'SeverityEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'WeatherWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -31,12 +29,12 @@ class SeverityEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'SeverityEnum') -> int:
+    def to_ordinal(cls, member: 'WeatherWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (SeverityEnum): The enum member to get the ordinal of.
+            member (WeatherWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_affectedcoastalregion.py
@@ -30,10 +30,10 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         Create instance of AffectedCoastalRegion for testing
         """
         instance = AffectedCoastalRegion(
-            code='dqypxmermlstakyelfcb',
-            name='bzpqdczbffubcvihwrsb',
+            code='fhlexfzbdhxplmhsuoqz',
+            name='lhmxgckofiyhnbgdaabj',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(75.3013516208057),
+            expected_max_wave_height_m=float(79.48866653629226),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )
@@ -44,7 +44,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'dqypxmermlstakyelfcb'
+        test_value = 'fhlexfzbdhxplmhsuoqz'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -52,7 +52,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'bzpqdczbffubcvihwrsb'
+        test_value = 'lhmxgckofiyhnbgdaabj'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -68,7 +68,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test expected_max_wave_height_m property
         """
-        test_value = float(75.3013516208057)
+        test_value = float(79.48866653629226)
         self.instance.expected_max_wave_height_m = test_value
         self.assertEqual(self.instance.expected_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_office.py
@@ -9,9 +9,9 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_mqtt_producer_data.office import Office
-from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
 from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.officetypeenum import OfficeTypeenum
+from jma_bosai_warning_mqtt_producer_data.officeeventenum import OfficeEventEnum
 
 
 class Test_Office(unittest.TestCase):
@@ -31,15 +31,15 @@ class Test_Office(unittest.TestCase):
         Create instance of Office for testing
         """
         instance = Office(
-            office_code='xnqjgaavhztkgdtzhkic',
-            area_code='vfjipppeutqdgysmboxo',
-            name_jp='rsduxpyqtelmdmbqqtdu',
-            name_en='sdohkefinxubgjzzlkss',
-            parent_office_code='lbmbzovtcazglpykzyqu',
+            office_code='zqhheaqfqbtsmnwxhcgd',
+            area_code='kdmyumlwaonwsilolvgj',
+            name_jp='btcxfateczzqjaisziws',
+            name_en='ezqvytarhmygytxsjwbz',
+            parent_office_code='qekrpovoflhqtkgzezch',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='dcmpewvywbgawpfltysf',
+            prefecture='yvignhwsqrbszrtqinnh',
             severity=SeverityEnum.info,
-            event=EventEnum.info
+            event=OfficeEventEnum.info
         )
         return instance
 
@@ -48,7 +48,7 @@ class Test_Office(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'xnqjgaavhztkgdtzhkic'
+        test_value = 'zqhheaqfqbtsmnwxhcgd'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -56,7 +56,7 @@ class Test_Office(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'vfjipppeutqdgysmboxo'
+        test_value = 'kdmyumlwaonwsilolvgj'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -64,7 +64,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'rsduxpyqtelmdmbqqtdu'
+        test_value = 'btcxfateczzqjaisziws'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -72,7 +72,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'sdohkefinxubgjzzlkss'
+        test_value = 'ezqvytarhmygytxsjwbz'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -80,7 +80,7 @@ class Test_Office(unittest.TestCase):
         """
         Test parent_office_code property
         """
-        test_value = 'lbmbzovtcazglpykzyqu'
+        test_value = 'qekrpovoflhqtkgzezch'
         self.instance.parent_office_code = test_value
         self.assertEqual(self.instance.parent_office_code, test_value)
     
@@ -96,7 +96,7 @@ class Test_Office(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'dcmpewvywbgawpfltysf'
+        test_value = 'yvignhwsqrbszrtqinnh'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -112,7 +112,7 @@ class Test_Office(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = OfficeEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_officeeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_warning_amqp_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.officeeventenum import OfficeEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_OfficeEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for OfficeEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.info
+        self.instance = OfficeEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of OfficeEventEnum
         """
-        return EventEnum.info
+        return OfficeEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.info.value, 'info')
+        self.assertEqual(OfficeEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_tsunamialert.py
@@ -9,10 +9,10 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_mqtt_producer_data.tsunamialert import TsunamiAlert
-from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_mqtt_producer_data.infotypeenum import InfoTypeenum
-from jma_bosai_warning_mqtt_producer_data.affectedcoastalregion import AffectedCoastalRegion
 from jma_bosai_warning_mqtt_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_mqtt_producer_data.affectedcoastalregion import AffectedCoastalRegion
 import datetime
 
 
@@ -33,18 +33,18 @@ class Test_TsunamiAlert(unittest.TestCase):
         Create instance of TsunamiAlert for testing
         """
         instance = TsunamiAlert(
-            event_id='amszqymmuhwytlecxisr',
-            serial=int(87),
+            event_id='nxiymokmrqxtnqdanipu',
+            serial=int(9),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='npjtwqoqkwgvnbjljgwe',
-            title_en='iwcxfksfpmjkljjdtawb',
-            bulletin_type='iouszzyutesnmofaxluq',
-            detail_url='islmcajmlkdlnffbwiog',
-            affected_coastal_regions=[None, None],
+            title_jp='mwrpswqiuuerwtuirdzu',
+            title_en='tutfvswglanbgjeimjhg',
+            bulletin_type='bcnvrernhdobkarkkkvf',
+            detail_url='dnyomzrldlpjtqgcqdmi',
+            affected_coastal_regions=[None, None, None, None, None],
             observations=[None, None],
-            prefecture='mwwbyuiubneflogkyynf',
+            prefecture='zdavxpwhxseqzrfmrphc',
             severity=SeverityEnum.info
         )
         return instance
@@ -54,7 +54,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'amszqymmuhwytlecxisr'
+        test_value = 'nxiymokmrqxtnqdanipu'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -62,7 +62,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test serial property
         """
-        test_value = int(87)
+        test_value = int(9)
         self.instance.serial = test_value
         self.assertEqual(self.instance.serial, test_value)
     
@@ -94,7 +94,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_jp property
         """
-        test_value = 'npjtwqoqkwgvnbjljgwe'
+        test_value = 'mwrpswqiuuerwtuirdzu'
         self.instance.title_jp = test_value
         self.assertEqual(self.instance.title_jp, test_value)
     
@@ -102,7 +102,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_en property
         """
-        test_value = 'iwcxfksfpmjkljjdtawb'
+        test_value = 'tutfvswglanbgjeimjhg'
         self.instance.title_en = test_value
         self.assertEqual(self.instance.title_en, test_value)
     
@@ -110,7 +110,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test bulletin_type property
         """
-        test_value = 'iouszzyutesnmofaxluq'
+        test_value = 'bcnvrernhdobkarkkkvf'
         self.instance.bulletin_type = test_value
         self.assertEqual(self.instance.bulletin_type, test_value)
     
@@ -118,7 +118,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test detail_url property
         """
-        test_value = 'islmcajmlkdlnffbwiog'
+        test_value = 'dnyomzrldlpjtqgcqdmi'
         self.instance.detail_url = test_value
         self.assertEqual(self.instance.detail_url, test_value)
     
@@ -126,7 +126,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test affected_coastal_regions property
         """
-        test_value = [None, None]
+        test_value = [None, None, None, None, None]
         self.instance.affected_coastal_regions = test_value
         self.assertEqual(self.instance.affected_coastal_regions, test_value)
     
@@ -142,7 +142,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'mwwbyuiubneflogkyynf'
+        test_value = 'zdavxpwhxseqzrfmrphc'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_tsunamiobservation.py
@@ -30,10 +30,10 @@ class Test_TsunamiObservation(unittest.TestCase):
         Create instance of TsunamiObservation for testing
         """
         instance = TsunamiObservation(
-            station_code='grlpwfpwmjwaxdmdanqb',
-            station_name_jp='jzeqbcitreqwmxoycqvc',
-            station_name_en='wwdlzohqdstuxyojemeb',
-            observed_max_wave_height_m=float(22.224994939358044),
+            station_code='sbmlgycikspndzhmjods',
+            station_name_jp='maggxptltmjuerjmxdfi',
+            station_name_en='jugaiurwwydpkeljpvrh',
+            observed_max_wave_height_m=float(99.63782041314644),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED
@@ -45,7 +45,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'grlpwfpwmjwaxdmdanqb'
+        test_value = 'sbmlgycikspndzhmjods'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -53,7 +53,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_jp property
         """
-        test_value = 'jzeqbcitreqwmxoycqvc'
+        test_value = 'maggxptltmjuerjmxdfi'
         self.instance.station_name_jp = test_value
         self.assertEqual(self.instance.station_name_jp, test_value)
     
@@ -61,7 +61,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_en property
         """
-        test_value = 'wwdlzohqdstuxyojemeb'
+        test_value = 'jugaiurwwydpkeljpvrh'
         self.instance.station_name_en = test_value
         self.assertEqual(self.instance.station_name_en, test_value)
     
@@ -69,7 +69,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test observed_max_wave_height_m property
         """
-        test_value = float(22.224994939358044)
+        test_value = float(99.63782041314644)
         self.instance.observed_max_wave_height_m = test_value
         self.assertEqual(self.instance.observed_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_warningitem.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
-from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 from jma_bosai_warning_mqtt_producer_data.statusenum import StatusEnum
+from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
 
 
 class Test_WarningItem(unittest.TestCase):
@@ -30,9 +30,9 @@ class Test_WarningItem(unittest.TestCase):
         Create instance of WarningItem for testing
         """
         instance = WarningItem(
-            code='cwnblsbmwriwxnmslagm',
-            code_description_jp='oqptsxtkcllhenhnulfa',
-            code_description_en='flepnmqodsmbyrydwbxc',
+            code='ghegvovudrmljxtvapas',
+            code_description_jp='vpivkhqxfthasjseonyl',
+            code_description_en='dnsgknmcgsbeujigydvb',
             status=StatusEnum.ISSUED,
             severity=SeverityEnum.info
         )
@@ -43,7 +43,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'cwnblsbmwriwxnmslagm'
+        test_value = 'ghegvovudrmljxtvapas'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -51,7 +51,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_jp property
         """
-        test_value = 'oqptsxtkcllhenhnulfa'
+        test_value = 'vpivkhqxfthasjseonyl'
         self.instance.code_description_jp = test_value
         self.assertEqual(self.instance.code_description_jp, test_value)
     
@@ -59,7 +59,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_en property
         """
-        test_value = 'flepnmqodsmbyrydwbxc'
+        test_value = 'dnsgknmcgsbeujigydvb'
         self.instance.code_description_en = test_value
         self.assertEqual(self.instance.code_description_en, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarning.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_warning_mqtt_producer_data.weatherwarning import WeatherWarning
 from jma_bosai_warning_mqtt_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_mqtt_producer_data.eventenum import EventEnum
+from jma_bosai_warning_mqtt_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
 from jma_bosai_warning_mqtt_producer_data.warningitem import WarningItem
 import datetime
 
@@ -32,17 +32,17 @@ class Test_WeatherWarning(unittest.TestCase):
         Create instance of WeatherWarning for testing
         """
         instance = WeatherWarning(
-            prefecture='ihdtnuuqpswfhdzpnklq',
+            prefecture='bpkwinvftanenocedzlq',
             severity=SeverityEnum.info,
-            office_code='nwijzqdttmjejnrmcnln',
-            area_code='dtprfacbnigugofnqqtb',
-            event=EventEnum.info,
-            area_name='uscrsiebbcqxehjcufsp',
+            office_code='oaqnrqkxbjtsoiejyzrz',
+            area_code='jhkyzppyxxvuvhbyitet',
+            event=WeatherWarningEventEnum.warning,
+            area_name='nnmorhvpnknxivbtazlw',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='uerbcecosedpzlyovjfy',
-            warnings=[None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='mkqldlvsldwhmkzigkfm',
+            warnings=[None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'ihdtnuuqpswfhdzpnklq'
+        test_value = 'bpkwinvftanenocedzlq'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -67,7 +67,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'nwijzqdttmjejnrmcnln'
+        test_value = 'oaqnrqkxbjtsoiejyzrz'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -75,7 +75,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'dtprfacbnigugofnqqtb'
+        test_value = 'jhkyzppyxxvuvhbyitet'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -83,7 +83,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.info
+        test_value = WeatherWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -91,7 +91,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_name property
         """
-        test_value = 'uscrsiebbcqxehjcufsp'
+        test_value = 'nnmorhvpnknxivbtazlw'
         self.instance.area_name = test_value
         self.assertEqual(self.instance.area_name, test_value)
     
@@ -115,7 +115,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test headline_text property
         """
-        test_value = 'uerbcecosedpzlyovjfy'
+        test_value = 'mkqldlvsldwhmkzigkfm'
         self.instance.headline_text = test_value
         self.assertEqual(self.instance.headline_text, test_value)
     
@@ -123,7 +123,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test warnings property
         """
-        test_value = [None, None]
+        test_value = [None]
         self.instance.warnings = test_value
         self.assertEqual(self.instance.warnings, test_value)
     
@@ -131,7 +131,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test time_defines property
         """
-        test_value = [datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+        test_value = [datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         self.instance.time_defines = test_value
         self.assertEqual(self.instance.time_defines, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_mqtt_producer/jma_bosai_warning_mqtt_producer_data/tests/test_weatherwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_mqtt_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
+
+
+class Test_WeatherWarningEventEnum(unittest.TestCase):
+    """
+    Test case for WeatherWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = WeatherWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WeatherWarningEventEnum
+        """
+        return WeatherWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(WeatherWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/__init__.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/__init__.py
@@ -1,9 +1,6 @@
-from .severityenum import SeverityEnum
-from .eventenum import EventEnum
-from .statusenum import StatusEnum
-from .warningitem import WarningItem
-from .weatherwarning import WeatherWarning
 from .officetypeenum import OfficeTypeenum
+from .severityenum import SeverityEnum
+from .officeeventenum import OfficeEventEnum
 from .office import Office
 from .infotypeenum import InfoTypeenum
 from .categoryenum import CategoryEnum
@@ -11,5 +8,9 @@ from .affectedcoastalregion import AffectedCoastalRegion
 from .arrivalstatusenum import ArrivalStatusenum
 from .tsunamiobservation import TsunamiObservation
 from .tsunamialert import TsunamiAlert
+from .weatherwarningeventenum import WeatherWarningEventEnum
+from .statusenum import StatusEnum
+from .warningitem import WarningItem
+from .weatherwarning import WeatherWarning
 
-__all__ = ["SeverityEnum", "EventEnum", "StatusEnum", "WarningItem", "WeatherWarning", "OfficeTypeenum", "Office", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert"]
+__all__ = ["OfficeTypeenum", "SeverityEnum", "OfficeEventEnum", "Office", "InfoTypeenum", "CategoryEnum", "AffectedCoastalRegion", "ArrivalStatusenum", "TsunamiObservation", "TsunamiAlert", "WeatherWarningEventEnum", "StatusEnum", "WarningItem", "WeatherWarning"]

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/affectedcoastalregion.py
@@ -166,10 +166,10 @@ class AffectedCoastalRegion:
             An instance of the dataclass.
         """
         return cls(
-            code='riinkmxuoxbeydmeplry',
-            name='wzcmwbikkxlthdckxcid',
+            code='grvybvqnbwsyyzmpuegm',
+            name='ijbvjkhcjevuwtxmyzgi',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(7.2629570651315145),
+            expected_max_wave_height_m=float(67.87928256495921),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/office.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
-from jma_bosai_warning_producer_data.eventenum import EventEnum
+from jma_bosai_warning_producer_data.officeeventenum import OfficeEventEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -31,7 +31,7 @@ class Office:
         office_type (OfficeTypeenum)
         prefecture (str)
         severity (SeverityEnum)
-        event (EventEnum)
+        event (OfficeEventEnum)
     """
     
     
@@ -43,7 +43,7 @@ class Office:
     office_type: OfficeTypeenum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_type"))
     prefecture: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="prefecture"))
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: OfficeEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'Office':
@@ -172,13 +172,13 @@ class Office:
             An instance of the dataclass.
         """
         return cls(
-            office_code='aamcsxjlpqskqgkxqnwp',
-            area_code='qiaybsyupkdgkxbobpxf',
-            name_jp='smqsxwrzwqvkedkhnjlc',
-            name_en='rlqqaukfnuoyuxisxkxa',
-            parent_office_code='uwsxvfwbusyvbutpyhnv',
+            office_code='oevlyklbskjhsloaeyst',
+            area_code='bxjcfvvqaedbvzaywaid',
+            name_jp='pgxkawidwfhclnnejbcc',
+            name_en='fqnodzqgnhkqskppjmjk',
+            parent_office_code='huvccysftqpuojyjvhcr',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='rvspdreirglveuullmqb',
+            prefecture='grudvzcntftbjdptofsl',
             severity=SeverityEnum.info,
-            event=EventEnum.warning
+            event=OfficeEventEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/officeeventenum.py
@@ -1,14 +1,14 @@
 from enum import Enum
 
 
-class EventEnum(Enum):
+class OfficeEventEnum(Enum):
     """
     Fixed MQTT topic event segment for retained office reference records.
     """
     info = 'info'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'EventEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'OfficeEventEnum':
         """
         Get enum member by ordinal
 
@@ -29,12 +29,12 @@ class EventEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'EventEnum') -> int:
+    def to_ordinal(cls, member: 'OfficeEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (EventEnum): The enum member to get the ordinal of.
+            member (OfficeEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamialert.py
@@ -13,9 +13,9 @@ from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
 from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
-from jma_bosai_warning_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
 from jma_bosai_warning_producer_data.affectedcoastalregion import AffectedCoastalRegion
+from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 import datetime
 
 
@@ -183,17 +183,17 @@ class TsunamiAlert:
             An instance of the dataclass.
         """
         return cls(
-            event_id='kococdpvlkkrlpghswnr',
-            serial=int(82),
+            event_id='jxketlvgfapqaroockou',
+            serial=int(33),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='nqlmcwqtjavyovxwafux',
-            title_en='swhtaiasmtgnuglambox',
-            bulletin_type='tzigxcfqfsesccojgtfj',
-            detail_url='uchzfvnslpvcsfmfudlj',
-            affected_coastal_regions=[None],
+            title_jp='gdqmmrysgiveqtuygplf',
+            title_en='adkrrupnvmljrwtawgtl',
+            bulletin_type='mukenoaudyyltgestbpk',
+            detail_url='byyvikbnrxpisngxjwri',
+            affected_coastal_regions=[None, None],
             observations=[None, None],
-            prefecture='xhyiosoifyyeaeuhxllf',
+            prefecture='hwyossoxevuzlcpczxjw',
             severity=SeverityEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/tsunamiobservation.py
@@ -168,10 +168,10 @@ class TsunamiObservation:
             An instance of the dataclass.
         """
         return cls(
-            station_code='yvelqxxzektzekivtkwe',
-            station_name_jp='infnqympinybnhxywvmz',
-            station_name_en='sjvaoyghqwqunwjckbvb',
-            observed_max_wave_height_m=float(3.4416693421128186),
+            station_code='cjpkqwodbfcteifvnroh',
+            station_name_jp='xvosslupgvrgmsqaueho',
+            station_name_en='zccchqfdtieiaweqrawf',
+            observed_max_wave_height_m=float(64.07940587733563),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/warningitem.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 import json
-from jma_bosai_warning_producer_data.statusenum import StatusEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.statusenum import StatusEnum
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -163,9 +163,9 @@ class WarningItem:
             An instance of the dataclass.
         """
         return cls(
-            code='diezkjiraidbyrghwejp',
-            code_description_jp='vwibyctlluygiwnymhld',
-            code_description_en='uqgphvhqfgwpdrciwcjz',
+            code='blcrntjdoejyutpcljxp',
+            code_description_jp='qputcpneqcslrodumrwp',
+            code_description_en='lcthotnftepkzpllzjrh',
             status=StatusEnum.ISSUED,
             severity=SeverityEnum.info
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarning.py
@@ -12,8 +12,8 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 from marshmallow import fields
 import json
+from jma_bosai_warning_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
 from jma_bosai_warning_producer_data.warningitem import WarningItem
-from jma_bosai_warning_producer_data.eventenum import EventEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 import datetime
 
@@ -29,7 +29,7 @@ class WeatherWarning:
         severity (SeverityEnum)
         office_code (str)
         area_code (str)
-        event (EventEnum)
+        event (WeatherWarningEventEnum)
         area_name (str)
         report_datetime (datetime.datetime)
         report_datetime_local (datetime.datetime)
@@ -43,7 +43,7 @@ class WeatherWarning:
     severity: SeverityEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="severity"))
     office_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="office_code"))
     area_code: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_code"))
-    event: EventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
+    event: WeatherWarningEventEnum=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="event"))
     area_name: str=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="area_name"))
     report_datetime: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
     report_datetime_local: datetime.datetime=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="report_datetime_local", encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso')))
@@ -178,15 +178,15 @@ class WeatherWarning:
             An instance of the dataclass.
         """
         return cls(
-            prefecture='awighpqqefzrghbgcqsa',
+            prefecture='dyckstaqrujnvncbzeja',
             severity=SeverityEnum.info,
-            office_code='pucmdschdsbfjftmcsym',
-            area_code='luqjzipetldojblvrhgp',
-            event=EventEnum.warning,
-            area_name='yqlgngzclmjlnatxdmkv',
+            office_code='rubjvrilwuhyoaxggzpu',
+            area_code='iuijcdoemrfyorlufdeb',
+            event=WeatherWarningEventEnum.warning,
+            area_name='xmotdpantvpchbxmdedd',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='qxplnrmszwgjqlkifitg',
-            warnings=[None, None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='ftmrrgbnameolndsvkci',
+            warnings=[None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/src/jma_bosai_warning_producer_data/weatherwarningeventenum.py
@@ -1,16 +1,14 @@
 from enum import Enum
 
 
-class SeverityEnum(Enum):
+class WeatherWarningEventEnum(Enum):
     """
-    Japan-native tsunami warning severity axis: advisory, warning, or emergency.
+    Fixed MQTT topic event segment for JMA Bosai weather warning state records.
     """
-    advisory = 'advisory'
     warning = 'warning'
-    emergency = 'emergency'
 
     @classmethod
-    def from_ordinal(cls, ordinal: int | str) -> 'SeverityEnum':
+    def from_ordinal(cls, ordinal: int | str) -> 'WeatherWarningEventEnum':
         """
         Get enum member by ordinal
 
@@ -31,12 +29,12 @@ class SeverityEnum(Enum):
             raise IndexError("Ordinal out of range for enum")
 
     @classmethod
-    def to_ordinal(cls, member: 'SeverityEnum') -> int:
+    def to_ordinal(cls, member: 'WeatherWarningEventEnum') -> int:
         """
         Get enum ordinal
 
         Args:
-            member (SeverityEnum): The enum member to get the ordinal of.
+            member (WeatherWarningEventEnum): The enum member to get the ordinal of.
 
         Returns:
             The ordinal of the enum member.

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_affectedcoastalregion.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_affectedcoastalregion.py
@@ -30,10 +30,10 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         Create instance of AffectedCoastalRegion for testing
         """
         instance = AffectedCoastalRegion(
-            code='riinkmxuoxbeydmeplry',
-            name='wzcmwbikkxlthdckxcid',
+            code='grvybvqnbwsyyzmpuegm',
+            name='ijbvjkhcjevuwtxmyzgi',
             category=CategoryEnum.MAJOR_WARNING,
-            expected_max_wave_height_m=float(7.2629570651315145),
+            expected_max_wave_height_m=float(67.87928256495921),
             expected_arrival_datetime=datetime.datetime.now(datetime.timezone.utc),
             expected_arrival_datetime_local=datetime.datetime.now(datetime.timezone.utc)
         )
@@ -44,7 +44,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'riinkmxuoxbeydmeplry'
+        test_value = 'grvybvqnbwsyyzmpuegm'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -52,7 +52,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'wzcmwbikkxlthdckxcid'
+        test_value = 'ijbvjkhcjevuwtxmyzgi'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -68,7 +68,7 @@ class Test_AffectedCoastalRegion(unittest.TestCase):
         """
         Test expected_max_wave_height_m property
         """
-        test_value = float(7.2629570651315145)
+        test_value = float(67.87928256495921)
         self.instance.expected_max_wave_height_m = test_value
         self.assertEqual(self.instance.expected_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_office.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_office.py
@@ -9,9 +9,9 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_producer_data.office import Office
-from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
-from jma_bosai_warning_producer_data.eventenum import EventEnum
+from jma_bosai_warning_producer_data.officeeventenum import OfficeEventEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.officetypeenum import OfficeTypeenum
 
 
 class Test_Office(unittest.TestCase):
@@ -31,15 +31,15 @@ class Test_Office(unittest.TestCase):
         Create instance of Office for testing
         """
         instance = Office(
-            office_code='aamcsxjlpqskqgkxqnwp',
-            area_code='qiaybsyupkdgkxbobpxf',
-            name_jp='smqsxwrzwqvkedkhnjlc',
-            name_en='rlqqaukfnuoyuxisxkxa',
-            parent_office_code='uwsxvfwbusyvbutpyhnv',
+            office_code='oevlyklbskjhsloaeyst',
+            area_code='bxjcfvvqaedbvzaywaid',
+            name_jp='pgxkawidwfhclnnejbcc',
+            name_en='fqnodzqgnhkqskppjmjk',
+            parent_office_code='huvccysftqpuojyjvhcr',
             office_type=OfficeTypeenum.PREFECTURE,
-            prefecture='rvspdreirglveuullmqb',
+            prefecture='grudvzcntftbjdptofsl',
             severity=SeverityEnum.info,
-            event=EventEnum.warning
+            event=OfficeEventEnum.info
         )
         return instance
 
@@ -48,7 +48,7 @@ class Test_Office(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'aamcsxjlpqskqgkxqnwp'
+        test_value = 'oevlyklbskjhsloaeyst'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -56,7 +56,7 @@ class Test_Office(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'qiaybsyupkdgkxbobpxf'
+        test_value = 'bxjcfvvqaedbvzaywaid'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -64,7 +64,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_jp property
         """
-        test_value = 'smqsxwrzwqvkedkhnjlc'
+        test_value = 'pgxkawidwfhclnnejbcc'
         self.instance.name_jp = test_value
         self.assertEqual(self.instance.name_jp, test_value)
     
@@ -72,7 +72,7 @@ class Test_Office(unittest.TestCase):
         """
         Test name_en property
         """
-        test_value = 'rlqqaukfnuoyuxisxkxa'
+        test_value = 'fqnodzqgnhkqskppjmjk'
         self.instance.name_en = test_value
         self.assertEqual(self.instance.name_en, test_value)
     
@@ -80,7 +80,7 @@ class Test_Office(unittest.TestCase):
         """
         Test parent_office_code property
         """
-        test_value = 'uwsxvfwbusyvbutpyhnv'
+        test_value = 'huvccysftqpuojyjvhcr'
         self.instance.parent_office_code = test_value
         self.assertEqual(self.instance.parent_office_code, test_value)
     
@@ -96,7 +96,7 @@ class Test_Office(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'rvspdreirglveuullmqb'
+        test_value = 'grudvzcntftbjdptofsl'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -112,7 +112,7 @@ class Test_Office(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.warning
+        test_value = OfficeEventEnum.info
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_officeeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_officeeventenum.py
@@ -4,29 +4,29 @@ import unittest
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
-from jma_bosai_warning_producer_data.eventenum import EventEnum
+from jma_bosai_warning_producer_data.officeeventenum import OfficeEventEnum
 
 
-class Test_EventEnum(unittest.TestCase):
+class Test_OfficeEventEnum(unittest.TestCase):
     """
-    Test case for EventEnum
+    Test case for OfficeEventEnum
     """
 
     def setUp(self):
         """
         Setup test
         """
-        self.instance = EventEnum.warning
+        self.instance = OfficeEventEnum.info
 
     @staticmethod
     def create_instance():
         """
-        Create instance of EventEnum
+        Create instance of OfficeEventEnum
         """
-        return EventEnum.warning
+        return OfficeEventEnum.info
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        self.assertEqual(EventEnum.warning.value, 'warning')
+        self.assertEqual(OfficeEventEnum.info.value, 'info')

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamialert.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamialert.py
@@ -10,9 +10,9 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src
 
 from jma_bosai_warning_producer_data.tsunamialert import TsunamiAlert
 from jma_bosai_warning_producer_data.infotypeenum import InfoTypeenum
-from jma_bosai_warning_producer_data.severityenum import SeverityEnum
-from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
 from jma_bosai_warning_producer_data.affectedcoastalregion import AffectedCoastalRegion
+from jma_bosai_warning_producer_data.tsunamiobservation import TsunamiObservation
+from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 import datetime
 
 
@@ -33,18 +33,18 @@ class Test_TsunamiAlert(unittest.TestCase):
         Create instance of TsunamiAlert for testing
         """
         instance = TsunamiAlert(
-            event_id='kococdpvlkkrlpghswnr',
-            serial=int(82),
+            event_id='jxketlvgfapqaroockou',
+            serial=int(33),
             info_type=InfoTypeenum.ISSUED,
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            title_jp='nqlmcwqtjavyovxwafux',
-            title_en='swhtaiasmtgnuglambox',
-            bulletin_type='tzigxcfqfsesccojgtfj',
-            detail_url='uchzfvnslpvcsfmfudlj',
-            affected_coastal_regions=[None],
+            title_jp='gdqmmrysgiveqtuygplf',
+            title_en='adkrrupnvmljrwtawgtl',
+            bulletin_type='mukenoaudyyltgestbpk',
+            detail_url='byyvikbnrxpisngxjwri',
+            affected_coastal_regions=[None, None],
             observations=[None, None],
-            prefecture='xhyiosoifyyeaeuhxllf',
+            prefecture='hwyossoxevuzlcpczxjw',
             severity=SeverityEnum.info
         )
         return instance
@@ -54,7 +54,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test event_id property
         """
-        test_value = 'kococdpvlkkrlpghswnr'
+        test_value = 'jxketlvgfapqaroockou'
         self.instance.event_id = test_value
         self.assertEqual(self.instance.event_id, test_value)
     
@@ -62,7 +62,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test serial property
         """
-        test_value = int(82)
+        test_value = int(33)
         self.instance.serial = test_value
         self.assertEqual(self.instance.serial, test_value)
     
@@ -94,7 +94,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_jp property
         """
-        test_value = 'nqlmcwqtjavyovxwafux'
+        test_value = 'gdqmmrysgiveqtuygplf'
         self.instance.title_jp = test_value
         self.assertEqual(self.instance.title_jp, test_value)
     
@@ -102,7 +102,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test title_en property
         """
-        test_value = 'swhtaiasmtgnuglambox'
+        test_value = 'adkrrupnvmljrwtawgtl'
         self.instance.title_en = test_value
         self.assertEqual(self.instance.title_en, test_value)
     
@@ -110,7 +110,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test bulletin_type property
         """
-        test_value = 'tzigxcfqfsesccojgtfj'
+        test_value = 'mukenoaudyyltgestbpk'
         self.instance.bulletin_type = test_value
         self.assertEqual(self.instance.bulletin_type, test_value)
     
@@ -118,7 +118,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test detail_url property
         """
-        test_value = 'uchzfvnslpvcsfmfudlj'
+        test_value = 'byyvikbnrxpisngxjwri'
         self.instance.detail_url = test_value
         self.assertEqual(self.instance.detail_url, test_value)
     
@@ -126,7 +126,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test affected_coastal_regions property
         """
-        test_value = [None]
+        test_value = [None, None]
         self.instance.affected_coastal_regions = test_value
         self.assertEqual(self.instance.affected_coastal_regions, test_value)
     
@@ -142,7 +142,7 @@ class Test_TsunamiAlert(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'xhyiosoifyyeaeuhxllf'
+        test_value = 'hwyossoxevuzlcpczxjw'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamiobservation.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_tsunamiobservation.py
@@ -30,10 +30,10 @@ class Test_TsunamiObservation(unittest.TestCase):
         Create instance of TsunamiObservation for testing
         """
         instance = TsunamiObservation(
-            station_code='yvelqxxzektzekivtkwe',
-            station_name_jp='infnqympinybnhxywvmz',
-            station_name_en='sjvaoyghqwqunwjckbvb',
-            observed_max_wave_height_m=float(3.4416693421128186),
+            station_code='cjpkqwodbfcteifvnroh',
+            station_name_jp='xvosslupgvrgmsqaueho',
+            station_name_en='zccchqfdtieiaweqrawf',
+            observed_max_wave_height_m=float(64.07940587733563),
             observed_at=datetime.datetime.now(datetime.timezone.utc),
             observed_at_local=datetime.datetime.now(datetime.timezone.utc),
             arrival_status=ArrivalStatusenum.ESTIMATED
@@ -45,7 +45,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_code property
         """
-        test_value = 'yvelqxxzektzekivtkwe'
+        test_value = 'cjpkqwodbfcteifvnroh'
         self.instance.station_code = test_value
         self.assertEqual(self.instance.station_code, test_value)
     
@@ -53,7 +53,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_jp property
         """
-        test_value = 'infnqympinybnhxywvmz'
+        test_value = 'xvosslupgvrgmsqaueho'
         self.instance.station_name_jp = test_value
         self.assertEqual(self.instance.station_name_jp, test_value)
     
@@ -61,7 +61,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test station_name_en property
         """
-        test_value = 'sjvaoyghqwqunwjckbvb'
+        test_value = 'zccchqfdtieiaweqrawf'
         self.instance.station_name_en = test_value
         self.assertEqual(self.instance.station_name_en, test_value)
     
@@ -69,7 +69,7 @@ class Test_TsunamiObservation(unittest.TestCase):
         """
         Test observed_max_wave_height_m property
         """
-        test_value = float(3.4416693421128186)
+        test_value = float(64.07940587733563)
         self.instance.observed_max_wave_height_m = test_value
         self.assertEqual(self.instance.observed_max_wave_height_m, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_warningitem.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_warningitem.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_producer_data.warningitem import WarningItem
-from jma_bosai_warning_producer_data.statusenum import StatusEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
+from jma_bosai_warning_producer_data.statusenum import StatusEnum
 
 
 class Test_WarningItem(unittest.TestCase):
@@ -30,9 +30,9 @@ class Test_WarningItem(unittest.TestCase):
         Create instance of WarningItem for testing
         """
         instance = WarningItem(
-            code='diezkjiraidbyrghwejp',
-            code_description_jp='vwibyctlluygiwnymhld',
-            code_description_en='uqgphvhqfgwpdrciwcjz',
+            code='blcrntjdoejyutpcljxp',
+            code_description_jp='qputcpneqcslrodumrwp',
+            code_description_en='lcthotnftepkzpllzjrh',
             status=StatusEnum.ISSUED,
             severity=SeverityEnum.info
         )
@@ -43,7 +43,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code property
         """
-        test_value = 'diezkjiraidbyrghwejp'
+        test_value = 'blcrntjdoejyutpcljxp'
         self.instance.code = test_value
         self.assertEqual(self.instance.code, test_value)
     
@@ -51,7 +51,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_jp property
         """
-        test_value = 'vwibyctlluygiwnymhld'
+        test_value = 'qputcpneqcslrodumrwp'
         self.instance.code_description_jp = test_value
         self.assertEqual(self.instance.code_description_jp, test_value)
     
@@ -59,7 +59,7 @@ class Test_WarningItem(unittest.TestCase):
         """
         Test code_description_en property
         """
-        test_value = 'uqgphvhqfgwpdrciwcjz'
+        test_value = 'lcthotnftepkzpllzjrh'
         self.instance.code_description_en = test_value
         self.assertEqual(self.instance.code_description_en, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarning.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarning.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
 
 from jma_bosai_warning_producer_data.weatherwarning import WeatherWarning
+from jma_bosai_warning_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
 from jma_bosai_warning_producer_data.warningitem import WarningItem
-from jma_bosai_warning_producer_data.eventenum import EventEnum
 from jma_bosai_warning_producer_data.severityenum import SeverityEnum
 import datetime
 
@@ -32,17 +32,17 @@ class Test_WeatherWarning(unittest.TestCase):
         Create instance of WeatherWarning for testing
         """
         instance = WeatherWarning(
-            prefecture='awighpqqefzrghbgcqsa',
+            prefecture='dyckstaqrujnvncbzeja',
             severity=SeverityEnum.info,
-            office_code='pucmdschdsbfjftmcsym',
-            area_code='luqjzipetldojblvrhgp',
-            event=EventEnum.warning,
-            area_name='yqlgngzclmjlnatxdmkv',
+            office_code='rubjvrilwuhyoaxggzpu',
+            area_code='iuijcdoemrfyorlufdeb',
+            event=WeatherWarningEventEnum.warning,
+            area_name='xmotdpantvpchbxmdedd',
             report_datetime=datetime.datetime.now(datetime.timezone.utc),
             report_datetime_local=datetime.datetime.now(datetime.timezone.utc),
-            headline_text='qxplnrmszwgjqlkifitg',
-            warnings=[None, None, None],
-            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+            headline_text='ftmrrgbnameolndsvkci',
+            warnings=[None, None],
+            time_defines=[datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         )
         return instance
 
@@ -51,7 +51,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test prefecture property
         """
-        test_value = 'awighpqqefzrghbgcqsa'
+        test_value = 'dyckstaqrujnvncbzeja'
         self.instance.prefecture = test_value
         self.assertEqual(self.instance.prefecture, test_value)
     
@@ -67,7 +67,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test office_code property
         """
-        test_value = 'pucmdschdsbfjftmcsym'
+        test_value = 'rubjvrilwuhyoaxggzpu'
         self.instance.office_code = test_value
         self.assertEqual(self.instance.office_code, test_value)
     
@@ -75,7 +75,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_code property
         """
-        test_value = 'luqjzipetldojblvrhgp'
+        test_value = 'iuijcdoemrfyorlufdeb'
         self.instance.area_code = test_value
         self.assertEqual(self.instance.area_code, test_value)
     
@@ -83,7 +83,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test event property
         """
-        test_value = EventEnum.warning
+        test_value = WeatherWarningEventEnum.warning
         self.instance.event = test_value
         self.assertEqual(self.instance.event, test_value)
     
@@ -91,7 +91,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test area_name property
         """
-        test_value = 'yqlgngzclmjlnatxdmkv'
+        test_value = 'xmotdpantvpchbxmdedd'
         self.instance.area_name = test_value
         self.assertEqual(self.instance.area_name, test_value)
     
@@ -115,7 +115,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test headline_text property
         """
-        test_value = 'qxplnrmszwgjqlkifitg'
+        test_value = 'ftmrrgbnameolndsvkci'
         self.instance.headline_text = test_value
         self.assertEqual(self.instance.headline_text, test_value)
     
@@ -123,7 +123,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test warnings property
         """
-        test_value = [None, None, None]
+        test_value = [None, None]
         self.instance.warnings = test_value
         self.assertEqual(self.instance.warnings, test_value)
     
@@ -131,7 +131,7 @@ class Test_WeatherWarning(unittest.TestCase):
         """
         Test time_defines property
         """
-        test_value = [datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
+        test_value = [datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc), datetime.datetime.now(datetime.timezone.utc)]
         self.instance.time_defines = test_value
         self.assertEqual(self.instance.time_defines, test_value)
     

--- a/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarningeventenum.py
+++ b/feeders/jma-bosai-warning/jma_bosai_warning_producer/jma_bosai_warning_producer_data/tests/test_weatherwarningeventenum.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), '../src'.replace('/', os.sep))))
+
+from jma_bosai_warning_producer_data.weatherwarningeventenum import WeatherWarningEventEnum
+
+
+class Test_WeatherWarningEventEnum(unittest.TestCase):
+    """
+    Test case for WeatherWarningEventEnum
+    """
+
+    def setUp(self):
+        """
+        Setup test
+        """
+        self.instance = WeatherWarningEventEnum.warning
+
+    @staticmethod
+    def create_instance():
+        """
+        Create instance of WeatherWarningEventEnum
+        """
+        return WeatherWarningEventEnum.warning
+
+    def test_enum_values(self):
+        """
+        Test that all enum values are defined
+        """
+        self.assertEqual(WeatherWarningEventEnum.warning.value, 'warning')

--- a/feeders/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
+++ b/feeders/jma-bosai-warning/xreg/jma-bosai-warning.xreg.json
@@ -323,6 +323,7 @@
                     }
                   },
                   "event": {
+                    "name": "OfficeEventEnum",
                     "type": "string",
                     "description": "Fixed MQTT topic event segment for retained office reference records.",
                     "enum": [
@@ -403,6 +404,7 @@
                     }
                   },
                   "event": {
+                    "name": "WeatherWarningEventEnum",
                     "type": "string",
                     "description": "Fixed MQTT topic event segment for JMA Bosai weather warning state records.",
                     "enum": [


### PR DESCRIPTION
## What

Give the inline `event` enums in the **jma-bosai-warning** contract distinct
JsonStructure `name`s (`OfficeEventEnum`, `WeatherWarningEventEnum`) so codegen
stops collapsing them into one module.

## Why — codegen collision (latent, not a live wire bug)

The two inline `event` enums (Office `info`, WeatherWarning `warning`) had
**no** JsonStructure `name`, so xrcg/avrotize derived both generated type names
from the property (`event` → `EventEnum`) and wrote them to the **same module**
`eventenum.py` with last-writer-wins. `warning` won; Office's `info` was dropped
from the generated enum. (TsunamiAlert has no `event` field and is unaffected.)

**Blast radius — same nuance as jma-bosai-volcano, unlike amedas (#1466):**
this feeder's bridge builds payloads with `event` as a plain **string**
(`"info"`/`"warning"`) and the generated serializer passes strings through
unchanged, so **the wire output was already correct**. The collision here is a
**latent defect**:

- the generated `event` field was typed `EventEnum` (missing the `info`
  member),
- `create_instance()` test data used `EventEnum.warning` for both classes
  (Office's should be `info`),
- any future enum-coercing consumer would break on the missing member.

## Change

- **Manifest**: two additive `name` lines on the inline `event` enums. Values,
  `required`, descriptions, and the sibling `descriptions` (altenums) maps
  unchanged.
- **Regenerated** Kafka + MQTT + AMQP producer packages (xrcg 0.10.15): new
  `officeeventenum.py` / `weatherwarningeventenum.py`; the orphaned
  `eventenum.py` (+ `test_eventenum.py`) **removed** from all three data
  packages. Generated dataclasses now carry the correct per-message enum type
  and correct `create_instance()` test values (Office → `info`,
  WeatherWarning → `warning`).
- **No bridge/app change** — the bridge never references the enum type (it
  spreads string dicts via `**payload`).

## Validation gates

| Gate | Result |
|------|--------|
| 1 import smoke | ✅ `Office.create_instance().event == OfficeEventEnum.info`, WeatherWarning → `WeatherWarningEventEnum.warning` |
| 2 py_compile | ✅ 0 errors |
| 4 unit tests | ✅ 17 passed |
| 6 mypy (MYPYPATH=producer src) | ✅ no issues, 10 files |
| Avro neutrality | ✅ 0 avro/avsc files changed |
| 5 Docker E2E | ⏸ deferred to CI (local Docker Desktop engine wedged, 500s) — runs on this PR |

## Mandatory expert reviews

xRegistry Expert and JSON Structure Expert reviews are running against this
exact final state (same reviewers that approved the identical amedas pattern
in #1466). Verdicts will be posted as a comment on this PR. The orphaned
`eventenum.py` regeneration-hygiene nit (raised on amedas) is already handled
here (all orphans `git rm`'d). Avro Schema Expert: no such agent is registered;
verified directly that the change is Avro-neutral (0 avro files changed).

## Related

Part of a three-feeder sweep of the same xrcg/avrotize inline-enum name
collision: jma-bosai-amedas (#1466, genuine wire fix), jma-bosai-volcano,
jma-bosai-warning (this PR). Upstream xrcg/avrotize codegen bug to be filed
separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
