### PR TITLE
fix(bluesky): always persist cursor on run() exit (fixes test (bluesky) flake)

### DIFF
--- a/feeders/bluesky/bluesky/bluesky.py
+++ b/feeders/bluesky/bluesky/bluesky.py
@@ -139,11 +139,15 @@ class BlueskyFirehose:
             source = iter_mock_firehose_events(max_events=12)
         else:
             source = iter_firehose_events(firehose_url=self.firehose_url, collections=list(self.collections) if self.collections else None, cursor_provider=lambda: self.cursor, user_agent=USER_AGENT)
-        async for event in source:
-            self._send_event(event)
-            if event.seq % 1000 == 0:
-                self.save_cursor()
-                self.producer.flush()
+        try:
+            async for event in source:
+                self._send_event(event)
+                if event.seq % 1000 == 0:
+                    self.save_cursor()
+                    self.producer.flush()
+        finally:
+            self.save_cursor()
+            self.producer.flush()
 
     def close(self) -> None:
         self.save_cursor()


### PR DESCRIPTION
## Root cause

`test (bluesky)` flaked on `test_bluesky_cursor_persistence_real` with
`AssertionError: Cursor file was not created` — **not** because the firehose
lacked data (it always has data), but because of a real bug in the bridge's
cursor-persistence logic.

`BlueskyFirehose.run()` only called `save_cursor()` inside the consume loop
when `event.seq % 1000 == 0`, and had **no save-on-exit**. The unconditional
save in `close()` is never reached when `run()` is cancelled — which is exactly
what the test does (`asyncio.wait_for(..., timeout=20)` → `task.cancel()`) and
what a production `SIGTERM` does.

Because the stream is filtered to `app.bsky.feed.post`, processed events are
**sparse in the global `seq` space**, so a processed post landing exactly on a
multiple of 1000 within the ~20s window is probabilistic (~50/50). When it
didn't hit, the cursor file was never written → assertion failed.

## Production impact

On graceful shutdown/restart, the feeder lost all cursor progress accumulated
since the last 1000-boundary → reprocessing or gaps on resume. This is a real
data-integrity bug, not just a test flake.

## Fix

Wrap the consume loop in `try/finally` so `save_cursor()` + `producer.flush()`
always run on normal completion, exception, **or cancellation**.

```python
try:
    async for event in source:
        self._send_event(event)
        if event.seq % 1000 == 0:
            self.save_cursor()
            self.producer.flush()
finally:
    self.save_cursor()
    self.producer.flush()
```

Since the firehose always delivers ≥1 event in the window, `self.cursor` is
always set, so the `finally` now makes the integration test deterministic —
no test change required.

## Validation

- Gate 1 import smoke: `import bluesky.bluesky` OK
- Gate 2 py_compile: OK
- Gate 6 mypy (`mypy.ini`): `Success: no issues found`
- Deterministic proof via the **mock** firehose path (seq 1..12, never
  `%1000==0`) for both `normal-exit` and `cancelled-mid-run`: cursor file
  written with `{"cursor": 12}` in both cases. Old code wrote nothing on
  either path.
