### PR TITLE
fix(tools): correct generator paths + guard hand-maintained EVENTS.md/KQL from clobber

### DIFF
--- a/feeders/aisstream/kql/create-kql-script.ps1
+++ b/feeders/aisstream/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\aisstream.xreg.json"
 $kqlFile = Join-Path $scriptDir "aisstream.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/australia-wildfires/kql/create-kql-script.ps1
+++ b/feeders/australia-wildfires/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\australia_wildfires.xreg.json"
 $kqlFile = Join-Path $scriptDir "australia_wildfires.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/autobahn/kql/create-kql-script.ps1
+++ b/feeders/autobahn/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\autobahn.xreg.json"
 $kqlFile = Join-Path $scriptDir "autobahn.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "DE.Autobahn"

--- a/feeders/aviationweather/kql/create-kql-script.ps1
+++ b/feeders/aviationweather/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\aviationweather.xreg.json"
 $kqlFile = Join-Path $scriptDir "aviationweather.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace gov.noaa.aviationweather

--- a/feeders/bafu-hydro/kql/create-kql-script.ps1
+++ b/feeders/bafu-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\bafu_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "bafu_hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/bfs-odl/kql/create-kql-script.ps1
+++ b/feeders/bfs-odl/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\bfs_odl.xreg.json"
 $kqlFile = Join-Path $scriptDir "bfs_odl.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/blitzortung/kql/create-kql-script.ps1
+++ b/feeders/blitzortung/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\blitzortung.xreg.json"
 $kqlFile = Join-Path $scriptDir "blitzortung.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/bluesky/kql/create-kql-script.ps1
+++ b/feeders/bluesky/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\bluesky.xreg.json"
 $kqlFile = Join-Path $scriptDir "bluesky.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/bom-australia/kql/create-kql-script.ps1
+++ b/feeders/bom-australia/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\bom_australia.xreg.json"
 $kqlFile = Join-Path $scriptDir "bom_australia.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace au.gov.bom

--- a/feeders/canada-aqhi/kql/create-kql-script.ps1
+++ b/feeders/canada-aqhi/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\canada-aqhi.xreg.json"
 $kqlFile = Join-Path $scriptDir "canada-aqhi.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace ca.gc.weather.aqhi

--- a/feeders/canada-eccc-wateroffice/kql/create-kql-script.ps1
+++ b/feeders/canada-eccc-wateroffice/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\canada-eccc-wateroffice.xreg.json"
 $kqlFile = Join-Path $scriptDir "canada-eccc-wateroffice.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/feeders/carbon-intensity/kql/create-kql-script.ps1
+++ b/feeders/carbon-intensity/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\carbon_intensity.xreg.json"
 $kqlFile = Join-Path $scriptDir "carbon_intensity.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/cbp-border-wait/kql/create-kql-script.ps1
+++ b/feeders/cbp-border-wait/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\cbp_border_wait.xreg.json"
 $kqlFile = Join-Path $scriptDir "cbp_border_wait.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/cdec-reservoirs/kql/create-kql-script.ps1
+++ b/feeders/cdec-reservoirs/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\cdec_reservoirs.xreg.json"
 $kqlFile = Join-Path $scriptDir "cdec_reservoirs.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/chmi-hydro/kql/create-kql-script.ps1
+++ b/feeders/chmi-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\chmi_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "chmi_hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace cz.gov.chmi.hydro

--- a/feeders/defra-aurn/kql/create-kql-script.ps1
+++ b/feeders/defra-aurn/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\defra_aurn.xreg.json"
 $kqlFile = Join-Path $scriptDir "defra_aurn.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "uk.gov.defra.aurn"

--- a/feeders/digitraffic-maritime/kql/create-kql-script.ps1
+++ b/feeders/digitraffic-maritime/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\digitraffic_maritime.xreg.json"
 $kqlFile = Join-Path $scriptDir "digitraffic_maritime.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/digitraffic-road/kql/create-kql-script.ps1
+++ b/feeders/digitraffic-road/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\digitraffic_road.xreg.json"
 $kqlFile = Join-Path $scriptDir "digitraffic_road.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/dwd-pollenflug/kql/create-kql-script.ps1
+++ b/feeders/dwd-pollenflug/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\dwd_pollenflug.xreg.json"
 $kqlFile = Join-Path $scriptDir "dwd_pollenflug.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace DE.DWD.Pollenflug

--- a/feeders/dwd/kql/create-kql-script.ps1
+++ b/feeders/dwd/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\dwd.xreg.json"
 $kqlFile = Join-Path $scriptDir "dwd.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/eaws-albina/kql/create-kql-script.ps1
+++ b/feeders/eaws-albina/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\eaws_albina.xreg.json"
 $kqlFile = Join-Path $scriptDir "eaws_albina.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/elexon-bmrs/kql/create-kql-script.ps1
+++ b/feeders/elexon-bmrs/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\elexon_bmrs.xreg.json"
 $kqlFile = Join-Path $scriptDir "elexon_bmrs.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace UK.Co.Elexon.BMRS

--- a/feeders/energidataservice-dk/kql/create-kql-script.ps1
+++ b/feeders/energidataservice-dk/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\energidataservice_dk.xreg.json"
 $kqlFile = Join-Path $scriptDir "energidataservice_dk.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/energy-charts/kql/create-kql-script.ps1
+++ b/feeders/energy-charts/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\energy_charts.xreg.json"
 $kqlFile = Join-Path $scriptDir "energy_charts.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/entur-norway/kql/create-kql-script.ps1
+++ b/feeders/entur-norway/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\entur-norway.xreg.json"
 $kqlFile = Join-Path $scriptDir "entur-norway.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/feeders/environment-canada/kql/create-kql-script.ps1
+++ b/feeders/environment-canada/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\environment_canada.xreg.json"
 $kqlFile = Join-Path $scriptDir "environment_canada.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace ca.gov.eccc.weather

--- a/feeders/epa-uv/kql/create-kql-script.ps1
+++ b/feeders/epa-uv/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\epa_uv.xreg.json"
 $kqlFile = Join-Path $scriptDir "epa_uv.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.epa.uvindex"

--- a/feeders/erddap/EVENTS.md
+++ b/feeders/erddap/EVENTS.md
@@ -1,3 +1,4 @@
+<!-- xreg-generator:hand-maintained — hand-polished beyond tools/printdoc.py output (CloudEvents envelope tables). tools/generate-events-md.ps1 skips this file. To refresh from the manifest: remove this line, regenerate, then re-apply the hand sections. -->
 # ERDDAP Events
 
 CloudEvents emitted by the generalized ERDDAP tabledap feeder.

--- a/feeders/eurdep-radiation/kql/create-kql-script.ps1
+++ b/feeders/eurdep-radiation/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\eurdep_radiation.xreg.json"
 $kqlFile = Join-Path $scriptDir "eurdep_radiation.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/fienta/kql/create-kql-script.ps1
+++ b/feeders/fienta/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\fienta.xreg.json"
 $kqlFile = Join-Path $scriptDir "fienta.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/feeders/fmi-finland/kql/create-kql-script.ps1
+++ b/feeders/fmi-finland/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\fmi-finland.xreg.json"
 $kqlFile = Join-Path $scriptDir "fmi-finland.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace fi.fmi.opendata.airquality

--- a/feeders/french-road-traffic/kql/create-kql-script.ps1
+++ b/feeders/french-road-traffic/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\french_road_traffic.xreg.json"
 $kqlFile = Join-Path $scriptDir "french_road_traffic.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/gbfs-bikeshare/EVENTS.md
+++ b/feeders/gbfs-bikeshare/EVENTS.md
@@ -1,3 +1,4 @@
+<!-- xreg-generator:hand-maintained — hand-polished beyond tools/printdoc.py output (README/CONTAINER link-triangle). tools/generate-events-md.ps1 skips this file. To refresh from the manifest: remove this line, regenerate, then re-apply the hand sections. -->
 # GBFS Bikeshare event reference
 
 This document defines the CloudEvents contract emitted by the GBFS bikeshare feeder. For the project overview see README.md; for the published container images and runtime configuration see CONTAINER.md.

--- a/feeders/gdacs/kql/create-kql-script.ps1
+++ b/feeders/gdacs/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\gdacs.xreg.json"
 $kqlFile = Join-Path $scriptDir "gdacs.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/geosphere-austria/kql/create-kql-script.ps1
+++ b/feeders/geosphere-austria/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\geosphere-austria.xreg.json"
 $kqlFile = Join-Path $scriptDir "geosphere-austria.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/german-waters/kql/create-kql-script.ps1
+++ b/feeders/german-waters/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\german_waters.xreg.json"
 $kqlFile = Join-Path $scriptDir "german_waters.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/gios-poland/kql/create-kql-script.ps1
+++ b/feeders/gios-poland/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\gios_poland.xreg.json"
 $kqlFile = Join-Path $scriptDir "gios_poland.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'pl.gov.gios.airquality'

--- a/feeders/gracedb/kql/create-kql-script.ps1
+++ b/feeders/gracedb/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\gracedb.xreg.json"
 $kqlFile = Join-Path $scriptDir "gracedb.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "org.ligo.gracedb"

--- a/feeders/gtfs/kql/create-kql-script.ps1
+++ b/feeders/gtfs/kql/create-kql-script.ps1
@@ -1,7 +1,7 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\gtfs.xreg.json"
 $kqlFile = Join-Path $scriptDir "gtfs.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace GeneralTransitFeed
 

--- a/feeders/hko-hong-kong/kql/create-kql-script.ps1
+++ b/feeders/hko-hong-kong/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\hko_hong_kong.xreg.json"
 $kqlFile = Join-Path $scriptDir "hko_hong_kong.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace hk.gov.hko.weather

--- a/feeders/hongkong-epd/kql/create-kql-script.ps1
+++ b/feeders/hongkong-epd/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\hongkong_epd.xreg.json"
 $kqlFile = Join-Path $scriptDir "hongkong_epd.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace hk.gov.epd.aqhi

--- a/feeders/hubeau-hydrometrie/kql/create-kql-script.ps1
+++ b/feeders/hubeau-hydrometrie/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\hubeau_hydrometrie.xreg.json"
 $kqlFile = Join-Path $scriptDir "hubeau_hydrometrie.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "fr.gov.eaufrance.hubeau.hydrometrie"

--- a/feeders/imgw-hydro/kql/create-kql-script.ps1
+++ b/feeders/imgw-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\imgw_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "imgw_hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace pl.gov.imgw.hydro

--- a/feeders/inpe-deter-brazil/kql/create-kql-script.ps1
+++ b/feeders/inpe-deter-brazil/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\inpe_deter_brazil.xreg.json"
 $kqlFile = Join-Path $scriptDir "inpe_deter_brazil.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/irail/kql/create-kql-script.ps1
+++ b/feeders/irail/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\irail.xreg.json"
 $kqlFile = Join-Path $scriptDir "irail.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/irceline-belgium/kql/create-kql-script.ps1
+++ b/feeders/irceline-belgium/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\irceline_belgium.xreg.json"
 $kqlFile = Join-Path $scriptDir "irceline_belgium.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "be.irceline"

--- a/feeders/ireland-opw-waterlevel/kql/create-kql-script.ps1
+++ b/feeders/ireland-opw-waterlevel/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\ireland_opw_waterlevel.xreg.json"
 $kqlFile = Join-Path $scriptDir "ireland_opw_waterlevel.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/jma-bosai-amedas/kql/create-kql-script.ps1
+++ b/feeders/jma-bosai-amedas/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\jma-bosai-amedas.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma-bosai-amedas.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace JP.JMA.Amedas

--- a/feeders/jma-bosai-quake/kql/create-kql-script.ps1
+++ b/feeders/jma-bosai-quake/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\jma-bosai-quake.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma-bosai-quake.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace JP.JMA.Quake

--- a/feeders/jma-bosai-volcano/kql/create-kql-script.ps1
+++ b/feeders/jma-bosai-volcano/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\jma-bosai-volcano.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma-bosai-volcano.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace JP.JMA.Volcano

--- a/feeders/jma-bosai-warning/kql/create-kql-script.ps1
+++ b/feeders/jma-bosai-warning/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\jma-bosai-warning.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma-bosai-warning.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace JP.JMA.BosaiWarning

--- a/feeders/jma-japan/kql/create-kql-script.ps1
+++ b/feeders/jma-japan/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\jma_japan.xreg.json"
 $kqlFile = Join-Path $scriptDir "jma_japan.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace jp.go.jma

--- a/feeders/king-county-marine/kql/create-kql-script.ps1
+++ b/feeders/king-county-marine/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\king_county_marine.xreg.json"
 $kqlFile = Join-Path $scriptDir "king_county_marine.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.wa.kingcounty.marine"

--- a/feeders/kmi-belgium/kql/create-kql-script.ps1
+++ b/feeders/kmi-belgium/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\kmi_belgium.xreg.json"
 $kqlFile = Join-Path $scriptDir "kmi_belgium.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "BE.Gov.KMI.Weather"

--- a/feeders/kystverket-ais/kql/create-kql-script.ps1
+++ b/feeders/kystverket-ais/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\kystverket-ais.xreg.json"
 $kqlFile = Join-Path $scriptDir "ais.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/laqn-london/kql/create-kql-script.ps1
+++ b/feeders/laqn-london/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\laqn-london.xreg.json"
 $kqlFile = Join-Path $scriptDir "laqn-london.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/luchtmeetnet-nl/kql/create-kql-script.ps1
+++ b/feeders/luchtmeetnet-nl/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\luchtmeetnet-nl.xreg.json"
 $kqlFile = Join-Path $scriptDir "luchtmeetnet-nl.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/madrid-traffic/kql/create-kql-script.ps1
+++ b/feeders/madrid-traffic/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\madrid-traffic.xreg.json"
 $kqlFile = Join-Path $scriptDir "madrid-traffic.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/meteoalarm/kql/create-kql-script.ps1
+++ b/feeders/meteoalarm/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\meteoalarm.xreg.json"
 $kqlFile = Join-Path $scriptDir "meteoalarm.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/mode-s/kql/create-kql-script.ps1
+++ b/feeders/mode-s/kql/create-kql-script.ps1
@@ -2,7 +2,7 @@ $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\mode-s.xreg.json"
 $recordFile = Join-Path $scriptDir "..\xreg\mode_s_adsb_record.avsc"
 $kqlFile = Join-Path $scriptDir "mode-s.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 $updatePolicyFile = Join-Path $scriptDir "update_policy.kql"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/ndw-road-traffic/kql/create-kql-script.ps1
+++ b/feeders/ndw-road-traffic/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\ndw-road-traffic.xreg.json"
 $kqlFile = Join-Path $scriptDir "ndw-road-traffic.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/feeders/nepal-bipad-hydrology/kql/create-kql-script.ps1
+++ b/feeders/nepal-bipad-hydrology/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nepal-bipad-hydrology.xreg.json"
 $kqlFile = Join-Path $scriptDir "nepal-bipad-hydrology.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/nextbus/kql/create-kql-script.ps1
+++ b/feeders/nextbus/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nextbus.xreg.json"
 $kqlFile = Join-Path $scriptDir "nextbus.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "nextbus"

--- a/feeders/nifc-usa-wildfires/kql/create-kql-script.ps1
+++ b/feeders/nifc-usa-wildfires/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nifc-usa-wildfires.xreg.json"
 $kqlFile = Join-Path $scriptDir "nifc-usa-wildfires.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/nina-bbk/kql/create-kql-script.ps1
+++ b/feeders/nina-bbk/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nina-bbk.xreg.json"
 $kqlFile = Join-Path $scriptDir "nina-bbk.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/noaa-goes/kql/create-kql-script.ps1
+++ b/feeders/noaa-goes/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\noaa-goes.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa-goes.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/noaa-ndbc/kql/create-kql-script.ps1
+++ b/feeders/noaa-ndbc/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\noaa-ndbc.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa-ndbc.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'microsoft.opendata.us.noaa.ndbc'

--- a/feeders/noaa-nws/kql/create-kql-script.ps1
+++ b/feeders/noaa-nws/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\noaa-nws.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa-nws.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/noaa-swpc-l1/kql/create-kql-script.ps1
+++ b/feeders/noaa-swpc-l1/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\noaa_swpc_l1.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa_swpc_l1.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/noaa/kql/create-kql-script.ps1
+++ b/feeders/noaa/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\noaa.xreg.json"
 $kqlFile = Join-Path $scriptDir "noaa.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "Microsoft.OpenData.US.NOAA"

--- a/feeders/nve-hydro/kql/create-kql-script.ps1
+++ b/feeders/nve-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nve_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "nve_hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "no.nve.hydrology"

--- a/feeders/nws-alerts/kql/create-kql-script.ps1
+++ b/feeders/nws-alerts/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nws-alerts.xreg.json"
 $kqlFile = Join-Path $scriptDir "nws-alerts.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/nws-forecasts/kql/create-kql-script.ps1
+++ b/feeders/nws-forecasts/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\nws-forecasts.xreg.json"
 $kqlFile = Join-Path $scriptDir "nws-forecasts.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "Microsoft.OpenData.US.NOAA.NWS.Forecasts"

--- a/feeders/paris-bicycle-counters/kql/create-kql-script.ps1
+++ b/feeders/paris-bicycle-counters/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\paris-bicycle-counters.xreg.json"
 $kqlFile = Join-Path $scriptDir "paris-bicycle-counters.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "FR.Paris.OpenData.Velo"

--- a/feeders/pegelonline/EVENTS.md
+++ b/feeders/pegelonline/EVENTS.md
@@ -1,3 +1,4 @@
+<!-- xreg-generator:hand-maintained — hand-polished beyond tools/printdoc.py output (README/CONTAINER link-triangle, CloudEvents envelope tables, deterministic-payload NOTE). tools/generate-events-md.ps1 skips this file. To refresh from the manifest: remove this line, regenerate, then re-apply the hand sections. -->
 # PegelOnline event reference
 
 This document defines the CloudEvents contract emitted by the PegelOnline feeder. For the project overview see [README.md](README.md); for the published container images and their environment-variable matrix see [CONTAINER.md](CONTAINER.md).

--- a/feeders/pegelonline/kql/create-kql-script.ps1
+++ b/feeders/pegelonline/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\pegelonline.xreg.json"
 $kqlFile = Join-Path $scriptDir "pegelonline.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/pegelonline/kql/pegelonline.kql
+++ b/feeders/pegelonline/kql/pegelonline.kql
@@ -1,3 +1,4 @@
+// xreg-generator:hand-maintained — carries hand-authored helpers (Map-friendly enrichment + trend functions) below the generated base. tools/generate-kql-from-xreg.ps1 skips this file. To refresh the base: remove this line, regenerate, then re-merge the helper tail.
 .create-merge table [_cloudevents_dispatch] (
     [specversion]: string,
     [type]: string,

--- a/feeders/ptwc-tsunami/kql/create-kql-script.ps1
+++ b/feeders/ptwc-tsunami/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\ptwc-tsunami.xreg.json"
 $kqlFile = Join-Path $scriptDir "ptwc-tsunami.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/rss/kql/create-kql-script.ps1
+++ b/feeders/rss/kql/create-kql-script.ps1
@@ -1,7 +1,7 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\feeds.xreg.json"
 $kqlFile = Join-Path $scriptDir "feeds.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/feeders/rws-waterwebservices/kql/create-kql-script.ps1
+++ b/feeders/rws-waterwebservices/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\rws_waterwebservices.xreg.json"
 $kqlFile = Join-Path $scriptDir "rws_waterwebservices.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'nl.rws.waterwebservices'

--- a/feeders/seattle-911/kql/create-kql-script.ps1
+++ b/feeders/seattle-911/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\seattle-911.xreg.json"
 $kqlFile = Join-Path $scriptDir "seattle-911.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "US.WA.Seattle.Fire911"

--- a/feeders/seattle-street-closures/kql/create-kql-script.ps1
+++ b/feeders/seattle-street-closures/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\seattle-street-closures.xreg.json"
 $kqlFile = Join-Path $scriptDir "seattle-street-closures.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "us.wa.seattle.streetclosures"

--- a/feeders/sensor-community/kql/create-kql-script.ps1
+++ b/feeders/sensor-community/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\sensor-community.xreg.json"
 $kqlFile = Join-Path $scriptDir "sensor-community.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/singapore-nea/kql/create-kql-script.ps1
+++ b/feeders/singapore-nea/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\singapore-nea.xreg.json"
 $kqlFile = Join-Path $scriptDir "singapore-nea.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/smhi-hydro/kql/create-kql-script.ps1
+++ b/feeders/smhi-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\smhi-hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "smhi-hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'se.gov.smhi.hydro'

--- a/feeders/smhi-weather/kql/create-kql-script.ps1
+++ b/feeders/smhi-weather/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\smhi-weather.xreg.json"
 $kqlFile = Join-Path $scriptDir "smhi-weather.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'SE.Gov.SMHI.Weather'

--- a/feeders/snotel/kql/create-kql-script.ps1
+++ b/feeders/snotel/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\snotel.xreg.json"
 $kqlFile = Join-Path $scriptDir "snotel.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace gov.usda.nrcs.snotel

--- a/feeders/syke-hydro/kql/create-kql-script.ps1
+++ b/feeders/syke-hydro/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\syke_hydro.xreg.json"
 $kqlFile = Join-Path $scriptDir "syke_hydro.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace fi.syke.hydrology

--- a/feeders/tepco-denkiyoho/kql/create-kql-script.ps1
+++ b/feeders/tepco-denkiyoho/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\tepco-denkiyoho.xreg.json"
 $kqlFile = Join-Path $scriptDir "tepco-denkiyoho.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace JP.TEPCO.Denkiyoho

--- a/feeders/ticketmaster/kql/create-kql-script.ps1
+++ b/feeders/ticketmaster/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\ticketmaster.xreg.json"
 $kqlFile = Join-Path $scriptDir "ticketmaster.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/uba-airdata/kql/create-kql-script.ps1
+++ b/feeders/uba-airdata/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\uba-airdata.xreg.json"
 $kqlFile = Join-Path $scriptDir "uba-airdata.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/uk-ea-flood-monitoring/kql/create-kql-script.ps1
+++ b/feeders/uk-ea-flood-monitoring/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\uk-ea-flood-monitoring.xreg.json"
 $kqlFile = Join-Path $scriptDir "uk-ea-flood-monitoring.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "uk.gov.environment.ea.floodmonitoring"

--- a/feeders/usgs-earthquakes/kql/create-kql-script.ps1
+++ b/feeders/usgs-earthquakes/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\usgs-earthquakes.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs-earthquakes.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/usgs-geomag/kql/create-kql-script.ps1
+++ b/feeders/usgs-geomag/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\usgs-geomag.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs-geomag.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "gov.usgs.geomag"

--- a/feeders/usgs-iv/kql/create-kql-script.ps1
+++ b/feeders/usgs-iv/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\usgs-iv.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs-iv.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/usgs-nwis-wq/kql/create-kql-script.ps1
+++ b/feeders/usgs-nwis-wq/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\usgs_nwis_wq.xreg.json"
 $kqlFile = Join-Path $scriptDir "usgs_nwis_wq.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace 'gov.usgs.waterservices.wq'

--- a/feeders/vatsim/kql/create-kql-script.ps1
+++ b/feeders/vatsim/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\vatsim.xreg.json"
 $kqlFile = Join-Path $scriptDir "vatsim.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/wallonia-issep/kql/create-kql-script.ps1
+++ b/feeders/wallonia-issep/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\wallonia_issep.xreg.json"
 $kqlFile = Join-Path $scriptDir "wallonia_issep.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/waterinfo-vmm/kql/create-kql-script.ps1
+++ b/feeders/waterinfo-vmm/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\waterinfo_vmm.xreg.json"
 $kqlFile = Join-Path $scriptDir "waterinfo_vmm.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified -Namespace "be.vlaanderen.waterinfo.vmm"

--- a/feeders/wikimedia-eventstreams/kql/create-kql-script.ps1
+++ b/feeders/wikimedia-eventstreams/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\wikimedia_eventstreams.xreg.json"
 $kqlFile = Join-Path $scriptDir "wikimedia_eventstreams.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile

--- a/feeders/wikimedia-osm-diffs/kql/create-kql-script.ps1
+++ b/feeders/wikimedia-osm-diffs/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\wikimedia_osm_diffs.xreg.json"
 $kqlFile = Join-Path $scriptDir "wikimedia_osm_diffs.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/wsdot/EVENTS.md
+++ b/feeders/wsdot/EVENTS.md
@@ -1,3 +1,4 @@
+<!-- xreg-generator:hand-maintained — hand-polished beyond tools/printdoc.py output (README/CONTAINER link-triangle). tools/generate-events-md.ps1 skips this file. To refresh from the manifest: remove this line, regenerate, then re-apply the hand sections. -->
 # WSDOT event reference
 
 This document defines the CloudEvents contract emitted by the WSDOT Traveler Information feeder. For the project overview see [README.md](README.md); for the published container images and their environment-variable matrix see [CONTAINER.md](CONTAINER.md).

--- a/feeders/wsdot/kql/create-kql-script.ps1
+++ b/feeders/wsdot/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\wsdot.xreg.json"
 $kqlFile = Join-Path $scriptDir "wsdot.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile -Qualified

--- a/feeders/xceed/kql/create-kql-script.ps1
+++ b/feeders/xceed/kql/create-kql-script.ps1
@@ -1,6 +1,6 @@
 $scriptDir = Split-Path -Parent $PSCommandPath
 $inputFile = Join-Path $scriptDir "..\xreg\xceed.xreg.json"
 $kqlFile = Join-Path $scriptDir "xceed.kql"
-$generatorScript = Join-Path $scriptDir "..\..\tools\generate-kql-from-xreg.ps1"
+$generatorScript = Join-Path $scriptDir "..\..\..\tools\generate-kql-from-xreg.ps1"
 & $generatorScript -XregPath $inputFile -OutputPath $kqlFile
 

--- a/tools/generate-events-md.ps1
+++ b/tools/generate-events-md.ps1
@@ -2,11 +2,11 @@
 .SYNOPSIS
     Regenerates source EVENTS.md files from xRegistry manifests.
 .DESCRIPTION
-    Discovery is repo-driven: every top-level <source>\xreg\*.xreg.json manifest
+    Discovery is repo-driven: every feeders\<source>\xreg\*.xreg.json manifest
     is picked up automatically. To add a source, commit the xRegistry manifest;
-    this script derives title/description metadata and writes <source>\EVENTS.md.
+    this script derives title/description metadata and writes feeders\<source>\EVENTS.md.
 .PARAMETER Source
-    Optional top-level source folder id to regenerate.
+    Optional source folder id (under feeders\) to regenerate.
 .PARAMETER Check
     Regenerate into a repository-local scratch directory and fail when committed
     EVENTS.md differs. Intended as a future CI gate.
@@ -17,8 +17,19 @@ param([string]$Source, [switch]$Check)
 $ErrorActionPreference = 'Continue'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RepoRoot = Split-Path -Parent $ScriptDir
+$FeedersRoot = Join-Path $RepoRoot 'feeders'
 $PrintDoc = Join-Path $ScriptDir 'printdoc.py'
 $ScratchDir = Join-Path $RepoRoot '.events-md-check'
+
+# Hand-maintenance guard: a few EVENTS.md files are hand-polished beyond what
+# printdoc.py emits (e.g. README/CONTAINER link-triangle, CloudEvents envelope
+# tables, the deterministic-payload NOTE). Regenerating them would silently
+# discard that work, so honour an opt-out sentinel: a file that declares
+# 'xreg-generator:hand-maintained' is skipped in both generate and -Check modes.
+function Test-Protected([string]$Path) {
+    if (-not (Test-Path $Path)) { return $false }
+    return [bool](Select-String -Path $Path -Pattern 'xreg-generator:hand-maintained' -SimpleMatch -Quiet)
+}
 
 function Humanize([string]$Value) {
     (($Value -split '[-_\s]+' | Where-Object { $_ }) | ForEach-Object { $_.Substring(0,1).ToUpperInvariant() + $(if ($_.Length -gt 1) { $_.Substring(1) } else { '' }) }) -join ' '
@@ -55,8 +66,8 @@ function Read-XregInfo([string]$Manifest) {
     return $r
 }
 function Get-Entries {
-    $excluded=@('.git','.github','tools','ghpages','docs','tests','node_modules','.events-md-check')
-    Get-ChildItem $RepoRoot -Directory | Where-Object { $excluded -notcontains $_.Name -and ((-not $Source) -or $_.Name -eq $Source) } | ForEach-Object {
+    $excluded=@('.git','.github','tools','ghpages','docs','tests','node_modules','.events-md-check','_poller_core')
+    Get-ChildItem $FeedersRoot -Directory | Where-Object { $excluded -notcontains $_.Name -and ((-not $Source) -or $_.Name -eq $Source) } | ForEach-Object {
         $dir=$_; $xreg=Join-Path $dir.FullName 'xreg'; if (-not (Test-Path $xreg)) { return }
         Get-ChildItem $xreg -Filter '*.xreg.json' -File | ForEach-Object {
             $xi=Read-XregInfo $_.FullName; $ri=Read-ReadmeInfo $dir.FullName; $human=Humanize $dir.Name
@@ -69,11 +80,15 @@ function Get-Entries {
     }
 }
 $entries=@(Get-Entries | Sort-Object Source, Manifest)
-if ($Source -and -not $entries.Count) { Write-Error "No top-level source with xRegistry manifest found for '$Source'."; exit 2 }
-if (-not $entries.Count) { Write-Error 'No top-level xRegistry manifests found.'; exit 2 }
+if ($Source -and -not $entries.Count) { Write-Error "No source with xRegistry manifest found under feeders/ for '$Source'."; exit 2 }
+if (-not $entries.Count) { Write-Error 'No xRegistry manifests found under feeders/.'; exit 2 }
 if ($Check) { if (Test-Path $ScratchDir) { Remove-Item $ScratchDir -Recurse -Force }; New-Item $ScratchDir -ItemType Directory -Force | Out-Null }
-$fail=@(); $stale=@()
+$fail=@(); $stale=@(); $protected=@()
 foreach ($e in $entries) {
+    if (Test-Protected $e.Output) {
+        Write-Host "Skipping $($e.Source): EVENTS.md is hand-maintained (sentinel present); not regenerating."
+        $protected += $e.Source; continue
+    }
     $target = if ($Check) { Join-Path $ScratchDir "$($e.Source).EVENTS.md" } else { $e.Output }
     Write-Host "Generating $($e.Source): $($e.Manifest) -> $target"
     $old=$env:PRINTDOC_SUPPRESS_COMPAT_NOTICE; $env:PRINTDOC_SUPPRESS_COMPAT_NOTICE='1'
@@ -90,4 +105,5 @@ if ($Check -and (Test-Path $ScratchDir)) { Remove-Item $ScratchDir -Recurse -For
 if ($fail.Count) { Write-Error "EVENTS.md generation failed for: $($fail -join ', ')" }
 if ($stale.Count) { Write-Error "Stale EVENTS.md files: $($stale -join ', ')" }
 if ($fail.Count -or $stale.Count) { exit 1 }
+if ($protected.Count) { Write-Host "Protected (hand-maintained, skipped): $($protected -join ', ')" }
 Write-Host "Processed $($entries.Count) xRegistry manifest(s)."

--- a/tools/generate-kql-from-xreg.ps1
+++ b/tools/generate-kql-from-xreg.ps1
@@ -312,6 +312,22 @@ function Test-IsDispatchChunk {
 
 $resolvedXregPath = (Resolve-Path $XregPath).Path
 $resolvedOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+# Hand-maintenance guard: this generator emits the base schema (tables, mappings,
+# materialized views, update policies) only. A few sources carry hand-authored
+# helper tails (e.g. Map-friendly enrichment + trend functions) below the base.
+# Overwriting them silently discards that work, so honour an opt-out sentinel: if
+# the target file declares 'xreg-generator:hand-maintained', skip regeneration.
+# To refresh the base for such a file, remove the sentinel, regenerate, then
+# re-merge the helper tail.
+if (Test-Path $resolvedOutputPath) {
+    $existingKql = Get-Content $resolvedOutputPath -Raw -ErrorAction SilentlyContinue
+    if ($existingKql -and ($existingKql -match 'xreg-generator:hand-maintained')) {
+        Write-Warning "Skipping ${resolvedOutputPath}: hand-maintained sentinel present; not overwriting. Remove the sentinel, regenerate the base, then re-merge the helper tail if the schema changed."
+        exit 0
+    }
+}
+
 $xregDocument = Get-Content $resolvedXregPath -Raw | ConvertFrom-Json
 
 $schemaUris = New-Object System.Collections.Generic.List[string]

--- a/tools/printdoc.py
+++ b/tools/printdoc.py
@@ -463,7 +463,7 @@ def extract_references(ctx: Ctx) -> list[str]:
 # Schema and manifest helpers
 
 def resolve_message_chain(msg: Json, groups: Json) -> tuple[Json,list[str]]:
-    merged=dict(msg); chain=[]; ref=msg.get("basemessageuri")
+    merged=dict(msg); chain=[]; ref=msg.get("basemessageuri") or msg.get("basemessage")
     if isinstance(ref,str):
         base=resolve_base(ref,groups)
         if base:


### PR DESCRIPTION
## What

Fixes two in-tree doc/schema generators that **silently broke at the `feeders/` restructure (#481)** and—worse—could **destroy hand-authored content** when run. Ships the path fixes **only**, plus a guard so the handful of hand-polished artifacts can't be clobbered. **No fleet regeneration.**

## The two path bugs

1. **KQL wrapper off-by-one.** Every `feeders/<src>/kql/create-kql-script.ps1` referenced `..\..\tools\generate-kql-from-xreg.ps1` (2 dots → `feeders/tools/`, which doesn't exist) instead of `..\..\..\tools\` (`kql→src→feeders→root`). Fixed on the **99** wrappers using the 2-dot form; the **8** already-correct (3-dot) and **6** alternate `Resolve-Path` wrappers were left untouched.
2. **EVENTS.md discovery pointed at the repo root.** `tools/generate-events-md.ps1` iterated `$RepoRoot` looking for `<root>/<src>/xreg`, but sources now live under `feeders/`. Repointed discovery to `feeders/`, excluded `_poller_core`, corrected the stale "top-level" doc/error text, and taught `printdoc.py` to resolve AMQP inheritance via the spec-canonical `basemessage` key (not just the xrcg `basemessageuri` synonym).

## Why a guard, not a fleet regen

Investigation (answering "did xrcg generate these?") established:

- **xrcg has no markdown/events/docs style** — the EVENTS.md generator is the repo's own `tools/printdoc.py`. `printdoc.py` **never** emitted the link-triangle or CloudEvents-envelope tables in any commit on any branch.
- The current generators **already match the fleet**: ~**110/114** EVENTS.md and ~**118/120** KQL files are reproduced by the base output (e.g. `autobahn` regenerates header-for-header identical).
- Only a few sources are **hand-polished beyond** the generator and would be **degraded** by a regen:
  - **EVENTS.md:** `pegelonline` (link-triangle + envelope tables + payload NOTE), `erddap` (envelope tables), `gbfs-bikeshare`, `wsdot` (link-triangle).
  - **KQL:** `pegelonline` (−311 lines of Map-friendly enrichment + trend helpers on regen). `jma-bosai-amedas` was a false positive (regen `+16`, no hand tail).

Blindly regenerating wiped pegelonline (−49 EVENTS.md lines, −311 KQL lines) earlier and had to be reverted. To stop that recurring, both generators now honour an opt-out **sentinel**: a target declaring `xreg-generator:hand-maintained` is skipped (EVENTS.md in both generate and `-Check` modes; KQL exits 0 with a warning **before** any avrotize work). The sentinel is added to the 5 outliers as an invisible HTML/`//` comment.

## Validation

- Both PowerShell generators parse clean; `printdoc.py` `py_compile` + **3/3** unit tests pass.
- EVENTS.md guard **skips** all 4 protected sources, does **not** skip `autobahn`.
- KQL guard **skips** the `pegelonline` wrapper (495→495 lines, diff `+1/−0` = just the sentinel) and still **generates** a non-protected source to a clean path (714 lines).

## Scope / impact

- 107 files: 99 KQL-wrapper path fixes + 2 generator guards + 1 discovery fix + 1 `printdoc` basemessage fix + 5 sentinels.
- **Neither generator is wired into CI today**, so there is no CI impact. This PR does not regenerate or alter any feeder's committed EVENTS.md/KQL content (beyond the 5 one-line sentinels).
