### PR TITLE
docs: fix root-catalog generator inputs for hsl-hfp (flag + upstream link)

### DIFF
--- a/tools/docs/generate_root_catalog.py
+++ b/tools/docs/generate_root_catalog.py
@@ -76,7 +76,7 @@ FLAG_BY_ID = {
     "laqn-london": "gb", "sensor-community": "un", "wallonia-issep": "be",
     "eaws-albina": "at", "gdacs": "un", "ptwc-tsunami": "un",
     "seattle-911": "us", "usgs-earthquakes": "us", "aisstream": "un",
-    "digitraffic-maritime": "fi", "kystverket-ais": "no", "mode-s": "un",
+    "digitraffic-maritime": "fi", "hsl-hfp": "fi", "kystverket-ais": "no", "mode-s": "un",
     "vatsim": "un", "gtfs": "un", "madrid-traffic": "es",
     "nextbus": "us", "paris-bicycle-counters": "fr",
     "seattle-street-closures": "us", "tfl-road-traffic": "gb",

--- a/tools/docs/upstream_links.json
+++ b/tools/docs/upstream_links.json
@@ -168,6 +168,10 @@
     "homepage": "https://www.aqhi.gov.hk/",
     "api_docs": "https://www.aqhi.gov.hk/en/aqhi/statistics-of-aqhi.html"
   },
+  "hsl-hfp": {
+    "homepage": "https://www.hsl.fi/en/hsl/open-data",
+    "api_docs": "https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/high-frequency-positioning/"
+  },
   "hubeau-hydrometrie": {
     "homepage": "https://hubeau.eaufrance.fr/",
     "api_docs": "https://hubeau.eaufrance.fr/page/api-hydrometrie"


### PR DESCRIPTION
## What

Fix the two missing `generate_root_catalog.py` inputs for **hsl-hfp** so the generator can reproduce the committed root-README catalog row.

## Why

After hsl-hfp shipped (#1490) the root catalog generator could **not** reproduce its committed README row. Every push that touches `**/xreg/*.xreg.json`, `catalog.json`, or the generator triggers the **Update root README catalog** workflow, which regenerated a **degraded** hsl-hfp row and tried to push it to `main`:

- Finnish flag `fi.png` -> **`un.png`** (UN placeholder) on both the summary and Region rows
- the **`↗ hsl.fi` upstream link was dropped** entirely

With branch protection now enabled on `main`, that auto-push is rejected (`GH006`), so the workflow has been **failing on every qualifying push** (including the v1.9.0 merge). Even without protection it would have silently degraded the README.

## Root cause

- `FLAG_BY_ID` had no `hsl-hfp` override. The desc prefix `"Finland / Helsinki"` is a *slashed* prefix that does not match a `FLAG` dict key (`"Finland"`), so the flag fell back to `"un"`. This is the documented override mechanism (cf. `digitraffic-maritime: "fi"`).
- `upstream_links.json` had no `hsl-hfp` entry, so the `↗ hsl.fi` link could not be rendered.

## Fix

- Add `"hsl-hfp": "fi"` to `FLAG_BY_ID`.
- Add the `hsl-hfp` entry to `upstream_links.json` (HSL open-data homepage + digitransit HFP api_docs).

## Verification

`python tools/docs/generate_root_catalog.py` now reproduces the committed `README.md` with **zero drift** (`git diff --quiet README.md` -> exit 0). The catalog workflow therefore becomes a clean **no-op** for hsl-hfp (regen -> no diff -> "No changes" -> pass, no push attempted).

## Note (separate, systemic)

This PR fixes the hsl-hfp drift, but the **Update root README catalog** workflow still pushes **directly to `main`**, which is incompatible with the newly-enabled branch protection for any *legitimate* future catalog change. That is a separate user decision (PR-based push vs. bot bypass) and is **not** changed here.
