### PR TITLE
feat(hsl-hfp): add Fabric Map with live transit layers

### DIFF
--- a/feeders/hsl-hfp/README.md
+++ b/feeders/hsl-hfp/README.md
@@ -31,6 +31,7 @@
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/hsl-hfp.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.hsl.fi/en/hsl/open-data)
 
 </td></tr></table>
@@ -162,7 +163,7 @@ The portal buttons wrap the underlying scripts and ARM templates documented belo
 
 ### Deploying into Microsoft Fabric
 
-HSL HFP targets Microsoft Fabric end-to-end: events land in a Fabric **Event Stream** (custom endpoint), an attached **Eventhouse / KQL database** materializes the contract from [`kql/`](kql/).
+HSL HFP targets Microsoft Fabric end-to-end: events land in a Fabric **Event Stream** (custom endpoint), an attached **Eventhouse / KQL database** materializes the contract from [`kql/`](kql/), and the bundled [**Fabric Map**](fabric/README.md) visualizes the live fleet on a basemap — ~1,700 vehicles colored by transport mode, the HSL stop network, and optional punctuality, density, and traffic-signal-priority overlays.
 
 Use the deploy button on the [project portal](https://clemensv.github.io/real-time-sources#hsl-hfp) to launch the Fabric ACI hosting model — it walks you through Fabric workspace selection and follow-up steps.
 
@@ -178,7 +179,7 @@ tools/deploy-fabric/deploy-fabric-aci.ps1 `
   -Location <azure-region>
 ```
 
-The script creates the Eventhouse, the KQL database with the [`kql/`](kql/) schema and update policies, the Event Stream with a custom endpoint, the ACI with the connection string wired in, and a storage account / file share mounted at `/state` for dedupe persistence.
+The script creates the Eventhouse, the KQL database with the [`kql/`](kql/) schema and update policies, the Event Stream with a custom endpoint, the ACI with the connection string wired in, and a storage account / file share mounted at `/state` for dedupe persistence. As a final step it runs the [`fabric/`](fabric/README.md) post-deploy hook, which creates the **`hsl-hfp-map`** Map item and wires its live vehicle, stop, punctuality, density, and signal-priority layers.
 
 [![Deploy Fabric ACI](https://img.shields.io/badge/Fabric-Container%20Feeder-117865?logo=microsoftfabric&logoColor=white)](https://clemensv.github.io/real-time-sources#hsl-hfp/fabric-aci)
 
@@ -334,6 +335,7 @@ hsl-hfp/
 ├── hsl_hfp_mqtt_producer/          # xRegistry-generated MQTT producer
 ├── hsl_hfp_amqp_producer/          # xRegistry-generated AMQP producer
 ├── kql/hsl-hfp.kql                 # Eventhouse table + update policies
+├── fabric/                         # Fabric Map post-deploy hook + layer wiring
 ├── Dockerfile.kafka                # builds the Kafka feeder image
 ├── Dockerfile.mqtt                 # builds the MQTT feeder image
 ├── Dockerfile.amqp                 # builds the AMQP feeder image
@@ -348,6 +350,7 @@ hsl-hfp/
 📑 <a href="EVENTS.md">EVENTS.md</a> &nbsp;·&nbsp;
 🐳 <a href="CONTAINER.md">CONTAINER.md</a> &nbsp;·&nbsp;
 🗄️ <a href="kql/hsl-hfp.kql">KQL schema</a> &nbsp;·&nbsp;
+🗺️ <a href="fabric/README.md">Fabric Map</a> &nbsp;·&nbsp;
 ↗ <a href="https://www.hsl.fi/en/hsl/open-data">HSL open data</a> &nbsp;·&nbsp;
 📖 <a href="https://digitransit.fi/en/developers/apis/5-realtime-api/vehicle-positions/high-frequency-positioning/">HFP docs</a>
 </sub>

--- a/feeders/hsl-hfp/fabric/README.md
+++ b/feeders/hsl-hfp/fabric/README.md
@@ -1,0 +1,156 @@
+# hsl-hfp Fabric assets
+
+Post-deploy artefacts for the **hsl-hfp** real-time-sources feeder (Helsinki
+Region Transport **HFP** — High-Frequency Positioning): a live Fabric **Map**
+visualisation of HSL's ~1,700 transit vehicles streaming GPS at ~1 Hz, plus the
+HSL stop network. The data plane is handled by the generic
+`tools/deploy-fabric/deploy-fabric.ps1` script (ACI + Event Hubs + KQL database
++ Eventstream into `_cloudevents_dispatch`). The generic deployer auto-discovers
+`hsl-hfp/fabric/post-deploy.ps1` via the common
+"`{source}/fabric/post-deploy.ps1`" hook convention and calls it at the end of a
+successful deploy.
+
+This map mirrors the **gtfs** transit map: it is parametric in the KQL database
+name, auto-discovers the source's bounding box from `['fi.hsl.gtfs.StopLatest']`
+(falling back to live vehicle positions, then the Helsinki city centre), and
+assumes the canonical schema laid down by `hsl-hfp/kql/hsl-hfp.kql`.
+
+There are **no route-line layers**: the HSL feeder ships no GTFS Shapes
+(polyline geometry), so unlike the generic gtfs map there is nothing to draw for
+route paths. Vehicle motion is conveyed instead by heading-oriented vehicle
+rectangles at street zoom.
+
+## Files
+
+| File | Purpose |
+| ---- | ------- |
+| `post-deploy.ps1` | Hook auto-invoked by `tools/deploy-fabric/deploy-fabric.ps1`. Acquires Fabric + Kusto tokens, then runs `wire_hsl_hfp_map.py` with the workspace/db/cluster IDs from the deployer's `-Context` hashtable (keys `WorkspaceId`, `DatabaseId`, `EventhouseClusterUri`, `DatabaseName`). Auto-creates a blank Map item named `hsl-hfp-map` if `HSL_HFP_FABRIC_MAP_ID` is not set (override the name with `HSL_HFP_FABRIC_MAP_NAME`). Can also be run standalone. |
+| `wire_hsl_hfp_map.py` | Installs the `hslhfp_*` KQL helper functions in the target database and idempotently wires the corresponding Fabric Map vector layers via `getDefinition` / `updateDefinition`. Auto-centres the basemap on the source's bounding box. |
+
+## Layers shipped
+
+| # | Layer name | Default | Zoom | Source query | Geometry | Colour / label |
+| - | ---------- | ------- | ---- | ------------ | -------- | -------------- |
+| 1 | HSL - Live vehicles | on | z8–16 | `hslhfp_vehicle_points(5m)` | Point (bubble) | colour by `transport_mode`; tooltip `desi` / `route_id` / `headsign` / speed / delay |
+| 2 | HSL - Live vehicles (detail) | on | z16+ | `hslhfp_vehicle_rectangles(5m)` | Polygon (heading-oriented rectangle) | colour by `transport_mode`; label `route_label` (= `desi`) |
+| 3 | HSL - Transit stops | on | z13+ | `hslhfp_stops_for_map()` | Point (bubble) | colour by `location_type`; label `stop_name` (`stop_code`) |
+| 4 | HSL - Vehicle punctuality | **off** | z11+ | `hslhfp_vehicle_points(5m)` | Point (bubble) | colour by delay band (early / on-time / late) |
+| 5 | HSL - Vehicle density | **off** | any | `hslhfp_vehicle_grid(5m, 0.01)` | Polygon (grid cell) | colour by live-vehicle count per ~1 km cell |
+| 6 | HSL - Traffic-signal priority | **off** | z12+ | `hslhfp_tlp_events(30m)` | Point (bubble) | colour by `tlr`/`tla` request / grant / reject |
+
+The live-vehicle layers filter the shared `['fi.hsl.hfp.VehicleEvent']` table to
+the `vp` GPS heartbeat (`___type in ('fi.hsl.hfp.vp','fi.hsl.hfp.upstream.vp')`),
+drop null and `0,0` coordinates, bound to the last 5 minutes by `___time`, and
+dedupe to the latest row per vehicle (`arg_max(___time, *) by ___subject`).
+
+The **transport_mode palette** (HSL house colours): bus `#007AC9` (blue), tram
+`#00985F` (green), commuter train `#8C4799` (purple), metro `#FF6319` (orange),
+ferry `#00B9E4` (cyan), U-line bus `#9E9E9E` and robot bus `#616161` (greys).
+
+## Schema assumed (freshly-deployed hsl_hfp database)
+
+Bracketed, dotted CloudEvents tables created by `hsl-hfp/kql/hsl-hfp.kql`:
+
+  * `['fi.hsl.hfp.VehicleEvent']` + MV `['fi.hsl.hfp.VehicleEventLatest']` —
+    the hero telemetry (`vp` heartbeat shares this table with the stop / door /
+    sign events). Geo `lat` / `long` (both nullable). `hdg`, `spd`, `dl`,
+    `desi`, `headsign`, `route_id`, `transport_mode`, `occu`, `temporal_type`,
+    identity `operator_id` / `vehicle_number` (`___subject` =
+    `{operator_id}/{vehicle_number}`).
+  * `['fi.hsl.gtfs.Stop']` + MV `['fi.hsl.gtfs.StopLatest']` — reference stops
+    (`stop_lat` / `stop_lon`, `stop_name`, `stop_code`, `location_type`,
+    `parent_station`).
+  * `['fi.hsl.gtfs.Route']` + MV `['fi.hsl.gtfs.RouteLatest']` — route lookup
+    (left-joined for `route_short_name` / `route_long_name`).
+  * `['fi.hsl.hfp.TrafficLightEvent']` + MV `…Latest` — transit-signal-priority
+    `tlr` / `tla` events.
+
+All `<X>Latest` MVs are `arg_max(___time, *) by ___type, ___source, ___subject`.
+The wire script reads the `*Latest` MVs directly so each layer query is
+constant-time regardless of how long the source has been ingesting.
+
+> **`dl` (delay) sign convention.** Per the HSL HFP spec and the
+> `hsl-hfp.kql` column docstring, a **positive** `dl` means the vehicle is
+> running **ahead** of schedule (early) and a **negative** `dl` means it is
+> **behind** schedule (late). The punctuality banding and the "N min late /
+> early" labels follow this convention.
+
+## Prerequisites
+
+1. The generic per-source bootstrap has already run for `hsl-hfp`:
+   ```powershell
+   ./tools/deploy-fabric/deploy-fabric.ps1 -Source hsl-hfp `
+       -ResourceGroup rg-hsl -Workspace <ws-guid> -Eventhouse <eh-guid>
+   ```
+   This applies `hsl-hfp/kql/hsl-hfp.kql` (database `hsl_hfp`) and stands up the
+   rest of the data plane.
+
+2. **A blank Fabric Map item exists** in the workspace, or you let the hook
+   auto-create one. The Fabric REST API doesn't (yet) expose programmatic
+   creation of `Map` items via the typed surface, but the generic `items` API
+   accepts `type=Map`, so this hook does that transparently when
+   `HSL_HFP_FABRIC_MAP_ID` is empty.
+
+3. The map item ID is exposed to the hook via the `HSL_HFP_FABRIC_MAP_ID`
+   environment variable. If absent the hook creates / reuses a Map named
+   `hsl-hfp-map` (override with `HSL_HFP_FABRIC_MAP_NAME`).
+
+## Auto-invocation
+
+```powershell
+$env:HSL_HFP_FABRIC_MAP_ID = "<map-guid>"  # optional; will be auto-created
+./tools/deploy-fabric/deploy-fabric.ps1 -Source hsl-hfp `
+    -ResourceGroup rg-hsl -Workspace "<ws-guid>"
+# ...generic steps...
+# [7/7] Running post-deploy hook (hsl-hfp/fabric/post-deploy.ps1)...
+#   Creating 7 helper functions in hsl_hfp
+#   Discovering bounding box from hslhfp_bbox()
+#     6943 features; lat=[60.10, 60.40] lon=[24.55, 25.25]
+#   layer HSL - Live vehicles
+#     rows: 1683
+#     palette mode_label: 6 colors
+#   ...
+#   OK - map <map-guid> updated with 6 layers
+```
+
+Skip with `-SkipPostDeployHook` if you only want the data plane.
+
+## Standalone re-wire
+
+After tweaking a layer query or colour ramp in `wire_hsl_hfp_map.py`:
+
+```powershell
+$env:HSL_HFP_FABRIC_MAP_ID = "<map-guid>"
+./hsl-hfp/fabric/post-deploy.ps1 `
+    -WorkspaceId   "<ws-guid>" `
+    -KqlDatabaseId "<kqldb-guid>" `
+    -KustoUri      "https://trd-xxxxxxxx.z1.kusto.fabric.microsoft.com" `
+    -KustoDatabase "hsl_hfp"
+```
+
+`FABRIC_TOKEN` and `KUSTO_TOKEN` are acquired via `az account get-access-token`
+automatically if not already set in the environment. Re-running is safe: the
+script removes the layers it previously wired (matched by their KQL source's
+`itemId` binding) and recreates them, so this is the normal edit loop.
+
+The script can also be invoked directly:
+
+```powershell
+python ./hsl-hfp/fabric/wire_hsl_hfp_map.py `
+    --workspace-id <ws> --map-id <map> --kql-db-id <kqldb> `
+    --kusto-uri https://<cluster>.kusto.fabric.microsoft.com --kusto-db hsl_hfp
+```
+
+## Why both `seriesGroup` AND a `match` expression?
+
+Empirically, Fabric Maps' documented `enableSeriesGroup` + `seriesGroup` +
+`customColors` schema populates the Data Layers panel legend correctly but does
+**not** drive per-feature paint colour — all bubbles/polygons fall back to the
+static fallback `color` (grey). What actually renders is a MapLibre-style
+`["match", ["get", column], v1, c1, ..., fallback]` expression on the paint
+property.
+
+The wire script writes **both** at deploy time: `customColors` (for the panel
+legend) and the `match` expression (for the renderer). The distinct values are
+enumerated from the live query result so the palette stays in sync with the
+data — colour by `transport_mode` picks up any new mode automatically.

--- a/feeders/hsl-hfp/fabric/post-deploy.ps1
+++ b/feeders/hsl-hfp/fabric/post-deploy.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    hsl-hfp-specific post-deploy hook: wires the HSL-HFP Fabric Map's
+    Kusto-backed layers against a freshly deployed hsl-hfp Eventhouse database.
+
+.DESCRIPTION
+    Auto-invoked by tools/deploy-fabric/deploy-fabric.ps1 (and the notebook
+    variant) at the end of a generic deployment via the well-known path
+    `<source>/fabric/post-deploy.ps1`. Can also be run standalone for
+    re-wiring after a layer/colour/KQL change.
+
+    The generic deployer has already applied `kql/hsl-hfp.kql` which lays down:
+        - bracketed CloudEvents tables `['fi.hsl.hfp.VehicleEvent']`,
+          `['fi.hsl.hfp.TrafficLightEvent']`, `['fi.hsl.hfp.DriverBlockEvent']`,
+          `['fi.hsl.gtfs.Stop']`, `['fi.hsl.gtfs.Route']`,
+          `['fi.hsl.gtfs.Operator']`
+        - `<X>Latest` materialized views over each
+
+    This hook then installs a handful of helper functions in the source's KQL
+    DB and wires the following Fabric Map vector layers onto an existing Map
+    item:
+
+        1.  Live vehicles (bubbles, z8-16, coloured by transport_mode)
+        2.  Live vehicles (detail) - heading-oriented rectangles (z16+)
+        3.  Transit stops (stratified to fit Fabric's 100k feature cap)
+        4.  Vehicle punctuality (off by default)
+        5.  Vehicle density grid (off by default)
+        6.  Traffic-signal priority events (off by default)
+
+    When invoked as a hook, the generic deployer passes a -Context hashtable
+    containing the IDs created by the bootstrap. The Fabric Map item itself
+    is NOT created by the generic deployer (the Fabric REST surface doesn't
+    yet expose Map-item creation), so this hook needs the map item id, which
+    it reads from the HSL_HFP_FABRIC_MAP_ID environment variable. If that
+    variable is missing the hook auto-creates a blank Map item named
+    `hsl-hfp-map` (overridable via HSL_HFP_FABRIC_MAP_NAME) in the target
+    workspace using the generic Fabric Items API (POST /v1/workspaces/{ws}/items
+    with type=Map). If a Map item with the chosen name already exists it is
+    reused.
+
+.PARAMETER Context
+    Hashtable provided by the generic deployer. Required keys consumed:
+        WorkspaceId, DatabaseId, EventhouseClusterUri, DatabaseName
+    Ignored keys: everything else.
+
+.PARAMETER WorkspaceId
+    Standalone-mode override. GUID of the Fabric workspace.
+
+.PARAMETER MapId
+    Standalone-mode override. GUID of the Fabric Map item. Defaults to
+    $env:HSL_HFP_FABRIC_MAP_ID.
+
+.PARAMETER KqlDatabaseId
+    Standalone-mode override. GUID of the KQL database with the hsl-hfp tables.
+
+.PARAMETER KustoUri
+    Standalone-mode override. Full https URI of the Kusto cluster.
+
+.PARAMETER KustoDatabase
+    KQL database name (default: hsl_hfp). Must match the name used by the
+    generic deployer.
+
+.EXAMPLE
+    # Auto-invoked: the user does not run this directly.
+    $env:HSL_HFP_FABRIC_MAP_ID = "<map-guid>"
+    ./tools/deploy-fabric/deploy-fabric.ps1 -Source hsl-hfp `
+        -ResourceGroup rg-hsl -Workspace <ws>
+
+.EXAMPLE
+    # Standalone re-wire after a layer tweak:
+    $env:HSL_HFP_FABRIC_MAP_ID = "<map-guid>"
+    ./post-deploy.ps1 `
+        -WorkspaceId   "<ws-guid>" `
+        -KqlDatabaseId "<kqldb-guid>" `
+        -KustoUri      "https://trd-xxxxxxxx.z1.kusto.fabric.microsoft.com"
+#>
+[CmdletBinding()]
+param(
+    [hashtable] $Context,
+    [string]    $WorkspaceId,
+    [string]    $MapId          = $env:HSL_HFP_FABRIC_MAP_ID,
+    [string]    $KqlDatabaseId,
+    [string]    $KustoUri,
+    [string]    $KustoDatabase  = "hsl_hfp"
+)
+
+$ErrorActionPreference = "Stop"
+$kustoDatabaseBound = $PSBoundParameters.ContainsKey('KustoDatabase')
+
+function Get-KustoAccessToken {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$KustoUri
+    )
+
+    $resources = @(
+        "https://kusto.kusto.windows.net",
+        $KustoUri
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($resource in $resources) {
+        $token = az account get-access-token --resource $resource --query accessToken -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($token)) {
+            return $token.Trim()
+        }
+    }
+
+    throw "Failed to acquire a Kusto access token for $KustoUri."
+}
+
+# Merge Context (hook invocation) with explicit params (standalone).
+if ($Context) {
+    if (-not $WorkspaceId   -and $Context.ContainsKey('WorkspaceId'))          { $WorkspaceId   = $Context.WorkspaceId }
+    if (-not $KqlDatabaseId -and $Context.ContainsKey('DatabaseId'))           { $KqlDatabaseId = $Context.DatabaseId }
+    if (-not $KustoUri      -and $Context.ContainsKey('EventhouseClusterUri')) { $KustoUri      = $Context.EventhouseClusterUri }
+    if (-not $kustoDatabaseBound -and $Context.ContainsKey('DatabaseName'))    { $KustoDatabase = $Context.DatabaseName }
+}
+
+if (-not $MapId) {
+    if (-not $WorkspaceId) {
+        throw "Cannot auto-create Map item: WorkspaceId not supplied (set -WorkspaceId or pass -Context with WorkspaceId)."
+    }
+    $mapName = if ($env:HSL_HFP_FABRIC_MAP_NAME) { $env:HSL_HFP_FABRIC_MAP_NAME } else { "hsl-hfp-map" }
+    Write-Host "  [hsl-hfp post-deploy] HSL_HFP_FABRIC_MAP_ID not set; auto-creating Map item '$mapName' in workspace $WorkspaceId..." -ForegroundColor Yellow
+    $fabApi = "https://api.fabric.microsoft.com/v1"
+    # Reuse if a Map by this name already exists
+    $items = az rest --method GET `
+        --url "$fabApi/workspaces/$WorkspaceId/items?type=Map" `
+        --resource "https://api.fabric.microsoft.com" 2>&1 | ConvertFrom-Json
+    $existing = $items.value | Where-Object { $_.displayName -eq $mapName } | Select-Object -First 1
+    if ($existing) {
+        $MapId = $existing.id
+        Write-Host "  [hsl-hfp post-deploy] Reusing existing Map '$mapName' (id $MapId)" -ForegroundColor Green
+    } else {
+        $tmpDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+        $bodyFile = Join-Path $tmpDir "map_create_$(Get-Random).json"
+        (@{ displayName = $mapName; type = "Map" } | ConvertTo-Json -Compress) `
+            | Out-File -Encoding utf8 -NoNewline $bodyFile
+        $created = az rest --method POST `
+            --url "$fabApi/workspaces/$WorkspaceId/items" `
+            --resource "https://api.fabric.microsoft.com" `
+            --body "@$bodyFile" `
+            --headers "Content-Type=application/json" 2>&1 | ConvertFrom-Json
+        if (-not $created.id) { throw "Failed to create Map item '$mapName'." }
+        $MapId = $created.id
+        Write-Host "  [hsl-hfp post-deploy] Created Map '$mapName' (id $MapId)" -ForegroundColor Green
+    }
+    $env:HSL_HFP_FABRIC_MAP_ID = $MapId
+}
+
+foreach ($pair in @(
+    @('WorkspaceId',   $WorkspaceId),
+    @('KqlDatabaseId', $KqlDatabaseId),
+    @('KustoUri',      $KustoUri)
+)) {
+    if (-not $pair[1]) { throw "Missing required value: $($pair[0])" }
+}
+
+# Acquire tokens via az CLI if not provided in the environment.
+if (-not $env:FABRIC_TOKEN) {
+    Write-Host "  [hsl-hfp post-deploy] Acquiring Fabric token via az CLI..."
+    $env:FABRIC_TOKEN = (az account get-access-token `
+        --resource "https://api.fabric.microsoft.com" `
+        --query accessToken -o tsv)
+}
+if (-not $env:KUSTO_TOKEN) {
+    Write-Host "  [hsl-hfp post-deploy] Acquiring Kusto token via az CLI..."
+    $env:KUSTO_TOKEN = Get-KustoAccessToken -KustoUri $KustoUri
+}
+
+$py = if ($env:PYTHON) { $env:PYTHON }
+      elseif (Get-Command py -ErrorAction SilentlyContinue) { "py" }
+      elseif (Get-Command python3 -ErrorAction SilentlyContinue) { "python3" }
+      else { "python" }
+$script = Join-Path $PSScriptRoot "wire_hsl_hfp_map.py"
+
+& $py $script `
+    --workspace-id $WorkspaceId `
+    --map-id       $MapId `
+    --kql-db-id    $KqlDatabaseId `
+    --kusto-uri    $KustoUri `
+    --kusto-db     $KustoDatabase
+if ($LASTEXITCODE -ne 0) { Write-Warning "wire_hsl_hfp_map.py exited with $LASTEXITCODE (map wiring failed but core deployment succeeded)" }

--- a/feeders/hsl-hfp/fabric/wire_hsl_hfp_map.py
+++ b/feeders/hsl-hfp/fabric/wire_hsl_hfp_map.py
@@ -1,0 +1,933 @@
+"""Idempotently (re)wire a Fabric Map item with Kusto-backed vector layers
+for a freshly-deployed hsl-hfp (Helsinki HSL High-Frequency Positioning)
+source.
+
+A fresh ``hsl-hfp/kql/hsl-hfp.kql`` deployment lays down the following schema
+in the target Eventhouse (KQL database ``hsl_hfp``):
+
+  * Bracketed, dotted CloudEvents-shaped base tables:
+    ``['fi.hsl.hfp.VehicleEvent']``      - the ~1 Hz vehicle telemetry
+                                           (``vp`` GPS heartbeat + stop / door
+                                           / sign events all share this table),
+    ``['fi.hsl.hfp.TrafficLightEvent']`` - transit-signal-priority ``tlr``/``tla``,
+    ``['fi.hsl.hfp.DriverBlockEvent']``  - driver / block sign-in / sign-out,
+    ``['fi.hsl.gtfs.Stop']``, ``['fi.hsl.gtfs.Route']``,
+    ``['fi.hsl.gtfs.Operator']``         - GTFS reference lookups.
+  * Per-table ``<X>Latest`` materialized views that pre-aggregate
+    ``arg_max(___time, *) by ___type, ___source, ___subject`` so callers get
+    the latest snapshot per logical entity without scanning history.
+
+This script wires the following layers (all parametric, no hand-wiring):
+
+  1.  Live vehicles - bubbles (z8-16, coloured by transport_mode)
+  2.  Live vehicles (detail) - heading-oriented rectangles (z16+)
+  3.  Transit stops - stratified to fit Fabric's 100k feature cap (z12+)
+  4.  Vehicle punctuality - delay-banded bubbles (off by default)
+  5.  Vehicle density grid - per-cell live vehicle count (off by default)
+  6.  Traffic-signal priority - tlr/tla request/grant points (off by default)
+
+The map's basemap centre + zoom are auto-discovered from the bounding box of
+``['fi.hsl.gtfs.StopLatest']`` (falling back to live vehicle positions, and
+finally to the Helsinki city centre) so the script needs no manual tuning.
+
+The Fabric Map item must already exist (see ``post-deploy.ps1`` which
+auto-creates it). This script is idempotent: re-running drops the layers it
+manages (matched by their KQL source's ``itemId`` binding) and recreates them,
+so colour ramps, query changes and viewport tweaks land cleanly.
+
+Inputs (env vars or CLI args, mirroring ``gtfs/fabric/wire_gtfs_map.py``):
+
+  FABRIC_WORKSPACE_ID   - GUID of the Fabric workspace containing the Map
+  FABRIC_MAP_ID         - GUID of the Fabric Map item to patch
+  FABRIC_KQL_DB_ID      - GUID of the KQL database with the hsl-hfp tables
+  KUSTO_CLUSTER_URI     - https://<cluster>.kusto.fabric.microsoft.com
+  KUSTO_DB              - KQL database name (default ``hsl_hfp``)
+  FABRIC_TOKEN          - bearer token for the Fabric REST API
+  KUSTO_TOKEN           - bearer token for the Kusto cluster
+  FABRIC_API_BASE       - override (default https://api.fabric.microsoft.com/v1)
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Token + HTTP helpers (factored to match the gtfs/pegelonline hook style).
+# ---------------------------------------------------------------------------
+
+def _get_token(env_name: str, scope: str) -> str:
+    tok = os.environ.get(env_name)
+    if tok:
+        return tok.strip()
+    try:
+        from azure.identity import DefaultAzureCredential
+    except ImportError as exc:
+        raise SystemExit(
+            f"{env_name} not set and azure-identity not installed; "
+            f"either set {env_name} or `pip install azure-identity`."
+        ) from exc
+    return DefaultAzureCredential().get_token(scope).token
+
+
+def _session(token: str) -> requests.Session:
+    s = requests.Session()
+    s.headers["Authorization"] = f"Bearer {token}"
+    s.headers["Content-Type"] = "application/json"
+    return s
+
+
+def _poll_lro(session: requests.Session, response: requests.Response) -> Any:
+    if response.status_code != 202:
+        response.raise_for_status()
+        return response.json() if response.content else None
+    op_url = response.headers["Location"]
+    while True:
+        status = session.get(op_url).json()
+        s = status.get("status")
+        if s == "Succeeded":
+            r = session.get(op_url + "/result")
+            return r.json() if r.content else None
+        if s == "Failed":
+            raise RuntimeError(f"Fabric LRO failed: {json.dumps(status)[:600]}")
+        time.sleep(2)
+
+
+def _kql_mgmt(ks: requests.Session, kusto_uri: str, db: str, csl: str) -> dict[str, Any]:
+    r = ks.post(f"{kusto_uri.rstrip('/')}/v1/rest/mgmt", json={"db": db, "csl": csl})
+    if r.status_code >= 400:
+        raise RuntimeError(f"KQL mgmt failed ({db}): HTTP {r.status_code} {r.text[:800]}")
+    return r.json()
+
+
+def _kql_query(ks: requests.Session, kusto_uri: str, db: str, csl: str) -> Optional[dict[str, Any]]:
+    r = ks.post(f"{kusto_uri.rstrip('/')}/v2/rest/query", json={"db": db, "csl": csl})
+    if r.status_code >= 400:
+        raise RuntimeError(f"KQL query failed ({db}): HTTP {r.status_code} {r.text[:800]}")
+    for frame in r.json():
+        if (frame.get("FrameType") == "DataTable"
+                and frame.get("TableKind") == "PrimaryResult"):
+            return frame
+    return None
+
+# ---------------------------------------------------------------------------
+# KQL helper functions installed in the target database.
+#
+# We lean on the materialized views (``['fi.hsl.hfp.VehicleEventLatest']``,
+# ``['fi.hsl.gtfs.StopLatest']``, ``['fi.hsl.gtfs.RouteLatest']``,
+# ``['fi.hsl.hfp.TrafficLightEventLatest']``) created by ``hsl-hfp.kql``. Each
+# MV reduces a CloudEvents-shaped table to one row per (___type, ___source,
+# ___subject) - i.e. one row per logical entity per source. Reading the MV
+# directly is constant-time regardless of how long the source has ingested.
+#
+# The live-vehicle layers filter the shared VehicleEvent table down to the
+# ``vp`` GPS heartbeat (``___type in ('fi.hsl.hfp.vp','fi.hsl.hfp.upstream.vp')``),
+# drop null / 0,0 coordinates and stale rows, and dedupe to the latest row per
+# vehicle (``arg_max(___time, *) by ___subject``).
+#
+# NOTE on ``dl`` (delay) sign convention: per the HSL HFP spec and the
+# hsl-hfp.kql column docstring, a POSITIVE ``dl`` means the vehicle is running
+# AHEAD of schedule (early) and a NEGATIVE ``dl`` means it is BEHIND (late).
+# ---------------------------------------------------------------------------
+
+HSL_HFP_FUNCTIONS: list[str] = [
+    # ------------------------------------------------------------------
+    # Reference stops: every located HSL stop / station / entrance. Null and
+    # 0,0 coordinates are dropped up front.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_stops() {
+    ['fi.hsl.gtfs.StopLatest']
+    | where isnotnull(stop_lat) and isnotnull(stop_lon)
+    | where stop_lat != 0.0 and stop_lon != 0.0
+    | project stop_id, stop_code, stop_name, stop_lat, stop_lon,
+              location_type, parent_station, platform_code, vehicle_type
+}
+''',
+    # ------------------------------------------------------------------
+    # Map bounding box: queried once at deploy time so the basemap centre and
+    # zoom auto-fit the source footprint. 1 % / 99 % quantiles guard against a
+    # single mislocated stop dragging the box across the country.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_bbox() {
+    hslhfp_stops()
+    | summarize lat_p01 = percentile(stop_lat, 1), lat_p99 = percentile(stop_lat, 99),
+                lon_p01 = percentile(stop_lon, 1), lon_p99 = percentile(stop_lon, 99),
+                cnt = count()
+}
+''',
+    # ------------------------------------------------------------------
+    # Live vehicle points: the most recent ``vp`` GPS heartbeat per vehicle
+    # (``___subject`` = operator_id/vehicle_number) within the lookback window,
+    # joined to its static route metadata for nicer labels. Colour + legend are
+    # driven by ``transport_mode`` (HSL-flavoured palette). ``dl`` keeps the HFP
+    # sign convention (positive = early / ahead, negative = late / behind).
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_vehicle_points(lookback:timespan) {
+    let routes = ['fi.hsl.gtfs.RouteLatest']
+        | project route_id, route_short_name, route_long_name, route_type;
+    ['fi.hsl.hfp.VehicleEventLatest']
+    | where ___type in ('fi.hsl.hfp.vp', 'fi.hsl.hfp.upstream.vp')
+    | where ___time > ago(lookback)
+    | where isnotnull(lat) and isnotnull(['long']) and lat != 0.0 and ['long'] != 0.0
+    | summarize arg_max(___time, *) by ___subject
+    | extend route_id = iff(isempty(route_id), route, route_id)
+    | lookup kind=leftouter routes on route_id
+    | extend age_min = datetime_diff('minute', now(), ___time)
+    | extend freshness = case(age_min <= 1, "live", age_min <= 2, "fresh",
+                              age_min <= 5, "recent", "stale")
+    | extend fill_color = case(
+        transport_mode == "bus",   "#007AC9",
+        transport_mode == "tram",  "#00985F",
+        transport_mode == "train", "#8C4799",
+        transport_mode == "metro", "#FF6319",
+        transport_mode == "ferry", "#00B9E4",
+        transport_mode == "ubus",  "#9E9E9E",
+        transport_mode == "robot", "#616161",
+        "#455A64")
+    | extend mode_label = case(
+        transport_mode == "bus",   "Bus",
+        transport_mode == "tram",  "Tram",
+        transport_mode == "train", "Commuter train",
+        transport_mode == "metro", "Metro",
+        transport_mode == "ferry", "Ferry",
+        transport_mode == "ubus",  "U-line bus",
+        transport_mode == "robot", "Robot bus",
+        "Other")
+    | extend route_label = coalesce(desi, route_short_name, route_id, "")
+    | extend speed_kmh = round(spd * 3.6, 1)
+    | extend punctuality = case(isnull(dl), "unknown",
+                                dl <= -300, "very late",
+                                dl <= -60,  "late",
+                                dl < 60,    "on time",
+                                "early")
+    | extend delay_label = case(isnull(dl), "n/a",
+                                dl <= -60, strcat(tostring(abs(dl) / 60), " min late"),
+                                dl >= 60,  strcat(tostring(dl / 60), " min early"),
+                                "on time")
+    | extend punct_color = case(punctuality == "very late", "#B91C1C",
+                                punctuality == "late",      "#F97316",
+                                punctuality == "on time",   "#10B981",
+                                punctuality == "early",     "#3B82F6",
+                                "#9CA3AF")
+    | extend punct_label = case(punctuality == "very late", "5+ min late",
+                                punctuality == "late",      "1-5 min late",
+                                punctuality == "on time",   "On time",
+                                punctuality == "early",     "Ahead of schedule",
+                                "Unknown")
+    | extend heading = iff(isnotnull(hdg) and hdg >= 0 and hdg <= 360, todouble(hdg), real(null))
+    | extend label = iff(isnotempty(route_label),
+                         iff(isnotempty(headsign), strcat(route_label, "  ", headsign), route_label),
+                         headsign)
+    | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(['long'], lat))
+    | project geometry, ___subject, operator_id, vehicle_number, transport_mode, mode_label,
+              route_id, route_short_name, route_long_name, desi, route_label, headsign,
+              latitude = lat, longitude = ['long'], heading, hdg, spd, speed_kmh, dl, delay_label,
+              punctuality, punct_color, punct_label, occu, temporal_type,
+              fill_color, freshness, age_min, label, ___time
+}
+''',
+    # ------------------------------------------------------------------
+    # Live vehicles rendered as bearing-oriented rectangles at z16+. Width and
+    # length scale with latitude so the rectangles look right at street zoom.
+    # Reuses ``hslhfp_vehicle_points`` so the colouring stays consistent.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_vehicle_rectangles(lookback:timespan) {
+    hslhfp_vehicle_points(lookback)
+    | extend render_heading = coalesce(heading, 0.0)
+    | extend rad = render_heading * pi() / 180.0
+    | extend lon_scale = 1.0 / cos(latitude * pi() / 180.0)
+    | extend half_len = 0.000060, half_wid = 0.000022
+    | extend dlon_len = sin(rad) * half_len * lon_scale,
+             dlat_len = cos(rad) * half_len,
+             dlon_wid = cos(rad) * half_wid * lon_scale,
+             dlat_wid = -sin(rad) * half_wid
+    | extend p1 = strcat("[", tostring(round(longitude + dlon_len + dlon_wid, 7)), ",",
+                              tostring(round(latitude + dlat_len + dlat_wid, 7)), "]"),
+             p2 = strcat("[", tostring(round(longitude + dlon_len - dlon_wid, 7)), ",",
+                              tostring(round(latitude + dlat_len - dlat_wid, 7)), "]"),
+             p3 = strcat("[", tostring(round(longitude - dlon_len - dlon_wid, 7)), ",",
+                              tostring(round(latitude - dlat_len - dlat_wid, 7)), "]"),
+             p4 = strcat("[", tostring(round(longitude - dlon_len + dlon_wid, 7)), ",",
+                              tostring(round(latitude - dlat_len + dlat_wid, 7)), "]")
+    | extend geometry = parse_json(strcat('{"type":"Polygon","coordinates":[[',
+                                          p1, ",", p2, ",", p3, ",", p4, ",", p1, ']]}'))
+    | project geometry, ___subject, operator_id, vehicle_number, transport_mode, mode_label,
+              route_id, route_label, desi, headsign, heading = round(render_heading, 0),
+              spd, speed_kmh, dl, delay_label, punctuality,
+              fill_color, freshness, age_min, label, ___time
+}
+''',
+    # ------------------------------------------------------------------
+    # All stops for the map: every logical station (platform-collapsed via
+    # ``parent_station``) shown as a small bubble. HSL has ~7k stops (well under
+    # Fabric's 100k cap) but we still stratify by ~0.005 degree (~0.5 km) cells
+    # keeping the 6 busiest stations per cell, mirroring the gtfs pattern so the
+    # layer scales if the feed ever widens.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_stops_for_map() {
+    hslhfp_stops()
+    | extend group_key = iff(isempty(parent_station), stop_id, parent_station)
+    | summarize stop_name = take_any(stop_name),
+                stop_code = take_any(stop_code),
+                lat = round(avg(stop_lat), 6),
+                lon = round(avg(stop_lon), 6),
+                platforms = dcount(stop_id, 1),
+                location_type = take_any(location_type)
+            by group_key
+    | extend cell = strcat(tostring(bin(lat, 0.005)), ":", tostring(bin(lon, 0.005)))
+    | partition hint.strategy=native by cell ( top 6 by platforms desc )
+    | extend stop_kind = case(location_type == 1, "Station",
+                              location_type == 2, "Entrance / exit",
+                              location_type == 3, "Node",
+                              location_type == 4, "Boarding area",
+                              "Stop / platform")
+    | extend marker_color = case(location_type == 1, "#0F172A",
+                                 location_type == 2, "#1E293B",
+                                 location_type == 3, "#475569",
+                                 location_type == 4, "#334155",
+                                 "#1E40AF")
+    | extend label = iff(isnotempty(stop_code), strcat(stop_name, " (", stop_code, ")"), stop_name)
+    | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(lon, lat))
+    | project geometry, stop_name, stop_code, platforms, stop_kind, marker_color, label
+}
+''',
+    # ------------------------------------------------------------------
+    # Vehicle density grid: per-cell count of live vehicles in the lookback
+    # window. Operational overview (off by default) of where the fleet is
+    # concentrated. Reuses ``hslhfp_vehicle_points`` for the freshness bound.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_vehicle_grid(lookback:timespan, resolution:real) {
+    hslhfp_vehicle_points(lookback)
+    | extend lon0 = bin(longitude, resolution), lat0 = bin(latitude, resolution)
+    | summarize vehicles = count(), avg_age = round(avg(age_min), 1),
+                modes = dcount(transport_mode) by lon0, lat0
+    | extend fill_color = case(vehicles >= 50, "#7a0177",
+                               vehicles >= 20, "#c51b8a",
+                               vehicles >= 5,  "#f768a1",
+                               "#fbb4b9")
+    | extend density_band = case(vehicles >= 50, "50+ vehicles",
+                                 vehicles >= 20, "20-49 vehicles",
+                                 vehicles >= 5,  "5-19 vehicles",
+                                 "1-4 vehicles")
+    | extend label = strcat(tostring(vehicles), " vehicles")
+    | extend geometry = bag_pack("type", "Polygon", "coordinates", pack_array(pack_array(
+        pack_array(lon0, lat0), pack_array(lon0 + resolution, lat0),
+        pack_array(lon0 + resolution, lat0 + resolution), pack_array(lon0, lat0 + resolution),
+        pack_array(lon0, lat0))))
+    | project geometry, vehicles, avg_age, modes, density_band, fill_color, label
+}
+''',
+    # ------------------------------------------------------------------
+    # Transit-signal-priority events: the latest tlr (request) / tla (response)
+    # per vehicle per signal group in the lookback window. Off by default - a
+    # diagnostic overlay for where buses/trams request green-light priority.
+    r'''
+.create-or-alter function with (folder = "Map", skipvalidation = "true") hslhfp_tlp_events(lookback:timespan) {
+    ['fi.hsl.hfp.TrafficLightEventLatest']
+    | where ___time > ago(lookback)
+    | where isnotnull(lat) and isnotnull(['long']) and lat != 0.0 and ['long'] != 0.0
+    | summarize arg_max(___time, *) by ___subject, signal_groupid
+    | extend tlp_kind = case(___type endswith "tla" and tlp_decision == "ACK", "Priority granted",
+                         ___type endswith "tla",                            "Priority rejected",
+                         ___type endswith "tlr",                            "Priority request",
+                         "Other")
+    | extend tlp_color = case(tlp_kind == "Priority granted",  "#10B981",
+                              tlp_kind == "Priority rejected", "#EF4444",
+                              tlp_kind == "Priority request",  "#F59E0B",
+                              "#9CA3AF")
+    | extend label = trim(" ", strcat(coalesce(desi, route_id, ""), " ", tlp_kind))
+    | extend geometry = bag_pack("type", "Point", "coordinates", pack_array(['long'], lat))
+    | project geometry, ___subject, transport_mode, desi, route_id, tlp_kind, tlp_decision,
+              tlp_prioritylevel, signal_groupid, tlp_color, label, ___time
+}
+''',
+]
+
+# ---------------------------------------------------------------------------
+# Layer styling - shared between layers. Fabric Maps doesn't honour
+# ``["get", "field"]`` data-driven colours in bubble/line/polygon paint
+# properties, so we use a hybrid: ``seriesGroup`` + ``customColors`` (for the
+# Data Layers panel legend) AND a MapLibre ``match`` expression on the paint
+# property (which is what actually renders). Both are written at deploy time;
+# ``customColors`` is populated from a per-layer ``distinct`` query.
+# ---------------------------------------------------------------------------
+
+LABEL_BASE = {
+    "enabled": False,
+    "size": 11,
+    "color": "#111111",
+    "textStrokeColor": "#FFFFFF",
+    "textStrokeWidth": 2,
+    "allowOverlap": False,
+}
+
+# Seed palettes (keyed on the legend label). When a layer's legend column
+# differs from its paint column the seed is re-enumerated from live data; the
+# seeds document the expected domain and act as a static fallback.
+MODE_PALETTE_SEED = {
+    "Bus": "#007AC9", "Tram": "#00985F", "Commuter train": "#8C4799",
+    "Metro": "#FF6319", "Ferry": "#00B9E4", "U-line bus": "#9E9E9E",
+    "Robot bus": "#616161", "Other": "#455A64",
+}
+STOP_PALETTE_SEED = {
+    "Stop / platform": "#1E40AF", "Station": "#0F172A", "Entrance / exit": "#1E293B",
+    "Node": "#475569", "Boarding area": "#334155",
+}
+PUNCT_PALETTE_SEED = {
+    "5+ min late": "#B91C1C", "1-5 min late": "#F97316", "On time": "#10B981",
+    "Ahead of schedule": "#3B82F6", "Unknown": "#9CA3AF",
+}
+DENSITY_PALETTE_SEED = {
+    "50+ vehicles": "#7a0177", "20-49 vehicles": "#c51b8a",
+    "5-19 vehicles": "#f768a1", "1-4 vehicles": "#fbb4b9",
+}
+TLP_PALETTE_SEED = {
+    "Priority granted": "#10B981", "Priority rejected": "#EF4444",
+    "Priority request": "#F59E0B", "Other": "#9CA3AF",
+}
+
+
+def _series(column: str, palette: dict[str, str],
+            paint_column: str | None = None) -> dict[str, Any]:
+    series: dict[str, Any] = {
+        "enableSeriesGroup": True,
+        "seriesGroup": column,
+        "customColors": dict(palette),
+    }
+    # When the legend column (seriesGroup) differs from the column that
+    # actually carries the paint colour, record the paint column so
+    # _populate_palette can map legend-label -> colour. This non-Fabric key is
+    # consumed and removed before the definition is serialised.
+    if paint_column and paint_column != column:
+        series["_paintColorColumn"] = paint_column
+    return series
+
+
+def _color_match(column: str, palette: dict[str, str], fallback: str = "#888888") -> list[Any]:
+    expr: list[Any] = ["match", ["get", column]]
+    for value, color in palette.items():
+        expr.append(value)
+        expr.append(color)
+    expr.append(fallback)
+    return expr
+
+
+def bubble_options(*, visible: bool, radius: int = 4,
+                   labels: bool = False, label_size: int = 11,
+                   min_zoom: float | None = None, max_zoom: float | None = None,
+                   color_column: str = "fill_color",
+                   legend_column: str | None = None,
+                   palette: dict[str, str] | None = None,
+                   tooltip_keys: list[str] | None = None,
+                   stroke_color: str = "#FFFFFF") -> dict[str, Any]:
+    pal = palette if palette is not None else {}
+    legend = legend_column or color_column
+    opts: dict[str, Any] = {
+        "type": "vector",
+        "visible": visible,
+        "pointLayerType": "bubble",
+        "bubbleOptions": {
+            "color": "#888888",
+            "radius": radius,
+            "strokeColor": stroke_color,
+            "strokeWidth": 1,
+            "opacity": 0.92,
+            **_series(legend, pal, paint_column=color_column),
+        },
+        "dataLabelKeys": ["label"],
+        "dataLabelOptions": dict(LABEL_BASE, enabled=labels, size=label_size),
+        "tooltipKeys": tooltip_keys or ["label"],
+        "enablePopups": True,
+    }
+    if min_zoom is not None:
+        opts["minZoom"] = min_zoom
+    if max_zoom is not None:
+        opts["maxZoom"] = max_zoom
+    return opts
+
+
+def polygon_options(*, visible: bool, color_column: str = "fill_color",
+                    legend_column: str | None = None,
+                    palette: dict[str, str] | None = None,
+                    fill_opacity: float = 0.55,
+                    stroke_color: Any = "#202020",
+                    stroke_width: int = 0,
+                    labels: bool = False, label_size: int = 10,
+                    min_zoom: float | None = None) -> dict[str, Any]:
+    pal = palette if palette is not None else {}
+    legend = legend_column or color_column
+    opts: dict[str, Any] = {
+        "type": "vector",
+        "visible": visible,
+        "polygonOptions": {
+            "fillColor": "#888888",
+            "fillOpacity": fill_opacity,
+            **_series(legend, pal, paint_column=color_column),
+        },
+        "lineOptions": {
+            "strokeColor": stroke_color,
+            "strokeWidth": stroke_width,
+            "strokeOpacity": 0.15,
+        },
+        "dataLabelKeys": ["label"],
+        "dataLabelOptions": dict(LABEL_BASE, enabled=labels, size=label_size),
+        "tooltipKeys": ["label", "vehicles", "avg_age", "modes", "density_band"],
+        "enablePopups": True,
+    }
+    if min_zoom is not None:
+        opts["minZoom"] = min_zoom
+    return opts
+
+
+def vehicle_rectangle_options() -> dict[str, Any]:
+    return {
+        "type": "vector",
+        "visible": True,
+        "minZoom": 16,
+        "polygonOptions": {
+            "fillColor": "#888888",
+            "fillOpacity": 0.95,
+            **_series("mode_label", dict(MODE_PALETTE_SEED), paint_column="fill_color"),
+        },
+        "lineOptions": {
+            "strokeColor": "#202020",
+            "strokeWidth": 1,
+            "strokeOpacity": 0.95,
+        },
+        "dataLabelKeys": ["route_label"],
+        "dataLabelOptions": dict(
+            LABEL_BASE,
+            enabled=True,
+            size=9,
+            color="#FFFFFF",
+            textStrokeColor="#000000",
+            textStrokeWidth=1.5,
+            allowOverlap=True,
+        ),
+        "tooltipKeys": [
+            "route_label", "desi", "mode_label", "route_id", "headsign",
+            "heading", "speed_kmh", "delay_label", "punctuality",
+            "freshness", "age_min", "vehicle_number", "operator_id", "___subject",
+        ],
+        "enablePopups": True,
+    }
+
+
+def _text_filter(field: str) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "type": "text",
+        "field": field,
+        "locked": False,
+        "value": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layer declarations - one entry per Fabric Map vector layer.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Layer:
+    name: str
+    kql: str
+    options: dict[str, Any]
+    filters: list[dict[str, Any]]
+
+
+def _layers() -> list[Layer]:
+    return [
+        Layer(
+            "HSL - Live vehicles",
+            "hslhfp_vehicle_points(5m)",
+            bubble_options(
+                visible=True, radius=4, min_zoom=8, max_zoom=16,
+                color_column="fill_color", legend_column="mode_label",
+                palette=MODE_PALETTE_SEED,
+                tooltip_keys=[
+                    "route_label", "desi", "route_id", "headsign", "mode_label",
+                    "speed_kmh", "delay_label", "punctuality", "occu",
+                    "freshness", "age_min", "___subject",
+                ],
+            ),
+            [_text_filter("transport_mode"), _text_filter("desi")],
+        ),
+        Layer(
+            "HSL - Live vehicles (detail)",
+            "hslhfp_vehicle_rectangles(5m)",
+            vehicle_rectangle_options(),
+            [_text_filter("transport_mode"), _text_filter("desi")],
+        ),
+        Layer(
+            "HSL - Transit stops",
+            "hslhfp_stops_for_map()",
+            bubble_options(
+                visible=True, radius=3, labels=True, label_size=10, min_zoom=13,
+                color_column="marker_color", legend_column="stop_kind",
+                palette=STOP_PALETTE_SEED,
+                tooltip_keys=["stop_name", "stop_code", "platforms", "stop_kind"],
+            ),
+            [],
+        ),
+        Layer(
+            "HSL - Vehicle punctuality",
+            "hslhfp_vehicle_points(5m)",
+            bubble_options(
+                visible=False, radius=5, min_zoom=11,
+                color_column="punct_color", legend_column="punct_label",
+                palette=PUNCT_PALETTE_SEED,
+                tooltip_keys=[
+                    "route_label", "desi", "punctuality", "delay_label",
+                    "mode_label", "speed_kmh", "age_min",
+                ],
+            ),
+            [_text_filter("punctuality"), _text_filter("transport_mode")],
+        ),
+        Layer(
+            "HSL - Vehicle density",
+            "hslhfp_vehicle_grid(5m, 0.01)",
+            polygon_options(
+                visible=False, color_column="fill_color", legend_column="density_band",
+                palette=DENSITY_PALETTE_SEED,
+            ),
+            [],
+        ),
+        Layer(
+            "HSL - Traffic-signal priority",
+            "hslhfp_tlp_events(30m)",
+            bubble_options(
+                visible=False, radius=6, min_zoom=12,
+                color_column="tlp_color", legend_column="tlp_kind",
+                palette=TLP_PALETTE_SEED,
+                tooltip_keys=[
+                    "label", "desi", "route_id", "tlp_kind", "tlp_decision",
+                    "tlp_prioritylevel", "signal_groupid", "transport_mode",
+                ],
+            ),
+            [_text_filter("tlp_kind"), _text_filter("transport_mode")],
+        ),
+    ]
+
+# ---------------------------------------------------------------------------
+# Map definition patching.
+# ---------------------------------------------------------------------------
+
+HELSINKI_CENTER = [24.9384, 60.1699]  # lon, lat - final basemap fallback
+
+
+def _b64(s: str) -> str:
+    return base64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+def _get_definition(fab: requests.Session, api_base: str, workspace_id: str,
+                    map_id: str) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    res = _poll_lro(
+        fab,
+        fab.post(f"{api_base}/workspaces/{workspace_id}/items/{map_id}/getDefinition"),
+    )
+    parts = {p["path"]: p for p in res["definition"]["parts"]}
+    if "map.json" not in parts:
+        raise RuntimeError("Map definition has no map.json part")
+    mp = json.loads(base64.b64decode(parts["map.json"]["payload"]).decode("utf-8"))
+    mp.setdefault("dataSources", [])
+    mp.setdefault("iconSources", [])
+    mp.setdefault("layerSources", [])
+    mp.setdefault("layerSettings", [])
+    if "$schema" not in mp:
+        mp["$schema"] = ("https://developer.microsoft.com/json-schemas/fabric/item/map/"
+                         "definition/2.0.0/schema.json")
+    return mp, parts
+
+
+def _put_definition(fab: requests.Session, api_base: str, workspace_id: str,
+                    map_id: str, mp: dict[str, Any],
+                    parts: dict[str, dict[str, Any]]) -> None:
+    parts["map.json"] = {
+        "path": "map.json",
+        "payload": _b64(json.dumps(mp, indent=2)),
+        "payloadType": "InlineBase64",
+    }
+    r = fab.post(
+        f"{api_base}/workspaces/{workspace_id}/items/{map_id}/updateDefinition",
+        json={"definition": {"parts": list(parts.values())}},
+    )
+    print(f"updateDefinition HTTP {r.status_code}")
+    _poll_lro(fab, r)
+
+
+def _bbox(ks: requests.Session, kusto_uri: str,
+          kusto_db: str) -> Optional[tuple[float, float, float, float, int]]:
+    """Return (lat_p01, lat_p99, lon_p01, lon_p99, n) or None.
+
+    Tries the stop bounding box first, then falls back to the live vehicle
+    footprint (a brand-new database may have telemetry before the GTFS static
+    reference has been ingested)."""
+    candidates = (
+        "hslhfp_bbox()",
+        ("hslhfp_vehicle_points(30m) | summarize "
+         "lat_p01 = percentile(latitude, 1), lat_p99 = percentile(latitude, 99), "
+         "lon_p01 = percentile(longitude, 1), lon_p99 = percentile(longitude, 99), "
+         "cnt = count()"),
+    )
+    for csl in candidates:
+        try:
+            frame = _kql_query(ks, kusto_uri, kusto_db, csl)
+        except Exception as exc:
+            print(f"  bbox lookup failed ({csl[:24]}...): {exc}")
+            continue
+        if not frame or not frame.get("Rows"):
+            continue
+        cols = [c["ColumnName"] for c in frame["Columns"]]
+        rec = dict(zip(cols, frame["Rows"][0]))
+        if not rec.get("cnt"):
+            continue
+        try:
+            return (
+                float(rec["lat_p01"]), float(rec["lat_p99"]),
+                float(rec["lon_p01"]), float(rec["lon_p99"]), int(rec["cnt"]),
+            )
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _zoom_for_extent(lat_span: float, lon_span: float) -> float:
+    """Pick a sensible default zoom for the bounding box. Tuned for a
+    ~1600x1000 viewport; errs on the side of zooming OUT slightly so the full
+    source is visible at first render."""
+    span = max(lat_span, lon_span / 2.0)  # account for Mercator distortion
+    if span >= 30:  return 3.5
+    if span >= 15:  return 4.5
+    if span >= 8:   return 5.5
+    if span >= 4:   return 6.7
+    if span >= 2:   return 8.0
+    if span >= 1:   return 9.5
+    if span >= 0.5: return 10.6
+    if span >= 0.2: return 11.5
+    return 12.5
+
+
+def _set_basemap(mp: dict[str, Any],
+                 bbox: Optional[tuple[float, float, float, float, int]]) -> None:
+    if bbox is None:
+        center = list(HELSINKI_CENTER)
+        zoom = 11.0
+    else:
+        lat_p01, lat_p99, lon_p01, lon_p99, _ = bbox
+        center = [(lon_p01 + lon_p99) / 2.0, (lat_p01 + lat_p99) / 2.0]
+        zoom = _zoom_for_extent(lat_p99 - lat_p01, lon_p99 - lon_p01)
+    mp["basemap"] = {
+        "options": {
+            "center": center,
+            "zoom": zoom,
+            "style": "grayscale_light",
+            "showLabels": True,
+        },
+        "controls": {
+            "zoom": True, "pitch": True, "compass": True, "scale": True,
+            "traffic": False, "style": True,
+        },
+        "backgroundColor": "#FFFFFF",
+        "theme": "light",
+    }
+    print(f"  basemap center={center} zoom={zoom}")
+
+
+def _populate_palette(ks: requests.Session, kusto_uri: str, kusto_db: str,
+                      layer: Layer) -> None:
+    """For each seriesGroup-bound paint property on the layer, fetch the
+    distinct values from the live data and populate ``customColors`` as an
+    identity map. Also write a MapLibre ``match`` expression to the paint
+    property (Fabric's ``seriesGroup`` populates the legend but does not
+    actually drive paint colour)."""
+    paint_key_for = {
+        "bubbleOptions": "color",
+        "lineOptions": "strokeColor",
+        "polygonOptions": "fillColor",
+    }
+    for sub, paint_key in paint_key_for.items():
+        block = layer.options.get(sub)
+        if not block or not block.get("enableSeriesGroup"):
+            continue
+        column = block.get("seriesGroup")
+        if not column:
+            continue
+        # Non-Fabric marker: when present the legend column (seriesGroup) is a
+        # human label distinct from the column carrying the paint colour.
+        paint_column = block.pop("_paintColorColumn", None)
+        if paint_column and paint_column != column:
+            block["customColors"] = {}
+        try:
+            if paint_column and paint_column != column:
+                frame = _kql_query(
+                    ks, kusto_uri, kusto_db,
+                    f"{layer.kql}\n| where isnotempty({column}) and isnotempty({paint_column})"
+                    f"\n| distinct {column}, {paint_column}\n| take 200",
+                )
+                pairs = [(row[0], row[1]) for row in (frame.get("Rows") or [])
+                         if row and row[0] and row[1]]
+            else:
+                frame = _kql_query(
+                    ks, kusto_uri, kusto_db,
+                    f"{layer.kql}\n| where isnotempty({column})"
+                    f"\n| distinct {column}\n| take 50",
+                )
+                pairs = [(row[0], row[0]) for row in (frame.get("Rows") or [])
+                         if row and row[0]]
+        except Exception as exc:
+            print(f"    palette enumeration failed for {layer.name}/{column}: {exc}")
+            pairs = []
+        if not pairs:
+            continue
+        block.setdefault("customColors", {})
+        for label, color in pairs:
+            block["customColors"].setdefault(label, color)
+        block[paint_key] = _color_match(column, block["customColors"])
+        print(f"    palette {column}: {len(block['customColors'])} colors")
+
+
+# ---------------------------------------------------------------------------
+# Top-level wiring entry point.
+# ---------------------------------------------------------------------------
+
+def wire(*, workspace_id: str, map_id: str, kql_db_id: str,
+         kusto_uri: str, kusto_db: str,
+         fabric_token: str, kusto_token: str,
+         api_base: str = "https://api.fabric.microsoft.com/v1") -> None:
+    fab = _session(fabric_token)
+    ks = _session(kusto_token)
+
+    # 1. Create/refresh the helper KQL functions in the target database.
+    print(f"Creating {len(HSL_HFP_FUNCTIONS)} helper functions in {kusto_db}")
+    for f in HSL_HFP_FUNCTIONS:
+        head = next((line.strip() for line in f.splitlines() if line.strip()), "")
+        print(f"  {head[:110]}")
+        _kql_mgmt(ks, kusto_uri, kusto_db, f)
+
+    # 2. Look up the source's geographic footprint to centre the basemap.
+    print("Discovering bounding box from hslhfp_bbox()")
+    bbox = _bbox(ks, kusto_uri, kusto_db)
+    if bbox is None:
+        print("  no stops/vehicles indexed yet; centring on Helsinki")
+    else:
+        lat_p01, lat_p99, lon_p01, lon_p99, n = bbox
+        print(f"  {n} features; lat=[{lat_p01:.3f}, {lat_p99:.3f}]"
+              f" lon=[{lon_p01:.3f}, {lon_p99:.3f}]")
+
+    # 3. Patch the map definition idempotently.
+    mp, parts = _get_definition(fab, api_base, workspace_id, map_id)
+    _set_basemap(mp, bbox)
+
+    # Drop previously-wired layers whose source is bound to this KQL DB so we
+    # don't accumulate stale layers across re-runs.
+    removed_src_ids = {
+        s["id"] for s in mp.get("layerSources", [])
+        if s.get("itemId") == kql_db_id
+    }
+    if removed_src_ids:
+        print(f"  removing {len(removed_src_ids)} pre-existing hsl-hfp layer source(s)")
+    mp["layerSettings"] = [ls for ls in mp.get("layerSettings", [])
+                           if ls.get("sourceId") not in removed_src_ids]
+    mp["layerSources"] = [s for s in mp.get("layerSources", [])
+                          if s["id"] not in removed_src_ids]
+    for path in list(parts):
+        if path.startswith("queries/layerSource-"):
+            sid = path.split("layerSource-", 1)[1].split(".kql", 1)[0]
+            if sid in removed_src_ids:
+                del parts[path]
+
+    # Ensure this KQL DB is registered as a data source.
+    if not any(d.get("itemId") == kql_db_id for d in mp["dataSources"]):
+        mp["dataSources"].append({
+            "itemType": "KqlDatabase",
+            "workspaceId": workspace_id,
+            "itemId": kql_db_id,
+        })
+
+    # 4. Add each layer, validating the query and populating the palette.
+    for layer in _layers():
+        print(f"  layer {layer.name}")
+        try:
+            cnt_frame = _kql_query(ks, kusto_uri, kusto_db, f"{layer.kql}\n| count")
+            cnt = cnt_frame["Rows"][0][0] if cnt_frame and cnt_frame.get("Rows") else "?"
+            print(f"    rows: {cnt}")
+        except Exception as exc:
+            print(f"    validation failed (skipping): {exc}")
+            continue
+
+        _populate_palette(ks, kusto_uri, kusto_db, layer)
+
+        src_id = str(uuid.uuid4())
+        mp["layerSources"].append({
+            "id": src_id,
+            "name": f"{layer.name}_source",
+            "type": "kusto",
+            "options": {"cluster": False},
+            "itemId": kql_db_id,
+            "refreshIntervalMs": 0,
+        })
+        mp["layerSettings"].append({
+            "id": str(uuid.uuid4()),
+            "name": layer.name,
+            "sourceId": src_id,
+            "geometryColumnName": "geometry",
+            "filters": layer.filters,
+            "options": layer.options,
+        })
+        parts[f"queries/layerSource-{src_id}.kql"] = {
+            "path": f"queries/layerSource-{src_id}.kql",
+            "payload": _b64(layer.kql),
+            "payloadType": "InlineBase64",
+        }
+
+    _put_definition(fab, api_base, workspace_id, map_id, mp, parts)
+    print(f"OK - map {map_id} updated with {len(_layers())} layers")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--workspace-id", default=os.environ.get("FABRIC_WORKSPACE_ID"))
+    ap.add_argument("--map-id",       default=os.environ.get("FABRIC_MAP_ID"))
+    ap.add_argument("--kql-db-id",    default=os.environ.get("FABRIC_KQL_DB_ID"))
+    ap.add_argument("--kusto-uri",    default=os.environ.get("KUSTO_CLUSTER_URI"))
+    ap.add_argument("--kusto-db",     default=os.environ.get("KUSTO_DB", "hsl_hfp"))
+    ap.add_argument("--api-base",     default=os.environ.get(
+        "FABRIC_API_BASE", "https://api.fabric.microsoft.com/v1"))
+    args = ap.parse_args(argv)
+
+    missing = [n for n in ("workspace_id", "map_id", "kql_db_id", "kusto_uri")
+               if not getattr(args, n)]
+    if missing:
+        ap.error("missing required: " + ", ".join("--" + m.replace("_", "-") for m in missing))
+        return 2
+
+    fabric_token = _get_token("FABRIC_TOKEN", "https://api.fabric.microsoft.com/.default")
+    kusto_token = _get_token("KUSTO_TOKEN", "https://kusto.fabric.microsoft.com/.default")
+
+    wire(
+        workspace_id=args.workspace_id,
+        map_id=args.map_id,
+        kql_db_id=args.kql_db_id,
+        kusto_uri=args.kusto_uri,
+        kusto_db=args.kusto_db,
+        fabric_token=fabric_token,
+        kusto_token=kusto_token,
+        api_base=args.api_base,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a Fabric **Map** to the **hsl-hfp** feeder (Helsinki HFP — ~1,700 transit vehicles streaming GPS at ~1 Hz), following the established `feeders/<source>/fabric/post-deploy.ps1` + `wire_<source>_map.py` pattern used by `gtfs`, `aisstream`, and `pegelonline`.

The generic `deploy-fabric.ps1` auto-discovers `feeders/hsl-hfp/fabric/post-deploy.ps1` as its final step, creates the `hsl-hfp-map` Map item, and wires Kusto-backed vector layers via `getDefinition`/`updateDefinition`.

## Layers

| # | Layer | Default | Source query |
|---|-------|---------|--------------|
| 1 | HSL - Live vehicles (bubbles by transport_mode) | on | `hslhfp_vehicle_points` |
| 2 | HSL - Live vehicles (detail, heading rectangles z16+) | on | `hslhfp_vehicle_rectangles` |
| 3 | HSL - Transit stops | on | `hslhfp_stops_for_map` |
| 4 | HSL - Vehicle punctuality (delay bands) | off | `hslhfp_vehicle_points` |
| 5 | HSL - Vehicle density (per-cell grid) | off | `hslhfp_vehicle_grid` |
| 6 | HSL - Traffic-signal priority (tlr/tla) | off | `hslhfp_tlp_events` |

Basemap bbox auto-fits from `hslhfp_bbox()` (StopLatest 1/99 percentiles); Helsinki fallback.

## Live end-to-end test

Deployed to the **ContosoRealTimeTest** Fabric workspace and fed live data from `mqtt.hsl.fi` (kafka container → Event Stream → KQL DB `hsl_hfp`):

- **784** live vehicles, **7,752** stops, **352** density cells, **690** TLP events
- basemap auto-fit to `lat[60.08..60.54] lon[24.22..25.47]` (Helsinki region), center `[24.84, 60.31]` zoom 10.6
- all **6** layerSources KQL-bound; 3 visible by default, 3 overlays off
- `updateDefinition` HTTP 202; GeoJSON geometry verified well-formed (Point / heading-oriented Polygon)

## Real bugs found & fixed during the live test

Per "Real Bugs Are Blockers", two genuine wire-script bugs surfaced only when the functions ran against real data (both produced a generic `HTTP 400 General_BadRequest` with **no** syntax detail, even with `skipvalidation="true"` — which skips only *semantic* checks, not parse):

1. **Column `long`** (real longitude) collides with the KQL `long` **type keyword** → bracket-quote as `['long']` (5 occurrences).
2. **Derived column `kind`** is a reserved KQL keyword → renamed to `tlp_kind` (the legitimate `lookup kind=leftouter` operator arg is preserved).

Reusable lesson for future map authoring: any source whose KQL columns collide with reserved keywords (`long`, `kind`, `bool`, `int`, …) must bracket-quote/rename them; the generic 400 gives no hint.

## Docs

- `feeders/hsl-hfp/fabric/README.md` (new) — layer table, schema assumptions, `dl` sign convention, auto-invocation + standalone re-wire.
- `feeders/hsl-hfp/README.md` — Fabric Map link in the doc-link row, Fabric deploy section, repo layout, and footer triangle.

## Gates

- Gate 2 py_compile ✅ · Gate 6 mypy (clean, file is in CI scope) ✅ · PS parse ✅
- No bridge/schema/producer changes → no Docker E2E needed for this map-only change.
