### PR TITLE
pilot(hsl-hfp): promote loc/dir/tlp_protocol back to enums (avrotize 3.7.0)

### DIFF
--- a/feeders/hsl-hfp/EVENTS.md
+++ b/feeders/hsl-hfp/EVENTS.md
@@ -100,7 +100,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -118,7 +118,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -135,6 +135,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -157,7 +168,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -175,7 +186,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -226,7 +237,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -244,7 +255,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -261,6 +272,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -283,7 +305,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -301,7 +323,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -352,7 +374,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -370,7 +392,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -387,6 +409,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -409,7 +442,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -427,7 +460,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -478,7 +511,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -496,7 +529,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -513,6 +546,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -535,7 +579,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -553,7 +597,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -604,7 +648,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -622,7 +666,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -639,6 +683,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -661,7 +716,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -679,7 +734,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -730,7 +785,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -748,7 +803,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -765,6 +820,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -787,7 +853,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -805,7 +871,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -856,7 +922,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -874,7 +940,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -891,6 +957,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -913,7 +990,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -931,7 +1008,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -982,7 +1059,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1000,7 +1077,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -1017,6 +1094,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1039,7 +1127,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1057,7 +1145,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -1108,7 +1196,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1126,7 +1214,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -1143,6 +1231,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1165,7 +1264,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1183,7 +1282,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -1234,7 +1333,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1252,7 +1351,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -1269,6 +1368,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1291,7 +1401,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1309,7 +1419,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -1360,7 +1470,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1378,7 +1488,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -1395,6 +1505,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1417,7 +1538,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1435,7 +1556,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -1486,7 +1607,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1504,7 +1625,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -1521,6 +1642,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1543,7 +1675,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1561,7 +1693,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -1612,7 +1744,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1628,7 +1760,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`tlp_requestid`** (null or int32, optional): Traffic-light priority request ID on the interval [0, 255]. Populated on `tlr` (the request) and echoed on `tla` (the response). Sourced from the HFP payload `tlp-requestid` field. Constraints: minimum `0`, maximum `255`.
 - **`tlp_requesttype`** (enum, optional): Type of the traffic-light priority request. One of `NORMAL`, `DOOR_CLOSE`, `DOOR_OPEN` or `ADVANCE`. Populated on `tlr`. Sourced from the HFP payload `tlp-requesttype` field.
 - **`tlp_prioritylevel`** (enum, optional): Priority level of the traffic-light priority request. One of `normal`, `high` or `norequest`. Populated on `tlr`. Sourced from the HFP payload `tlp-prioritylevel` field.
@@ -1641,7 +1773,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`tlp_line_configid`** (null or int32, optional): ID of the line configuration in DOI. Populated on `tlr`. Sourced from the HFP payload `tlp-line-configid` field.
 - **`tlp_point_configid`** (null or int32, optional): Point configuration ID. Populated on `tlr`. Sourced from the HFP payload `tlp-point-configid` field.
 - **`tlp_frequency`** (null or int32, optional): Frequency used for the traffic-light priority request. Populated on `tlr`. Sourced from the HFP payload `tlp-frequency` field.
-- **`tlp_protocol`** (null or string, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
+- **`tlp_protocol`** (enum, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
 ##### `temporal_type` values
 
 - `ongoing`
@@ -1655,6 +1787,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 ##### `tlp_requesttype` values
 
 - `NORMAL`
@@ -1676,6 +1819,10 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 
 - `ACK`
 - `NAK`
+##### `tlp_protocol` values
+
+- `MQTT`
+- `KAR-MQTT`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1698,7 +1845,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1714,7 +1861,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "tlp_requestid": 0,
   "tlp_requesttype": "NORMAL",
   "tlp_prioritylevel": "normal",
@@ -1727,7 +1874,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "tlp_line_configid": 0,
   "tlp_point_configid": 0,
   "tlp_frequency": 0,
-  "tlp_protocol": "string"
+  "tlp_protocol": "MQTT"
 }
 ```
 
@@ -1775,7 +1922,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -1791,7 +1938,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`tlp_requestid`** (null or int32, optional): Traffic-light priority request ID on the interval [0, 255]. Populated on `tlr` (the request) and echoed on `tla` (the response). Sourced from the HFP payload `tlp-requestid` field. Constraints: minimum `0`, maximum `255`.
 - **`tlp_requesttype`** (enum, optional): Type of the traffic-light priority request. One of `NORMAL`, `DOOR_CLOSE`, `DOOR_OPEN` or `ADVANCE`. Populated on `tlr`. Sourced from the HFP payload `tlp-requesttype` field.
 - **`tlp_prioritylevel`** (enum, optional): Priority level of the traffic-light priority request. One of `normal`, `high` or `norequest`. Populated on `tlr`. Sourced from the HFP payload `tlp-prioritylevel` field.
@@ -1804,7 +1951,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`tlp_line_configid`** (null or int32, optional): ID of the line configuration in DOI. Populated on `tlr`. Sourced from the HFP payload `tlp-line-configid` field.
 - **`tlp_point_configid`** (null or int32, optional): Point configuration ID. Populated on `tlr`. Sourced from the HFP payload `tlp-point-configid` field.
 - **`tlp_frequency`** (null or int32, optional): Frequency used for the traffic-light priority request. Populated on `tlr`. Sourced from the HFP payload `tlp-frequency` field.
-- **`tlp_protocol`** (null or string, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
+- **`tlp_protocol`** (enum, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
 ##### `temporal_type` values
 
 - `ongoing`
@@ -1818,6 +1965,17 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 ##### `tlp_requesttype` values
 
 - `NORMAL`
@@ -1839,6 +1997,10 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 
 - `ACK`
 - `NAK`
+##### `tlp_protocol` values
+
+- `MQTT`
+- `KAR-MQTT`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1861,7 +2023,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -1877,7 +2039,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "tlp_requestid": 0,
   "tlp_requesttype": "NORMAL",
   "tlp_prioritylevel": "normal",
@@ -1890,7 +2052,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "tlp_line_configid": 0,
   "tlp_point_configid": 0,
   "tlp_frequency": 0,
-  "tlp_protocol": "string"
+  "tlp_protocol": "MQTT"
 }
 ```
 
@@ -1944,7 +2106,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -1960,6 +2122,13 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -1988,7 +2157,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -2044,7 +2213,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -2060,6 +2229,13 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2088,7 +2264,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -2144,7 +2320,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -2160,6 +2336,13 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2188,7 +2371,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -2244,7 +2427,7 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -2260,6 +2443,13 @@ Each event identifies the real-world resource with `{operator_id}/{vehicle_numbe
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2288,7 +2478,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -2497,7 +2687,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -2515,7 +2705,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -2532,6 +2722,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2554,7 +2755,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -2572,7 +2773,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -2621,7 +2822,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -2639,7 +2840,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -2656,6 +2857,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2678,7 +2890,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -2696,7 +2908,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -2745,7 +2957,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -2763,7 +2975,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -2780,6 +2992,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2802,7 +3025,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -2820,7 +3043,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -2869,7 +3092,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -2887,7 +3110,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -2904,6 +3127,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -2926,7 +3160,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -2944,7 +3178,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -2993,7 +3227,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3011,7 +3245,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3028,6 +3262,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3050,7 +3295,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3068,7 +3313,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3117,7 +3362,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3135,7 +3380,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3152,6 +3397,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3174,7 +3430,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3192,7 +3448,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3241,7 +3497,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3259,7 +3515,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3276,6 +3532,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3298,7 +3565,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3316,7 +3583,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3365,7 +3632,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3383,7 +3650,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3400,6 +3667,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3422,7 +3700,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3440,7 +3718,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3489,7 +3767,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3507,7 +3785,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3524,6 +3802,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3546,7 +3835,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3564,7 +3853,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3613,7 +3902,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3631,7 +3920,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3648,6 +3937,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3670,7 +3970,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3688,7 +3988,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3737,7 +4037,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3755,7 +4055,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3772,6 +4072,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3794,7 +4105,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3812,7 +4123,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3861,7 +4172,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -3879,7 +4190,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`ttarr`** (null or string, optional): UTC timestamp of the scheduled arrival time to the stop related to a stop event, ISO 8601. Populated on the stop and door events (`due`,`arr`,`dep`,`ars`,`pde`,`pas`,`wait`,`doo`,`doc`); absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttarr` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`ttdep`** (null or string, optional): UTC timestamp of the scheduled departure time from the stop related to a stop event, ISO 8601. Populated on the stop and door events; absent on `vp` and on the service-journey sign events. Sourced from the HFP payload `ttdep` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Populated on the service-journey sign events (`vja`,`vjout`). Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
@@ -3896,6 +4207,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -3918,7 +4240,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -3936,7 +4258,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "ttarr": "string",
   "ttdep": "string",
   "dr_type": 0
@@ -3985,7 +4307,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -4001,7 +4323,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`tlp_requestid`** (null or int32, optional): Traffic-light priority request ID on the interval [0, 255]. Populated on `tlr` (the request) and echoed on `tla` (the response). Sourced from the HFP payload `tlp-requestid` field. Constraints: minimum `0`, maximum `255`.
 - **`tlp_requesttype`** (enum, optional): Type of the traffic-light priority request. One of `NORMAL`, `DOOR_CLOSE`, `DOOR_OPEN` or `ADVANCE`. Populated on `tlr`. Sourced from the HFP payload `tlp-requesttype` field.
 - **`tlp_prioritylevel`** (enum, optional): Priority level of the traffic-light priority request. One of `normal`, `high` or `norequest`. Populated on `tlr`. Sourced from the HFP payload `tlp-prioritylevel` field.
@@ -4014,7 +4336,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`tlp_line_configid`** (null or int32, optional): ID of the line configuration in DOI. Populated on `tlr`. Sourced from the HFP payload `tlp-line-configid` field.
 - **`tlp_point_configid`** (null or int32, optional): Point configuration ID. Populated on `tlr`. Sourced from the HFP payload `tlp-point-configid` field.
 - **`tlp_frequency`** (null or int32, optional): Frequency used for the traffic-light priority request. Populated on `tlr`. Sourced from the HFP payload `tlp-frequency` field.
-- **`tlp_protocol`** (null or string, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
+- **`tlp_protocol`** (enum, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
 ##### `temporal_type` values
 
 - `ongoing`
@@ -4028,6 +4350,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 ##### `tlp_requesttype` values
 
 - `NORMAL`
@@ -4049,6 +4382,10 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 
 - `ACK`
 - `NAK`
+##### `tlp_protocol` values
+
+- `MQTT`
+- `KAR-MQTT`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4071,7 +4408,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -4087,7 +4424,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "tlp_requestid": 0,
   "tlp_requesttype": "NORMAL",
   "tlp_prioritylevel": "normal",
@@ -4100,7 +4437,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "tlp_line_configid": 0,
   "tlp_point_configid": 0,
   "tlp_frequency": 0,
-  "tlp_protocol": "string"
+  "tlp_protocol": "MQTT"
 }
 ```
 
@@ -4146,7 +4483,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`geohash_level`** (null or string, optional): Geohash precision level (0-5) from the MQTT-topic level, indicating how many leading digits of the vehicle position have changed since the previous message. Carried as a string to mirror the topic verbatim.
 - **`geohash`** (null or string, optional): Slash-delimited geohash of the vehicle position assembled from the trailing MQTT-topic levels (e.g. `60;24/18/71/93`), used by HSL for geographic topic filtering. Carried as a string to mirror the topic verbatim.
 - **`desi`** (null or string, optional): Route number visible to passengers — the public-facing line label shown on the head sign, e.g. `551`, `H72`. Sourced from the HFP payload `desi` field. Not populated on driver/block sign events (`da`,`dout`,`ba`,`bout`).
-- **`dir`** (null or string, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
+- **`dir`** (enum, optional): Route direction of the trip as a string, either `"1"` or `"2"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`dl`** (null or int32, optional, s): Offset from the scheduled timetable in seconds (s). Negative values indicate the vehicle is lagging behind schedule, positive values indicate running ahead. Sourced from the HFP payload `dl` field. Not populated on `da`,`dout`,`ba`,`bout`.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. The operating day typically ends around 04:30 local time on the following calendar day, so the final moments of day `2018-04-05` fall at 2018-04-06T04:30 local. Sourced from the HFP payload `oday` field. Not populated on `da`,`dout`. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`jrn`** (null or int32, optional): Internal journey descriptor used by HSL. Not meant to be useful for external consumers. Sourced from the HFP payload `jrn` field.
@@ -4162,7 +4499,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`tlp_requestid`** (null or int32, optional): Traffic-light priority request ID on the interval [0, 255]. Populated on `tlr` (the request) and echoed on `tla` (the response). Sourced from the HFP payload `tlp-requestid` field. Constraints: minimum `0`, maximum `255`.
 - **`tlp_requesttype`** (enum, optional): Type of the traffic-light priority request. One of `NORMAL`, `DOOR_CLOSE`, `DOOR_OPEN` or `ADVANCE`. Populated on `tlr`. Sourced from the HFP payload `tlp-requesttype` field.
 - **`tlp_prioritylevel`** (enum, optional): Priority level of the traffic-light priority request. One of `normal`, `high` or `norequest`. Populated on `tlr`. Sourced from the HFP payload `tlp-prioritylevel` field.
@@ -4175,7 +4512,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`tlp_line_configid`** (null or int32, optional): ID of the line configuration in DOI. Populated on `tlr`. Sourced from the HFP payload `tlp-line-configid` field.
 - **`tlp_point_configid`** (null or int32, optional): Point configuration ID. Populated on `tlr`. Sourced from the HFP payload `tlp-point-configid` field.
 - **`tlp_frequency`** (null or int32, optional): Frequency used for the traffic-light priority request. Populated on `tlr`. Sourced from the HFP payload `tlp-frequency` field.
-- **`tlp_protocol`** (null or string, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
+- **`tlp_protocol`** (enum, optional): Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.
 ##### `temporal_type` values
 
 - `ongoing`
@@ -4189,6 +4526,17 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `dir` values
+
+- `1`
+- `2`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 ##### `tlp_requesttype` values
 
 - `NORMAL`
@@ -4210,6 +4558,10 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 
 - `ACK`
 - `NAK`
+##### `tlp_protocol` values
+
+- `MQTT`
+- `KAR-MQTT`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4232,7 +4584,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "geohash_level": "string",
   "geohash": "string",
   "desi": "string",
-  "dir": "string",
+  "dir": "1",
   "dl": 0,
   "oday": "string",
   "jrn": 0,
@@ -4248,7 +4600,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "tlp_requestid": 0,
   "tlp_requesttype": "NORMAL",
   "tlp_prioritylevel": "normal",
@@ -4261,7 +4613,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "tlp_line_configid": 0,
   "tlp_point_configid": 0,
   "tlp_frequency": 0,
-  "tlp_protocol": "string"
+  "tlp_protocol": "MQTT"
 }
 ```
 
@@ -4313,7 +4665,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -4329,6 +4681,13 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4357,7 +4716,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -4411,7 +4770,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -4427,6 +4786,13 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4455,7 +4821,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -4509,7 +4875,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -4525,6 +4891,13 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4553,7 +4926,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }
@@ -4607,7 +4980,7 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - **`acc`** (null or double, optional, m/s²): Acceleration in metres per second squared (m/s^2), derived from the speed delta between this and the previous message. Negative values indicate the vehicle is decelerating. Sourced from the HFP payload `acc` field.
 - **`odo`** (null or int32, optional, m): Odometer reading in metres (m) since the start of the trip. The upstream notes the value is currently not very reliable. Sourced from the HFP payload `odo` field.
 - **`drst`** (null or int32, optional): Door status. `0` = all doors closed, `1` = at least one door open. `null` when unknown. Sourced from the HFP payload `drst` field. Constraints: minimum `0`, maximum `1`.
-- **`loc`** (null or string, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
+- **`loc`** (enum, optional): Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field.
 - **`oday`** (null or string, optional): Operating day of the trip in `YYYY-MM-DD`. Populated on the block events `ba`/`bout`; not populated on the driver sign events `da`/`dout`. Sourced from the HFP payload `oday` field. Constraints: pattern `^\d{4}-\d{2}-\d{2}$`.
 - **`dr_type`** (null or int32, optional): Type of the driver. `0` = service technician, `1` = normal driver. Sourced from the HFP payload `dr-type` field. Constraints: minimum `0`, maximum `1`.
 ##### `temporal_type` values
@@ -4623,6 +4996,13 @@ No CloudEvents `subject` template is declared. Use the transport location and pa
 - `metro`
 - `ubus`
 - `robot`
+##### `loc` values
+
+- `GPS`
+- `ODO`
+- `MAN`
+- `DR`
+- `N/A`
 #### Example payload
 
 Synthetic example values are generated deterministically from the schema: constants, defaults, or examples win; otherwise strings use `"string"`, numbers use `0`, booleans use `false`, enums use their first value, arrays contain one item, nullable fields use a non-null example when possible, and timestamps use `2024-01-01T00:00:00Z`.
@@ -4651,7 +5031,7 @@ Synthetic example values are generated deterministically from the schema: consta
   "acc": 0,
   "odo": 0,
   "drst": 0,
-  "loc": "string",
+  "loc": "GPS",
   "oday": "string",
   "dr_type": 0
 }

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .fi import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, Operator, Stop, Route
+from .fi import Stop, Route, Operator, DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent
 
-__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "Operator", "Stop", "Route"]
+__all__ = ["Stop", "Route", "Operator", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/__init__.py
@@ -1,3 +1,3 @@
-from .hsl import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, Operator, Stop, Route
+from .hsl import Stop, Route, Operator, DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent
 
-__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "Operator", "Stop", "Route"]
+__all__ = ["Stop", "Route", "Operator", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/__init__.py
@@ -1,4 +1,4 @@
-from .hfp import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum
-from .gtfs import Operator, Stop, Route
+from .gtfs import Stop, Route, Operator
+from .hfp import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent
 
-__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "Operator", "Stop", "Route"]
+__all__ = ["Stop", "Route", "Operator", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/__init__.py
@@ -1,5 +1,5 @@
-from .operator import Operator
 from .stop import Stop
 from .route import Route
+from .operator import Operator
 
-__all__ = ["Operator", "Stop", "Route"]
+__all__ = ["Stop", "Route", "Operator"]

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/operator.py
@@ -159,8 +159,8 @@ class Operator:
             An instance of the dataclass.
         """
         return cls(
-            operator_id='ckiwpgzngvjggfevnjmc',
-            operator_number=int(10),
-            name='tsrmvarfvyhsxmxyyhjl',
-            note='fscmquskeeomppyftkrc'
+            operator_id='duhzulgefmvjxpkncpac',
+            operator_number=int(7),
+            name='xzuwnahmwzgnwsdctnbh',
+            note='xwkrmconfwuipvmbbved'
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/route.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/route.py
@@ -165,11 +165,11 @@ class Route:
             An instance of the dataclass.
         """
         return cls(
-            route_id='pmpbfuynxzedplmyamjn',
-            agency_id='wnynygpukhigaoufleef',
-            route_short_name='qadindqurrabnhbzckbh',
-            route_long_name='kaakipjmgwdxtllafdiq',
-            route_desc='nxdeawikvgpjpwdllfsv',
-            route_type=int(68),
-            route_url='cioanoprsbbwqeoalhxu'
+            route_id='wkpccnmzxxpametjqhaf',
+            agency_id='nrneooadnkyjiorgswfb',
+            route_short_name='nupiioncxaoemhttbfow',
+            route_long_name='owejhupdgwxisfxgqpin',
+            route_desc='wfwaertcnjiefdkdykvg',
+            route_type=int(71),
+            route_url='ixlapaebqirhyafbktva'
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/gtfs/stop.py
@@ -179,18 +179,18 @@ class Stop:
             An instance of the dataclass.
         """
         return cls(
-            stop_id='kazkinjonuknwayigoya',
-            stop_code='vzzzubdcazdpetylxvuc',
-            stop_name='cfenrafqicuqyncfuhrh',
-            stop_desc='ihqbjvoajgmiqsouuzgd',
-            stop_lat=float(65.90508731463582),
-            stop_lon=float(84.28366923660397),
-            zone_id='kdrmmmeaalbiuupujizx',
-            stop_url='wjbpynclbhqjwndlpuuc',
-            location_type=int(23),
-            parent_station='abijtsosyleincpmyfqr',
-            platform_code='hclwwdasnkpnhfiwvomk',
-            wheelchair_boarding=int(3),
-            vehicle_type=int(20),
-            digistop_id='hkebuqwzcmhhvybmewsb'
+            stop_id='whaxwbapypbbtlvoqkvj',
+            stop_code='kpuvehjplbrswqnofrqi',
+            stop_name='olprrhyptjswxxihiqbz',
+            stop_desc='cruycahcufwxbvgmseqe',
+            stop_lat=float(11.515290970394254),
+            stop_lon=float(33.44540264506346),
+            zone_id='rddllnneejobrovrbdig',
+            stop_url='xjnfrtdydufarwliuicn',
+            location_type=int(27),
+            parent_station='rjlnlrugwkeaorgaidap',
+            platform_code='dysexyftlfqynppgkmlg',
+            wheelchair_boarding=int(73),
+            vehicle_type=int(95),
+            digistop_id='miyquoqycpbmjjqlpesb'
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/__init__.py
@@ -1,11 +1,14 @@
 from .driverblockevent import DriverBlockEvent
 from .temporaltypeenum import TemporalTypeEnum
 from .transportmodeenum import TransportModeEnum
-from .vehicleevent import VehicleEvent
+from .locenum import LocEnum
 from .trafficlightevent import TrafficLightEvent
 from .tlpdecisionenum import TlpDecisionEnum
 from .tlpprioritylevelenum import TlpPriorityLevelEnum
 from .tlpreasonenum import TlpReasonEnum
 from .tlprequesttypeenum import TlpRequestTypeEnum
+from .direnum import DirEnum
+from .tlpprotocolenum import TlpProtocolEnum
+from .vehicleevent import VehicleEvent
 
-__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum"]
+__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/direnum.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/direnum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class DirEnum(Enum):
     """
-    Route direction of the trip as a string, either `1` or `2`. Relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`).
+    Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim.
     """
     VALUE_1 = '1'
     VALUE_2 = '2'

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/driverblockevent.py
@@ -43,7 +43,7 @@ class DriverBlockEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         oday (typing.Optional[str])
         dr_type (typing.Optional[int])
     """
@@ -71,7 +71,7 @@ class DriverBlockEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
 
@@ -208,29 +208,29 @@ class DriverBlockEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(98),
-            veh=int(94),
-            tst='wdlgzeskrsskyhgqtjao',
-            tsi=int(72),
-            operator_id='ltqasclqkcxyneyaoyuo',
-            vehicle_number='pdmwytsludwfaywjrjbh',
+            oper=int(8),
+            veh=int(56),
+            tst='qedmelqavcuowqmduuwe',
+            tsi=int(29),
+            operator_id='mqvexzdkozrrgqbsxome',
+            vehicle_number='bhaxrikdceytmzhksylw',
             temporal_type=None,
             transport_mode=None,
-            route_id='iumujjaguzzpjnuftwnq',
-            direction_id='ryftzqdktkutghsknime',
-            headsign='dxzpzomiravspjjtvnue',
-            start_time='dhuehoaiuwqolsipnwhp',
-            next_stop='hxtfwqbbmsjlcbcvyrqw',
-            geohash_level='xunvftznbopgtdaclbhs',
-            geohash='iuximbvrmtynsjwilxcr',
-            spd=float(94.55649620955153),
-            hdg=int(19),
-            lat=float(75.56849177119187),
-            long=float(84.63671478327183),
-            acc=float(10.040208157153563),
-            odo=int(22),
-            drst=int(59),
-            loc='nfeepltgspyottktrqme',
-            oday='thivszkioxflweldknry',
-            dr_type=int(76)
+            route_id='yhikxcrznrtbewdfixed',
+            direction_id='hklhtrkeuumkoreuzmtr',
+            headsign='eokywfuofomepcivnfid',
+            start_time='ybkfympjmgvmzolmivbu',
+            next_stop='stdqvbbssxlruuqhwsgi',
+            geohash_level='nwemjweledhfwuozbcvj',
+            geohash='weovafdywtontpvniogl',
+            spd=float(94.03397448118712),
+            hdg=int(30),
+            lat=float(12.993147317319043),
+            long=float(32.87243421527168),
+            acc=float(97.00678803820662),
+            odo=int(9),
+            drst=int(95),
+            loc=None,
+            oday='mhvitlprzwptojrxfrrn',
+            dr_type=int(33)
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/locenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/locenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class LocEnum(Enum):
     """
-    Source of the reported vehicle location: `GPS` satellite fix; `ODO` computed from the odometer; `MAN` manually set; `DR` dead reckoning (used in tunnels and other GPS-denied locations); `N/A` location unavailable. From the HFP payload `loc` field.
+    Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim.
     """
     GPS = 'GPS'
     ODO = 'ODO'

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/tlpprotocolenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/tlpprotocolenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class TlpProtocolEnum(Enum):
     """
-    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. From the HFP payload `tlp-protocol` field.
+    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. Populated on `tlr`. From the HFP payload `tlp-protocol` field. The `-` in `KAR-MQTT` is sanitized to the Avro symbol `KAR_MQTT` while the JSON wire value `KAR-MQTT` is preserved verbatim.
     """
     MQTT = 'MQTT'
     KAR_MINUSMQTT = 'KAR-MQTT'

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/trafficlightevent.py
@@ -37,7 +37,7 @@ class TrafficLightEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -53,7 +53,7 @@ class TrafficLightEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         tlp_requestid (typing.Optional[int])
         tlp_requesttype (typing.Optional[Any])
         tlp_prioritylevel (typing.Optional[Any])
@@ -66,7 +66,7 @@ class TrafficLightEvent:
         tlp_line_configid (typing.Optional[int])
         tlp_point_configid (typing.Optional[int])
         tlp_frequency (typing.Optional[int])
-        tlp_protocol (typing.Optional[str])
+        tlp_protocol (typing.Optional[Any])
     """
     
     
@@ -86,7 +86,7 @@ class TrafficLightEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -102,7 +102,7 @@ class TrafficLightEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     tlp_requestid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requestid"))
     tlp_requesttype: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requesttype"))
     tlp_prioritylevel: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-prioritylevel"))
@@ -115,7 +115,7 @@ class TrafficLightEvent:
     tlp_line_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-line-configid"))
     tlp_point_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-point-configid"))
     tlp_frequency: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-frequency"))
-    tlp_protocol: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
+    tlp_protocol: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'TrafficLightEvent':
@@ -316,50 +316,50 @@ class TrafficLightEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(93),
-            veh=int(2),
-            tst='fxiciogomthxkhilluvr',
-            tsi=int(68),
-            operator_id='wutcmizquzfkozvetldy',
-            vehicle_number='vtoltlghtkyivvxejgqh',
+            oper=int(84),
+            veh=int(23),
+            tst='vhuicdcquiztyvfqozus',
+            tsi=int(76),
+            operator_id='hrivpfvntcwchgbdzcuu',
+            vehicle_number='chcznqrhftkjngdstlml',
             temporal_type=None,
             transport_mode=None,
-            route_id='yzdchfwejqdrvoahwbmj',
-            direction_id='wemeucipeentljeaqeid',
-            headsign='ewumatrnwpctnvdyfejb',
-            start_time='qfyistjhebnnamfcmzlb',
-            next_stop='sonwtrnxrkulhhwdejvj',
-            geohash_level='lcydxsyrrhnshimwedoj',
-            geohash='qpmgzecqeqsiqharjppv',
-            desi='wxrgixsepvwtjrxjfhlq',
-            dir='gbyevgcejrfscukadaxx',
-            dl=int(81),
-            oday='shqsqonncuevqtzslbld',
-            jrn=int(2),
-            line=int(90),
-            start='lcpmukfciwochvmelddf',
-            stop=int(25),
-            route='wdwihnprrjrgyjvarovy',
-            occu=int(54),
-            spd=float(31.7262733890038),
-            hdg=int(3),
-            lat=float(40.303523297513365),
-            long=float(46.58856575403071),
-            acc=float(3.230060128517931),
-            odo=int(51),
-            drst=int(44),
-            loc='vdqnpuogqezdmnxiavix',
-            tlp_requestid=int(35),
+            route_id='tyaskiyuwbrfwaydignb',
+            direction_id='swgmqublanllusopkotc',
+            headsign='kbvdkeorqnnefuecpbaj',
+            start_time='mibcamphvfshvvjpzkwp',
+            next_stop='cuwkfqnwwhsqhxpgcsuf',
+            geohash_level='fgtojgipzljdjbsoxptq',
+            geohash='umtyjijdmliweibyzycf',
+            desi='vzhpvejmbgtigoaurtbk',
+            dir=None,
+            dl=int(50),
+            oday='cqmwyqtgamrfbvguvdsx',
+            jrn=int(0),
+            line=int(50),
+            start='ztthgpudlmlkluatsbuo',
+            stop=int(99),
+            route='dhpxlqxbgfurtcrsycja',
+            occu=int(68),
+            spd=float(41.32159818502513),
+            hdg=int(87),
+            lat=float(18.417064996442424),
+            long=float(34.22560882101895),
+            acc=float(65.6016528933167),
+            odo=int(94),
+            drst=int(47),
+            loc=None,
+            tlp_requestid=int(97),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(82),
+            tlp_att_seq=int(45),
             tlp_decision=None,
-            sid=int(57),
-            signal_groupid=int(89),
-            tlp_signalgroupnbr=int(93),
-            tlp_line_configid=int(68),
-            tlp_point_configid=int(26),
-            tlp_frequency=int(95),
-            tlp_protocol='kkspwbzuhuxsldfngqio'
+            sid=int(38),
+            signal_groupid=int(87),
+            tlp_signalgroupnbr=int(36),
+            tlp_line_configid=int(10),
+            tlp_point_configid=int(79),
+            tlp_frequency=int(24),
+            tlp_protocol=None
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/src/hsl_hfp_amqp_producer_data/fi/hsl/hfp/vehicleevent.py
@@ -37,7 +37,7 @@ class VehicleEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -55,7 +55,7 @@ class VehicleEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         ttarr (typing.Optional[str])
         ttdep (typing.Optional[str])
         dr_type (typing.Optional[int])
@@ -78,7 +78,7 @@ class VehicleEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -96,7 +96,7 @@ class VehicleEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     ttarr: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttarr"))
     ttdep: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttdep"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
@@ -234,42 +234,42 @@ class VehicleEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(42),
-            veh=int(3),
-            tst='rwusbzsmhtcytafogzmb',
-            tsi=int(94),
-            operator_id='revycplygvcockdjrsds',
-            vehicle_number='aanwetaknqtfmkzepmgs',
+            oper=int(22),
+            veh=int(22),
+            tst='cakadjwheajiuubcrmez',
+            tsi=int(47),
+            operator_id='jhrytjtrhhfmteibsswd',
+            vehicle_number='mjwfdhtlhxpwnmwxmhuv',
             temporal_type=None,
             transport_mode=None,
-            route_id='qjwvpndxxovnyxwzjfsp',
-            direction_id='zjjxvjkvneynipdfmuzb',
-            headsign='qowbccckvdsixskaxviz',
-            start_time='foxtbrjbutliemnpjign',
-            next_stop='zsslpfihvrzwjfygnhrg',
-            geohash_level='hiuaxzbzrqixabyujstp',
-            geohash='vfkouwmwlhxiulownajp',
-            desi='hwjrbqkifypseiqwgabh',
-            dir='antfxgobhzyzsoddmkxg',
-            dl=int(87),
-            oday='awyjvhbikawpucojjerj',
-            jrn=int(69),
-            line=int(10),
-            start='yaboaatdprvoppfopcee',
-            stop=int(76),
-            route='cfisdaahalkhlqfficzb',
-            occu=int(35),
-            seq=int(76),
-            label='dblkgaxpjyzwvhqjbjpj',
-            spd=float(44.78410488346345),
-            hdg=int(53),
-            lat=float(44.66045833286688),
-            long=float(57.76647390567905),
-            acc=float(38.76471638575101),
-            odo=int(0),
-            drst=int(3),
-            loc='vowqubmbmfhdtitumgpe',
-            ttarr='dkvcslyesegggoztfizp',
-            ttdep='nwuqugqxpfbtlpgxdipx',
-            dr_type=int(49)
+            route_id='wlzwqixsrdqaaeokxqwa',
+            direction_id='bgvhhagchjkqqdribkwp',
+            headsign='aeytjbodzjrzqqtiimka',
+            start_time='mornaaznejrwuyypowlv',
+            next_stop='duieyvyyavwqafjabeyl',
+            geohash_level='ahtxfknndhlcvngjknwp',
+            geohash='frauetlfrjqvrohvzyiw',
+            desi='oynfxizblnwifocumyib',
+            dir=None,
+            dl=int(43),
+            oday='wyjhjubrwipcttotjxtr',
+            jrn=int(55),
+            line=int(87),
+            start='oywhkaljdoildtrrqdvq',
+            stop=int(11),
+            route='fanphmiuqhhniilgmhol',
+            occu=int(3),
+            seq=int(81),
+            label='fveykisdqtuzmhywvjvw',
+            spd=float(97.57348321802698),
+            hdg=int(12),
+            lat=float(61.40169433939708),
+            long=float(99.69734405987187),
+            acc=float(70.73624742968764),
+            odo=int(82),
+            drst=int(83),
+            loc=None,
+            ttarr='xlkxnzwlqnqozzznchof',
+            ttdep='ggwqweiajxuuaxzmgftg',
+            dr_type=int(37)
         )

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_driverblockevent.py
@@ -29,31 +29,31 @@ class Test_DriverBlockEvent(unittest.TestCase):
         Create instance of DriverBlockEvent for testing
         """
         instance = DriverBlockEvent(
-            oper=int(98),
-            veh=int(94),
-            tst='wdlgzeskrsskyhgqtjao',
-            tsi=int(72),
-            operator_id='ltqasclqkcxyneyaoyuo',
-            vehicle_number='pdmwytsludwfaywjrjbh',
+            oper=int(8),
+            veh=int(56),
+            tst='qedmelqavcuowqmduuwe',
+            tsi=int(29),
+            operator_id='mqvexzdkozrrgqbsxome',
+            vehicle_number='bhaxrikdceytmzhksylw',
             temporal_type=None,
             transport_mode=None,
-            route_id='iumujjaguzzpjnuftwnq',
-            direction_id='ryftzqdktkutghsknime',
-            headsign='dxzpzomiravspjjtvnue',
-            start_time='dhuehoaiuwqolsipnwhp',
-            next_stop='hxtfwqbbmsjlcbcvyrqw',
-            geohash_level='xunvftznbopgtdaclbhs',
-            geohash='iuximbvrmtynsjwilxcr',
-            spd=float(94.55649620955153),
-            hdg=int(19),
-            lat=float(75.56849177119187),
-            long=float(84.63671478327183),
-            acc=float(10.040208157153563),
-            odo=int(22),
-            drst=int(59),
-            loc='nfeepltgspyottktrqme',
-            oday='thivszkioxflweldknry',
-            dr_type=int(76)
+            route_id='yhikxcrznrtbewdfixed',
+            direction_id='hklhtrkeuumkoreuzmtr',
+            headsign='eokywfuofomepcivnfid',
+            start_time='ybkfympjmgvmzolmivbu',
+            next_stop='stdqvbbssxlruuqhwsgi',
+            geohash_level='nwemjweledhfwuozbcvj',
+            geohash='weovafdywtontpvniogl',
+            spd=float(94.03397448118712),
+            hdg=int(30),
+            lat=float(12.993147317319043),
+            long=float(32.87243421527168),
+            acc=float(97.00678803820662),
+            odo=int(9),
+            drst=int(95),
+            loc=None,
+            oday='mhvitlprzwptojrxfrrn',
+            dr_type=int(33)
         )
         return instance
 
@@ -62,7 +62,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(98)
+        test_value = int(8)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -70,7 +70,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(94)
+        test_value = int(56)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -78,7 +78,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'wdlgzeskrsskyhgqtjao'
+        test_value = 'qedmelqavcuowqmduuwe'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -86,7 +86,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(72)
+        test_value = int(29)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -94,7 +94,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'ltqasclqkcxyneyaoyuo'
+        test_value = 'mqvexzdkozrrgqbsxome'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -102,7 +102,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'pdmwytsludwfaywjrjbh'
+        test_value = 'bhaxrikdceytmzhksylw'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -126,7 +126,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'iumujjaguzzpjnuftwnq'
+        test_value = 'yhikxcrznrtbewdfixed'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -134,7 +134,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'ryftzqdktkutghsknime'
+        test_value = 'hklhtrkeuumkoreuzmtr'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -142,7 +142,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'dxzpzomiravspjjtvnue'
+        test_value = 'eokywfuofomepcivnfid'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -150,7 +150,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'dhuehoaiuwqolsipnwhp'
+        test_value = 'ybkfympjmgvmzolmivbu'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -158,7 +158,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'hxtfwqbbmsjlcbcvyrqw'
+        test_value = 'stdqvbbssxlruuqhwsgi'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -166,7 +166,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'xunvftznbopgtdaclbhs'
+        test_value = 'nwemjweledhfwuozbcvj'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -174,7 +174,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'iuximbvrmtynsjwilxcr'
+        test_value = 'weovafdywtontpvniogl'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -182,7 +182,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(94.55649620955153)
+        test_value = float(94.03397448118712)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -190,7 +190,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(19)
+        test_value = int(30)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -198,7 +198,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(75.56849177119187)
+        test_value = float(12.993147317319043)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -206,7 +206,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(84.63671478327183)
+        test_value = float(32.87243421527168)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -214,7 +214,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(10.040208157153563)
+        test_value = float(97.00678803820662)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -222,7 +222,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(22)
+        test_value = int(9)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -230,7 +230,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(59)
+        test_value = int(95)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -238,7 +238,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'nfeepltgspyottktrqme'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -246,7 +246,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'thivszkioxflweldknry'
+        test_value = 'mhvitlprzwptojrxfrrn'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -254,7 +254,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(76)
+        test_value = int(33)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_operator.py
@@ -28,10 +28,10 @@ class Test_Operator(unittest.TestCase):
         Create instance of Operator for testing
         """
         instance = Operator(
-            operator_id='ckiwpgzngvjggfevnjmc',
-            operator_number=int(10),
-            name='tsrmvarfvyhsxmxyyhjl',
-            note='fscmquskeeomppyftkrc'
+            operator_id='duhzulgefmvjxpkncpac',
+            operator_number=int(7),
+            name='xzuwnahmwzgnwsdctnbh',
+            note='xwkrmconfwuipvmbbved'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'ckiwpgzngvjggfevnjmc'
+        test_value = 'duhzulgefmvjxpkncpac'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -48,7 +48,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_number property
         """
-        test_value = int(10)
+        test_value = int(7)
         self.instance.operator_number = test_value
         self.assertEqual(self.instance.operator_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'tsrmvarfvyhsxmxyyhjl'
+        test_value = 'xzuwnahmwzgnwsdctnbh'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -64,7 +64,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test note property
         """
-        test_value = 'fscmquskeeomppyftkrc'
+        test_value = 'xwkrmconfwuipvmbbved'
         self.instance.note = test_value
         self.assertEqual(self.instance.note, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_route.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_route.py
@@ -28,13 +28,13 @@ class Test_Route(unittest.TestCase):
         Create instance of Route for testing
         """
         instance = Route(
-            route_id='pmpbfuynxzedplmyamjn',
-            agency_id='wnynygpukhigaoufleef',
-            route_short_name='qadindqurrabnhbzckbh',
-            route_long_name='kaakipjmgwdxtllafdiq',
-            route_desc='nxdeawikvgpjpwdllfsv',
-            route_type=int(68),
-            route_url='cioanoprsbbwqeoalhxu'
+            route_id='wkpccnmzxxpametjqhaf',
+            agency_id='nrneooadnkyjiorgswfb',
+            route_short_name='nupiioncxaoemhttbfow',
+            route_long_name='owejhupdgwxisfxgqpin',
+            route_desc='wfwaertcnjiefdkdykvg',
+            route_type=int(71),
+            route_url='ixlapaebqirhyafbktva'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'pmpbfuynxzedplmyamjn'
+        test_value = 'wkpccnmzxxpametjqhaf'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_Route(unittest.TestCase):
         """
         Test agency_id property
         """
-        test_value = 'wnynygpukhigaoufleef'
+        test_value = 'nrneooadnkyjiorgswfb'
         self.instance.agency_id = test_value
         self.assertEqual(self.instance.agency_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_short_name property
         """
-        test_value = 'qadindqurrabnhbzckbh'
+        test_value = 'nupiioncxaoemhttbfow'
         self.instance.route_short_name = test_value
         self.assertEqual(self.instance.route_short_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_long_name property
         """
-        test_value = 'kaakipjmgwdxtllafdiq'
+        test_value = 'owejhupdgwxisfxgqpin'
         self.instance.route_long_name = test_value
         self.assertEqual(self.instance.route_long_name, test_value)
     
@@ -75,7 +75,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_desc property
         """
-        test_value = 'nxdeawikvgpjpwdllfsv'
+        test_value = 'wfwaertcnjiefdkdykvg'
         self.instance.route_desc = test_value
         self.assertEqual(self.instance.route_desc, test_value)
     
@@ -83,7 +83,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_type property
         """
-        test_value = int(68)
+        test_value = int(71)
         self.instance.route_type = test_value
         self.assertEqual(self.instance.route_type, test_value)
     
@@ -91,7 +91,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_url property
         """
-        test_value = 'cioanoprsbbwqeoalhxu'
+        test_value = 'ixlapaebqirhyafbktva'
         self.instance.route_url = test_value
         self.assertEqual(self.instance.route_url, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_stop.py
@@ -28,20 +28,20 @@ class Test_Stop(unittest.TestCase):
         Create instance of Stop for testing
         """
         instance = Stop(
-            stop_id='kazkinjonuknwayigoya',
-            stop_code='vzzzubdcazdpetylxvuc',
-            stop_name='cfenrafqicuqyncfuhrh',
-            stop_desc='ihqbjvoajgmiqsouuzgd',
-            stop_lat=float(65.90508731463582),
-            stop_lon=float(84.28366923660397),
-            zone_id='kdrmmmeaalbiuupujizx',
-            stop_url='wjbpynclbhqjwndlpuuc',
-            location_type=int(23),
-            parent_station='abijtsosyleincpmyfqr',
-            platform_code='hclwwdasnkpnhfiwvomk',
-            wheelchair_boarding=int(3),
-            vehicle_type=int(20),
-            digistop_id='hkebuqwzcmhhvybmewsb'
+            stop_id='whaxwbapypbbtlvoqkvj',
+            stop_code='kpuvehjplbrswqnofrqi',
+            stop_name='olprrhyptjswxxihiqbz',
+            stop_desc='cruycahcufwxbvgmseqe',
+            stop_lat=float(11.515290970394254),
+            stop_lon=float(33.44540264506346),
+            zone_id='rddllnneejobrovrbdig',
+            stop_url='xjnfrtdydufarwliuicn',
+            location_type=int(27),
+            parent_station='rjlnlrugwkeaorgaidap',
+            platform_code='dysexyftlfqynppgkmlg',
+            wheelchair_boarding=int(73),
+            vehicle_type=int(95),
+            digistop_id='miyquoqycpbmjjqlpesb'
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_id property
         """
-        test_value = 'kazkinjonuknwayigoya'
+        test_value = 'whaxwbapypbbtlvoqkvj'
         self.instance.stop_id = test_value
         self.assertEqual(self.instance.stop_id, test_value)
     
@@ -58,7 +58,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_code property
         """
-        test_value = 'vzzzubdcazdpetylxvuc'
+        test_value = 'kpuvehjplbrswqnofrqi'
         self.instance.stop_code = test_value
         self.assertEqual(self.instance.stop_code, test_value)
     
@@ -66,7 +66,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_name property
         """
-        test_value = 'cfenrafqicuqyncfuhrh'
+        test_value = 'olprrhyptjswxxihiqbz'
         self.instance.stop_name = test_value
         self.assertEqual(self.instance.stop_name, test_value)
     
@@ -74,7 +74,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_desc property
         """
-        test_value = 'ihqbjvoajgmiqsouuzgd'
+        test_value = 'cruycahcufwxbvgmseqe'
         self.instance.stop_desc = test_value
         self.assertEqual(self.instance.stop_desc, test_value)
     
@@ -82,7 +82,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lat property
         """
-        test_value = float(65.90508731463582)
+        test_value = float(11.515290970394254)
         self.instance.stop_lat = test_value
         self.assertEqual(self.instance.stop_lat, test_value)
     
@@ -90,7 +90,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lon property
         """
-        test_value = float(84.28366923660397)
+        test_value = float(33.44540264506346)
         self.instance.stop_lon = test_value
         self.assertEqual(self.instance.stop_lon, test_value)
     
@@ -98,7 +98,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test zone_id property
         """
-        test_value = 'kdrmmmeaalbiuupujizx'
+        test_value = 'rddllnneejobrovrbdig'
         self.instance.zone_id = test_value
         self.assertEqual(self.instance.zone_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_url property
         """
-        test_value = 'wjbpynclbhqjwndlpuuc'
+        test_value = 'xjnfrtdydufarwliuicn'
         self.instance.stop_url = test_value
         self.assertEqual(self.instance.stop_url, test_value)
     
@@ -114,7 +114,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test location_type property
         """
-        test_value = int(23)
+        test_value = int(27)
         self.instance.location_type = test_value
         self.assertEqual(self.instance.location_type, test_value)
     
@@ -122,7 +122,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test parent_station property
         """
-        test_value = 'abijtsosyleincpmyfqr'
+        test_value = 'rjlnlrugwkeaorgaidap'
         self.instance.parent_station = test_value
         self.assertEqual(self.instance.parent_station, test_value)
     
@@ -130,7 +130,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test platform_code property
         """
-        test_value = 'hclwwdasnkpnhfiwvomk'
+        test_value = 'dysexyftlfqynppgkmlg'
         self.instance.platform_code = test_value
         self.assertEqual(self.instance.platform_code, test_value)
     
@@ -138,7 +138,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test wheelchair_boarding property
         """
-        test_value = int(3)
+        test_value = int(73)
         self.instance.wheelchair_boarding = test_value
         self.assertEqual(self.instance.wheelchair_boarding, test_value)
     
@@ -146,7 +146,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test vehicle_type property
         """
-        test_value = int(20)
+        test_value = int(95)
         self.instance.vehicle_type = test_value
         self.assertEqual(self.instance.vehicle_type, test_value)
     
@@ -154,7 +154,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test digistop_id property
         """
-        test_value = 'hkebuqwzcmhhvybmewsb'
+        test_value = 'miyquoqycpbmjjqlpesb'
         self.instance.digistop_id = test_value
         self.assertEqual(self.instance.digistop_id, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_trafficlightevent.py
@@ -29,52 +29,52 @@ class Test_TrafficLightEvent(unittest.TestCase):
         Create instance of TrafficLightEvent for testing
         """
         instance = TrafficLightEvent(
-            oper=int(93),
-            veh=int(2),
-            tst='fxiciogomthxkhilluvr',
-            tsi=int(68),
-            operator_id='wutcmizquzfkozvetldy',
-            vehicle_number='vtoltlghtkyivvxejgqh',
+            oper=int(84),
+            veh=int(23),
+            tst='vhuicdcquiztyvfqozus',
+            tsi=int(76),
+            operator_id='hrivpfvntcwchgbdzcuu',
+            vehicle_number='chcznqrhftkjngdstlml',
             temporal_type=None,
             transport_mode=None,
-            route_id='yzdchfwejqdrvoahwbmj',
-            direction_id='wemeucipeentljeaqeid',
-            headsign='ewumatrnwpctnvdyfejb',
-            start_time='qfyistjhebnnamfcmzlb',
-            next_stop='sonwtrnxrkulhhwdejvj',
-            geohash_level='lcydxsyrrhnshimwedoj',
-            geohash='qpmgzecqeqsiqharjppv',
-            desi='wxrgixsepvwtjrxjfhlq',
-            dir='gbyevgcejrfscukadaxx',
-            dl=int(81),
-            oday='shqsqonncuevqtzslbld',
-            jrn=int(2),
-            line=int(90),
-            start='lcpmukfciwochvmelddf',
-            stop=int(25),
-            route='wdwihnprrjrgyjvarovy',
-            occu=int(54),
-            spd=float(31.7262733890038),
-            hdg=int(3),
-            lat=float(40.303523297513365),
-            long=float(46.58856575403071),
-            acc=float(3.230060128517931),
-            odo=int(51),
-            drst=int(44),
-            loc='vdqnpuogqezdmnxiavix',
-            tlp_requestid=int(35),
+            route_id='tyaskiyuwbrfwaydignb',
+            direction_id='swgmqublanllusopkotc',
+            headsign='kbvdkeorqnnefuecpbaj',
+            start_time='mibcamphvfshvvjpzkwp',
+            next_stop='cuwkfqnwwhsqhxpgcsuf',
+            geohash_level='fgtojgipzljdjbsoxptq',
+            geohash='umtyjijdmliweibyzycf',
+            desi='vzhpvejmbgtigoaurtbk',
+            dir=None,
+            dl=int(50),
+            oday='cqmwyqtgamrfbvguvdsx',
+            jrn=int(0),
+            line=int(50),
+            start='ztthgpudlmlkluatsbuo',
+            stop=int(99),
+            route='dhpxlqxbgfurtcrsycja',
+            occu=int(68),
+            spd=float(41.32159818502513),
+            hdg=int(87),
+            lat=float(18.417064996442424),
+            long=float(34.22560882101895),
+            acc=float(65.6016528933167),
+            odo=int(94),
+            drst=int(47),
+            loc=None,
+            tlp_requestid=int(97),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(82),
+            tlp_att_seq=int(45),
             tlp_decision=None,
-            sid=int(57),
-            signal_groupid=int(89),
-            tlp_signalgroupnbr=int(93),
-            tlp_line_configid=int(68),
-            tlp_point_configid=int(26),
-            tlp_frequency=int(95),
-            tlp_protocol='kkspwbzuhuxsldfngqio'
+            sid=int(38),
+            signal_groupid=int(87),
+            tlp_signalgroupnbr=int(36),
+            tlp_line_configid=int(10),
+            tlp_point_configid=int(79),
+            tlp_frequency=int(24),
+            tlp_protocol=None
         )
         return instance
 
@@ -83,7 +83,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(93)
+        test_value = int(84)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -91,7 +91,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(2)
+        test_value = int(23)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -99,7 +99,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'fxiciogomthxkhilluvr'
+        test_value = 'vhuicdcquiztyvfqozus'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -107,7 +107,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(68)
+        test_value = int(76)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -115,7 +115,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'wutcmizquzfkozvetldy'
+        test_value = 'hrivpfvntcwchgbdzcuu'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -123,7 +123,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'vtoltlghtkyivvxejgqh'
+        test_value = 'chcznqrhftkjngdstlml'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -147,7 +147,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'yzdchfwejqdrvoahwbmj'
+        test_value = 'tyaskiyuwbrfwaydignb'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'wemeucipeentljeaqeid'
+        test_value = 'swgmqublanllusopkotc'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -163,7 +163,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'ewumatrnwpctnvdyfejb'
+        test_value = 'kbvdkeorqnnefuecpbaj'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -171,7 +171,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'qfyistjhebnnamfcmzlb'
+        test_value = 'mibcamphvfshvvjpzkwp'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -179,7 +179,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'sonwtrnxrkulhhwdejvj'
+        test_value = 'cuwkfqnwwhsqhxpgcsuf'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -187,7 +187,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'lcydxsyrrhnshimwedoj'
+        test_value = 'fgtojgipzljdjbsoxptq'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -195,7 +195,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'qpmgzecqeqsiqharjppv'
+        test_value = 'umtyjijdmliweibyzycf'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -203,7 +203,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'wxrgixsepvwtjrxjfhlq'
+        test_value = 'vzhpvejmbgtigoaurtbk'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -211,7 +211,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'gbyevgcejrfscukadaxx'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -219,7 +219,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(81)
+        test_value = int(50)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -227,7 +227,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'shqsqonncuevqtzslbld'
+        test_value = 'cqmwyqtgamrfbvguvdsx'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -235,7 +235,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(2)
+        test_value = int(0)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -243,7 +243,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(90)
+        test_value = int(50)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -251,7 +251,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'lcpmukfciwochvmelddf'
+        test_value = 'ztthgpudlmlkluatsbuo'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -259,7 +259,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(25)
+        test_value = int(99)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -267,7 +267,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'wdwihnprrjrgyjvarovy'
+        test_value = 'dhpxlqxbgfurtcrsycja'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -275,7 +275,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(54)
+        test_value = int(68)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -283,7 +283,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(31.7262733890038)
+        test_value = float(41.32159818502513)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -291,7 +291,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(3)
+        test_value = int(87)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -299,7 +299,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(40.303523297513365)
+        test_value = float(18.417064996442424)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -307,7 +307,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(46.58856575403071)
+        test_value = float(34.22560882101895)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -315,7 +315,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(3.230060128517931)
+        test_value = float(65.6016528933167)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -323,7 +323,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(51)
+        test_value = int(94)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -331,7 +331,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(44)
+        test_value = int(47)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -339,7 +339,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'vdqnpuogqezdmnxiavix'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -347,7 +347,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_requestid property
         """
-        test_value = int(35)
+        test_value = int(97)
         self.instance.tlp_requestid = test_value
         self.assertEqual(self.instance.tlp_requestid, test_value)
     
@@ -379,7 +379,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_att_seq property
         """
-        test_value = int(82)
+        test_value = int(45)
         self.instance.tlp_att_seq = test_value
         self.assertEqual(self.instance.tlp_att_seq, test_value)
     
@@ -395,7 +395,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test sid property
         """
-        test_value = int(57)
+        test_value = int(38)
         self.instance.sid = test_value
         self.assertEqual(self.instance.sid, test_value)
     
@@ -403,7 +403,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test signal_groupid property
         """
-        test_value = int(89)
+        test_value = int(87)
         self.instance.signal_groupid = test_value
         self.assertEqual(self.instance.signal_groupid, test_value)
     
@@ -411,7 +411,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_signalgroupnbr property
         """
-        test_value = int(93)
+        test_value = int(36)
         self.instance.tlp_signalgroupnbr = test_value
         self.assertEqual(self.instance.tlp_signalgroupnbr, test_value)
     
@@ -419,7 +419,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_line_configid property
         """
-        test_value = int(68)
+        test_value = int(10)
         self.instance.tlp_line_configid = test_value
         self.assertEqual(self.instance.tlp_line_configid, test_value)
     
@@ -427,7 +427,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_point_configid property
         """
-        test_value = int(26)
+        test_value = int(79)
         self.instance.tlp_point_configid = test_value
         self.assertEqual(self.instance.tlp_point_configid, test_value)
     
@@ -435,7 +435,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_frequency property
         """
-        test_value = int(95)
+        test_value = int(24)
         self.instance.tlp_frequency = test_value
         self.assertEqual(self.instance.tlp_frequency, test_value)
     
@@ -443,7 +443,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_protocol property
         """
-        test_value = 'kkspwbzuhuxsldfngqio'
+        test_value = None
         self.instance.tlp_protocol = test_value
         self.assertEqual(self.instance.tlp_protocol, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_amqp_producer/hsl_hfp_amqp_producer_data/tests/test_vehicleevent.py
@@ -29,44 +29,44 @@ class Test_VehicleEvent(unittest.TestCase):
         Create instance of VehicleEvent for testing
         """
         instance = VehicleEvent(
-            oper=int(42),
-            veh=int(3),
-            tst='rwusbzsmhtcytafogzmb',
-            tsi=int(94),
-            operator_id='revycplygvcockdjrsds',
-            vehicle_number='aanwetaknqtfmkzepmgs',
+            oper=int(22),
+            veh=int(22),
+            tst='cakadjwheajiuubcrmez',
+            tsi=int(47),
+            operator_id='jhrytjtrhhfmteibsswd',
+            vehicle_number='mjwfdhtlhxpwnmwxmhuv',
             temporal_type=None,
             transport_mode=None,
-            route_id='qjwvpndxxovnyxwzjfsp',
-            direction_id='zjjxvjkvneynipdfmuzb',
-            headsign='qowbccckvdsixskaxviz',
-            start_time='foxtbrjbutliemnpjign',
-            next_stop='zsslpfihvrzwjfygnhrg',
-            geohash_level='hiuaxzbzrqixabyujstp',
-            geohash='vfkouwmwlhxiulownajp',
-            desi='hwjrbqkifypseiqwgabh',
-            dir='antfxgobhzyzsoddmkxg',
-            dl=int(87),
-            oday='awyjvhbikawpucojjerj',
-            jrn=int(69),
-            line=int(10),
-            start='yaboaatdprvoppfopcee',
-            stop=int(76),
-            route='cfisdaahalkhlqfficzb',
-            occu=int(35),
-            seq=int(76),
-            label='dblkgaxpjyzwvhqjbjpj',
-            spd=float(44.78410488346345),
-            hdg=int(53),
-            lat=float(44.66045833286688),
-            long=float(57.76647390567905),
-            acc=float(38.76471638575101),
-            odo=int(0),
-            drst=int(3),
-            loc='vowqubmbmfhdtitumgpe',
-            ttarr='dkvcslyesegggoztfizp',
-            ttdep='nwuqugqxpfbtlpgxdipx',
-            dr_type=int(49)
+            route_id='wlzwqixsrdqaaeokxqwa',
+            direction_id='bgvhhagchjkqqdribkwp',
+            headsign='aeytjbodzjrzqqtiimka',
+            start_time='mornaaznejrwuyypowlv',
+            next_stop='duieyvyyavwqafjabeyl',
+            geohash_level='ahtxfknndhlcvngjknwp',
+            geohash='frauetlfrjqvrohvzyiw',
+            desi='oynfxizblnwifocumyib',
+            dir=None,
+            dl=int(43),
+            oday='wyjhjubrwipcttotjxtr',
+            jrn=int(55),
+            line=int(87),
+            start='oywhkaljdoildtrrqdvq',
+            stop=int(11),
+            route='fanphmiuqhhniilgmhol',
+            occu=int(3),
+            seq=int(81),
+            label='fveykisdqtuzmhywvjvw',
+            spd=float(97.57348321802698),
+            hdg=int(12),
+            lat=float(61.40169433939708),
+            long=float(99.69734405987187),
+            acc=float(70.73624742968764),
+            odo=int(82),
+            drst=int(83),
+            loc=None,
+            ttarr='xlkxnzwlqnqozzznchof',
+            ttdep='ggwqweiajxuuaxzmgftg',
+            dr_type=int(37)
         )
         return instance
 
@@ -75,7 +75,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(42)
+        test_value = int(22)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -83,7 +83,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(3)
+        test_value = int(22)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -91,7 +91,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'rwusbzsmhtcytafogzmb'
+        test_value = 'cakadjwheajiuubcrmez'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -99,7 +99,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(94)
+        test_value = int(47)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -107,7 +107,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'revycplygvcockdjrsds'
+        test_value = 'jhrytjtrhhfmteibsswd'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'aanwetaknqtfmkzepmgs'
+        test_value = 'mjwfdhtlhxpwnmwxmhuv'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -139,7 +139,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'qjwvpndxxovnyxwzjfsp'
+        test_value = 'wlzwqixsrdqaaeokxqwa'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -147,7 +147,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'zjjxvjkvneynipdfmuzb'
+        test_value = 'bgvhhagchjkqqdribkwp'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'qowbccckvdsixskaxviz'
+        test_value = 'aeytjbodzjrzqqtiimka'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -163,7 +163,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'foxtbrjbutliemnpjign'
+        test_value = 'mornaaznejrwuyypowlv'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -171,7 +171,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'zsslpfihvrzwjfygnhrg'
+        test_value = 'duieyvyyavwqafjabeyl'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -179,7 +179,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'hiuaxzbzrqixabyujstp'
+        test_value = 'ahtxfknndhlcvngjknwp'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -187,7 +187,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'vfkouwmwlhxiulownajp'
+        test_value = 'frauetlfrjqvrohvzyiw'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -195,7 +195,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'hwjrbqkifypseiqwgabh'
+        test_value = 'oynfxizblnwifocumyib'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -203,7 +203,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'antfxgobhzyzsoddmkxg'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -211,7 +211,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(87)
+        test_value = int(43)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -219,7 +219,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'awyjvhbikawpucojjerj'
+        test_value = 'wyjhjubrwipcttotjxtr'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -227,7 +227,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(69)
+        test_value = int(55)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -235,7 +235,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(10)
+        test_value = int(87)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -243,7 +243,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'yaboaatdprvoppfopcee'
+        test_value = 'oywhkaljdoildtrrqdvq'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -251,7 +251,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(76)
+        test_value = int(11)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -259,7 +259,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'cfisdaahalkhlqfficzb'
+        test_value = 'fanphmiuqhhniilgmhol'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -267,7 +267,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(35)
+        test_value = int(3)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -275,7 +275,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test seq property
         """
-        test_value = int(76)
+        test_value = int(81)
         self.instance.seq = test_value
         self.assertEqual(self.instance.seq, test_value)
     
@@ -283,7 +283,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test label property
         """
-        test_value = 'dblkgaxpjyzwvhqjbjpj'
+        test_value = 'fveykisdqtuzmhywvjvw'
         self.instance.label = test_value
         self.assertEqual(self.instance.label, test_value)
     
@@ -291,7 +291,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(44.78410488346345)
+        test_value = float(97.57348321802698)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -299,7 +299,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(53)
+        test_value = int(12)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -307,7 +307,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(44.66045833286688)
+        test_value = float(61.40169433939708)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -315,7 +315,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(57.76647390567905)
+        test_value = float(99.69734405987187)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -323,7 +323,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(38.76471638575101)
+        test_value = float(70.73624742968764)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -331,7 +331,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(0)
+        test_value = int(82)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -339,7 +339,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(3)
+        test_value = int(83)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -347,7 +347,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'vowqubmbmfhdtitumgpe'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -355,7 +355,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttarr property
         """
-        test_value = 'dkvcslyesegggoztfizp'
+        test_value = 'xlkxnzwlqnqozzznchof'
         self.instance.ttarr = test_value
         self.assertEqual(self.instance.ttarr, test_value)
     
@@ -363,7 +363,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttdep property
         """
-        test_value = 'nwuqugqxpfbtlpgxdipx'
+        test_value = 'ggwqweiajxuuaxzmgftg'
         self.instance.ttdep = test_value
         self.assertEqual(self.instance.ttdep, test_value)
     
@@ -371,7 +371,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(49)
+        test_value = int(37)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .fi import Stop, Operator, Route, DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum
+from .fi import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent, Stop, Operator, Route
 
-__all__ = ["Stop", "Operator", "Route", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum"]
+__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "Stop", "Operator", "Route"]

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/__init__.py
@@ -1,3 +1,3 @@
-from .hsl import Stop, Operator, Route, DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum
+from .hsl import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent, Stop, Operator, Route
 
-__all__ = ["Stop", "Operator", "Route", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum"]
+__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "Stop", "Operator", "Route"]

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/__init__.py
@@ -1,4 +1,4 @@
+from .hfp import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DirEnum, TlpProtocolEnum, VehicleEvent
 from .gtfs import Stop, Operator, Route
-from .hfp import DriverBlockEvent, TemporalTypeEnum, TransportModeEnum, VehicleEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum
 
-__all__ = ["Stop", "Operator", "Route", "DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum"]
+__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "Stop", "Operator", "Route"]

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/operator.py
@@ -159,8 +159,8 @@ class Operator:
             An instance of the dataclass.
         """
         return cls(
-            operator_id='vixtyhujkfkwswhsaurx',
-            operator_number=int(8),
-            name='krxvhipircktadpxdynn',
-            note='gizjlepjgtowrnlcybem'
+            operator_id='vwpbjjfwajgippdmajot',
+            operator_number=int(38),
+            name='fvhffelienvklisyiiwh',
+            note='bpnmkysuydizbwyvrrjs'
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/route.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/route.py
@@ -165,11 +165,11 @@ class Route:
             An instance of the dataclass.
         """
         return cls(
-            route_id='trkionjdvikrmzotzhfm',
-            agency_id='cnhtiigvqjdgcnbcjyme',
-            route_short_name='dorresrbgjrcxnmkkpim',
-            route_long_name='ywejvpkexmzhtbefhzud',
-            route_desc='osipgcgzlgsxbtgamxye',
-            route_type=int(81),
-            route_url='yyxajhucclqwtpsyapzo'
+            route_id='estqznyoilymivrkpalm',
+            agency_id='gbmzotrgxeijcdvivdxu',
+            route_short_name='ukvrehgyhaijhrpwilsn',
+            route_long_name='wigopdnemcvrxqdcdmyv',
+            route_desc='ooudjttcezsfsakgwgle',
+            route_type=int(61),
+            route_url='tcbpexdwrohhjccthmvk'
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/gtfs/stop.py
@@ -179,18 +179,18 @@ class Stop:
             An instance of the dataclass.
         """
         return cls(
-            stop_id='erauhdzyovqownfcjzer',
-            stop_code='lsyncfbnxcxkqkuaylhj',
-            stop_name='uobwqmcirnuwhbivgdla',
-            stop_desc='bcxuowvqffnftctlhdsq',
-            stop_lat=float(68.44865499396307),
-            stop_lon=float(87.70979632615085),
-            zone_id='lmevrmghblrozkwewnql',
-            stop_url='ubezwsvpttwohtamphak',
-            location_type=int(86),
-            parent_station='mlzvuuqjxjlkwzbucxin',
-            platform_code='ordjnemehlcoevnjcphz',
-            wheelchair_boarding=int(3),
-            vehicle_type=int(78),
-            digistop_id='dkwzlicdmhosfqhgyfzg'
+            stop_id='wjiwsvuqbirfqqdoydka',
+            stop_code='ryswekdpdnuennvmorvt',
+            stop_name='dgocusdriylcmgcbbges',
+            stop_desc='wmanmyotqalinyzzrvoq',
+            stop_lat=float(56.45595402892016),
+            stop_lon=float(12.550508429008755),
+            zone_id='bqpmemwapqkyllveomom',
+            stop_url='xpycohcewpnqwtxxgfgv',
+            location_type=int(80),
+            parent_station='dcrupeoeajkvfhdlgpvj',
+            platform_code='rilerqtecydleacqhrzl',
+            wheelchair_boarding=int(60),
+            vehicle_type=int(25),
+            digistop_id='ifheyuyqmpkeeerjcewx'
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/__init__.py
@@ -1,11 +1,14 @@
 from .driverblockevent import DriverBlockEvent
 from .temporaltypeenum import TemporalTypeEnum
 from .transportmodeenum import TransportModeEnum
-from .vehicleevent import VehicleEvent
+from .locenum import LocEnum
 from .trafficlightevent import TrafficLightEvent
 from .tlpdecisionenum import TlpDecisionEnum
 from .tlpprioritylevelenum import TlpPriorityLevelEnum
 from .tlpreasonenum import TlpReasonEnum
 from .tlprequesttypeenum import TlpRequestTypeEnum
+from .direnum import DirEnum
+from .tlpprotocolenum import TlpProtocolEnum
+from .vehicleevent import VehicleEvent
 
-__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "VehicleEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum"]
+__all__ = ["DriverBlockEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/direnum.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/direnum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class DirEnum(Enum):
     """
-    Route direction of the trip as a string, either `1` or `2`. Relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`).
+    Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim.
     """
     VALUE_1 = '1'
     VALUE_2 = '2'

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/driverblockevent.py
@@ -43,7 +43,7 @@ class DriverBlockEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         oday (typing.Optional[str])
         dr_type (typing.Optional[int])
     """
@@ -71,7 +71,7 @@ class DriverBlockEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
 
@@ -208,29 +208,29 @@ class DriverBlockEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(57),
-            veh=int(28),
-            tst='dowrunlckeweutfflevd',
-            tsi=int(68),
-            operator_id='mjktjjuuoibekmrcfzto',
-            vehicle_number='czrznfbmzjilzpbbcgrx',
+            oper=int(24),
+            veh=int(65),
+            tst='vyzlqojnzghmyoepldss',
+            tsi=int(99),
+            operator_id='rjmrcacyuxgugspclfhb',
+            vehicle_number='abeaivabkcbwjgiqilqi',
             temporal_type=None,
             transport_mode=None,
-            route_id='vucumzirsgxrbjsofjke',
-            direction_id='pifxrbqrimedcydnmbzp',
-            headsign='wxlbpgnujycrcofjutvw',
-            start_time='qzjykxitiatfbbkqlbth',
-            next_stop='qnmaufvlnmiiincghzec',
-            geohash_level='zxykxtczarrlvrhdkkpf',
-            geohash='aoszwkzcfchttjcgbbna',
-            spd=float(84.19469919584715),
-            hdg=int(18),
-            lat=float(17.660818495321074),
-            long=float(56.22445498580928),
-            acc=float(71.85702806610139),
-            odo=int(4),
-            drst=int(44),
-            loc='fmktwhlndplpinatxify',
-            oday='dugkyusqqdnbdbktdojo',
-            dr_type=int(44)
+            route_id='guegvxvtlvtsjrouyweg',
+            direction_id='stpnvlzyfoclsytfbmsw',
+            headsign='zbdvihgvsqkckhnzkqay',
+            start_time='tfucyqeufiaxohetllua',
+            next_stop='gqfapxcpukpujkdirsmo',
+            geohash_level='uiwvaagjrvzfsxoulcmf',
+            geohash='bltlezhvisipofgarnlp',
+            spd=float(73.72996199954527),
+            hdg=int(66),
+            lat=float(87.32494522971099),
+            long=float(99.82230909797963),
+            acc=float(53.98469339382004),
+            odo=int(45),
+            drst=int(26),
+            loc=None,
+            oday='jwjxictducqjiszhchdr',
+            dr_type=int(85)
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/locenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/locenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class LocEnum(Enum):
     """
-    Source of the reported vehicle location: `GPS` satellite fix; `ODO` computed from the odometer; `MAN` manually set; `DR` dead reckoning (used in tunnels and other GPS-denied locations); `N/A` location unavailable. From the HFP payload `loc` field.
+    Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim.
     """
     GPS = 'GPS'
     ODO = 'ODO'

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/tlpprotocolenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/tlpprotocolenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class TlpProtocolEnum(Enum):
     """
-    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. From the HFP payload `tlp-protocol` field.
+    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. Populated on `tlr`. From the HFP payload `tlp-protocol` field. The `-` in `KAR-MQTT` is sanitized to the Avro symbol `KAR_MQTT` while the JSON wire value `KAR-MQTT` is preserved verbatim.
     """
     MQTT = 'MQTT'
     KAR_MINUSMQTT = 'KAR-MQTT'

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/trafficlightevent.py
@@ -37,7 +37,7 @@ class TrafficLightEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -53,7 +53,7 @@ class TrafficLightEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         tlp_requestid (typing.Optional[int])
         tlp_requesttype (typing.Optional[Any])
         tlp_prioritylevel (typing.Optional[Any])
@@ -66,7 +66,7 @@ class TrafficLightEvent:
         tlp_line_configid (typing.Optional[int])
         tlp_point_configid (typing.Optional[int])
         tlp_frequency (typing.Optional[int])
-        tlp_protocol (typing.Optional[str])
+        tlp_protocol (typing.Optional[Any])
     """
     
     
@@ -86,7 +86,7 @@ class TrafficLightEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -102,7 +102,7 @@ class TrafficLightEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     tlp_requestid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requestid"))
     tlp_requesttype: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requesttype"))
     tlp_prioritylevel: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-prioritylevel"))
@@ -115,7 +115,7 @@ class TrafficLightEvent:
     tlp_line_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-line-configid"))
     tlp_point_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-point-configid"))
     tlp_frequency: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-frequency"))
-    tlp_protocol: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
+    tlp_protocol: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'TrafficLightEvent':
@@ -316,50 +316,50 @@ class TrafficLightEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(53),
-            veh=int(22),
-            tst='fhubtodecrdnzxlkmrao',
-            tsi=int(30),
-            operator_id='orimbllpcxzsziuirpzd',
-            vehicle_number='bzyecmicciyrutcqlvif',
+            oper=int(10),
+            veh=int(36),
+            tst='rlkfviyrgfwafrwnskzm',
+            tsi=int(4),
+            operator_id='egioauzexxyvarpawqbo',
+            vehicle_number='ahlwhtqzsygnylopftfy',
             temporal_type=None,
             transport_mode=None,
-            route_id='lgflcgrhrkmsyxkbkwmu',
-            direction_id='wedzddzufbfrjyechszq',
-            headsign='qhdesmkmqaxpelblnsjp',
-            start_time='muezelqwvtzcvovxydon',
-            next_stop='wbolcdqohgoxacakimpf',
-            geohash_level='tusmlberkuoathfyyypy',
-            geohash='cfacpidwgqbrdyaweqcb',
-            desi='ytutlrcodhmpyvjdfmms',
-            dir='rzsgrddwytjepnhmagfs',
-            dl=int(70),
-            oday='chojlypphtweoavrouuq',
-            jrn=int(52),
-            line=int(26),
-            start='ysghokvjsjjxrsinbfwb',
-            stop=int(89),
-            route='ftklosznkmcoavuejztc',
-            occu=int(28),
-            spd=float(91.96704877353169),
-            hdg=int(27),
-            lat=float(4.47318934895693),
-            long=float(21.217661962155297),
-            acc=float(6.460214075935311),
-            odo=int(93),
-            drst=int(70),
-            loc='reuswxvywnempjxweafh',
-            tlp_requestid=int(77),
+            route_id='ozpyrajtcpsosxytbgez',
+            direction_id='woopcrqzqkvaogutiywr',
+            headsign='tsfxeijnlesimgsncwcf',
+            start_time='ephcyymzmkmkzvcmdtol',
+            next_stop='nrikwucttlzwqrxculkf',
+            geohash_level='itkvsyqdhzhwfnxoffyq',
+            geohash='vdxowwcfboirebksajqr',
+            desi='shbsqopwctqenocekxdv',
+            dir=None,
+            dl=int(67),
+            oday='myyvrwagdbgqpqarjrtt',
+            jrn=int(51),
+            line=int(25),
+            start='zpqvojsotveueirhuhpx',
+            stop=int(70),
+            route='towinprbyjntpsfcjykv',
+            occu=int(13),
+            spd=float(58.040857688152),
+            hdg=int(32),
+            lat=float(73.72004636153261),
+            long=float(41.162964839821505),
+            acc=float(83.4004673578086),
+            odo=int(39),
+            drst=int(43),
+            loc=None,
+            tlp_requestid=int(55),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(44),
+            tlp_att_seq=int(83),
             tlp_decision=None,
-            sid=int(72),
-            signal_groupid=int(25),
-            tlp_signalgroupnbr=int(58),
-            tlp_line_configid=int(89),
-            tlp_point_configid=int(63),
-            tlp_frequency=int(94),
-            tlp_protocol='wgduynpabxcxhobsjhok'
+            sid=int(59),
+            signal_groupid=int(68),
+            tlp_signalgroupnbr=int(60),
+            tlp_line_configid=int(31),
+            tlp_point_configid=int(44),
+            tlp_frequency=int(5),
+            tlp_protocol=None
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/src/hsl_hfp_mqtt_producer_data/fi/hsl/hfp/vehicleevent.py
@@ -37,7 +37,7 @@ class VehicleEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -55,7 +55,7 @@ class VehicleEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         ttarr (typing.Optional[str])
         ttdep (typing.Optional[str])
         dr_type (typing.Optional[int])
@@ -78,7 +78,7 @@ class VehicleEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -96,7 +96,7 @@ class VehicleEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     ttarr: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttarr"))
     ttdep: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttdep"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
@@ -234,42 +234,42 @@ class VehicleEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(42),
-            veh=int(69),
-            tst='cfrnnqayrvglxylayvwy',
-            tsi=int(2),
-            operator_id='ioqicespopfazcnekmfd',
-            vehicle_number='xqiqsrmqwonpdpfosgmh',
+            oper=int(62),
+            veh=int(61),
+            tst='wwupbwahhwacvjzmklte',
+            tsi=int(38),
+            operator_id='ruxinqyhycmhcajjftcj',
+            vehicle_number='pdnliomgvcahpzqtlrrn',
             temporal_type=None,
             transport_mode=None,
-            route_id='rezzkdromztbuqszfsnr',
-            direction_id='yllehcgawgyhvhbumema',
-            headsign='hcbpruwrfeiltkoamqwr',
-            start_time='xlwbvoekesuwxicrvwys',
-            next_stop='pikucdokwlcvnbtxvfln',
-            geohash_level='gudfzdbiehfktjhmkusx',
-            geohash='kjbmrzqynixsoruuoluh',
-            desi='cjiqcbvaicurmbqobxny',
-            dir='cfdflgmvhreebhslifpg',
-            dl=int(76),
-            oday='zlpxwzbmacqcmnidjdva',
-            jrn=int(95),
-            line=int(15),
-            start='oeostkjjfgmwepvsjpig',
-            stop=int(75),
-            route='dcwarprmpgvyljvpouxs',
-            occu=int(16),
-            seq=int(98),
-            label='qvouekkgoevnvlmthbes',
-            spd=float(42.563176610567155),
-            hdg=int(72),
-            lat=float(72.93376043460161),
-            long=float(17.800272437290985),
-            acc=float(44.83544714552542),
-            odo=int(33),
-            drst=int(97),
-            loc='ybzovbcrgfnvjsfvsjzs',
-            ttarr='ealwuxpvcbphohpqdwds',
-            ttdep='ddpleouftppfmffxifcc',
-            dr_type=int(53)
+            route_id='ggpbkxlubgwkabbdpkhx',
+            direction_id='ordcrdqvmykukflihocm',
+            headsign='srfnhywanyumdmyuamrd',
+            start_time='atmcjfjdzwralrydnyua',
+            next_stop='cdsfqfaanrhpyqpdjuav',
+            geohash_level='fclqbbtynyxsxncgsjtz',
+            geohash='qsugkgmuxdbrphorizlp',
+            desi='uyspxjdfbbrxssqlexgl',
+            dir=None,
+            dl=int(88),
+            oday='tnnpqdktllxfbecmeovu',
+            jrn=int(78),
+            line=int(19),
+            start='cfhiliqqwepsyyummhbs',
+            stop=int(97),
+            route='goyokqowgnvbmabwyhxw',
+            occu=int(95),
+            seq=int(10),
+            label='hrmmamftwpgrafxrscgt',
+            spd=float(56.752242731409076),
+            hdg=int(38),
+            lat=float(46.35727185803135),
+            long=float(15.852558896288793),
+            acc=float(21.72535335196022),
+            odo=int(82),
+            drst=int(63),
+            loc=None,
+            ttarr='wrbsxfuaryrwexntrwzh',
+            ttdep='rsvnlyrqoczrbvowjvwb',
+            dr_type=int(97)
         )

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_driverblockevent.py
@@ -29,31 +29,31 @@ class Test_DriverBlockEvent(unittest.TestCase):
         Create instance of DriverBlockEvent for testing
         """
         instance = DriverBlockEvent(
-            oper=int(57),
-            veh=int(28),
-            tst='dowrunlckeweutfflevd',
-            tsi=int(68),
-            operator_id='mjktjjuuoibekmrcfzto',
-            vehicle_number='czrznfbmzjilzpbbcgrx',
+            oper=int(24),
+            veh=int(65),
+            tst='vyzlqojnzghmyoepldss',
+            tsi=int(99),
+            operator_id='rjmrcacyuxgugspclfhb',
+            vehicle_number='abeaivabkcbwjgiqilqi',
             temporal_type=None,
             transport_mode=None,
-            route_id='vucumzirsgxrbjsofjke',
-            direction_id='pifxrbqrimedcydnmbzp',
-            headsign='wxlbpgnujycrcofjutvw',
-            start_time='qzjykxitiatfbbkqlbth',
-            next_stop='qnmaufvlnmiiincghzec',
-            geohash_level='zxykxtczarrlvrhdkkpf',
-            geohash='aoszwkzcfchttjcgbbna',
-            spd=float(84.19469919584715),
-            hdg=int(18),
-            lat=float(17.660818495321074),
-            long=float(56.22445498580928),
-            acc=float(71.85702806610139),
-            odo=int(4),
-            drst=int(44),
-            loc='fmktwhlndplpinatxify',
-            oday='dugkyusqqdnbdbktdojo',
-            dr_type=int(44)
+            route_id='guegvxvtlvtsjrouyweg',
+            direction_id='stpnvlzyfoclsytfbmsw',
+            headsign='zbdvihgvsqkckhnzkqay',
+            start_time='tfucyqeufiaxohetllua',
+            next_stop='gqfapxcpukpujkdirsmo',
+            geohash_level='uiwvaagjrvzfsxoulcmf',
+            geohash='bltlezhvisipofgarnlp',
+            spd=float(73.72996199954527),
+            hdg=int(66),
+            lat=float(87.32494522971099),
+            long=float(99.82230909797963),
+            acc=float(53.98469339382004),
+            odo=int(45),
+            drst=int(26),
+            loc=None,
+            oday='jwjxictducqjiszhchdr',
+            dr_type=int(85)
         )
         return instance
 
@@ -62,7 +62,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(57)
+        test_value = int(24)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -70,7 +70,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(28)
+        test_value = int(65)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -78,7 +78,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'dowrunlckeweutfflevd'
+        test_value = 'vyzlqojnzghmyoepldss'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -86,7 +86,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(68)
+        test_value = int(99)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -94,7 +94,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'mjktjjuuoibekmrcfzto'
+        test_value = 'rjmrcacyuxgugspclfhb'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -102,7 +102,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'czrznfbmzjilzpbbcgrx'
+        test_value = 'abeaivabkcbwjgiqilqi'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -126,7 +126,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'vucumzirsgxrbjsofjke'
+        test_value = 'guegvxvtlvtsjrouyweg'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -134,7 +134,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'pifxrbqrimedcydnmbzp'
+        test_value = 'stpnvlzyfoclsytfbmsw'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -142,7 +142,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'wxlbpgnujycrcofjutvw'
+        test_value = 'zbdvihgvsqkckhnzkqay'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -150,7 +150,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'qzjykxitiatfbbkqlbth'
+        test_value = 'tfucyqeufiaxohetllua'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -158,7 +158,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'qnmaufvlnmiiincghzec'
+        test_value = 'gqfapxcpukpujkdirsmo'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -166,7 +166,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'zxykxtczarrlvrhdkkpf'
+        test_value = 'uiwvaagjrvzfsxoulcmf'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -174,7 +174,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'aoszwkzcfchttjcgbbna'
+        test_value = 'bltlezhvisipofgarnlp'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -182,7 +182,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(84.19469919584715)
+        test_value = float(73.72996199954527)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -190,7 +190,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(18)
+        test_value = int(66)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -198,7 +198,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(17.660818495321074)
+        test_value = float(87.32494522971099)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -206,7 +206,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(56.22445498580928)
+        test_value = float(99.82230909797963)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -214,7 +214,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(71.85702806610139)
+        test_value = float(53.98469339382004)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -222,7 +222,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(4)
+        test_value = int(45)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -230,7 +230,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(44)
+        test_value = int(26)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -238,7 +238,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'fmktwhlndplpinatxify'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -246,7 +246,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'dugkyusqqdnbdbktdojo'
+        test_value = 'jwjxictducqjiszhchdr'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -254,7 +254,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(44)
+        test_value = int(85)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_operator.py
@@ -28,10 +28,10 @@ class Test_Operator(unittest.TestCase):
         Create instance of Operator for testing
         """
         instance = Operator(
-            operator_id='vixtyhujkfkwswhsaurx',
-            operator_number=int(8),
-            name='krxvhipircktadpxdynn',
-            note='gizjlepjgtowrnlcybem'
+            operator_id='vwpbjjfwajgippdmajot',
+            operator_number=int(38),
+            name='fvhffelienvklisyiiwh',
+            note='bpnmkysuydizbwyvrrjs'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'vixtyhujkfkwswhsaurx'
+        test_value = 'vwpbjjfwajgippdmajot'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -48,7 +48,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_number property
         """
-        test_value = int(8)
+        test_value = int(38)
         self.instance.operator_number = test_value
         self.assertEqual(self.instance.operator_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'krxvhipircktadpxdynn'
+        test_value = 'fvhffelienvklisyiiwh'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -64,7 +64,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test note property
         """
-        test_value = 'gizjlepjgtowrnlcybem'
+        test_value = 'bpnmkysuydizbwyvrrjs'
         self.instance.note = test_value
         self.assertEqual(self.instance.note, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_route.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_route.py
@@ -28,13 +28,13 @@ class Test_Route(unittest.TestCase):
         Create instance of Route for testing
         """
         instance = Route(
-            route_id='trkionjdvikrmzotzhfm',
-            agency_id='cnhtiigvqjdgcnbcjyme',
-            route_short_name='dorresrbgjrcxnmkkpim',
-            route_long_name='ywejvpkexmzhtbefhzud',
-            route_desc='osipgcgzlgsxbtgamxye',
-            route_type=int(81),
-            route_url='yyxajhucclqwtpsyapzo'
+            route_id='estqznyoilymivrkpalm',
+            agency_id='gbmzotrgxeijcdvivdxu',
+            route_short_name='ukvrehgyhaijhrpwilsn',
+            route_long_name='wigopdnemcvrxqdcdmyv',
+            route_desc='ooudjttcezsfsakgwgle',
+            route_type=int(61),
+            route_url='tcbpexdwrohhjccthmvk'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'trkionjdvikrmzotzhfm'
+        test_value = 'estqznyoilymivrkpalm'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_Route(unittest.TestCase):
         """
         Test agency_id property
         """
-        test_value = 'cnhtiigvqjdgcnbcjyme'
+        test_value = 'gbmzotrgxeijcdvivdxu'
         self.instance.agency_id = test_value
         self.assertEqual(self.instance.agency_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_short_name property
         """
-        test_value = 'dorresrbgjrcxnmkkpim'
+        test_value = 'ukvrehgyhaijhrpwilsn'
         self.instance.route_short_name = test_value
         self.assertEqual(self.instance.route_short_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_long_name property
         """
-        test_value = 'ywejvpkexmzhtbefhzud'
+        test_value = 'wigopdnemcvrxqdcdmyv'
         self.instance.route_long_name = test_value
         self.assertEqual(self.instance.route_long_name, test_value)
     
@@ -75,7 +75,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_desc property
         """
-        test_value = 'osipgcgzlgsxbtgamxye'
+        test_value = 'ooudjttcezsfsakgwgle'
         self.instance.route_desc = test_value
         self.assertEqual(self.instance.route_desc, test_value)
     
@@ -83,7 +83,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_type property
         """
-        test_value = int(81)
+        test_value = int(61)
         self.instance.route_type = test_value
         self.assertEqual(self.instance.route_type, test_value)
     
@@ -91,7 +91,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_url property
         """
-        test_value = 'yyxajhucclqwtpsyapzo'
+        test_value = 'tcbpexdwrohhjccthmvk'
         self.instance.route_url = test_value
         self.assertEqual(self.instance.route_url, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_stop.py
@@ -28,20 +28,20 @@ class Test_Stop(unittest.TestCase):
         Create instance of Stop for testing
         """
         instance = Stop(
-            stop_id='erauhdzyovqownfcjzer',
-            stop_code='lsyncfbnxcxkqkuaylhj',
-            stop_name='uobwqmcirnuwhbivgdla',
-            stop_desc='bcxuowvqffnftctlhdsq',
-            stop_lat=float(68.44865499396307),
-            stop_lon=float(87.70979632615085),
-            zone_id='lmevrmghblrozkwewnql',
-            stop_url='ubezwsvpttwohtamphak',
-            location_type=int(86),
-            parent_station='mlzvuuqjxjlkwzbucxin',
-            platform_code='ordjnemehlcoevnjcphz',
-            wheelchair_boarding=int(3),
-            vehicle_type=int(78),
-            digistop_id='dkwzlicdmhosfqhgyfzg'
+            stop_id='wjiwsvuqbirfqqdoydka',
+            stop_code='ryswekdpdnuennvmorvt',
+            stop_name='dgocusdriylcmgcbbges',
+            stop_desc='wmanmyotqalinyzzrvoq',
+            stop_lat=float(56.45595402892016),
+            stop_lon=float(12.550508429008755),
+            zone_id='bqpmemwapqkyllveomom',
+            stop_url='xpycohcewpnqwtxxgfgv',
+            location_type=int(80),
+            parent_station='dcrupeoeajkvfhdlgpvj',
+            platform_code='rilerqtecydleacqhrzl',
+            wheelchair_boarding=int(60),
+            vehicle_type=int(25),
+            digistop_id='ifheyuyqmpkeeerjcewx'
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_id property
         """
-        test_value = 'erauhdzyovqownfcjzer'
+        test_value = 'wjiwsvuqbirfqqdoydka'
         self.instance.stop_id = test_value
         self.assertEqual(self.instance.stop_id, test_value)
     
@@ -58,7 +58,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_code property
         """
-        test_value = 'lsyncfbnxcxkqkuaylhj'
+        test_value = 'ryswekdpdnuennvmorvt'
         self.instance.stop_code = test_value
         self.assertEqual(self.instance.stop_code, test_value)
     
@@ -66,7 +66,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_name property
         """
-        test_value = 'uobwqmcirnuwhbivgdla'
+        test_value = 'dgocusdriylcmgcbbges'
         self.instance.stop_name = test_value
         self.assertEqual(self.instance.stop_name, test_value)
     
@@ -74,7 +74,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_desc property
         """
-        test_value = 'bcxuowvqffnftctlhdsq'
+        test_value = 'wmanmyotqalinyzzrvoq'
         self.instance.stop_desc = test_value
         self.assertEqual(self.instance.stop_desc, test_value)
     
@@ -82,7 +82,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lat property
         """
-        test_value = float(68.44865499396307)
+        test_value = float(56.45595402892016)
         self.instance.stop_lat = test_value
         self.assertEqual(self.instance.stop_lat, test_value)
     
@@ -90,7 +90,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lon property
         """
-        test_value = float(87.70979632615085)
+        test_value = float(12.550508429008755)
         self.instance.stop_lon = test_value
         self.assertEqual(self.instance.stop_lon, test_value)
     
@@ -98,7 +98,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test zone_id property
         """
-        test_value = 'lmevrmghblrozkwewnql'
+        test_value = 'bqpmemwapqkyllveomom'
         self.instance.zone_id = test_value
         self.assertEqual(self.instance.zone_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_url property
         """
-        test_value = 'ubezwsvpttwohtamphak'
+        test_value = 'xpycohcewpnqwtxxgfgv'
         self.instance.stop_url = test_value
         self.assertEqual(self.instance.stop_url, test_value)
     
@@ -114,7 +114,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test location_type property
         """
-        test_value = int(86)
+        test_value = int(80)
         self.instance.location_type = test_value
         self.assertEqual(self.instance.location_type, test_value)
     
@@ -122,7 +122,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test parent_station property
         """
-        test_value = 'mlzvuuqjxjlkwzbucxin'
+        test_value = 'dcrupeoeajkvfhdlgpvj'
         self.instance.parent_station = test_value
         self.assertEqual(self.instance.parent_station, test_value)
     
@@ -130,7 +130,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test platform_code property
         """
-        test_value = 'ordjnemehlcoevnjcphz'
+        test_value = 'rilerqtecydleacqhrzl'
         self.instance.platform_code = test_value
         self.assertEqual(self.instance.platform_code, test_value)
     
@@ -138,7 +138,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test wheelchair_boarding property
         """
-        test_value = int(3)
+        test_value = int(60)
         self.instance.wheelchair_boarding = test_value
         self.assertEqual(self.instance.wheelchair_boarding, test_value)
     
@@ -146,7 +146,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test vehicle_type property
         """
-        test_value = int(78)
+        test_value = int(25)
         self.instance.vehicle_type = test_value
         self.assertEqual(self.instance.vehicle_type, test_value)
     
@@ -154,7 +154,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test digistop_id property
         """
-        test_value = 'dkwzlicdmhosfqhgyfzg'
+        test_value = 'ifheyuyqmpkeeerjcewx'
         self.instance.digistop_id = test_value
         self.assertEqual(self.instance.digistop_id, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_trafficlightevent.py
@@ -29,52 +29,52 @@ class Test_TrafficLightEvent(unittest.TestCase):
         Create instance of TrafficLightEvent for testing
         """
         instance = TrafficLightEvent(
-            oper=int(53),
-            veh=int(22),
-            tst='fhubtodecrdnzxlkmrao',
-            tsi=int(30),
-            operator_id='orimbllpcxzsziuirpzd',
-            vehicle_number='bzyecmicciyrutcqlvif',
+            oper=int(10),
+            veh=int(36),
+            tst='rlkfviyrgfwafrwnskzm',
+            tsi=int(4),
+            operator_id='egioauzexxyvarpawqbo',
+            vehicle_number='ahlwhtqzsygnylopftfy',
             temporal_type=None,
             transport_mode=None,
-            route_id='lgflcgrhrkmsyxkbkwmu',
-            direction_id='wedzddzufbfrjyechszq',
-            headsign='qhdesmkmqaxpelblnsjp',
-            start_time='muezelqwvtzcvovxydon',
-            next_stop='wbolcdqohgoxacakimpf',
-            geohash_level='tusmlberkuoathfyyypy',
-            geohash='cfacpidwgqbrdyaweqcb',
-            desi='ytutlrcodhmpyvjdfmms',
-            dir='rzsgrddwytjepnhmagfs',
-            dl=int(70),
-            oday='chojlypphtweoavrouuq',
-            jrn=int(52),
-            line=int(26),
-            start='ysghokvjsjjxrsinbfwb',
-            stop=int(89),
-            route='ftklosznkmcoavuejztc',
-            occu=int(28),
-            spd=float(91.96704877353169),
-            hdg=int(27),
-            lat=float(4.47318934895693),
-            long=float(21.217661962155297),
-            acc=float(6.460214075935311),
-            odo=int(93),
-            drst=int(70),
-            loc='reuswxvywnempjxweafh',
-            tlp_requestid=int(77),
+            route_id='ozpyrajtcpsosxytbgez',
+            direction_id='woopcrqzqkvaogutiywr',
+            headsign='tsfxeijnlesimgsncwcf',
+            start_time='ephcyymzmkmkzvcmdtol',
+            next_stop='nrikwucttlzwqrxculkf',
+            geohash_level='itkvsyqdhzhwfnxoffyq',
+            geohash='vdxowwcfboirebksajqr',
+            desi='shbsqopwctqenocekxdv',
+            dir=None,
+            dl=int(67),
+            oday='myyvrwagdbgqpqarjrtt',
+            jrn=int(51),
+            line=int(25),
+            start='zpqvojsotveueirhuhpx',
+            stop=int(70),
+            route='towinprbyjntpsfcjykv',
+            occu=int(13),
+            spd=float(58.040857688152),
+            hdg=int(32),
+            lat=float(73.72004636153261),
+            long=float(41.162964839821505),
+            acc=float(83.4004673578086),
+            odo=int(39),
+            drst=int(43),
+            loc=None,
+            tlp_requestid=int(55),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(44),
+            tlp_att_seq=int(83),
             tlp_decision=None,
-            sid=int(72),
-            signal_groupid=int(25),
-            tlp_signalgroupnbr=int(58),
-            tlp_line_configid=int(89),
-            tlp_point_configid=int(63),
-            tlp_frequency=int(94),
-            tlp_protocol='wgduynpabxcxhobsjhok'
+            sid=int(59),
+            signal_groupid=int(68),
+            tlp_signalgroupnbr=int(60),
+            tlp_line_configid=int(31),
+            tlp_point_configid=int(44),
+            tlp_frequency=int(5),
+            tlp_protocol=None
         )
         return instance
 
@@ -83,7 +83,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(53)
+        test_value = int(10)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -91,7 +91,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(22)
+        test_value = int(36)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -99,7 +99,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'fhubtodecrdnzxlkmrao'
+        test_value = 'rlkfviyrgfwafrwnskzm'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -107,7 +107,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(30)
+        test_value = int(4)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -115,7 +115,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'orimbllpcxzsziuirpzd'
+        test_value = 'egioauzexxyvarpawqbo'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -123,7 +123,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'bzyecmicciyrutcqlvif'
+        test_value = 'ahlwhtqzsygnylopftfy'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -147,7 +147,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'lgflcgrhrkmsyxkbkwmu'
+        test_value = 'ozpyrajtcpsosxytbgez'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'wedzddzufbfrjyechszq'
+        test_value = 'woopcrqzqkvaogutiywr'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -163,7 +163,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'qhdesmkmqaxpelblnsjp'
+        test_value = 'tsfxeijnlesimgsncwcf'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -171,7 +171,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'muezelqwvtzcvovxydon'
+        test_value = 'ephcyymzmkmkzvcmdtol'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -179,7 +179,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'wbolcdqohgoxacakimpf'
+        test_value = 'nrikwucttlzwqrxculkf'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -187,7 +187,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'tusmlberkuoathfyyypy'
+        test_value = 'itkvsyqdhzhwfnxoffyq'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -195,7 +195,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'cfacpidwgqbrdyaweqcb'
+        test_value = 'vdxowwcfboirebksajqr'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -203,7 +203,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'ytutlrcodhmpyvjdfmms'
+        test_value = 'shbsqopwctqenocekxdv'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -211,7 +211,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'rzsgrddwytjepnhmagfs'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -219,7 +219,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(70)
+        test_value = int(67)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -227,7 +227,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'chojlypphtweoavrouuq'
+        test_value = 'myyvrwagdbgqpqarjrtt'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -235,7 +235,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(52)
+        test_value = int(51)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -243,7 +243,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(26)
+        test_value = int(25)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -251,7 +251,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'ysghokvjsjjxrsinbfwb'
+        test_value = 'zpqvojsotveueirhuhpx'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -259,7 +259,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(89)
+        test_value = int(70)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -267,7 +267,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'ftklosznkmcoavuejztc'
+        test_value = 'towinprbyjntpsfcjykv'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -275,7 +275,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(28)
+        test_value = int(13)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -283,7 +283,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(91.96704877353169)
+        test_value = float(58.040857688152)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -291,7 +291,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(27)
+        test_value = int(32)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -299,7 +299,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(4.47318934895693)
+        test_value = float(73.72004636153261)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -307,7 +307,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(21.217661962155297)
+        test_value = float(41.162964839821505)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -315,7 +315,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(6.460214075935311)
+        test_value = float(83.4004673578086)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -323,7 +323,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(93)
+        test_value = int(39)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -331,7 +331,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(70)
+        test_value = int(43)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -339,7 +339,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'reuswxvywnempjxweafh'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -347,7 +347,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_requestid property
         """
-        test_value = int(77)
+        test_value = int(55)
         self.instance.tlp_requestid = test_value
         self.assertEqual(self.instance.tlp_requestid, test_value)
     
@@ -379,7 +379,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_att_seq property
         """
-        test_value = int(44)
+        test_value = int(83)
         self.instance.tlp_att_seq = test_value
         self.assertEqual(self.instance.tlp_att_seq, test_value)
     
@@ -395,7 +395,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test sid property
         """
-        test_value = int(72)
+        test_value = int(59)
         self.instance.sid = test_value
         self.assertEqual(self.instance.sid, test_value)
     
@@ -403,7 +403,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test signal_groupid property
         """
-        test_value = int(25)
+        test_value = int(68)
         self.instance.signal_groupid = test_value
         self.assertEqual(self.instance.signal_groupid, test_value)
     
@@ -411,7 +411,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_signalgroupnbr property
         """
-        test_value = int(58)
+        test_value = int(60)
         self.instance.tlp_signalgroupnbr = test_value
         self.assertEqual(self.instance.tlp_signalgroupnbr, test_value)
     
@@ -419,7 +419,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_line_configid property
         """
-        test_value = int(89)
+        test_value = int(31)
         self.instance.tlp_line_configid = test_value
         self.assertEqual(self.instance.tlp_line_configid, test_value)
     
@@ -427,7 +427,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_point_configid property
         """
-        test_value = int(63)
+        test_value = int(44)
         self.instance.tlp_point_configid = test_value
         self.assertEqual(self.instance.tlp_point_configid, test_value)
     
@@ -435,7 +435,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_frequency property
         """
-        test_value = int(94)
+        test_value = int(5)
         self.instance.tlp_frequency = test_value
         self.assertEqual(self.instance.tlp_frequency, test_value)
     
@@ -443,7 +443,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_protocol property
         """
-        test_value = 'wgduynpabxcxhobsjhok'
+        test_value = None
         self.instance.tlp_protocol = test_value
         self.assertEqual(self.instance.tlp_protocol, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_mqtt_producer/hsl_hfp_mqtt_producer_data/tests/test_vehicleevent.py
@@ -29,44 +29,44 @@ class Test_VehicleEvent(unittest.TestCase):
         Create instance of VehicleEvent for testing
         """
         instance = VehicleEvent(
-            oper=int(42),
-            veh=int(69),
-            tst='cfrnnqayrvglxylayvwy',
-            tsi=int(2),
-            operator_id='ioqicespopfazcnekmfd',
-            vehicle_number='xqiqsrmqwonpdpfosgmh',
+            oper=int(62),
+            veh=int(61),
+            tst='wwupbwahhwacvjzmklte',
+            tsi=int(38),
+            operator_id='ruxinqyhycmhcajjftcj',
+            vehicle_number='pdnliomgvcahpzqtlrrn',
             temporal_type=None,
             transport_mode=None,
-            route_id='rezzkdromztbuqszfsnr',
-            direction_id='yllehcgawgyhvhbumema',
-            headsign='hcbpruwrfeiltkoamqwr',
-            start_time='xlwbvoekesuwxicrvwys',
-            next_stop='pikucdokwlcvnbtxvfln',
-            geohash_level='gudfzdbiehfktjhmkusx',
-            geohash='kjbmrzqynixsoruuoluh',
-            desi='cjiqcbvaicurmbqobxny',
-            dir='cfdflgmvhreebhslifpg',
-            dl=int(76),
-            oday='zlpxwzbmacqcmnidjdva',
-            jrn=int(95),
-            line=int(15),
-            start='oeostkjjfgmwepvsjpig',
-            stop=int(75),
-            route='dcwarprmpgvyljvpouxs',
-            occu=int(16),
-            seq=int(98),
-            label='qvouekkgoevnvlmthbes',
-            spd=float(42.563176610567155),
-            hdg=int(72),
-            lat=float(72.93376043460161),
-            long=float(17.800272437290985),
-            acc=float(44.83544714552542),
-            odo=int(33),
-            drst=int(97),
-            loc='ybzovbcrgfnvjsfvsjzs',
-            ttarr='ealwuxpvcbphohpqdwds',
-            ttdep='ddpleouftppfmffxifcc',
-            dr_type=int(53)
+            route_id='ggpbkxlubgwkabbdpkhx',
+            direction_id='ordcrdqvmykukflihocm',
+            headsign='srfnhywanyumdmyuamrd',
+            start_time='atmcjfjdzwralrydnyua',
+            next_stop='cdsfqfaanrhpyqpdjuav',
+            geohash_level='fclqbbtynyxsxncgsjtz',
+            geohash='qsugkgmuxdbrphorizlp',
+            desi='uyspxjdfbbrxssqlexgl',
+            dir=None,
+            dl=int(88),
+            oday='tnnpqdktllxfbecmeovu',
+            jrn=int(78),
+            line=int(19),
+            start='cfhiliqqwepsyyummhbs',
+            stop=int(97),
+            route='goyokqowgnvbmabwyhxw',
+            occu=int(95),
+            seq=int(10),
+            label='hrmmamftwpgrafxrscgt',
+            spd=float(56.752242731409076),
+            hdg=int(38),
+            lat=float(46.35727185803135),
+            long=float(15.852558896288793),
+            acc=float(21.72535335196022),
+            odo=int(82),
+            drst=int(63),
+            loc=None,
+            ttarr='wrbsxfuaryrwexntrwzh',
+            ttdep='rsvnlyrqoczrbvowjvwb',
+            dr_type=int(97)
         )
         return instance
 
@@ -75,7 +75,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(42)
+        test_value = int(62)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -83,7 +83,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(69)
+        test_value = int(61)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -91,7 +91,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'cfrnnqayrvglxylayvwy'
+        test_value = 'wwupbwahhwacvjzmklte'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -99,7 +99,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(2)
+        test_value = int(38)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -107,7 +107,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'ioqicespopfazcnekmfd'
+        test_value = 'ruxinqyhycmhcajjftcj'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'xqiqsrmqwonpdpfosgmh'
+        test_value = 'pdnliomgvcahpzqtlrrn'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -139,7 +139,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'rezzkdromztbuqszfsnr'
+        test_value = 'ggpbkxlubgwkabbdpkhx'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -147,7 +147,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'yllehcgawgyhvhbumema'
+        test_value = 'ordcrdqvmykukflihocm'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'hcbpruwrfeiltkoamqwr'
+        test_value = 'srfnhywanyumdmyuamrd'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -163,7 +163,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'xlwbvoekesuwxicrvwys'
+        test_value = 'atmcjfjdzwralrydnyua'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -171,7 +171,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'pikucdokwlcvnbtxvfln'
+        test_value = 'cdsfqfaanrhpyqpdjuav'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -179,7 +179,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'gudfzdbiehfktjhmkusx'
+        test_value = 'fclqbbtynyxsxncgsjtz'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -187,7 +187,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'kjbmrzqynixsoruuoluh'
+        test_value = 'qsugkgmuxdbrphorizlp'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -195,7 +195,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'cjiqcbvaicurmbqobxny'
+        test_value = 'uyspxjdfbbrxssqlexgl'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -203,7 +203,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'cfdflgmvhreebhslifpg'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -211,7 +211,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(76)
+        test_value = int(88)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -219,7 +219,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'zlpxwzbmacqcmnidjdva'
+        test_value = 'tnnpqdktllxfbecmeovu'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -227,7 +227,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(95)
+        test_value = int(78)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -235,7 +235,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(15)
+        test_value = int(19)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -243,7 +243,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'oeostkjjfgmwepvsjpig'
+        test_value = 'cfhiliqqwepsyyummhbs'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -251,7 +251,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(75)
+        test_value = int(97)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -259,7 +259,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'dcwarprmpgvyljvpouxs'
+        test_value = 'goyokqowgnvbmabwyhxw'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -267,7 +267,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(16)
+        test_value = int(95)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -275,7 +275,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test seq property
         """
-        test_value = int(98)
+        test_value = int(10)
         self.instance.seq = test_value
         self.assertEqual(self.instance.seq, test_value)
     
@@ -283,7 +283,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test label property
         """
-        test_value = 'qvouekkgoevnvlmthbes'
+        test_value = 'hrmmamftwpgrafxrscgt'
         self.instance.label = test_value
         self.assertEqual(self.instance.label, test_value)
     
@@ -291,7 +291,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(42.563176610567155)
+        test_value = float(56.752242731409076)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -299,7 +299,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(72)
+        test_value = int(38)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -307,7 +307,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(72.93376043460161)
+        test_value = float(46.35727185803135)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -315,7 +315,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(17.800272437290985)
+        test_value = float(15.852558896288793)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -323,7 +323,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(44.83544714552542)
+        test_value = float(21.72535335196022)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -331,7 +331,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(33)
+        test_value = int(82)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -339,7 +339,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(97)
+        test_value = int(63)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -347,7 +347,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'ybzovbcrgfnvjsfvsjzs'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -355,7 +355,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttarr property
         """
-        test_value = 'ealwuxpvcbphohpqdwds'
+        test_value = 'wrbsxfuaryrwexntrwzh'
         self.instance.ttarr = test_value
         self.assertEqual(self.instance.ttarr, test_value)
     
@@ -363,7 +363,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttdep property
         """
-        test_value = 'ddpleouftppfmffxifcc'
+        test_value = 'rsvnlyrqoczrbvowjvwb'
         self.instance.ttdep = test_value
         self.assertEqual(self.instance.ttdep, test_value)
     
@@ -371,7 +371,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(53)
+        test_value = int(97)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/__init__.py
@@ -1,3 +1,3 @@
-from .fi import Stop, Operator, Route, TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, DriverBlockEvent, VehicleEvent
+from .fi import TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, LocEnum, DirEnum, TlpProtocolEnum, VehicleEvent, DriverBlockEvent, Stop, Route, Operator
 
-__all__ = ["Stop", "Operator", "Route", "TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "DriverBlockEvent", "VehicleEvent"]
+__all__ = ["TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "DriverBlockEvent", "Stop", "Route", "Operator"]

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/__init__.py
@@ -1,3 +1,3 @@
-from .hsl import Stop, Operator, Route, TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, DriverBlockEvent, VehicleEvent
+from .hsl import TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, LocEnum, DirEnum, TlpProtocolEnum, VehicleEvent, DriverBlockEvent, Stop, Route, Operator
 
-__all__ = ["Stop", "Operator", "Route", "TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "DriverBlockEvent", "VehicleEvent"]
+__all__ = ["TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "DriverBlockEvent", "Stop", "Route", "Operator"]

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/__init__.py
@@ -1,4 +1,4 @@
-from .gtfs import Stop, Operator, Route
-from .hfp import TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, DriverBlockEvent, VehicleEvent
+from .hfp import TrafficLightEvent, TemporalTypeEnum, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TransportModeEnum, LocEnum, DirEnum, TlpProtocolEnum, VehicleEvent, DriverBlockEvent
+from .gtfs import Stop, Route, Operator
 
-__all__ = ["Stop", "Operator", "Route", "TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "DriverBlockEvent", "VehicleEvent"]
+__all__ = ["TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "DriverBlockEvent", "Stop", "Route", "Operator"]

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/__init__.py
@@ -1,5 +1,5 @@
 from .stop import Stop
-from .operator import Operator
 from .route import Route
+from .operator import Operator
 
-__all__ = ["Stop", "Operator", "Route"]
+__all__ = ["Stop", "Route", "Operator"]

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/operator.py
@@ -159,8 +159,8 @@ class Operator:
             An instance of the dataclass.
         """
         return cls(
-            operator_id='bqopgjqidbsjqwtbmdel',
-            operator_number=int(4),
-            name='gfywrzxrrgirpqhqjphr',
-            note='agkyjqhnjrkoyxonjlaj'
+            operator_id='noieokxfynmkkiihujeq',
+            operator_number=int(77),
+            name='vhaytjcadsxxyyyeypfh',
+            note='dkgnvjhvctiyneckxpvj'
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/route.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/route.py
@@ -165,11 +165,11 @@ class Route:
             An instance of the dataclass.
         """
         return cls(
-            route_id='spnejztwxmicpuoyfbbn',
-            agency_id='smjmqibifkewcgwumigt',
-            route_short_name='byindjjokmzcjmxeqtao',
-            route_long_name='tlfdlbkhsbuwuxeepkkr',
-            route_desc='jidmittrvpnnfmyeyqmq',
-            route_type=int(18),
-            route_url='xptzhsazfbkvnjgabwdo'
+            route_id='bihshpwxnuixcatatqdl',
+            agency_id='myzpexopmvzmoeqptpqi',
+            route_short_name='yqvqxxncjijeohzacpjz',
+            route_long_name='xgxyvjneskphgsdbbuck',
+            route_desc='ijspdaqqcowqhhvcygvc',
+            route_type=int(40),
+            route_url='xflxnwhcupdtvojklirp'
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/gtfs/stop.py
@@ -179,18 +179,18 @@ class Stop:
             An instance of the dataclass.
         """
         return cls(
-            stop_id='cbmhldxkgdjjqyolmwxn',
-            stop_code='gamnpfzjjdfzyowxafdp',
-            stop_name='mrcynnprexdisgzsxozd',
-            stop_desc='nuibstpkkiraglcnchtk',
-            stop_lat=float(65.30091869929826),
-            stop_lon=float(36.9671982141103),
-            zone_id='zlusyxdpachfsnvroztx',
-            stop_url='fbiltojknvtofybkhidr',
-            location_type=int(44),
-            parent_station='shyuasdtkpzhqhejfjlu',
-            platform_code='ggponclamdcneqreovke',
-            wheelchair_boarding=int(10),
-            vehicle_type=int(16),
-            digistop_id='ygucxsbmadrynrzzceve'
+            stop_id='vebabzlduamvqznuyrju',
+            stop_code='ummddvuwkjobfixlsfqc',
+            stop_name='zkklwizrdsmokxdnwshz',
+            stop_desc='gtnnmxfnrcqggjvyzcnr',
+            stop_lat=float(90.35006150982657),
+            stop_lon=float(47.0964891294616),
+            zone_id='auvohksrlqljtclttzzh',
+            stop_url='xazpnhterjhqkqeogjnr',
+            location_type=int(39),
+            parent_station='thjsdjfassqvwhvudoby',
+            platform_code='rmtutvcsqndrqvoccbnv',
+            wheelchair_boarding=int(45),
+            vehicle_type=int(8),
+            digistop_id='zkcztzvkeozmpnjtwwiy'
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/__init__.py
@@ -5,7 +5,10 @@ from .tlpprioritylevelenum import TlpPriorityLevelEnum
 from .tlpreasonenum import TlpReasonEnum
 from .tlprequesttypeenum import TlpRequestTypeEnum
 from .transportmodeenum import TransportModeEnum
-from .driverblockevent import DriverBlockEvent
+from .locenum import LocEnum
+from .direnum import DirEnum
+from .tlpprotocolenum import TlpProtocolEnum
 from .vehicleevent import VehicleEvent
+from .driverblockevent import DriverBlockEvent
 
-__all__ = ["TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "DriverBlockEvent", "VehicleEvent"]
+__all__ = ["TrafficLightEvent", "TemporalTypeEnum", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "TlpProtocolEnum", "VehicleEvent", "DriverBlockEvent"]

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/direnum.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/direnum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class DirEnum(Enum):
     """
-    Route direction of the trip as a string, either `1` or `2`. Relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`).
+    Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim.
     """
     VALUE_1 = '1'
     VALUE_2 = '2'

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/driverblockevent.py
@@ -43,7 +43,7 @@ class DriverBlockEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         oday (typing.Optional[str])
         dr_type (typing.Optional[int])
     """
@@ -71,7 +71,7 @@ class DriverBlockEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
 
@@ -208,29 +208,29 @@ class DriverBlockEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(87),
-            veh=int(71),
-            tst='zrjrgkutfluoqmckhamy',
-            tsi=int(56),
-            operator_id='hhlosgcbszuwdchfjaiv',
-            vehicle_number='srrwpuigbzhkwysworpv',
+            oper=int(98),
+            veh=int(13),
+            tst='xdlmielttopjgbivoldg',
+            tsi=int(45),
+            operator_id='hvbygijnevnrvwhxaprz',
+            vehicle_number='kaclundisitdpccgmdxs',
             temporal_type=None,
             transport_mode=None,
-            route_id='urntecuebogsgyhqrcro',
-            direction_id='ekkiknbpiqgpuwfioexd',
-            headsign='gjwfddnrqwfrfwrjinec',
-            start_time='fqgyaowgebraxpobmlxb',
-            next_stop='xjwpngnwrijhpskdrxuy',
-            geohash_level='sxgfelakjgrqrysxioeg',
-            geohash='vnlwmubddicvroweetwe',
-            spd=float(85.41655963300046),
-            hdg=int(35),
-            lat=float(9.939962666912837),
-            long=float(54.598379794735486),
-            acc=float(36.91139308982455),
-            odo=int(70),
-            drst=int(37),
-            loc='cqaekffxcbhedtahttje',
-            oday='vjlkeecekpbkrpvenlbc',
-            dr_type=int(16)
+            route_id='kbvgnefqskolotjegmge',
+            direction_id='dstyczptxqxzcvsbmhpa',
+            headsign='mnkxyyfzkwydnzhfxvga',
+            start_time='mnjotngytltqmodyadyq',
+            next_stop='mpirbdpmhuiybjxziqcy',
+            geohash_level='amwxmvpslazcncrvqwgf',
+            geohash='htfxqbqgxzoppudsubos',
+            spd=float(44.953398368988275),
+            hdg=int(58),
+            lat=float(83.95743611768901),
+            long=float(21.60759560191129),
+            acc=float(66.20724106005734),
+            odo=int(5),
+            drst=int(25),
+            loc=None,
+            oday='eepmygoyfdbbytbvbwkb',
+            dr_type=int(70)
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/locenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/locenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class LocEnum(Enum):
     """
-    Source of the reported vehicle location: `GPS` satellite fix; `ODO` computed from the odometer; `MAN` manually set; `DR` dead reckoning (used in tunnels and other GPS-denied locations); `N/A` location unavailable. From the HFP payload `loc` field.
+    Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim.
     """
     GPS = 'GPS'
     ODO = 'ODO'

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/tlpprotocolenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/tlpprotocolenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class TlpProtocolEnum(Enum):
     """
-    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. From the HFP payload `tlp-protocol` field.
+    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. Populated on `tlr`. From the HFP payload `tlp-protocol` field. The `-` in `KAR-MQTT` is sanitized to the Avro symbol `KAR_MQTT` while the JSON wire value `KAR-MQTT` is preserved verbatim.
     """
     MQTT = 'MQTT'
     KAR_MINUSMQTT = 'KAR-MQTT'

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/trafficlightevent.py
@@ -37,7 +37,7 @@ class TrafficLightEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -53,7 +53,7 @@ class TrafficLightEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         tlp_requestid (typing.Optional[int])
         tlp_requesttype (typing.Optional[Any])
         tlp_prioritylevel (typing.Optional[Any])
@@ -66,7 +66,7 @@ class TrafficLightEvent:
         tlp_line_configid (typing.Optional[int])
         tlp_point_configid (typing.Optional[int])
         tlp_frequency (typing.Optional[int])
-        tlp_protocol (typing.Optional[str])
+        tlp_protocol (typing.Optional[Any])
     """
     
     
@@ -86,7 +86,7 @@ class TrafficLightEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -102,7 +102,7 @@ class TrafficLightEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     tlp_requestid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requestid"))
     tlp_requesttype: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requesttype"))
     tlp_prioritylevel: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-prioritylevel"))
@@ -115,7 +115,7 @@ class TrafficLightEvent:
     tlp_line_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-line-configid"))
     tlp_point_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-point-configid"))
     tlp_frequency: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-frequency"))
-    tlp_protocol: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
+    tlp_protocol: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'TrafficLightEvent':
@@ -316,50 +316,50 @@ class TrafficLightEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(49),
-            veh=int(98),
-            tst='rjgbsascrgmlumrrymdg',
-            tsi=int(62),
-            operator_id='kyezkfumrfgfpozfwkao',
-            vehicle_number='ufgdscpqozzrvviwawvo',
+            oper=int(73),
+            veh=int(80),
+            tst='ymmwfdhvsltiutynipmr',
+            tsi=int(59),
+            operator_id='wjwticmopuwlcmzqnvvs',
+            vehicle_number='qyhfdjzjfhkqfhfqhkfk',
             temporal_type=None,
             transport_mode=None,
-            route_id='vtrydtuvkmbznanoslrs',
-            direction_id='adgoeqxmxqdahoizamws',
-            headsign='ldlvivrdvcmeyitilpfh',
-            start_time='kltudoroqferxnpufhmv',
-            next_stop='jgxfspngauiliyoqogxc',
-            geohash_level='kfqvtoppjigavnqduqdx',
-            geohash='uzpefvkguogvisugwhff',
-            desi='uuftsojnkcfdaterwtsg',
-            dir='fhmoekqpikytigftygjd',
-            dl=int(57),
-            oday='dhlwpplwwjvrxnjumnqx',
-            jrn=int(48),
-            line=int(5),
-            start='ffuemzucndazjhnlhelb',
-            stop=int(49),
-            route='rmbrygccvpqlzhmgxbey',
-            occu=int(70),
-            spd=float(32.193923080201834),
-            hdg=int(62),
-            lat=float(52.11533703502692),
-            long=float(12.055115798888883),
-            acc=float(14.565083784820665),
-            odo=int(61),
-            drst=int(43),
-            loc='ktagmsldsvxrsatcmwei',
-            tlp_requestid=int(17),
+            route_id='oevqejfnihnhivtunppl',
+            direction_id='bisqsximazsegiyclnth',
+            headsign='kvadhdphpxyabqdtjvwu',
+            start_time='oeivyavxkossvrvwqmjr',
+            next_stop='wfnqrpmvnrqvkpvaizph',
+            geohash_level='ayzgerucjthvslzlljos',
+            geohash='elngpzqjpfjuwtybgoxu',
+            desi='oxogazihnumrbskzvrtd',
+            dir=None,
+            dl=int(15),
+            oday='xaucasvverhxzuyfqjed',
+            jrn=int(79),
+            line=int(62),
+            start='tdyuphwreznmavuxfvcq',
+            stop=int(87),
+            route='fgmhdwpaeucqgxsfkapo',
+            occu=int(14),
+            spd=float(44.036625108439765),
+            hdg=int(58),
+            lat=float(98.9524966578608),
+            long=float(40.21201616838154),
+            acc=float(36.05886398084134),
+            odo=int(98),
+            drst=int(53),
+            loc=None,
+            tlp_requestid=int(37),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(63),
+            tlp_att_seq=int(2),
             tlp_decision=None,
-            sid=int(59),
-            signal_groupid=int(2),
-            tlp_signalgroupnbr=int(65),
-            tlp_line_configid=int(30),
-            tlp_point_configid=int(85),
-            tlp_frequency=int(88),
-            tlp_protocol='cqnjfvbomdmmflciwsul'
+            sid=int(51),
+            signal_groupid=int(95),
+            tlp_signalgroupnbr=int(96),
+            tlp_line_configid=int(65),
+            tlp_point_configid=int(23),
+            tlp_frequency=int(64),
+            tlp_protocol=None
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/src/hsl_hfp_producer_data/fi/hsl/hfp/vehicleevent.py
@@ -37,7 +37,7 @@ class VehicleEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -55,7 +55,7 @@ class VehicleEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         ttarr (typing.Optional[str])
         ttdep (typing.Optional[str])
         dr_type (typing.Optional[int])
@@ -78,7 +78,7 @@ class VehicleEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -96,7 +96,7 @@ class VehicleEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     ttarr: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttarr"))
     ttdep: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttdep"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
@@ -234,42 +234,42 @@ class VehicleEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(55),
-            veh=int(2),
-            tst='aphcqwvsjioyivtpjixa',
-            tsi=int(73),
-            operator_id='zswecbkxqnejtmqodxbc',
-            vehicle_number='ybfbmpkjelfmpwqscdss',
+            oper=int(95),
+            veh=int(92),
+            tst='lpdsonholrfpzvchmgtd',
+            tsi=int(34),
+            operator_id='alustcyuisnjdowrqatr',
+            vehicle_number='sxftsdtgntrgzaprjrxq',
             temporal_type=None,
             transport_mode=None,
-            route_id='wclkpceqhxohiacmayfx',
-            direction_id='mtcvkpqcpgcloxmajiec',
-            headsign='jpytqbmivkbnhprelkbo',
-            start_time='fffoaimexynjusoqxqmu',
-            next_stop='bydqiphgxbmbnhrhxhhm',
-            geohash_level='xmjqdbosgnihzljfuthl',
-            geohash='azrftcpblcxursxfaufz',
-            desi='djyowwiewnnqeiyqcfqr',
-            dir='ctnjrmomaabupfvxmhqe',
-            dl=int(41),
-            oday='mgwbwtdtlqhmcizcthoq',
-            jrn=int(44),
-            line=int(25),
-            start='bhwtutavpblmcmapeout',
-            stop=int(98),
-            route='ylqdcybvbyliagqxikvg',
-            occu=int(8),
-            seq=int(70),
-            label='cnypugwtctethoqfqctv',
-            spd=float(51.608450576349085),
-            hdg=int(53),
-            lat=float(51.04182146948949),
-            long=float(63.048533903029444),
-            acc=float(75.49006538207271),
-            odo=int(63),
-            drst=int(63),
-            loc='wkxmdyclrvryixqmsbhk',
-            ttarr='pibxijnvjdasslzlqibi',
-            ttdep='yirrziafnwzjkuhxmwqg',
-            dr_type=int(85)
+            route_id='akqhqcrnxtdsxmxpqdsv',
+            direction_id='icvgwfmwzckjocvngjen',
+            headsign='cegygrtdsqohuwqrodgp',
+            start_time='ukcszynkcwkpsunyfhrs',
+            next_stop='refbvtouohjjjcaqmcab',
+            geohash_level='nxaujhkarhfykknnwzko',
+            geohash='twzhwnqxlmdvxutqtbpv',
+            desi='mkrijhcqyvwvharbinbp',
+            dir=None,
+            dl=int(69),
+            oday='gxgecnsjvdahzalbbzhx',
+            jrn=int(99),
+            line=int(53),
+            start='yukftcqdnfjgfddgvfjz',
+            stop=int(42),
+            route='odhhfhpeinskspisyxrs',
+            occu=int(92),
+            seq=int(68),
+            label='cnuuggvgqtwnogtjbgpe',
+            spd=float(84.46931120688193),
+            hdg=int(27),
+            lat=float(9.77845714600678),
+            long=float(13.261928155771107),
+            acc=float(0.7470162683309134),
+            odo=int(56),
+            drst=int(79),
+            loc=None,
+            ttarr='xicuthqqlnsyzogzinih',
+            ttdep='zypscolonlpuvsicthju',
+            dr_type=int(73)
         )

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_driverblockevent.py
@@ -29,31 +29,31 @@ class Test_DriverBlockEvent(unittest.TestCase):
         Create instance of DriverBlockEvent for testing
         """
         instance = DriverBlockEvent(
-            oper=int(87),
-            veh=int(71),
-            tst='zrjrgkutfluoqmckhamy',
-            tsi=int(56),
-            operator_id='hhlosgcbszuwdchfjaiv',
-            vehicle_number='srrwpuigbzhkwysworpv',
+            oper=int(98),
+            veh=int(13),
+            tst='xdlmielttopjgbivoldg',
+            tsi=int(45),
+            operator_id='hvbygijnevnrvwhxaprz',
+            vehicle_number='kaclundisitdpccgmdxs',
             temporal_type=None,
             transport_mode=None,
-            route_id='urntecuebogsgyhqrcro',
-            direction_id='ekkiknbpiqgpuwfioexd',
-            headsign='gjwfddnrqwfrfwrjinec',
-            start_time='fqgyaowgebraxpobmlxb',
-            next_stop='xjwpngnwrijhpskdrxuy',
-            geohash_level='sxgfelakjgrqrysxioeg',
-            geohash='vnlwmubddicvroweetwe',
-            spd=float(85.41655963300046),
-            hdg=int(35),
-            lat=float(9.939962666912837),
-            long=float(54.598379794735486),
-            acc=float(36.91139308982455),
-            odo=int(70),
-            drst=int(37),
-            loc='cqaekffxcbhedtahttje',
-            oday='vjlkeecekpbkrpvenlbc',
-            dr_type=int(16)
+            route_id='kbvgnefqskolotjegmge',
+            direction_id='dstyczptxqxzcvsbmhpa',
+            headsign='mnkxyyfzkwydnzhfxvga',
+            start_time='mnjotngytltqmodyadyq',
+            next_stop='mpirbdpmhuiybjxziqcy',
+            geohash_level='amwxmvpslazcncrvqwgf',
+            geohash='htfxqbqgxzoppudsubos',
+            spd=float(44.953398368988275),
+            hdg=int(58),
+            lat=float(83.95743611768901),
+            long=float(21.60759560191129),
+            acc=float(66.20724106005734),
+            odo=int(5),
+            drst=int(25),
+            loc=None,
+            oday='eepmygoyfdbbytbvbwkb',
+            dr_type=int(70)
         )
         return instance
 
@@ -62,7 +62,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(87)
+        test_value = int(98)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -70,7 +70,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(71)
+        test_value = int(13)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -78,7 +78,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'zrjrgkutfluoqmckhamy'
+        test_value = 'xdlmielttopjgbivoldg'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -86,7 +86,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(56)
+        test_value = int(45)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -94,7 +94,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'hhlosgcbszuwdchfjaiv'
+        test_value = 'hvbygijnevnrvwhxaprz'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -102,7 +102,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'srrwpuigbzhkwysworpv'
+        test_value = 'kaclundisitdpccgmdxs'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -126,7 +126,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'urntecuebogsgyhqrcro'
+        test_value = 'kbvgnefqskolotjegmge'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -134,7 +134,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'ekkiknbpiqgpuwfioexd'
+        test_value = 'dstyczptxqxzcvsbmhpa'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -142,7 +142,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'gjwfddnrqwfrfwrjinec'
+        test_value = 'mnkxyyfzkwydnzhfxvga'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -150,7 +150,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'fqgyaowgebraxpobmlxb'
+        test_value = 'mnjotngytltqmodyadyq'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -158,7 +158,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'xjwpngnwrijhpskdrxuy'
+        test_value = 'mpirbdpmhuiybjxziqcy'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -166,7 +166,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'sxgfelakjgrqrysxioeg'
+        test_value = 'amwxmvpslazcncrvqwgf'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -174,7 +174,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'vnlwmubddicvroweetwe'
+        test_value = 'htfxqbqgxzoppudsubos'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -182,7 +182,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(85.41655963300046)
+        test_value = float(44.953398368988275)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -190,7 +190,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(35)
+        test_value = int(58)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -198,7 +198,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(9.939962666912837)
+        test_value = float(83.95743611768901)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -206,7 +206,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(54.598379794735486)
+        test_value = float(21.60759560191129)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -214,7 +214,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(36.91139308982455)
+        test_value = float(66.20724106005734)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -222,7 +222,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(70)
+        test_value = int(5)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -230,7 +230,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(37)
+        test_value = int(25)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -238,7 +238,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'cqaekffxcbhedtahttje'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -246,7 +246,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'vjlkeecekpbkrpvenlbc'
+        test_value = 'eepmygoyfdbbytbvbwkb'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -254,7 +254,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(16)
+        test_value = int(70)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_operator.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_operator.py
@@ -28,10 +28,10 @@ class Test_Operator(unittest.TestCase):
         Create instance of Operator for testing
         """
         instance = Operator(
-            operator_id='bqopgjqidbsjqwtbmdel',
-            operator_number=int(4),
-            name='gfywrzxrrgirpqhqjphr',
-            note='agkyjqhnjrkoyxonjlaj'
+            operator_id='noieokxfynmkkiihujeq',
+            operator_number=int(77),
+            name='vhaytjcadsxxyyyeypfh',
+            note='dkgnvjhvctiyneckxpvj'
         )
         return instance
 
@@ -40,7 +40,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'bqopgjqidbsjqwtbmdel'
+        test_value = 'noieokxfynmkkiihujeq'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -48,7 +48,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test operator_number property
         """
-        test_value = int(4)
+        test_value = int(77)
         self.instance.operator_number = test_value
         self.assertEqual(self.instance.operator_number, test_value)
     
@@ -56,7 +56,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test name property
         """
-        test_value = 'gfywrzxrrgirpqhqjphr'
+        test_value = 'vhaytjcadsxxyyyeypfh'
         self.instance.name = test_value
         self.assertEqual(self.instance.name, test_value)
     
@@ -64,7 +64,7 @@ class Test_Operator(unittest.TestCase):
         """
         Test note property
         """
-        test_value = 'agkyjqhnjrkoyxonjlaj'
+        test_value = 'dkgnvjhvctiyneckxpvj'
         self.instance.note = test_value
         self.assertEqual(self.instance.note, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_route.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_route.py
@@ -28,13 +28,13 @@ class Test_Route(unittest.TestCase):
         Create instance of Route for testing
         """
         instance = Route(
-            route_id='spnejztwxmicpuoyfbbn',
-            agency_id='smjmqibifkewcgwumigt',
-            route_short_name='byindjjokmzcjmxeqtao',
-            route_long_name='tlfdlbkhsbuwuxeepkkr',
-            route_desc='jidmittrvpnnfmyeyqmq',
-            route_type=int(18),
-            route_url='xptzhsazfbkvnjgabwdo'
+            route_id='bihshpwxnuixcatatqdl',
+            agency_id='myzpexopmvzmoeqptpqi',
+            route_short_name='yqvqxxncjijeohzacpjz',
+            route_long_name='xgxyvjneskphgsdbbuck',
+            route_desc='ijspdaqqcowqhhvcygvc',
+            route_type=int(40),
+            route_url='xflxnwhcupdtvojklirp'
         )
         return instance
 
@@ -43,7 +43,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'spnejztwxmicpuoyfbbn'
+        test_value = 'bihshpwxnuixcatatqdl'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -51,7 +51,7 @@ class Test_Route(unittest.TestCase):
         """
         Test agency_id property
         """
-        test_value = 'smjmqibifkewcgwumigt'
+        test_value = 'myzpexopmvzmoeqptpqi'
         self.instance.agency_id = test_value
         self.assertEqual(self.instance.agency_id, test_value)
     
@@ -59,7 +59,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_short_name property
         """
-        test_value = 'byindjjokmzcjmxeqtao'
+        test_value = 'yqvqxxncjijeohzacpjz'
         self.instance.route_short_name = test_value
         self.assertEqual(self.instance.route_short_name, test_value)
     
@@ -67,7 +67,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_long_name property
         """
-        test_value = 'tlfdlbkhsbuwuxeepkkr'
+        test_value = 'xgxyvjneskphgsdbbuck'
         self.instance.route_long_name = test_value
         self.assertEqual(self.instance.route_long_name, test_value)
     
@@ -75,7 +75,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_desc property
         """
-        test_value = 'jidmittrvpnnfmyeyqmq'
+        test_value = 'ijspdaqqcowqhhvcygvc'
         self.instance.route_desc = test_value
         self.assertEqual(self.instance.route_desc, test_value)
     
@@ -83,7 +83,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_type property
         """
-        test_value = int(18)
+        test_value = int(40)
         self.instance.route_type = test_value
         self.assertEqual(self.instance.route_type, test_value)
     
@@ -91,7 +91,7 @@ class Test_Route(unittest.TestCase):
         """
         Test route_url property
         """
-        test_value = 'xptzhsazfbkvnjgabwdo'
+        test_value = 'xflxnwhcupdtvojklirp'
         self.instance.route_url = test_value
         self.assertEqual(self.instance.route_url, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_stop.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_stop.py
@@ -28,20 +28,20 @@ class Test_Stop(unittest.TestCase):
         Create instance of Stop for testing
         """
         instance = Stop(
-            stop_id='cbmhldxkgdjjqyolmwxn',
-            stop_code='gamnpfzjjdfzyowxafdp',
-            stop_name='mrcynnprexdisgzsxozd',
-            stop_desc='nuibstpkkiraglcnchtk',
-            stop_lat=float(65.30091869929826),
-            stop_lon=float(36.9671982141103),
-            zone_id='zlusyxdpachfsnvroztx',
-            stop_url='fbiltojknvtofybkhidr',
-            location_type=int(44),
-            parent_station='shyuasdtkpzhqhejfjlu',
-            platform_code='ggponclamdcneqreovke',
-            wheelchair_boarding=int(10),
-            vehicle_type=int(16),
-            digistop_id='ygucxsbmadrynrzzceve'
+            stop_id='vebabzlduamvqznuyrju',
+            stop_code='ummddvuwkjobfixlsfqc',
+            stop_name='zkklwizrdsmokxdnwshz',
+            stop_desc='gtnnmxfnrcqggjvyzcnr',
+            stop_lat=float(90.35006150982657),
+            stop_lon=float(47.0964891294616),
+            zone_id='auvohksrlqljtclttzzh',
+            stop_url='xazpnhterjhqkqeogjnr',
+            location_type=int(39),
+            parent_station='thjsdjfassqvwhvudoby',
+            platform_code='rmtutvcsqndrqvoccbnv',
+            wheelchair_boarding=int(45),
+            vehicle_type=int(8),
+            digistop_id='zkcztzvkeozmpnjtwwiy'
         )
         return instance
 
@@ -50,7 +50,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_id property
         """
-        test_value = 'cbmhldxkgdjjqyolmwxn'
+        test_value = 'vebabzlduamvqznuyrju'
         self.instance.stop_id = test_value
         self.assertEqual(self.instance.stop_id, test_value)
     
@@ -58,7 +58,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_code property
         """
-        test_value = 'gamnpfzjjdfzyowxafdp'
+        test_value = 'ummddvuwkjobfixlsfqc'
         self.instance.stop_code = test_value
         self.assertEqual(self.instance.stop_code, test_value)
     
@@ -66,7 +66,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_name property
         """
-        test_value = 'mrcynnprexdisgzsxozd'
+        test_value = 'zkklwizrdsmokxdnwshz'
         self.instance.stop_name = test_value
         self.assertEqual(self.instance.stop_name, test_value)
     
@@ -74,7 +74,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_desc property
         """
-        test_value = 'nuibstpkkiraglcnchtk'
+        test_value = 'gtnnmxfnrcqggjvyzcnr'
         self.instance.stop_desc = test_value
         self.assertEqual(self.instance.stop_desc, test_value)
     
@@ -82,7 +82,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lat property
         """
-        test_value = float(65.30091869929826)
+        test_value = float(90.35006150982657)
         self.instance.stop_lat = test_value
         self.assertEqual(self.instance.stop_lat, test_value)
     
@@ -90,7 +90,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_lon property
         """
-        test_value = float(36.9671982141103)
+        test_value = float(47.0964891294616)
         self.instance.stop_lon = test_value
         self.assertEqual(self.instance.stop_lon, test_value)
     
@@ -98,7 +98,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test zone_id property
         """
-        test_value = 'zlusyxdpachfsnvroztx'
+        test_value = 'auvohksrlqljtclttzzh'
         self.instance.zone_id = test_value
         self.assertEqual(self.instance.zone_id, test_value)
     
@@ -106,7 +106,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test stop_url property
         """
-        test_value = 'fbiltojknvtofybkhidr'
+        test_value = 'xazpnhterjhqkqeogjnr'
         self.instance.stop_url = test_value
         self.assertEqual(self.instance.stop_url, test_value)
     
@@ -114,7 +114,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test location_type property
         """
-        test_value = int(44)
+        test_value = int(39)
         self.instance.location_type = test_value
         self.assertEqual(self.instance.location_type, test_value)
     
@@ -122,7 +122,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test parent_station property
         """
-        test_value = 'shyuasdtkpzhqhejfjlu'
+        test_value = 'thjsdjfassqvwhvudoby'
         self.instance.parent_station = test_value
         self.assertEqual(self.instance.parent_station, test_value)
     
@@ -130,7 +130,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test platform_code property
         """
-        test_value = 'ggponclamdcneqreovke'
+        test_value = 'rmtutvcsqndrqvoccbnv'
         self.instance.platform_code = test_value
         self.assertEqual(self.instance.platform_code, test_value)
     
@@ -138,7 +138,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test wheelchair_boarding property
         """
-        test_value = int(10)
+        test_value = int(45)
         self.instance.wheelchair_boarding = test_value
         self.assertEqual(self.instance.wheelchair_boarding, test_value)
     
@@ -146,7 +146,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test vehicle_type property
         """
-        test_value = int(16)
+        test_value = int(8)
         self.instance.vehicle_type = test_value
         self.assertEqual(self.instance.vehicle_type, test_value)
     
@@ -154,7 +154,7 @@ class Test_Stop(unittest.TestCase):
         """
         Test digistop_id property
         """
-        test_value = 'ygucxsbmadrynrzzceve'
+        test_value = 'zkcztzvkeozmpnjtwwiy'
         self.instance.digistop_id = test_value
         self.assertEqual(self.instance.digistop_id, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_trafficlightevent.py
@@ -29,52 +29,52 @@ class Test_TrafficLightEvent(unittest.TestCase):
         Create instance of TrafficLightEvent for testing
         """
         instance = TrafficLightEvent(
-            oper=int(49),
-            veh=int(98),
-            tst='rjgbsascrgmlumrrymdg',
-            tsi=int(62),
-            operator_id='kyezkfumrfgfpozfwkao',
-            vehicle_number='ufgdscpqozzrvviwawvo',
+            oper=int(73),
+            veh=int(80),
+            tst='ymmwfdhvsltiutynipmr',
+            tsi=int(59),
+            operator_id='wjwticmopuwlcmzqnvvs',
+            vehicle_number='qyhfdjzjfhkqfhfqhkfk',
             temporal_type=None,
             transport_mode=None,
-            route_id='vtrydtuvkmbznanoslrs',
-            direction_id='adgoeqxmxqdahoizamws',
-            headsign='ldlvivrdvcmeyitilpfh',
-            start_time='kltudoroqferxnpufhmv',
-            next_stop='jgxfspngauiliyoqogxc',
-            geohash_level='kfqvtoppjigavnqduqdx',
-            geohash='uzpefvkguogvisugwhff',
-            desi='uuftsojnkcfdaterwtsg',
-            dir='fhmoekqpikytigftygjd',
-            dl=int(57),
-            oday='dhlwpplwwjvrxnjumnqx',
-            jrn=int(48),
-            line=int(5),
-            start='ffuemzucndazjhnlhelb',
-            stop=int(49),
-            route='rmbrygccvpqlzhmgxbey',
-            occu=int(70),
-            spd=float(32.193923080201834),
-            hdg=int(62),
-            lat=float(52.11533703502692),
-            long=float(12.055115798888883),
-            acc=float(14.565083784820665),
-            odo=int(61),
-            drst=int(43),
-            loc='ktagmsldsvxrsatcmwei',
-            tlp_requestid=int(17),
+            route_id='oevqejfnihnhivtunppl',
+            direction_id='bisqsximazsegiyclnth',
+            headsign='kvadhdphpxyabqdtjvwu',
+            start_time='oeivyavxkossvrvwqmjr',
+            next_stop='wfnqrpmvnrqvkpvaizph',
+            geohash_level='ayzgerucjthvslzlljos',
+            geohash='elngpzqjpfjuwtybgoxu',
+            desi='oxogazihnumrbskzvrtd',
+            dir=None,
+            dl=int(15),
+            oday='xaucasvverhxzuyfqjed',
+            jrn=int(79),
+            line=int(62),
+            start='tdyuphwreznmavuxfvcq',
+            stop=int(87),
+            route='fgmhdwpaeucqgxsfkapo',
+            occu=int(14),
+            spd=float(44.036625108439765),
+            hdg=int(58),
+            lat=float(98.9524966578608),
+            long=float(40.21201616838154),
+            acc=float(36.05886398084134),
+            odo=int(98),
+            drst=int(53),
+            loc=None,
+            tlp_requestid=int(37),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(63),
+            tlp_att_seq=int(2),
             tlp_decision=None,
-            sid=int(59),
-            signal_groupid=int(2),
-            tlp_signalgroupnbr=int(65),
-            tlp_line_configid=int(30),
-            tlp_point_configid=int(85),
-            tlp_frequency=int(88),
-            tlp_protocol='cqnjfvbomdmmflciwsul'
+            sid=int(51),
+            signal_groupid=int(95),
+            tlp_signalgroupnbr=int(96),
+            tlp_line_configid=int(65),
+            tlp_point_configid=int(23),
+            tlp_frequency=int(64),
+            tlp_protocol=None
         )
         return instance
 
@@ -83,7 +83,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(49)
+        test_value = int(73)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -91,7 +91,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(98)
+        test_value = int(80)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -99,7 +99,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'rjgbsascrgmlumrrymdg'
+        test_value = 'ymmwfdhvsltiutynipmr'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -107,7 +107,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(62)
+        test_value = int(59)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -115,7 +115,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'kyezkfumrfgfpozfwkao'
+        test_value = 'wjwticmopuwlcmzqnvvs'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -123,7 +123,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'ufgdscpqozzrvviwawvo'
+        test_value = 'qyhfdjzjfhkqfhfqhkfk'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -147,7 +147,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'vtrydtuvkmbznanoslrs'
+        test_value = 'oevqejfnihnhivtunppl'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'adgoeqxmxqdahoizamws'
+        test_value = 'bisqsximazsegiyclnth'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -163,7 +163,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'ldlvivrdvcmeyitilpfh'
+        test_value = 'kvadhdphpxyabqdtjvwu'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -171,7 +171,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'kltudoroqferxnpufhmv'
+        test_value = 'oeivyavxkossvrvwqmjr'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -179,7 +179,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'jgxfspngauiliyoqogxc'
+        test_value = 'wfnqrpmvnrqvkpvaizph'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -187,7 +187,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'kfqvtoppjigavnqduqdx'
+        test_value = 'ayzgerucjthvslzlljos'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -195,7 +195,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'uzpefvkguogvisugwhff'
+        test_value = 'elngpzqjpfjuwtybgoxu'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -203,7 +203,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'uuftsojnkcfdaterwtsg'
+        test_value = 'oxogazihnumrbskzvrtd'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -211,7 +211,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'fhmoekqpikytigftygjd'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -219,7 +219,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(57)
+        test_value = int(15)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -227,7 +227,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'dhlwpplwwjvrxnjumnqx'
+        test_value = 'xaucasvverhxzuyfqjed'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -235,7 +235,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(48)
+        test_value = int(79)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -243,7 +243,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(5)
+        test_value = int(62)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -251,7 +251,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'ffuemzucndazjhnlhelb'
+        test_value = 'tdyuphwreznmavuxfvcq'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -259,7 +259,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(49)
+        test_value = int(87)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -267,7 +267,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'rmbrygccvpqlzhmgxbey'
+        test_value = 'fgmhdwpaeucqgxsfkapo'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -275,7 +275,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(70)
+        test_value = int(14)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -283,7 +283,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(32.193923080201834)
+        test_value = float(44.036625108439765)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -291,7 +291,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(62)
+        test_value = int(58)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -299,7 +299,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(52.11533703502692)
+        test_value = float(98.9524966578608)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -307,7 +307,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(12.055115798888883)
+        test_value = float(40.21201616838154)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -315,7 +315,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(14.565083784820665)
+        test_value = float(36.05886398084134)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -323,7 +323,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(61)
+        test_value = int(98)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -331,7 +331,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(43)
+        test_value = int(53)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -339,7 +339,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'ktagmsldsvxrsatcmwei'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -347,7 +347,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_requestid property
         """
-        test_value = int(17)
+        test_value = int(37)
         self.instance.tlp_requestid = test_value
         self.assertEqual(self.instance.tlp_requestid, test_value)
     
@@ -379,7 +379,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_att_seq property
         """
-        test_value = int(63)
+        test_value = int(2)
         self.instance.tlp_att_seq = test_value
         self.assertEqual(self.instance.tlp_att_seq, test_value)
     
@@ -395,7 +395,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test sid property
         """
-        test_value = int(59)
+        test_value = int(51)
         self.instance.sid = test_value
         self.assertEqual(self.instance.sid, test_value)
     
@@ -403,7 +403,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test signal_groupid property
         """
-        test_value = int(2)
+        test_value = int(95)
         self.instance.signal_groupid = test_value
         self.assertEqual(self.instance.signal_groupid, test_value)
     
@@ -411,7 +411,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_signalgroupnbr property
         """
-        test_value = int(65)
+        test_value = int(96)
         self.instance.tlp_signalgroupnbr = test_value
         self.assertEqual(self.instance.tlp_signalgroupnbr, test_value)
     
@@ -419,7 +419,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_line_configid property
         """
-        test_value = int(30)
+        test_value = int(65)
         self.instance.tlp_line_configid = test_value
         self.assertEqual(self.instance.tlp_line_configid, test_value)
     
@@ -427,7 +427,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_point_configid property
         """
-        test_value = int(85)
+        test_value = int(23)
         self.instance.tlp_point_configid = test_value
         self.assertEqual(self.instance.tlp_point_configid, test_value)
     
@@ -435,7 +435,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_frequency property
         """
-        test_value = int(88)
+        test_value = int(64)
         self.instance.tlp_frequency = test_value
         self.assertEqual(self.instance.tlp_frequency, test_value)
     
@@ -443,7 +443,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_protocol property
         """
-        test_value = 'cqnjfvbomdmmflciwsul'
+        test_value = None
         self.instance.tlp_protocol = test_value
         self.assertEqual(self.instance.tlp_protocol, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_producer/hsl_hfp_producer_data/tests/test_vehicleevent.py
@@ -29,44 +29,44 @@ class Test_VehicleEvent(unittest.TestCase):
         Create instance of VehicleEvent for testing
         """
         instance = VehicleEvent(
-            oper=int(55),
-            veh=int(2),
-            tst='aphcqwvsjioyivtpjixa',
-            tsi=int(73),
-            operator_id='zswecbkxqnejtmqodxbc',
-            vehicle_number='ybfbmpkjelfmpwqscdss',
+            oper=int(95),
+            veh=int(92),
+            tst='lpdsonholrfpzvchmgtd',
+            tsi=int(34),
+            operator_id='alustcyuisnjdowrqatr',
+            vehicle_number='sxftsdtgntrgzaprjrxq',
             temporal_type=None,
             transport_mode=None,
-            route_id='wclkpceqhxohiacmayfx',
-            direction_id='mtcvkpqcpgcloxmajiec',
-            headsign='jpytqbmivkbnhprelkbo',
-            start_time='fffoaimexynjusoqxqmu',
-            next_stop='bydqiphgxbmbnhrhxhhm',
-            geohash_level='xmjqdbosgnihzljfuthl',
-            geohash='azrftcpblcxursxfaufz',
-            desi='djyowwiewnnqeiyqcfqr',
-            dir='ctnjrmomaabupfvxmhqe',
-            dl=int(41),
-            oday='mgwbwtdtlqhmcizcthoq',
-            jrn=int(44),
-            line=int(25),
-            start='bhwtutavpblmcmapeout',
-            stop=int(98),
-            route='ylqdcybvbyliagqxikvg',
-            occu=int(8),
-            seq=int(70),
-            label='cnypugwtctethoqfqctv',
-            spd=float(51.608450576349085),
-            hdg=int(53),
-            lat=float(51.04182146948949),
-            long=float(63.048533903029444),
-            acc=float(75.49006538207271),
-            odo=int(63),
-            drst=int(63),
-            loc='wkxmdyclrvryixqmsbhk',
-            ttarr='pibxijnvjdasslzlqibi',
-            ttdep='yirrziafnwzjkuhxmwqg',
-            dr_type=int(85)
+            route_id='akqhqcrnxtdsxmxpqdsv',
+            direction_id='icvgwfmwzckjocvngjen',
+            headsign='cegygrtdsqohuwqrodgp',
+            start_time='ukcszynkcwkpsunyfhrs',
+            next_stop='refbvtouohjjjcaqmcab',
+            geohash_level='nxaujhkarhfykknnwzko',
+            geohash='twzhwnqxlmdvxutqtbpv',
+            desi='mkrijhcqyvwvharbinbp',
+            dir=None,
+            dl=int(69),
+            oday='gxgecnsjvdahzalbbzhx',
+            jrn=int(99),
+            line=int(53),
+            start='yukftcqdnfjgfddgvfjz',
+            stop=int(42),
+            route='odhhfhpeinskspisyxrs',
+            occu=int(92),
+            seq=int(68),
+            label='cnuuggvgqtwnogtjbgpe',
+            spd=float(84.46931120688193),
+            hdg=int(27),
+            lat=float(9.77845714600678),
+            long=float(13.261928155771107),
+            acc=float(0.7470162683309134),
+            odo=int(56),
+            drst=int(79),
+            loc=None,
+            ttarr='xicuthqqlnsyzogzinih',
+            ttdep='zypscolonlpuvsicthju',
+            dr_type=int(73)
         )
         return instance
 
@@ -75,7 +75,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(55)
+        test_value = int(95)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -83,7 +83,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(2)
+        test_value = int(92)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -91,7 +91,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'aphcqwvsjioyivtpjixa'
+        test_value = 'lpdsonholrfpzvchmgtd'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -99,7 +99,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(73)
+        test_value = int(34)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -107,7 +107,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'zswecbkxqnejtmqodxbc'
+        test_value = 'alustcyuisnjdowrqatr'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'ybfbmpkjelfmpwqscdss'
+        test_value = 'sxftsdtgntrgzaprjrxq'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -139,7 +139,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'wclkpceqhxohiacmayfx'
+        test_value = 'akqhqcrnxtdsxmxpqdsv'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -147,7 +147,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'mtcvkpqcpgcloxmajiec'
+        test_value = 'icvgwfmwzckjocvngjen'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'jpytqbmivkbnhprelkbo'
+        test_value = 'cegygrtdsqohuwqrodgp'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -163,7 +163,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'fffoaimexynjusoqxqmu'
+        test_value = 'ukcszynkcwkpsunyfhrs'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -171,7 +171,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'bydqiphgxbmbnhrhxhhm'
+        test_value = 'refbvtouohjjjcaqmcab'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -179,7 +179,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'xmjqdbosgnihzljfuthl'
+        test_value = 'nxaujhkarhfykknnwzko'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -187,7 +187,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'azrftcpblcxursxfaufz'
+        test_value = 'twzhwnqxlmdvxutqtbpv'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -195,7 +195,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'djyowwiewnnqeiyqcfqr'
+        test_value = 'mkrijhcqyvwvharbinbp'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -203,7 +203,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'ctnjrmomaabupfvxmhqe'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -211,7 +211,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(41)
+        test_value = int(69)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -219,7 +219,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'mgwbwtdtlqhmcizcthoq'
+        test_value = 'gxgecnsjvdahzalbbzhx'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -227,7 +227,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(44)
+        test_value = int(99)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -235,7 +235,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(25)
+        test_value = int(53)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -243,7 +243,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'bhwtutavpblmcmapeout'
+        test_value = 'yukftcqdnfjgfddgvfjz'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -251,7 +251,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(98)
+        test_value = int(42)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -259,7 +259,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'ylqdcybvbyliagqxikvg'
+        test_value = 'odhhfhpeinskspisyxrs'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -267,7 +267,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(8)
+        test_value = int(92)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -275,7 +275,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test seq property
         """
-        test_value = int(70)
+        test_value = int(68)
         self.instance.seq = test_value
         self.assertEqual(self.instance.seq, test_value)
     
@@ -283,7 +283,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test label property
         """
-        test_value = 'cnypugwtctethoqfqctv'
+        test_value = 'cnuuggvgqtwnogtjbgpe'
         self.instance.label = test_value
         self.assertEqual(self.instance.label, test_value)
     
@@ -291,7 +291,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(51.608450576349085)
+        test_value = float(84.46931120688193)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -299,7 +299,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(53)
+        test_value = int(27)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -307,7 +307,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(51.04182146948949)
+        test_value = float(9.77845714600678)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -315,7 +315,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(63.048533903029444)
+        test_value = float(13.261928155771107)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -323,7 +323,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(75.49006538207271)
+        test_value = float(0.7470162683309134)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -331,7 +331,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(63)
+        test_value = int(56)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -339,7 +339,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(63)
+        test_value = int(79)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -347,7 +347,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'wkxmdyclrvryixqmsbhk'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -355,7 +355,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttarr property
         """
-        test_value = 'pibxijnvjdasslzlqibi'
+        test_value = 'xicuthqqlnsyzogzinih'
         self.instance.ttarr = test_value
         self.assertEqual(self.instance.ttarr, test_value)
     
@@ -363,7 +363,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttdep property
         """
-        test_value = 'yirrziafnwzjkuhxmwqg'
+        test_value = 'zypscolonlpuvsicthju'
         self.instance.ttdep = test_value
         self.assertEqual(self.instance.ttdep, test_value)
     
@@ -371,7 +371,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(85)
+        test_value = int(73)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/__init__.py
@@ -1,3 +1,3 @@
-from .fi import VehicleEvent, TemporalTypeEnum, TransportModeEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DriverBlockEvent
+from .fi import VehicleEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, DirEnum, DriverBlockEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TlpProtocolEnum
 
-__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DriverBlockEvent"]
+__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "DriverBlockEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TlpProtocolEnum"]

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/__init__.py
@@ -1,3 +1,3 @@
-from .hsl import VehicleEvent, TemporalTypeEnum, TransportModeEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DriverBlockEvent
+from .hsl import VehicleEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, DirEnum, DriverBlockEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TlpProtocolEnum
 
-__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DriverBlockEvent"]
+__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "DriverBlockEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TlpProtocolEnum"]

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/__init__.py
@@ -1,3 +1,3 @@
-from .hfp import VehicleEvent, TemporalTypeEnum, TransportModeEnum, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, DriverBlockEvent
+from .hfp import VehicleEvent, TemporalTypeEnum, TransportModeEnum, LocEnum, DirEnum, DriverBlockEvent, TrafficLightEvent, TlpDecisionEnum, TlpPriorityLevelEnum, TlpReasonEnum, TlpRequestTypeEnum, TlpProtocolEnum
 
-__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DriverBlockEvent"]
+__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "DriverBlockEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TlpProtocolEnum"]

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/__init__.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/__init__.py
@@ -1,11 +1,14 @@
 from .vehicleevent import VehicleEvent
 from .temporaltypeenum import TemporalTypeEnum
 from .transportmodeenum import TransportModeEnum
+from .locenum import LocEnum
+from .direnum import DirEnum
+from .driverblockevent import DriverBlockEvent
 from .trafficlightevent import TrafficLightEvent
 from .tlpdecisionenum import TlpDecisionEnum
 from .tlpprioritylevelenum import TlpPriorityLevelEnum
 from .tlpreasonenum import TlpReasonEnum
 from .tlprequesttypeenum import TlpRequestTypeEnum
-from .driverblockevent import DriverBlockEvent
+from .tlpprotocolenum import TlpProtocolEnum
 
-__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "DriverBlockEvent"]
+__all__ = ["VehicleEvent", "TemporalTypeEnum", "TransportModeEnum", "LocEnum", "DirEnum", "DriverBlockEvent", "TrafficLightEvent", "TlpDecisionEnum", "TlpPriorityLevelEnum", "TlpReasonEnum", "TlpRequestTypeEnum", "TlpProtocolEnum"]

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/direnum.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/direnum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class DirEnum(Enum):
     """
-    Route direction of the trip as a string, either `1` or `2`. Relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`).
+    Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim.
     """
     VALUE_1 = '1'
     VALUE_2 = '2'

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/driverblockevent.py
@@ -43,7 +43,7 @@ class DriverBlockEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         oday (typing.Optional[str])
         dr_type (typing.Optional[int])
     """
@@ -71,7 +71,7 @@ class DriverBlockEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
 
@@ -208,29 +208,29 @@ class DriverBlockEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(12),
-            veh=int(20),
-            tst='sjqntobsiqkrraledupo',
-            tsi=int(26),
-            operator_id='xhexcgspvrbvyqqmsxvn',
-            vehicle_number='utspzwfvszlmzeskwtwo',
+            oper=int(77),
+            veh=int(17),
+            tst='ttukfzkpknqfoszfzfbo',
+            tsi=int(73),
+            operator_id='bjdivkdffexphpmtyprt',
+            vehicle_number='ievkwljpkryunofeamaw',
             temporal_type=None,
             transport_mode=None,
-            route_id='thckzndzaduczsrbdmcx',
-            direction_id='zsbkrvyethqfpccemfzp',
-            headsign='jyhkkcohwikccrhxhoqb',
-            start_time='nninswuajghfgablfxpl',
-            next_stop='mtjuofeyhrgshcfbifvv',
-            geohash_level='ohyfsngtojivtavxfcpg',
-            geohash='uhasjzhglxgmbumfwjyp',
-            spd=float(35.740713143007554),
-            hdg=int(51),
-            lat=float(16.743472321379393),
-            long=float(68.79004944008929),
-            acc=float(1.921939114250304),
-            odo=int(66),
-            drst=int(44),
-            loc='veopohaqlfmdotbhlwdu',
-            oday='gpatndalxqqwuhphxvxs',
-            dr_type=int(8)
+            route_id='fqxgqcrmnupumfhnznmd',
+            direction_id='shgqmswkneslpynfurzn',
+            headsign='lttauhnfcxpsyzypmkwz',
+            start_time='wyoxlgrspwovgtzzmrdh',
+            next_stop='junwqtaexidbsltxkkjp',
+            geohash_level='hejotfvlzntiuvplzcob',
+            geohash='mipjvgopteefyofbyrxf',
+            spd=float(28.469370047938447),
+            hdg=int(7),
+            lat=float(34.63221356963327),
+            long=float(17.287706515652935),
+            acc=float(45.28150973729392),
+            odo=int(45),
+            drst=int(47),
+            loc=None,
+            oday='wgvsmgxhhgslzxprwnce',
+            dr_type=int(60)
         )

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/locenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/locenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class LocEnum(Enum):
     """
-    Source of the reported vehicle location: `GPS` satellite fix; `ODO` computed from the odometer; `MAN` manually set; `DR` dead reckoning (used in tunnels and other GPS-denied locations); `N/A` location unavailable. From the HFP payload `loc` field.
+    Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim.
     """
     GPS = 'GPS'
     ODO = 'ODO'

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/tlpprotocolenum.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/tlpprotocolenum.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class TlpProtocolEnum(Enum):
     """
-    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. From the HFP payload `tlp-protocol` field.
+    Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. Populated on `tlr`. From the HFP payload `tlp-protocol` field. The `-` in `KAR-MQTT` is sanitized to the Avro symbol `KAR_MQTT` while the JSON wire value `KAR-MQTT` is preserved verbatim.
     """
     MQTT = 'MQTT'
     KAR_MINUSMQTT = 'KAR-MQTT'

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/trafficlightevent.py
@@ -37,7 +37,7 @@ class TrafficLightEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -53,7 +53,7 @@ class TrafficLightEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         tlp_requestid (typing.Optional[int])
         tlp_requesttype (typing.Optional[Any])
         tlp_prioritylevel (typing.Optional[Any])
@@ -66,7 +66,7 @@ class TrafficLightEvent:
         tlp_line_configid (typing.Optional[int])
         tlp_point_configid (typing.Optional[int])
         tlp_frequency (typing.Optional[int])
-        tlp_protocol (typing.Optional[str])
+        tlp_protocol (typing.Optional[Any])
     """
     
     
@@ -86,7 +86,7 @@ class TrafficLightEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -102,7 +102,7 @@ class TrafficLightEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     tlp_requestid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requestid"))
     tlp_requesttype: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-requesttype"))
     tlp_prioritylevel: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-prioritylevel"))
@@ -115,7 +115,7 @@ class TrafficLightEvent:
     tlp_line_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-line-configid"))
     tlp_point_configid: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-point-configid"))
     tlp_frequency: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-frequency"))
-    tlp_protocol: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
+    tlp_protocol: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="tlp-protocol"))
 
     @classmethod
     def from_serializer_dict(cls, data: dict) -> 'TrafficLightEvent':
@@ -316,50 +316,50 @@ class TrafficLightEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(54),
-            veh=int(25),
-            tst='xzbqtpagrlirwjrtcqei',
-            tsi=int(43),
-            operator_id='zcybwxxxraltvadhuyak',
-            vehicle_number='bnzncdyusqbadxdlvfta',
+            oper=int(59),
+            veh=int(75),
+            tst='jlkchsmtkorispwkbkzf',
+            tsi=int(81),
+            operator_id='btnxjrfhywtjatmlfuxm',
+            vehicle_number='epxidepxlkrdbdqnvrec',
             temporal_type=None,
             transport_mode=None,
-            route_id='kktgvzmkhlnhsojpixfh',
-            direction_id='meeixdnvtsripzjfhpji',
-            headsign='cogwhriemnaeosoraypb',
-            start_time='cvpupblnkfbfqjsiiuxy',
-            next_stop='lpkrrhzzzoyvhmsfsjir',
-            geohash_level='loxicokqrsjecgzombue',
-            geohash='mwcibkljyykjbiycrdzw',
-            desi='rwqadmotvdsvozroukvy',
-            dir='swedonbqgjlxxuazsfxm',
-            dl=int(18),
-            oday='knzgmzkrbejpjxooykzm',
-            jrn=int(100),
-            line=int(21),
-            start='aqenyxdlznicdjwhwdnq',
-            stop=int(64),
-            route='cxgmfkyphbstchgkesjd',
-            occu=int(15),
-            spd=float(34.29556906791774),
-            hdg=int(5),
-            lat=float(93.02438270198405),
-            long=float(48.976929245591926),
-            acc=float(36.25765489298838),
-            odo=int(52),
-            drst=int(21),
-            loc='mfgjieahbupwgbfjfuro',
-            tlp_requestid=int(30),
+            route_id='hpqpuyrihmwfddkscyin',
+            direction_id='xlgozpmyzanfsnjywvru',
+            headsign='tlzrhqzyaqtizwfotutp',
+            start_time='dgrvchwlhhmkhlmyqyls',
+            next_stop='kbwplwzsrxvavevdixfj',
+            geohash_level='yqhifvteovjfwlythjqa',
+            geohash='clbtkdwgsaxjjucgador',
+            desi='kvsifumqmuxfpcgdokdx',
+            dir=None,
+            dl=int(22),
+            oday='vmsulywssjtgedjapnia',
+            jrn=int(98),
+            line=int(91),
+            start='cekszfljtvaadvlbtcki',
+            stop=int(80),
+            route='oxaxeqgiuxsqgypqqcsf',
+            occu=int(45),
+            spd=float(60.90200433551247),
+            hdg=int(9),
+            lat=float(3.2312184361246166),
+            long=float(19.662095641159084),
+            acc=float(87.36432246646292),
+            odo=int(10),
+            drst=int(97),
+            loc=None,
+            tlp_requestid=int(1),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(52),
+            tlp_att_seq=int(64),
             tlp_decision=None,
-            sid=int(10),
-            signal_groupid=int(36),
-            tlp_signalgroupnbr=int(16),
-            tlp_line_configid=int(25),
-            tlp_point_configid=int(31),
-            tlp_frequency=int(36),
-            tlp_protocol='pvfmtbslfvwleiwfxywt'
+            sid=int(75),
+            signal_groupid=int(41),
+            tlp_signalgroupnbr=int(63),
+            tlp_line_configid=int(79),
+            tlp_point_configid=int(9),
+            tlp_frequency=int(20),
+            tlp_protocol=None
         )

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/src/hsl_hfp_upstream_data/fi/hsl/hfp/vehicleevent.py
@@ -37,7 +37,7 @@ class VehicleEvent:
         geohash_level (typing.Optional[str])
         geohash (typing.Optional[str])
         desi (typing.Optional[str])
-        dir (typing.Optional[str])
+        dir (typing.Optional[Any])
         dl (typing.Optional[int])
         oday (typing.Optional[str])
         jrn (typing.Optional[int])
@@ -55,7 +55,7 @@ class VehicleEvent:
         acc (typing.Optional[float])
         odo (typing.Optional[int])
         drst (typing.Optional[int])
-        loc (typing.Optional[str])
+        loc (typing.Optional[Any])
         ttarr (typing.Optional[str])
         ttdep (typing.Optional[str])
         dr_type (typing.Optional[int])
@@ -78,7 +78,7 @@ class VehicleEvent:
     geohash_level: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash_level"))
     geohash: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="geohash"))
     desi: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="desi"))
-    dir: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
+    dir: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dir"))
     dl: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dl"))
     oday: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="oday"))
     jrn: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="jrn"))
@@ -96,7 +96,7 @@ class VehicleEvent:
     acc: typing.Optional[float]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="acc"))
     odo: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="odo"))
     drst: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="drst"))
-    loc: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
+    loc: typing.Optional[Any]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="loc"))
     ttarr: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttarr"))
     ttdep: typing.Optional[str]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="ttdep"))
     dr_type: typing.Optional[int]=dataclasses.field(kw_only=True, metadata=dataclasses_json.config(field_name="dr-type"))
@@ -234,42 +234,42 @@ class VehicleEvent:
             An instance of the dataclass.
         """
         return cls(
-            oper=int(50),
-            veh=int(74),
-            tst='itkvjrgcnthmgzrkzlcx',
-            tsi=int(75),
-            operator_id='urxgkxqpnadxwsfqbkjp',
-            vehicle_number='vszbgzyowigvorcdlxba',
+            oper=int(42),
+            veh=int(50),
+            tst='nvakfnvxjwtdcibakdak',
+            tsi=int(100),
+            operator_id='jmgrttiwftruvbtlvsab',
+            vehicle_number='lzcohivskxghczvmssua',
             temporal_type=None,
             transport_mode=None,
-            route_id='lheoyvqlgeqnrlngnqkh',
-            direction_id='llzikxxheutusjtebfmu',
-            headsign='saoljrydixyrgffpgpnl',
-            start_time='fbapiwqwekpmjhlvddjs',
-            next_stop='fawtksmeuwmxgonazakg',
-            geohash_level='jmkccdroxiaanbcorfsq',
-            geohash='kleuoplvyhbsglazwjgq',
-            desi='pjcvwofnehyrftwzfaxy',
-            dir='roohpapyaihiwliwxuzr',
-            dl=int(61),
-            oday='evwvlrigkovfhefawvzv',
-            jrn=int(92),
-            line=int(80),
-            start='huonzmkucwtuszpwsoyx',
-            stop=int(33),
-            route='rscbkeeznjuaebbjdoxu',
-            occu=int(68),
-            seq=int(45),
-            label='bzkwfpjxfwdqjabnmgcf',
-            spd=float(41.75429008609826),
-            hdg=int(71),
-            lat=float(80.74093905402421),
-            long=float(19.685298914832728),
-            acc=float(91.80676181448422),
-            odo=int(46),
-            drst=int(44),
-            loc='weogrbxsbpioriuqydvd',
-            ttarr='ujvajrzqlxkouapqjreu',
-            ttdep='knotdlrysfbvnqtvydyj',
-            dr_type=int(64)
+            route_id='folmzrlgemsocfyrmtdx',
+            direction_id='oabjbroqughcgylmcimd',
+            headsign='txiixjvxpgqcfehkyzji',
+            start_time='lwhzxrjrehkoktwxxexo',
+            next_stop='mjwoktvbydnbpstfvzle',
+            geohash_level='exijuzpjckuepookxtph',
+            geohash='fhceozkhgspipobdpwxp',
+            desi='bsrbwcsdtyahessyufjo',
+            dir=None,
+            dl=int(33),
+            oday='xegcvplosiqhcfflouwb',
+            jrn=int(2),
+            line=int(60),
+            start='fbnrnoyjgrvhlrzkpqvo',
+            stop=int(20),
+            route='pktrqdtarfevpokgmrlt',
+            occu=int(95),
+            seq=int(58),
+            label='kpbwvxkmbjsgjhwoclff',
+            spd=float(55.34316544760184),
+            hdg=int(21),
+            lat=float(69.31685460398666),
+            long=float(83.77805587004522),
+            acc=float(86.92633894982635),
+            odo=int(2),
+            drst=int(92),
+            loc=None,
+            ttarr='cdvzhwxuibnmitvfyycz',
+            ttdep='lkthwppadixddpaucejd',
+            dr_type=int(0)
         )

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_driverblockevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_driverblockevent.py
@@ -29,31 +29,31 @@ class Test_DriverBlockEvent(unittest.TestCase):
         Create instance of DriverBlockEvent for testing
         """
         instance = DriverBlockEvent(
-            oper=int(12),
-            veh=int(20),
-            tst='sjqntobsiqkrraledupo',
-            tsi=int(26),
-            operator_id='xhexcgspvrbvyqqmsxvn',
-            vehicle_number='utspzwfvszlmzeskwtwo',
+            oper=int(77),
+            veh=int(17),
+            tst='ttukfzkpknqfoszfzfbo',
+            tsi=int(73),
+            operator_id='bjdivkdffexphpmtyprt',
+            vehicle_number='ievkwljpkryunofeamaw',
             temporal_type=None,
             transport_mode=None,
-            route_id='thckzndzaduczsrbdmcx',
-            direction_id='zsbkrvyethqfpccemfzp',
-            headsign='jyhkkcohwikccrhxhoqb',
-            start_time='nninswuajghfgablfxpl',
-            next_stop='mtjuofeyhrgshcfbifvv',
-            geohash_level='ohyfsngtojivtavxfcpg',
-            geohash='uhasjzhglxgmbumfwjyp',
-            spd=float(35.740713143007554),
-            hdg=int(51),
-            lat=float(16.743472321379393),
-            long=float(68.79004944008929),
-            acc=float(1.921939114250304),
-            odo=int(66),
-            drst=int(44),
-            loc='veopohaqlfmdotbhlwdu',
-            oday='gpatndalxqqwuhphxvxs',
-            dr_type=int(8)
+            route_id='fqxgqcrmnupumfhnznmd',
+            direction_id='shgqmswkneslpynfurzn',
+            headsign='lttauhnfcxpsyzypmkwz',
+            start_time='wyoxlgrspwovgtzzmrdh',
+            next_stop='junwqtaexidbsltxkkjp',
+            geohash_level='hejotfvlzntiuvplzcob',
+            geohash='mipjvgopteefyofbyrxf',
+            spd=float(28.469370047938447),
+            hdg=int(7),
+            lat=float(34.63221356963327),
+            long=float(17.287706515652935),
+            acc=float(45.28150973729392),
+            odo=int(45),
+            drst=int(47),
+            loc=None,
+            oday='wgvsmgxhhgslzxprwnce',
+            dr_type=int(60)
         )
         return instance
 
@@ -62,7 +62,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(12)
+        test_value = int(77)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -70,7 +70,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(20)
+        test_value = int(17)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -78,7 +78,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'sjqntobsiqkrraledupo'
+        test_value = 'ttukfzkpknqfoszfzfbo'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -86,7 +86,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(26)
+        test_value = int(73)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -94,7 +94,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'xhexcgspvrbvyqqmsxvn'
+        test_value = 'bjdivkdffexphpmtyprt'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -102,7 +102,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'utspzwfvszlmzeskwtwo'
+        test_value = 'ievkwljpkryunofeamaw'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -126,7 +126,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'thckzndzaduczsrbdmcx'
+        test_value = 'fqxgqcrmnupumfhnznmd'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -134,7 +134,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'zsbkrvyethqfpccemfzp'
+        test_value = 'shgqmswkneslpynfurzn'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -142,7 +142,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'jyhkkcohwikccrhxhoqb'
+        test_value = 'lttauhnfcxpsyzypmkwz'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -150,7 +150,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'nninswuajghfgablfxpl'
+        test_value = 'wyoxlgrspwovgtzzmrdh'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -158,7 +158,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'mtjuofeyhrgshcfbifvv'
+        test_value = 'junwqtaexidbsltxkkjp'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -166,7 +166,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'ohyfsngtojivtavxfcpg'
+        test_value = 'hejotfvlzntiuvplzcob'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -174,7 +174,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'uhasjzhglxgmbumfwjyp'
+        test_value = 'mipjvgopteefyofbyrxf'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -182,7 +182,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(35.740713143007554)
+        test_value = float(28.469370047938447)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -190,7 +190,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(51)
+        test_value = int(7)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -198,7 +198,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(16.743472321379393)
+        test_value = float(34.63221356963327)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -206,7 +206,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(68.79004944008929)
+        test_value = float(17.287706515652935)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -214,7 +214,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(1.921939114250304)
+        test_value = float(45.28150973729392)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -222,7 +222,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(66)
+        test_value = int(45)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -230,7 +230,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(44)
+        test_value = int(47)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -238,7 +238,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'veopohaqlfmdotbhlwdu'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -246,7 +246,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'gpatndalxqqwuhphxvxs'
+        test_value = 'wgvsmgxhhgslzxprwnce'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -254,7 +254,7 @@ class Test_DriverBlockEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(8)
+        test_value = int(60)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_trafficlightevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_trafficlightevent.py
@@ -29,52 +29,52 @@ class Test_TrafficLightEvent(unittest.TestCase):
         Create instance of TrafficLightEvent for testing
         """
         instance = TrafficLightEvent(
-            oper=int(54),
-            veh=int(25),
-            tst='xzbqtpagrlirwjrtcqei',
-            tsi=int(43),
-            operator_id='zcybwxxxraltvadhuyak',
-            vehicle_number='bnzncdyusqbadxdlvfta',
+            oper=int(59),
+            veh=int(75),
+            tst='jlkchsmtkorispwkbkzf',
+            tsi=int(81),
+            operator_id='btnxjrfhywtjatmlfuxm',
+            vehicle_number='epxidepxlkrdbdqnvrec',
             temporal_type=None,
             transport_mode=None,
-            route_id='kktgvzmkhlnhsojpixfh',
-            direction_id='meeixdnvtsripzjfhpji',
-            headsign='cogwhriemnaeosoraypb',
-            start_time='cvpupblnkfbfqjsiiuxy',
-            next_stop='lpkrrhzzzoyvhmsfsjir',
-            geohash_level='loxicokqrsjecgzombue',
-            geohash='mwcibkljyykjbiycrdzw',
-            desi='rwqadmotvdsvozroukvy',
-            dir='swedonbqgjlxxuazsfxm',
-            dl=int(18),
-            oday='knzgmzkrbejpjxooykzm',
-            jrn=int(100),
-            line=int(21),
-            start='aqenyxdlznicdjwhwdnq',
-            stop=int(64),
-            route='cxgmfkyphbstchgkesjd',
-            occu=int(15),
-            spd=float(34.29556906791774),
-            hdg=int(5),
-            lat=float(93.02438270198405),
-            long=float(48.976929245591926),
-            acc=float(36.25765489298838),
-            odo=int(52),
-            drst=int(21),
-            loc='mfgjieahbupwgbfjfuro',
-            tlp_requestid=int(30),
+            route_id='hpqpuyrihmwfddkscyin',
+            direction_id='xlgozpmyzanfsnjywvru',
+            headsign='tlzrhqzyaqtizwfotutp',
+            start_time='dgrvchwlhhmkhlmyqyls',
+            next_stop='kbwplwzsrxvavevdixfj',
+            geohash_level='yqhifvteovjfwlythjqa',
+            geohash='clbtkdwgsaxjjucgador',
+            desi='kvsifumqmuxfpcgdokdx',
+            dir=None,
+            dl=int(22),
+            oday='vmsulywssjtgedjapnia',
+            jrn=int(98),
+            line=int(91),
+            start='cekszfljtvaadvlbtcki',
+            stop=int(80),
+            route='oxaxeqgiuxsqgypqqcsf',
+            occu=int(45),
+            spd=float(60.90200433551247),
+            hdg=int(9),
+            lat=float(3.2312184361246166),
+            long=float(19.662095641159084),
+            acc=float(87.36432246646292),
+            odo=int(10),
+            drst=int(97),
+            loc=None,
+            tlp_requestid=int(1),
             tlp_requesttype=None,
             tlp_prioritylevel=None,
             tlp_reason=None,
-            tlp_att_seq=int(52),
+            tlp_att_seq=int(64),
             tlp_decision=None,
-            sid=int(10),
-            signal_groupid=int(36),
-            tlp_signalgroupnbr=int(16),
-            tlp_line_configid=int(25),
-            tlp_point_configid=int(31),
-            tlp_frequency=int(36),
-            tlp_protocol='pvfmtbslfvwleiwfxywt'
+            sid=int(75),
+            signal_groupid=int(41),
+            tlp_signalgroupnbr=int(63),
+            tlp_line_configid=int(79),
+            tlp_point_configid=int(9),
+            tlp_frequency=int(20),
+            tlp_protocol=None
         )
         return instance
 
@@ -83,7 +83,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(54)
+        test_value = int(59)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -91,7 +91,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(25)
+        test_value = int(75)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -99,7 +99,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'xzbqtpagrlirwjrtcqei'
+        test_value = 'jlkchsmtkorispwkbkzf'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -107,7 +107,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(43)
+        test_value = int(81)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -115,7 +115,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'zcybwxxxraltvadhuyak'
+        test_value = 'btnxjrfhywtjatmlfuxm'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -123,7 +123,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'bnzncdyusqbadxdlvfta'
+        test_value = 'epxidepxlkrdbdqnvrec'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -147,7 +147,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'kktgvzmkhlnhsojpixfh'
+        test_value = 'hpqpuyrihmwfddkscyin'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'meeixdnvtsripzjfhpji'
+        test_value = 'xlgozpmyzanfsnjywvru'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -163,7 +163,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'cogwhriemnaeosoraypb'
+        test_value = 'tlzrhqzyaqtizwfotutp'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -171,7 +171,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'cvpupblnkfbfqjsiiuxy'
+        test_value = 'dgrvchwlhhmkhlmyqyls'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -179,7 +179,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'lpkrrhzzzoyvhmsfsjir'
+        test_value = 'kbwplwzsrxvavevdixfj'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -187,7 +187,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'loxicokqrsjecgzombue'
+        test_value = 'yqhifvteovjfwlythjqa'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -195,7 +195,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'mwcibkljyykjbiycrdzw'
+        test_value = 'clbtkdwgsaxjjucgador'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -203,7 +203,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'rwqadmotvdsvozroukvy'
+        test_value = 'kvsifumqmuxfpcgdokdx'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -211,7 +211,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'swedonbqgjlxxuazsfxm'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -219,7 +219,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(18)
+        test_value = int(22)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -227,7 +227,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'knzgmzkrbejpjxooykzm'
+        test_value = 'vmsulywssjtgedjapnia'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -235,7 +235,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(100)
+        test_value = int(98)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -243,7 +243,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(21)
+        test_value = int(91)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -251,7 +251,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'aqenyxdlznicdjwhwdnq'
+        test_value = 'cekszfljtvaadvlbtcki'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -259,7 +259,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(64)
+        test_value = int(80)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -267,7 +267,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'cxgmfkyphbstchgkesjd'
+        test_value = 'oxaxeqgiuxsqgypqqcsf'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -275,7 +275,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(15)
+        test_value = int(45)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -283,7 +283,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(34.29556906791774)
+        test_value = float(60.90200433551247)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -291,7 +291,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(5)
+        test_value = int(9)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -299,7 +299,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(93.02438270198405)
+        test_value = float(3.2312184361246166)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -307,7 +307,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(48.976929245591926)
+        test_value = float(19.662095641159084)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -315,7 +315,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(36.25765489298838)
+        test_value = float(87.36432246646292)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -323,7 +323,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(52)
+        test_value = int(10)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -331,7 +331,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(21)
+        test_value = int(97)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -339,7 +339,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'mfgjieahbupwgbfjfuro'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -347,7 +347,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_requestid property
         """
-        test_value = int(30)
+        test_value = int(1)
         self.instance.tlp_requestid = test_value
         self.assertEqual(self.instance.tlp_requestid, test_value)
     
@@ -379,7 +379,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_att_seq property
         """
-        test_value = int(52)
+        test_value = int(64)
         self.instance.tlp_att_seq = test_value
         self.assertEqual(self.instance.tlp_att_seq, test_value)
     
@@ -395,7 +395,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test sid property
         """
-        test_value = int(10)
+        test_value = int(75)
         self.instance.sid = test_value
         self.assertEqual(self.instance.sid, test_value)
     
@@ -403,7 +403,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test signal_groupid property
         """
-        test_value = int(36)
+        test_value = int(41)
         self.instance.signal_groupid = test_value
         self.assertEqual(self.instance.signal_groupid, test_value)
     
@@ -411,7 +411,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_signalgroupnbr property
         """
-        test_value = int(16)
+        test_value = int(63)
         self.instance.tlp_signalgroupnbr = test_value
         self.assertEqual(self.instance.tlp_signalgroupnbr, test_value)
     
@@ -419,7 +419,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_line_configid property
         """
-        test_value = int(25)
+        test_value = int(79)
         self.instance.tlp_line_configid = test_value
         self.assertEqual(self.instance.tlp_line_configid, test_value)
     
@@ -427,7 +427,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_point_configid property
         """
-        test_value = int(31)
+        test_value = int(9)
         self.instance.tlp_point_configid = test_value
         self.assertEqual(self.instance.tlp_point_configid, test_value)
     
@@ -435,7 +435,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_frequency property
         """
-        test_value = int(36)
+        test_value = int(20)
         self.instance.tlp_frequency = test_value
         self.assertEqual(self.instance.tlp_frequency, test_value)
     
@@ -443,7 +443,7 @@ class Test_TrafficLightEvent(unittest.TestCase):
         """
         Test tlp_protocol property
         """
-        test_value = 'pvfmtbslfvwleiwfxywt'
+        test_value = None
         self.instance.tlp_protocol = test_value
         self.assertEqual(self.instance.tlp_protocol, test_value)
     

--- a/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_vehicleevent.py
+++ b/feeders/hsl-hfp/hsl_hfp_upstream_producer/hsl_hfp_upstream_data/tests/test_vehicleevent.py
@@ -29,44 +29,44 @@ class Test_VehicleEvent(unittest.TestCase):
         Create instance of VehicleEvent for testing
         """
         instance = VehicleEvent(
-            oper=int(50),
-            veh=int(74),
-            tst='itkvjrgcnthmgzrkzlcx',
-            tsi=int(75),
-            operator_id='urxgkxqpnadxwsfqbkjp',
-            vehicle_number='vszbgzyowigvorcdlxba',
+            oper=int(42),
+            veh=int(50),
+            tst='nvakfnvxjwtdcibakdak',
+            tsi=int(100),
+            operator_id='jmgrttiwftruvbtlvsab',
+            vehicle_number='lzcohivskxghczvmssua',
             temporal_type=None,
             transport_mode=None,
-            route_id='lheoyvqlgeqnrlngnqkh',
-            direction_id='llzikxxheutusjtebfmu',
-            headsign='saoljrydixyrgffpgpnl',
-            start_time='fbapiwqwekpmjhlvddjs',
-            next_stop='fawtksmeuwmxgonazakg',
-            geohash_level='jmkccdroxiaanbcorfsq',
-            geohash='kleuoplvyhbsglazwjgq',
-            desi='pjcvwofnehyrftwzfaxy',
-            dir='roohpapyaihiwliwxuzr',
-            dl=int(61),
-            oday='evwvlrigkovfhefawvzv',
-            jrn=int(92),
-            line=int(80),
-            start='huonzmkucwtuszpwsoyx',
-            stop=int(33),
-            route='rscbkeeznjuaebbjdoxu',
-            occu=int(68),
-            seq=int(45),
-            label='bzkwfpjxfwdqjabnmgcf',
-            spd=float(41.75429008609826),
-            hdg=int(71),
-            lat=float(80.74093905402421),
-            long=float(19.685298914832728),
-            acc=float(91.80676181448422),
-            odo=int(46),
-            drst=int(44),
-            loc='weogrbxsbpioriuqydvd',
-            ttarr='ujvajrzqlxkouapqjreu',
-            ttdep='knotdlrysfbvnqtvydyj',
-            dr_type=int(64)
+            route_id='folmzrlgemsocfyrmtdx',
+            direction_id='oabjbroqughcgylmcimd',
+            headsign='txiixjvxpgqcfehkyzji',
+            start_time='lwhzxrjrehkoktwxxexo',
+            next_stop='mjwoktvbydnbpstfvzle',
+            geohash_level='exijuzpjckuepookxtph',
+            geohash='fhceozkhgspipobdpwxp',
+            desi='bsrbwcsdtyahessyufjo',
+            dir=None,
+            dl=int(33),
+            oday='xegcvplosiqhcfflouwb',
+            jrn=int(2),
+            line=int(60),
+            start='fbnrnoyjgrvhlrzkpqvo',
+            stop=int(20),
+            route='pktrqdtarfevpokgmrlt',
+            occu=int(95),
+            seq=int(58),
+            label='kpbwvxkmbjsgjhwoclff',
+            spd=float(55.34316544760184),
+            hdg=int(21),
+            lat=float(69.31685460398666),
+            long=float(83.77805587004522),
+            acc=float(86.92633894982635),
+            odo=int(2),
+            drst=int(92),
+            loc=None,
+            ttarr='cdvzhwxuibnmitvfyycz',
+            ttdep='lkthwppadixddpaucejd',
+            dr_type=int(0)
         )
         return instance
 
@@ -75,7 +75,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oper property
         """
-        test_value = int(50)
+        test_value = int(42)
         self.instance.oper = test_value
         self.assertEqual(self.instance.oper, test_value)
     
@@ -83,7 +83,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test veh property
         """
-        test_value = int(74)
+        test_value = int(50)
         self.instance.veh = test_value
         self.assertEqual(self.instance.veh, test_value)
     
@@ -91,7 +91,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tst property
         """
-        test_value = 'itkvjrgcnthmgzrkzlcx'
+        test_value = 'nvakfnvxjwtdcibakdak'
         self.instance.tst = test_value
         self.assertEqual(self.instance.tst, test_value)
     
@@ -99,7 +99,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test tsi property
         """
-        test_value = int(75)
+        test_value = int(100)
         self.instance.tsi = test_value
         self.assertEqual(self.instance.tsi, test_value)
     
@@ -107,7 +107,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test operator_id property
         """
-        test_value = 'urxgkxqpnadxwsfqbkjp'
+        test_value = 'jmgrttiwftruvbtlvsab'
         self.instance.operator_id = test_value
         self.assertEqual(self.instance.operator_id, test_value)
     
@@ -115,7 +115,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test vehicle_number property
         """
-        test_value = 'vszbgzyowigvorcdlxba'
+        test_value = 'lzcohivskxghczvmssua'
         self.instance.vehicle_number = test_value
         self.assertEqual(self.instance.vehicle_number, test_value)
     
@@ -139,7 +139,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route_id property
         """
-        test_value = 'lheoyvqlgeqnrlngnqkh'
+        test_value = 'folmzrlgemsocfyrmtdx'
         self.instance.route_id = test_value
         self.assertEqual(self.instance.route_id, test_value)
     
@@ -147,7 +147,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test direction_id property
         """
-        test_value = 'llzikxxheutusjtebfmu'
+        test_value = 'oabjbroqughcgylmcimd'
         self.instance.direction_id = test_value
         self.assertEqual(self.instance.direction_id, test_value)
     
@@ -155,7 +155,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test headsign property
         """
-        test_value = 'saoljrydixyrgffpgpnl'
+        test_value = 'txiixjvxpgqcfehkyzji'
         self.instance.headsign = test_value
         self.assertEqual(self.instance.headsign, test_value)
     
@@ -163,7 +163,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start_time property
         """
-        test_value = 'fbapiwqwekpmjhlvddjs'
+        test_value = 'lwhzxrjrehkoktwxxexo'
         self.instance.start_time = test_value
         self.assertEqual(self.instance.start_time, test_value)
     
@@ -171,7 +171,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test next_stop property
         """
-        test_value = 'fawtksmeuwmxgonazakg'
+        test_value = 'mjwoktvbydnbpstfvzle'
         self.instance.next_stop = test_value
         self.assertEqual(self.instance.next_stop, test_value)
     
@@ -179,7 +179,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash_level property
         """
-        test_value = 'jmkccdroxiaanbcorfsq'
+        test_value = 'exijuzpjckuepookxtph'
         self.instance.geohash_level = test_value
         self.assertEqual(self.instance.geohash_level, test_value)
     
@@ -187,7 +187,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test geohash property
         """
-        test_value = 'kleuoplvyhbsglazwjgq'
+        test_value = 'fhceozkhgspipobdpwxp'
         self.instance.geohash = test_value
         self.assertEqual(self.instance.geohash, test_value)
     
@@ -195,7 +195,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test desi property
         """
-        test_value = 'pjcvwofnehyrftwzfaxy'
+        test_value = 'bsrbwcsdtyahessyufjo'
         self.instance.desi = test_value
         self.assertEqual(self.instance.desi, test_value)
     
@@ -203,7 +203,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dir property
         """
-        test_value = 'roohpapyaihiwliwxuzr'
+        test_value = None
         self.instance.dir = test_value
         self.assertEqual(self.instance.dir, test_value)
     
@@ -211,7 +211,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dl property
         """
-        test_value = int(61)
+        test_value = int(33)
         self.instance.dl = test_value
         self.assertEqual(self.instance.dl, test_value)
     
@@ -219,7 +219,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test oday property
         """
-        test_value = 'evwvlrigkovfhefawvzv'
+        test_value = 'xegcvplosiqhcfflouwb'
         self.instance.oday = test_value
         self.assertEqual(self.instance.oday, test_value)
     
@@ -227,7 +227,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test jrn property
         """
-        test_value = int(92)
+        test_value = int(2)
         self.instance.jrn = test_value
         self.assertEqual(self.instance.jrn, test_value)
     
@@ -235,7 +235,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test line property
         """
-        test_value = int(80)
+        test_value = int(60)
         self.instance.line = test_value
         self.assertEqual(self.instance.line, test_value)
     
@@ -243,7 +243,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test start property
         """
-        test_value = 'huonzmkucwtuszpwsoyx'
+        test_value = 'fbnrnoyjgrvhlrzkpqvo'
         self.instance.start = test_value
         self.assertEqual(self.instance.start, test_value)
     
@@ -251,7 +251,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test stop property
         """
-        test_value = int(33)
+        test_value = int(20)
         self.instance.stop = test_value
         self.assertEqual(self.instance.stop, test_value)
     
@@ -259,7 +259,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test route property
         """
-        test_value = 'rscbkeeznjuaebbjdoxu'
+        test_value = 'pktrqdtarfevpokgmrlt'
         self.instance.route = test_value
         self.assertEqual(self.instance.route, test_value)
     
@@ -267,7 +267,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test occu property
         """
-        test_value = int(68)
+        test_value = int(95)
         self.instance.occu = test_value
         self.assertEqual(self.instance.occu, test_value)
     
@@ -275,7 +275,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test seq property
         """
-        test_value = int(45)
+        test_value = int(58)
         self.instance.seq = test_value
         self.assertEqual(self.instance.seq, test_value)
     
@@ -283,7 +283,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test label property
         """
-        test_value = 'bzkwfpjxfwdqjabnmgcf'
+        test_value = 'kpbwvxkmbjsgjhwoclff'
         self.instance.label = test_value
         self.assertEqual(self.instance.label, test_value)
     
@@ -291,7 +291,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test spd property
         """
-        test_value = float(41.75429008609826)
+        test_value = float(55.34316544760184)
         self.instance.spd = test_value
         self.assertEqual(self.instance.spd, test_value)
     
@@ -299,7 +299,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test hdg property
         """
-        test_value = int(71)
+        test_value = int(21)
         self.instance.hdg = test_value
         self.assertEqual(self.instance.hdg, test_value)
     
@@ -307,7 +307,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test lat property
         """
-        test_value = float(80.74093905402421)
+        test_value = float(69.31685460398666)
         self.instance.lat = test_value
         self.assertEqual(self.instance.lat, test_value)
     
@@ -315,7 +315,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test long property
         """
-        test_value = float(19.685298914832728)
+        test_value = float(83.77805587004522)
         self.instance.long = test_value
         self.assertEqual(self.instance.long, test_value)
     
@@ -323,7 +323,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test acc property
         """
-        test_value = float(91.80676181448422)
+        test_value = float(86.92633894982635)
         self.instance.acc = test_value
         self.assertEqual(self.instance.acc, test_value)
     
@@ -331,7 +331,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test odo property
         """
-        test_value = int(46)
+        test_value = int(2)
         self.instance.odo = test_value
         self.assertEqual(self.instance.odo, test_value)
     
@@ -339,7 +339,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test drst property
         """
-        test_value = int(44)
+        test_value = int(92)
         self.instance.drst = test_value
         self.assertEqual(self.instance.drst, test_value)
     
@@ -347,7 +347,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test loc property
         """
-        test_value = 'weogrbxsbpioriuqydvd'
+        test_value = None
         self.instance.loc = test_value
         self.assertEqual(self.instance.loc, test_value)
     
@@ -355,7 +355,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttarr property
         """
-        test_value = 'ujvajrzqlxkouapqjreu'
+        test_value = 'cdvzhwxuibnmitvfyycz'
         self.instance.ttarr = test_value
         self.assertEqual(self.instance.ttarr, test_value)
     
@@ -363,7 +363,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test ttdep property
         """
-        test_value = 'knotdlrysfbvnqtvydyj'
+        test_value = 'lkthwppadixddpaucejd'
         self.instance.ttdep = test_value
         self.assertEqual(self.instance.ttdep, test_value)
     
@@ -371,7 +371,7 @@ class Test_VehicleEvent(unittest.TestCase):
         """
         Test dr_type property
         """
-        test_value = int(64)
+        test_value = int(0)
         self.instance.dr_type = test_value
         self.assertEqual(self.instance.dr_type, test_value)
     

--- a/feeders/hsl-hfp/xreg/hsl-hfp.xreg.json
+++ b/feeders/hsl-hfp/xreg/hsl-hfp.xreg.json
@@ -1943,7 +1943,9 @@
                             "dir": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/DirEnum"
+                                }
                               ],
                               "description": "Route direction of the trip as a string, either `\"1\"` or `\"2\"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`."
                             },
@@ -2089,7 +2091,9 @@
                             "loc": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/LocEnum"
+                                }
                               ],
                               "description": "Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field."
                             },
@@ -2153,6 +2157,27 @@
                             "robot"
                           ],
                           "description": "Transport mode of the vehicle: `bus`, `tram`, `train`, `ferry`, `metro`, `ubus` (U-line bus) or `robot` (robot bus). From the MQTT-topic `transport_mode` level."
+                        },
+                        "LocEnum": {
+                          "name": "LocEnum",
+                          "type": "string",
+                          "enum": [
+                            "GPS",
+                            "ODO",
+                            "MAN",
+                            "DR",
+                            "N/A"
+                          ],
+                          "description": "Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim."
+                        },
+                        "DirEnum": {
+                          "name": "DirEnum",
+                          "type": "string",
+                          "enum": [
+                            "1",
+                            "2"
+                          ],
+                          "description": "Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim."
                         }
                       }
                     }
@@ -2286,7 +2311,9 @@
                             "dir": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/DirEnum"
+                                }
                               ],
                               "description": "Route direction of the trip as a string, either `\"1\"` or `\"2\"`. After type conversion this matches the `direction_id` topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). Sourced from the HFP payload `dir` field. Not populated on `da`,`dout`,`ba`,`bout`."
                             },
@@ -2417,7 +2444,9 @@
                             "loc": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/LocEnum"
+                                }
                               ],
                               "description": "Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field."
                             },
@@ -2552,7 +2581,9 @@
                             "tlp_protocol": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/TlpProtocolEnum"
+                                }
                               ],
                               "description": "Protocol used for the traffic-light priority request. One of `MQTT` or `KAR-MQTT`. Populated on `tlr`. Sourced from the HFP payload `tlp-protocol` field.",
                               "altnames": {
@@ -2632,6 +2663,36 @@
                             "robot"
                           ],
                           "description": "Transport mode of the vehicle: `bus`, `tram`, `train`, `ferry`, `metro`, `ubus` (U-line bus) or `robot` (robot bus). From the MQTT-topic `transport_mode` level."
+                        },
+                        "LocEnum": {
+                          "name": "LocEnum",
+                          "type": "string",
+                          "enum": [
+                            "GPS",
+                            "ODO",
+                            "MAN",
+                            "DR",
+                            "N/A"
+                          ],
+                          "description": "Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim."
+                        },
+                        "DirEnum": {
+                          "name": "DirEnum",
+                          "type": "string",
+                          "enum": [
+                            "1",
+                            "2"
+                          ],
+                          "description": "Route direction of the trip as a string, either `1` or `2`. Matches the `direction_id` MQTT-topic level; relative to GTFS it is offset by one (HFP `1` = GTFS `0`, HFP `2` = GTFS `1`). From the HFP payload `dir` field. The digit-leading wire values are sanitized to the Avro symbols `_1`/`_2` while the JSON wire values `1`/`2` are preserved verbatim."
+                        },
+                        "TlpProtocolEnum": {
+                          "name": "TlpProtocolEnum",
+                          "type": "string",
+                          "enum": [
+                            "MQTT",
+                            "KAR-MQTT"
+                          ],
+                          "description": "Protocol used for the traffic-light priority request: `MQTT` or `KAR-MQTT`. Populated on `tlr`. From the HFP payload `tlp-protocol` field. The `-` in `KAR-MQTT` is sanitized to the Avro symbol `KAR_MQTT` while the JSON wire value `KAR-MQTT` is preserved verbatim."
                         }
                       }
                     }
@@ -2821,7 +2882,9 @@
                             "loc": {
                               "type": [
                                 "null",
-                                "string"
+                                {
+                                  "$ref": "#/definitions/fi/hsl/hfp/LocEnum"
+                                }
                               ],
                               "description": "Source of the reported location. One of `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). Sourced from the HFP payload `loc` field."
                             },
@@ -2877,6 +2940,18 @@
                             "robot"
                           ],
                           "description": "Transport mode of the vehicle: `bus`, `tram`, `train`, `ferry`, `metro`, `ubus` (U-line bus) or `robot` (robot bus). From the MQTT-topic `transport_mode` level."
+                        },
+                        "LocEnum": {
+                          "name": "LocEnum",
+                          "type": "string",
+                          "enum": [
+                            "GPS",
+                            "ODO",
+                            "MAN",
+                            "DR",
+                            "N/A"
+                          ],
+                          "description": "Source of the reported location: `GPS` (satellite fix), `ODO` (computed from the odometer), `MAN` (manually set), `DR` (dead reckoning, used in tunnels and other GPS-denied locations) or `N/A` (location unavailable). From the HFP payload `loc` field. The `N/A` wire value contains a `/`, so the generated Avro symbol is sanitized to `N_A` while the JSON wire value `N/A` is preserved verbatim."
                         }
                       }
                     }

--- a/tools/require-xrcg.ps1
+++ b/tools/require-xrcg.ps1
@@ -1,4 +1,35 @@
 $script:RequiredXrcgVersion = '0.11.0'
+# Minimum avrotize the generators MUST resolve. xrcg 0.11.0 depends on
+# `avrotize>=3.6.0` with an open upper bound, so a clean install pulls the
+# latest (>=3.7.0). But a *cached* avrotize 3.6.0 in the active environment
+# would silently regenerate broken artifacts for the enum symbols that only
+# 3.7.0 sanitizes (`N/A` slash, digit-leading `1`/`2`, `KAR-MQTT` hyphen --
+# clemensv/avrotize #382/#383/#385). Enforce the floor explicitly so the
+# generator fails fast instead of emitting invalid Avro/Kusto.
+$script:MinimumAvrotizeVersion = '3.7.0'
+
+function Assert-AvrotizeVersion {
+    param(
+        [string] $MinimumVersion = $script:MinimumAvrotizeVersion
+    )
+
+    $versionOutput = & python -c "import importlib.metadata as m; print(m.version('avrotize'))" 2>$null | Out-String
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+        throw "avrotize >= $MinimumVersion is required for producer generation, but it is not importable. Install it with 'python -m pip install --upgrade `"avrotize>=$MinimumVersion`"'."
+    }
+
+    $versionMatch = [regex]::Match($versionOutput, '(?<version>\d+\.\d+\.\d+)')
+    if (-not $versionMatch.Success) {
+        throw "Unable to parse the installed avrotize version from: $versionOutput"
+    }
+
+    $installedVersion = $versionMatch.Groups['version'].Value
+    if ([version]$installedVersion -lt [version]$MinimumVersion) {
+        throw "avrotize >= $MinimumVersion is required for producer generation, but the active environment resolves $installedVersion. A cached older avrotize silently emits invalid Avro/Kusto for non-identifier enum symbols. Upgrade with 'python -m pip install --upgrade `"avrotize>=$MinimumVersion`"' and re-run the generator."
+    }
+
+    Write-Host "Using avrotize $installedVersion" -ForegroundColor DarkGray
+}
 
 function Assert-XrcgVersion {
     param(
@@ -26,6 +57,10 @@ function Assert-XrcgVersion {
     }
 
     Write-Host "Using xrcg $installedVersion" -ForegroundColor DarkGray
+
+    # xrcg drives avrotize for Avro/Kusto emission; enforce the avrotize floor
+    # in the same gate so both halves of the codegen toolchain are pinned.
+    Assert-AvrotizeVersion
 }
 
 function Convert-GeneratedPyprojects {


### PR DESCRIPTION
## Summary

Promotes three hsl-hfp payload fields — `loc`, `dir`, `tlp_protocol` — from
plain `string` back to proper **enum** types, now that **avrotize 3.7.0**
(fixes clemensv/avrotize #382 / #383 / #385) sanitizes enum symbols that are
not valid identifiers. These three were demoted to `string` at authoring time
purely to dodge the pre-3.7.0 `s2a`/`s2k` crash; the domain constraint is now
restorable without breaking codegen.

| Enum | Wire values | Why it broke Avro pre-3.7.0 |
|---|---|---|
| `LocEnum` | `GPS,ODO,MAN,DR,N/A` | `/` in `N/A` |
| `DirEnum` | `1,2` | digit-leading |
| `TlpProtocolEnum` | `MQTT,KAR-MQTT` | `-` hyphen |

avrotize 3.7.0 sanitizes the **Avro symbol** (`N/A`→`N_A`, `1`→`_1`,
`KAR-MQTT`→`KAR_MQTT`) and records the original-value map in the Avro `doc`,
while the generated Python enum keeps the **wire value as `.value`**
(`N_SLASHA = 'N/A'`). Runtime is JSON-only (dataclasses_json), so the HFP wire
payload round-trips **byte-identically**: `loc="N/A"`, `dir="1"`,
`tlp-protocol="KAR-MQTT"` are emitted verbatim.

## Changes

- **Manifest** (`feeders/hsl-hfp/xreg/hsl-hfp.xreg.json`): +3 named single-typed
  enum defs (replicated per-schema where each field lives), 6 field-ref flips
  `["null","string"]` → `["null",{"$ref":Enum}]`. Endpoints and messagegroups
  untouched (byte-identical).
- **Regenerated** all four producer packages with xrcg 0.11.0 + avrotize 3.7.0
  (never hand-edited).
- **No bridge change** — `mapping.py` already passes raw wire scalars into the
  (now enum-typed, `Optional[Any]`) fields; its docstring anticipated this.
- **EVENTS.md** refreshed from the manifest (enum fields now documented with
  value lists).
- **`tools/require-xrcg.ps1`** now also asserts `avrotize>=3.7.0` so a *cached*
  3.6.0 can't silently regenerate broken artifacts.

## Validation

- **Gate 1 import-smoke** (3 transports) ✓
- **Gate 2 py_compile** — 172 generated files compile; 12/12 enum modules ✓
- **Gate 4 unit tests** — 158 generated data-class tests + 36 feeder tests ✓
- **Gate 5 Docker E2E** — `TestHslHfpDockerFlow` PASS (107s): live `vp`
  telemetry + `gtfs` reference validated against the checked-in schemas, with
  the promoted enums on the wire ✓
- **Gate 6 mypy** — clean ✓
- **KQL** regen is a no-op (enum → Kusto `string` column, unchanged) ✓
- **Runtime wire proof** — raw-scalar path, enum-member path, and `from_data`
  round-trip all emit `loc="N/A"`, `dir="1"`, `tlp-protocol="KAR-MQTT"`
  verbatim ✓

## Mandatory expert reviews (all PASS, no blockers)

- **xRegistry Expert — PASS.** Diff touches only the 3 event schemas
  (endpoints/messagegroups hash-match parent); all 6 `$ref`s resolve; `xrcg
  validate` exit 0; CE `subject` + Kafka `key` (`{operator_id}/{vehicle_number}`)
  untouched; no `$id` collisions. Nits informational only.
- **JSON Structure Expert — PASS.** Core §3.7.7 (enum on named single-typed
  def, not a union) + §3.5.1 (`$ref` nested in `type`) compliant; per-`$id`
  locality correct (DriverBlockEvent carries only `LocEnum`); fields stay
  Optional (not in `required`); no `anyOf`/composition/`format` misuse. This is
  the faithful realization of the prior review's "hoist to named enum def"
  guidance. Lone nit (per-value `altenums`) explicitly recommended *against* for
  baseline consistency.
- **Avro Schema Expert — PASS.** avrotize 3.7.0 `s2a` emits valid Avro
  (symbols sanitized, original map in `doc`); `s2py` keeps `.value` = wire
  string; null-first unions mirror; no identifier collisions; KQL columns remain
  `string`. Round-trip stable.

`container-and-delivery` skill walkthrough is **N/A** — this is a schema
refinement of an already-shipped source, not a new source; the Docker E2E gate
covers the delivery-contract surface affected by the change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
