### PR TITLE
ci(dependabot): raise auto-merge poll window from ~45 to ~150 min

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,10 @@ jobs:
 
           INITIAL_DELAY=60      # let sibling pull_request checks register
           INTERVAL=30           # seconds between polls
-          MAX_POLLS=90          # ~45 min ceiling after the initial delay
+          MAX_POLLS=300         # ~150 min ceiling after the initial delay
+                                # (must outlast a queue-saturated fleet-wide
+                                #  docker matrix; the loop exits early as soon
+                                #  as every sibling check has concluded)
 
           echo "Waiting ${INITIAL_DELAY}s for sibling checks to register..."
           sleep "$INITIAL_DELAY"


### PR DESCRIPTION
## What

Raise the dependabot auto-merge workflow's poll-window ceiling from **~45 min** (`MAX_POLLS=90`) to **~150 min** (`MAX_POLLS=300`).

```diff
           INITIAL_DELAY=60      # let sibling pull_request checks register
           INTERVAL=30           # seconds between polls
-          MAX_POLLS=90          # ~45 min ceiling after the initial delay
+          MAX_POLLS=300         # ~150 min ceiling after the initial delay
```

## Why

`dependabot-auto-merge.yml` polls each PR's check rollup (excluding its own run) and squash-merges once **every** sibling check has concluded successfully. The ceiling was `90 × 30s = ~45 min`.

That window is **shorter than a queue-saturated fleet-wide docker matrix**. When the shared Actions runner queue is busy (e.g. a large flow-test escalation running concurrently), a dependabot PR's scoped checks sit `queued` past 45 min — not failing, just waiting for a runner. The loop hits its ceiling, exits 1 with `Checks did not all conclude within the poll window`, and **nothing ever merges**. This is exactly the mechanism that let the dependabot backlog accumulate.

## Behaviour preserved

- **Early exit unchanged** — the loop still merges as soon as two consecutive all-green polls confirm every sibling check concluded. Normal narrow-scope dependabot PRs (single-feeder `requirements.txt`/`pyproject.toml`) still merge in their usual ~15–20 min. The higher ceiling only matters under runner-queue saturation.
- **Strong gate preserved** — still waits for **all** substantive checks (mypy, lint, feeder tests, docker builds/flows), fails fast on any real failure (`bucket == fail|cancel`), and only then squash-merges. This is *not* a switch to `--auto` (which would merge as soon as the two required checks pass, before the scoped feeder tests conclude).

## Validation

- `yaml.safe_load` parses the workflow cleanly.
- Surgical 4-line diff; no logic change beyond the ceiling constant + an explanatory comment.

## Context

Follow-up to the dependabot backlog clear-out (#1526, #1498). This addresses the *recurrence root cause* so the auto-merge workflow can actually complete instead of always timing out.
