### PR TITLE
ci(notebook-wheels): serialize publish to fix release-recreate 404 race

### DIFF
--- a/.github/workflows/publish-notebook-wheels.yml
+++ b/.github/workflows/publish-notebook-wheels.yml
@@ -27,6 +27,16 @@ on:
 permissions:
   contents: write
 
+# The release tag is fixed (`notebook-wheels`) and is deleted + recreated on
+# every run. Concurrent runs (e.g. a burst of merges to main) would otherwise
+# race: one job deletes the release another job is mid-upload to, yielding
+# `HTTP 404` on asset upload and leaving the release deleted. Serialize on a
+# single group and cancel superseded in-flight runs so only the newest push
+# publishes — the release always reflects the latest commit on main.
+concurrency:
+  group: publish-notebook-wheels
+  cancel-in-progress: true
+
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-notebook-wheels.yml
+++ b/.github/workflows/publish-notebook-wheels.yml
@@ -30,11 +30,13 @@ permissions:
 # The release tag is fixed (`notebook-wheels`) and is deleted + recreated on
 # every run. Concurrent runs (e.g. a burst of merges to main) would otherwise
 # race: one job deletes the release another job is mid-upload to, yielding
-# `HTTP 404` on asset upload and leaving the release deleted. Serialize on a
-# single group and cancel superseded in-flight runs so only the newest push
-# publishes — the release always reflects the latest commit on main.
+# `HTTP 404` on asset upload and leaving the release deleted. Serialize per ref
+# and cancel superseded in-flight runs so only the newest push on a given ref
+# publishes — the release always reflects the latest commit on main. The group
+# is keyed by ref so a PR's build run (which never publishes) cannot cancel an
+# in-flight main publish and leave the release deleted.
 concurrency:
-  group: publish-notebook-wheels
+  group: publish-notebook-wheels-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

The **Publish Notebook Wheels** workflow deletes + recreates a single fixed `notebook-wheels` release on every push to `main`. It has **no `concurrency` guard**, so a burst of merges spawns many concurrent `publish` jobs that race on the same release:

- one job runs `gh release delete notebook-wheels --cleanup-tag` while another is mid `gh release create` / asset upload →
- `HTTP 404: Not Found` uploading `<source>-notebook-wheels.zip` to the release id, then `cleaning up draft failed: HTTP 404`.

During the recent dependabot-backlog clear, **~18 of 20 rapid-fire runs failed** this way; only the two non-overlapping pushes succeeded. The **last** failing run left the release **deleted entirely**, so `tools/deploy-fabric/deploy-feeder-notebook.ps1` can no longer download wheels from Cloud Shell.

## Fix

Add a workflow-level concurrency group:

```yaml
concurrency:
  group: publish-notebook-wheels
  cancel-in-progress: true
```

Only the newest push publishes; superseded in-flight runs are canceled before they can race. The release always reflects the latest commit on `main`.

## Validation

- YAML parses (`yaml.safe_load` → top keys `name/on/permissions/concurrency/jobs`).
- Merging this PR touches `publish-notebook-wheels.yml` (a trigger path) → one clean, un-raced run recreates the `notebook-wheels` release with all current source bundles.

Per repo policy *"All Issues Are Issues — Pre-existing Is Not a Pass."*
