### PR TITLE
fix(tools): install-avrotize.ps1 -> avrotize>=3.7.0 to match codegen gate

### DIFF
--- a/tools/install-avrotize.ps1
+++ b/tools/install-avrotize.ps1
@@ -66,7 +66,7 @@ $activateScript = "$venvPath\Scripts\Activate.ps1"
 if (Test-Path $activateScript) {
     Write-Host "Activating virtual environment and installing avrotize..."
     & $activateScript
-    pip install avrotize==3.6.0 xrcg==0.11.0
+    pip install "avrotize>=3.7.0" xrcg==0.11.0
     Write-Host "avrotize has been installed successfully in the virtual environment."
 } else {
     Write-Host "Failed to activate virtual environment."


### PR DESCRIPTION
## Problem

`tools/install-avrotize.ps1` installed **`avrotize==3.6.0`**, but the codegen
gate `tools/require-xrcg.ps1` enforces **`MinimumAvrotizeVersion = '3.7.0'`**
via `Assert-AvrotizeVersion`. A developer who ran the setup script and then
invoked `generate_producer.ps1` hit a hard throw, because **3.6.0 is the exact
version the 3.7.0 floor exists to reject** — avrotize 3.6.0 emits invalid Avro
`name`s and ambiguous/`$.dr-type` Kusto columns for non-identifier enum symbols
(avrotize #382 / #383 / #385, fixed in 3.7.0 and leveraged by the merged
hsl-hfp enum-promotion pilot #1525).

This was the only avrotize version pin repo-wide; **no CI workflow installs or
runs avrotize** (producers/KQL are checked in), so this only affected local dev
toolchain setup.

## Fix

Align the installer to the enforced floor:

```diff
-    pip install avrotize==3.6.0 xrcg==0.11.0
+    pip install "avrotize>=3.7.0" xrcg==0.11.0
```

`xrcg==0.11.0` already matches `RequiredXrcgVersion='0.11.0'`.

## Validation

- `install-avrotize.ps1` parses OK (PowerShell AST parser).
- Pins now exactly mirror `require-xrcg.ps1` (`avrotize>=3.7.0`, `xrcg==0.11.0`).
- Tooling-only `.ps1` change: no Python / Dockerfile / schema / generated
  producer touched; mypy + lint unaffected.
