### PR TITLE
fix(rss): pin soupsieve>=2.8.4 to clear ReDoS/OOM advisories

### DIFF
--- a/feeders/rss/pyproject.toml
+++ b/feeders/rss/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "BeautifulSoup4>=4.12.3",
+    "soupsieve>=2.8.4",  # security pin (transitive via bs4): ReDoS/OOM in <=2.8.3
     "avro>=1.12.1,<2.0.0",
     "cloudevents>=1.12.1,<2.0.0",
     "confluent-kafka>=2.14.2",

--- a/feeders/rss/rssbridge_amqp/pyproject.toml
+++ b/feeders/rss/rssbridge_amqp/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "feedparser>=6.0.11",
     "listparser>=0.20",
     "BeautifulSoup4>=4.12.3",
+    "soupsieve>=2.8.4",  # security pin (transitive via bs4): ReDoS/OOM in <=2.8.3
 ]
 
 [project.scripts]

--- a/feeders/rss/rssbridge_mqtt/pyproject.toml
+++ b/feeders/rss/rssbridge_mqtt/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "avro>=1.12.1,<2.0.0",
     "beautifulsoup4>=4.12.3",
+    "soupsieve>=2.8.4",  # security pin (transitive via bs4): ReDoS/OOM in <=2.8.3
     "cloudevents>=1.11.0,<2.0.0",
     "dataclasses_json>=0.6.7",
     "feedparser>=6.0.11",


### PR DESCRIPTION
## Pin `soupsieve>=2.8.4` in the rss feeder (clears 4 high Dependabot alerts)

`soupsieve` is a **transitive** dependency of `beautifulsoup4` — the `rss` bridge uses bs4 to strip HTML from feed content. Versions **≤2.8.3** carry four high-severity advisories:

| Alert | Advisory |
|---|---|
| #419, #421 | Memory exhaustion via large comma-separated selector lists |
| #420, #422 | ReDoS via the selector parser |

Patched in **2.8.4**. Dependabot can't auto-open a PR for a transitive dep with no lockfile, so this adds an explicit floor.

### Change
Added `"soupsieve>=2.8.4"` after the `beautifulsoup4` entry in all **three** rss app pyprojects that pull bs4:
- `feeders/rss/pyproject.toml` (Kafka)
- `feeders/rss/rssbridge_mqtt/pyproject.toml` (MQTT)
- `feeders/rss/rssbridge_amqp/pyproject.toml` (AMQP — not flagged by Dependabot but shares the identical transitive risk)

### Validation (Gate 1)
`python tools/ci/import_smoke.py feeders/rss` → **PASS** (rssbridge, rssbridge_amqp, rssbridge_mqtt all import cleanly). The resolver now installs **soupsieve 2.8.4** (dev env had 2.4). Production containers are unaffected either way since they already install producers first, but the pin removes the advisory and guarantees the patched selector parser.

No runtime code, schema, or contract change.
