### PR TITLE
feat(gtfs): add keyless MTA New York City GTFS config-add entry

### DIFF
--- a/feeders/gtfs/CONTAINER.md
+++ b/feeders/gtfs/CONTAINER.md
@@ -243,7 +243,7 @@ docker run --rm \
 
 ### Known GTFS-Realtime sources
 
-Use MobilityData’s [Mobility Database](https://database.mobilitydata.org/) and agency developer portals to find operator-specific GTFS Schedule and GTFS-Realtime feeds. Some are free and keyless; others require API keys or custom headers. The packaged catalog ships only disabled entries: `mbta-boston` (real keyless MBTA URLs), `tfnsw-sydney` (Transport for NSW Sydney / NSW feeds, ready to enable with `TFNSW_API_KEY`), and `keyed-operator-template` (`REPLACE_WITH_*` placeholders plus `${SOME_GTFS_KEY}` headers).
+Use MobilityData’s [Mobility Database](https://database.mobilitydata.org/) and agency developer portals to find operator-specific GTFS Schedule and GTFS-Realtime feeds. Some are free and keyless; others require API keys or custom headers. The packaged catalog ships only disabled entries: `mbta-boston` (real keyless MBTA URLs), `mta-nyc` (real keyless Metropolitan Transportation Authority New York City feeds — subway, LIRR, Metro-North, and alerts, plus GTFS Schedule archives; high volume), `tfnsw-sydney` (Transport for NSW Sydney / NSW feeds, ready to enable with `TFNSW_API_KEY`), and `keyed-operator-template` (`REPLACE_WITH_*` placeholders plus `${SOME_GTFS_KEY}` headers).
 
 ### Kafka image
 

--- a/feeders/gtfs/README.md
+++ b/feeders/gtfs/README.md
@@ -224,6 +224,7 @@ docker run --rm \
 The GTFS ecosystem is decentralized: MobilityData’s [Mobility Database](https://database.mobilitydata.org/) catalogs many schedule and realtime feeds, and agencies often publish their own GTFS-Realtime endpoints. Many are free and keyless; others require registration, an API key, or custom headers. The packaged catalog intentionally ships only disabled entries:
 
 - `mbta-boston` — disabled, fully worked, keyless MBTA GTFS-Realtime URLs plus the public GTFS Schedule zip.
+- `mta-nyc` — disabled, fully worked, keyless Metropolitan Transportation Authority (New York City) feeds: 11 GTFS-Realtime endpoints covering NYC Transit subway (all divisions), Long Island Rail Road, Metro-North Railroad, and system-wide service alerts, plus 7 public GTFS Schedule archives. No API key required since the 2023 MTA open-data migration to `api-endpoint.mta.info`; high volume.
 - `tfnsw-sydney` — disabled, ready-to-enable Transport for NSW GTFS-Realtime feeds for Sydney / NSW trains, buses, ferries, light rail, and rail alerts; requires `TFNSW_API_KEY` in the documented `Authorization: apikey ...` header.
 - `keyed-operator-template` — disabled template showing `REPLACE_WITH_*` URLs and `${SOME_GTFS_KEY}` header expansion.
 

--- a/feeders/gtfs/gtfs_core/gtfs_core/sources/gtfs-sources.json
+++ b/feeders/gtfs/gtfs_core/gtfs_core/sources/gtfs-sources.json
@@ -17,6 +17,35 @@
       ]
     },
     {
+      "name": "mta-nyc",
+      "enabled": false,
+      "description": "Metropolitan Transportation Authority (New York City, US) public keyless GTFS-Realtime feeds covering NYC Transit subway (all divisions: A/C/E, B/D/F/M, G, J/Z, L, N/Q/R/W, 1-7/S, Staten Island Railway), Long Island Rail Road, Metro-North Railroad, and system-wide service alerts, plus the public NYCT subway and borough-bus GTFS Schedule archives. No API key required since the 2023 MTA open-data migration to api-endpoint.mta.info. High volume: the combined feeds emit tens of thousands of trip-update, vehicle-position, and alert entities per poll. Add 'mta-nyc' to GTFS_SOURCES to enable.",
+      "agency": "mta-nyc",
+      "route": "*",
+      "gtfs_rt_urls": [
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-g",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-jz",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-l",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-nqrw",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-si",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/lirr%2Fgtfs-lirr",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/mnr%2Fgtfs-mnr",
+        "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fall-alerts"
+      ],
+      "gtfs_urls": [
+        "http://web.mta.info/developers/files/google_transit_supplemented.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_bx.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_b.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_m.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_q.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_si.zip",
+        "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_busco.zip"
+      ]
+    },
+    {
       "name": "tfnsw-sydney",
       "enabled": false,
       "description": "Transport for NSW (Sydney and New South Wales, Australia) API-key-protected GTFS-Realtime feeds for trains, buses, ferries, light rail, and service alerts. Add 'tfnsw-sydney' to GTFS_SOURCES to enable.",

--- a/feeders/gtfs/tests/test_gtfs_source_catalog.py
+++ b/feeders/gtfs/tests/test_gtfs_source_catalog.py
@@ -8,7 +8,7 @@ from gtfs_core import DEFAULT_SOURCES_FILE, load_source_configs, select_entries
 def test_default_catalog_loads_disabled_examples_only():
     configs = load_source_configs(selector="*")
     assert DEFAULT_SOURCES_FILE.endswith("gtfs-sources.json")
-    assert [config["agency"] for config in configs] == ["mbta", "tfnsw", "replace-me"]
+    assert [config["agency"] for config in configs] == ["mbta", "mta-nyc", "tfnsw", "replace-me"]
     assert configs[0]["gtfs_rt_urls"] == [
         "https://cdn.mbta.com/realtime/TripUpdates.pb",
         "https://cdn.mbta.com/realtime/VehiclePositions.pb",
@@ -26,7 +26,22 @@ def test_selector_returns_named_entries_in_requested_order():
 
 
 def test_selector_star_includes_disabled_templates():
-    assert len(load_source_configs(selector="*")) == 3
+    assert len(load_source_configs(selector="*")) == 4
+
+
+def test_mta_nyc_entry_exposes_all_keyless_feeds():
+    configs = load_source_configs(selector="mta-nyc")
+    assert len(configs) == 1
+    entry = configs[0]
+    assert entry["agency"] == "mta-nyc"
+    # 11 keyless GTFS-Realtime feeds (NYCT subway divisions + LIRR + MNR + alerts)
+    assert len(entry["gtfs_rt_urls"]) == 11
+    assert all(url.startswith("https://api-endpoint.mta.info/") for url in entry["gtfs_rt_urls"])
+    # 7 public GTFS Schedule archives (subway supplemented + borough buses)
+    assert len(entry["gtfs_urls"]) == 7
+    # keyless: no auth headers required post-2023 MTA open-data migration
+    assert entry["gtfs_rt_headers"] is None
+    assert entry["gtfs_headers"] is None
 
 
 def test_unknown_selector_raises():


### PR DESCRIPTION
## MTA New York City — GTFS config-add

Adds an `mta-nyc` entry to the **existing** `gtfs` feeder's packaged source catalog. This is a **config-add**, not a new source: no xreg/schema/producer/Dockerfile change. Selectable via `GTFS_SOURCES=mta-nyc`.

### What it covers
The Metropolitan Transportation Authority's public **keyless** open-data feeds:

| Kind | Count | Detail |
|---|---|---|
| GTFS-Realtime | 11 | NYC Transit subway — all divisions (A/C/E, B/D/F/M, G, J/Z, L, N/Q/R/W, 1-7/S, Staten Island Railway) + Long Island Rail Road + Metro-North Railroad + system-wide service alerts |
| GTFS Schedule (static) | 7 | Subway supplemented schedule + borough-bus archives (Bronx, Brooklyn, Manhattan, Queens, Staten Island, Bus Company) |

No API key required since the **2023 MTA open-data migration** to `api-endpoint.mta.info`.

### Verification (all 18 URLs, live)
- 11 GTFS-Realtime endpoints → **HTTP 200 + valid protobuf** (first byte `0x0A`), no auth header.
- 7 GTFS Schedule zips → **HTTP 206 + PK zip magic**, no auth header.

### Changes
- `gtfs-sources.json` — new `mta-nyc` entry after `mbta-boston`, `enabled:false` per the gtfs "no universal default feed" policy (operators opt in via `GTFS_SOURCES=mta-nyc`).
- `test_gtfs_source_catalog.py` — update the pinned agency list + `*`-selector count (3→4); add a dedicated `mta-nyc` test asserting 11 RT + 7 static feeds, all keyless.
- `README.md` / `CONTAINER.md` — document the new keyless entry.

### Gates
- Gate 2 py_compile: ✓ (catalog JSON parses, test compiles)
- Gate 4 unit tests: ✓ — `test_gtfs_source_catalog.py` **12 passed** locally (loader fully parses + validates the new entry via `load_source_configs`)
- Gate 6 mypy: N/A — only touched file under `tests/` (mypy-excluded) + a data JSON + docs
- No runtime `.py` changed → no Docker rebuild / Docker E2E needed for this config-add; the existing gtfs Kafka/MQTT/AMQP E2E already covers the bridge.
