### PR TITLE
docs(candidates): record 2026-07-16 live recheck of 5 remaining transit config-add candidates

### DIFF
--- a/tools/candidates/transit/canadian-transit.md
+++ b/tools/candidates/transit/canadian-transit.md
@@ -1,5 +1,8 @@
 # Canadian Transit GTFS-RT — TTC, TransLink, STM
 
+> 🟡 **PARTIAL** · recheck 2026-07-16 (live)
+> **STM Montréal ✅ shipped** as `gtfs` / `stm-montreal` (keyed `apiKey` header; in open PR #1541). **TTC** has **no keyless GTFS-RT** — `bustime.ttc.ca` resolves but connection-fails on `gtfsrt/*` (TTC real-time is NextBus/Umo format, not GTFS-RT). **TransLink** (Vancouver) GTFS-RT needs a **free API key** (`gtfs.translink.ca` / RTTI portal; not in creds). No further keyless config-add available.
+
 **Country/Region**: Canada (Toronto, Vancouver, Montreal)
 **Publishers**: TTC (Toronto), TransLink (Vancouver), STM (Montreal), and more
 **API Endpoints**:

--- a/tools/candidates/transit/digitransit-finland.md
+++ b/tools/candidates/transit/digitransit-finland.md
@@ -1,5 +1,8 @@
 # Digitransit — Finland National Journey Planner
 
+> ⚪ **NOT VIABLE for a GTFS-RT config-add** · recheck 2026-07-16 (live)
+> `DIGITRANSIT_SUBSCRIPTION_KEY` is now in creds and **valid** (routing GraphQL: no-key → 401, with-key → 200), **but the GTFS-RT HTTP feed is gone**: `realtime.digitransit.fi` no longer resolves (DNS-dead). Per current Digitransit docs, GTFS-RT **trip-updates are discontinued** (GraphQL only) and **vehicle-positions moved to Waltti open data** (`data.waltti.fi` → 407, its own key) or the **HSL GTFS-RT API** (already shipped keyless as `gtfs` / `hsl-helsinki`). The subscription key unlocks routing/geocoding, not a GTFS-RT feed — there is nothing to point a config-add at. Finnish GTFS-RT coverage we can have is HSL (shipped) or Waltti (separate portal + key).
+
 **Country/Region**: Finland (national, with focus on Helsinki HSL region)
 **Publisher**: Fintraffic / HSL (Helsinki Region Transport) / Waltti
 **API Endpoint**: `https://api.digitransit.fi/routing/v2/hsl/gtfs/v1` (HSL), `https://api.digitransit.fi/routing/v2/finland/gtfs/v1` (national)

--- a/tools/candidates/transit/israel-mot-transit.md
+++ b/tools/candidates/transit/israel-mot-transit.md
@@ -1,5 +1,8 @@
 # Israel Ministry of Transport — Open Data Portal (SIRI/GTFS-RT Transit)
 
+> 🔴 **BLOCKED — not a `gtfs` config-add** · recheck 2026-07-16 (live)
+> Real-time is **SIRI-SM/VM behind a free `ISRAEL_MOT` registration key** (not in creds) — SIRI, not GTFS-RT, so this is a bespoke `siri`-family build, not a generic GTFS-RT catalog entry. Static GTFS is keyless (`gtfs.mot.gov.il` → 200, 148 MB zip) but static-only ≠ real-time. No keyless GTFS-RT feed exists.
+
 **Country/Region**: Israel
 **Publisher**: Ministry of Transport and Road Safety (משרד התחבורה והבטיחות בדרכים)
 **API Endpoint**: `https://data.gov.il/api/3/action/` (CKAN portal) + SIRI/GTFS real-time feeds

--- a/tools/candidates/transit/sbb-opentransport.md
+++ b/tools/candidates/transit/sbb-opentransport.md
@@ -1,5 +1,8 @@
 # SBB / Open Transport Data Switzerland
 
+> 🔴 **BLOCKED for a `gtfs` config-add** · recheck 2026-07-16 (live)
+> Official **opentransportdata.swiss GTFS-RT requires an API token** (`SBB_OTD`, not in creds) — `api.opentransportdata.swiss` is gated (no-auth → 404/401). The keyless **community API** (`transport.opendata.ch`) is proprietary HAFAS JSON, **not GTFS-RT**, so it would be a bespoke build, not a GTFS-RT catalog entry. Needs a user-obtained free key.
+
 **Country/Region**: Switzerland (national)
 **Publisher**: SBB CFF FFS / Swiss Federal Office of Transport (BAV/OFT) via opentransportdata.swiss
 **API Endpoint**: `https://transport.opendata.ch/v1/` (community) and `https://api.opentransportdata.swiss/` (official)

--- a/tools/candidates/transit/stib-mivb-brussels.md
+++ b/tools/candidates/transit/stib-mivb-brussels.md
@@ -1,5 +1,8 @@
 # STIB-MIVB Brussels Open Data
 
+> 🔴 **BLOCKED for a `gtfs` config-add** · recheck 2026-07-16 (live)
+> GTFS-RT via the STIB Opendatasoft portal **requires an `Apikey`** (`STIB`, not in creds); the real-time vehicle-position dataset is gated (no-auth → 302 redirect to auth). Needs a user-obtained free key.
+
 **Country/Region**: Belgium - Brussels Capital Region
 **Publisher**: STIB-MIVB (Brussels public transport operator)
 **API Endpoint**: `https://data.stib-mivb.brussels/`


### PR DESCRIPTION
## What

Records the **2026-07-16 live recheck** of the five remaining Wave-0 transit candidates that were still open for a generic `gtfs` config-add. Each candidate file gets a status banner (matching the existing `> ✅ SHIPPED …` convention) with the live probe evidence.

**Net result: none became newly shippable as a keyless GTFS-RT config-add.** All five need a user action (a free registration key) or are the wrong protocol / a dead feed.

| Candidate | Verdict | Evidence |
|---|---|---|
| Israel MoT | 🔴 not a `gtfs` config-add | realtime = SIRI-SM/VM + free `ISRAEL_MOT` key → bespoke `siri` build; static GTFS keyless (200, 148 MB) |
| Digitransit Finland | ⚪ not viable | key valid (routing GraphQL 401→200) but `realtime.digitransit.fi` DNS-dead; GTFS-RT HTTP discontinued → Waltti (own key) / HSL (shipped) |
| Canada TTC/TransLink | 🟡 partial | STM shipped (#1541); TTC no keyless GTFS-RT (`bustime.ttc.ca` conn-fails); TransLink needs free key |
| SBB opentransportdata.swiss | 🔴 blocked | GTFS-RT needs `SBB_OTD` token; community `transport.opendata.ch` is HAFAS JSON not GTFS-RT |
| STIB-MIVB Brussels | 🔴 blocked | GTFS-RT needs `Apikey`; realtime dataset gated (302→auth) |

Environment sanity-checked: the SNCF NAP proxy control returned 200 in 0.5 s, so the failures are real, not local network artifacts.

## Scope

Docs-only (`tools/candidates/transit/*.md`). No feeder, schema, or code changes. Complements #1541 (STM + SNCF config-adds).
