### PR TITLE
ci: stop uploading .dockerbuild build-record artifacts

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -17,6 +17,12 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # docker/build-push-action uploads a ".dockerbuild" build-record artifact per
+  # matrix leg by default. With ~100 containers x several variants per run that
+  # exhausts the Actions artifact storage quota within days, and the records are
+  # never consumed. Disable the upload and the job summary that drives it.
+  DOCKER_BUILD_RECORD_UPLOAD: false
+  DOCKER_BUILD_SUMMARY: false
 
 jobs:
   find-dockerfiles:


### PR DESCRIPTION
Artifact storage quota was exhausted.

**Root cause:** `docker/build-push-action` uploads a per-matrix-leg `.dockerbuild` build record by default. Inventory of the repo's Actions artifacts:

| | count | size |
|---|---|---|
| live `.dockerbuild` artifacts | 182,262 | 8.15 GB |
| live non-dockerbuild artifacts | 0 | 0 |

100% of live artifact storage was build records that nothing ever consumes.

**Fix:** set `DOCKER_BUILD_RECORD_UPLOAD=false` and `DOCKER_BUILD_SUMMARY=false` at the workflow level in `build_containers.yml`, covering both `build-and-push` steps (base + transport matrices).

**Companion cleanup (out of band):** old workflow runs older than 2026-07-01 are being purged via the API (deleting a run deletes its artifacts and logs), retaining July runs. Nothing but `.dockerbuild` records is lost.