### PR TITLE
docs: regenerate source hero blocks (14 new, 118 refreshed)

### DIFF
--- a/feeders/australia-wildfires/CONTAINER.md
+++ b/feeders/australia-wildfires/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-2_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/bafu-hydro/CONTAINER.md
+++ b/feeders/bafu-hydro/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/bafu-hydro/README.md
+++ b/feeders/bafu-hydro/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/bfs-odl/CONTAINER.md
+++ b/feeders/bfs-odl/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # BfS ODL
 
-<sub>~1,700 stations, hourly gamma dose rate · Kafka · MQTT · AMQP · <a href="https://odlinfo.bfs.de/">upstream</a> · <a href="https://odlinfo.bfs.de/ODL/EN/service/data-interface/data-interface_node.html">API docs</a></sub>
+<sub>~1,700 stations, hourly gamma dose rate · Kafka · MQTT · AMQP · <a href="https://odlinfo.bfs.de/">upstream</a> · <a href="https://odlinfo.bfs.de/ODL/EN/service/datenschnittstelle/datenschnittstelle_node.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#bfs-odl/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/bfs_odl.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/bfs-odl.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://odlinfo.bfs.de/)
 
 </td></tr></table>

--- a/feeders/bfs-odl/README.md
+++ b/feeders/bfs-odl/README.md
@@ -8,7 +8,7 @@
 
 # BfS ODL
 
-<sub>~1,700 stations, hourly gamma dose rate · Kafka · MQTT · AMQP · <a href="https://odlinfo.bfs.de/">upstream</a> · <a href="https://odlinfo.bfs.de/ODL/EN/service/data-interface/data-interface_node.html">API docs</a></sub>
+<sub>~1,700 stations, hourly gamma dose rate · Kafka · MQTT · AMQP · <a href="https://odlinfo.bfs.de/">upstream</a> · <a href="https://odlinfo.bfs.de/ODL/EN/service/datenschnittstelle/datenschnittstelle_node.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#bfs-odl/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/bfs_odl.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/bfs-odl.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://odlinfo.bfs.de/)
 
 </td></tr></table>

--- a/feeders/canada-eccc-wateroffice/CONTAINER.md
+++ b/feeders/canada-eccc-wateroffice/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Canada — ~2,100 hydrometric stations, ECCC/WSC
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#canada-eccc-wateroffice) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#canada-eccc-wateroffice/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/canada-eccc-wateroffice.kql) &nbsp;·&nbsp;

--- a/feeders/canada-eccc-wateroffice/README.md
+++ b/feeders/canada-eccc-wateroffice/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Canada — ~2,100 hydrometric stations, ECCC/WSC
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#canada-eccc-wateroffice) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#canada-eccc-wateroffice/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/canada-eccc-wateroffice.kql) &nbsp;·&nbsp;

--- a/feeders/cap-alerts/CONTAINER.md
+++ b/feeders/cap-alerts/CONTAINER.md
@@ -1,4 +1,31 @@
-# CAP Alerts Kafka, MQTT, and AMQP containers
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
+# CAP Alerts
+
+<sub>configurable CAP 1.2 public alerts · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable CAP 1.2 public alerts
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#cap-alerts) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#cap-alerts/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/cap-alerts.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Overview](README.md) · [Events](EVENTS.md) · [Source contract](xreg/cap-alerts.xreg.json)
 

--- a/feeders/cap-alerts/README.md
+++ b/feeders/cap-alerts/README.md
@@ -1,4 +1,31 @@
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
 # CAP Alerts
+
+<sub>configurable CAP 1.2 public alerts · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable CAP 1.2 public alerts
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#cap-alerts) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#cap-alerts/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/cap-alerts.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Events](EVENTS.md) · [Container contract](CONTAINER.md) · [Source contract](xreg/cap-alerts.xreg.json)
 

--- a/feeders/carbon-intensity/CONTAINER.md
+++ b/feeders/carbon-intensity/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-2_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/carbon-intensity/README.md
+++ b/feeders/carbon-intensity/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-2_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/cbp-border-wait/CONTAINER.md
+++ b/feeders/cbp-border-wait/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/cbp-border-wait/README.md
+++ b/feeders/cbp-border-wait/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/celestrak/CONTAINER.md
+++ b/feeders/celestrak/CONTAINER.md
@@ -1,14 +1,14 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<div style="font-size:48px">🛰️</div><br>
-<sub><b>Space</b></sub>
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
 </td>
 <td valign="middle">
 
-# CelesTrak
+# CelesTrak Orbital Data
 
-<sub>public satellite catalog and orbital elements · Kafka · MQTT · AMQP</sub>
+<sub>satellite catalog (SATCAT) and GP orbital element sets, keyed by NORAD catalog number · Kafka · MQTT · AMQP · <a href="https://celestrak.org/">upstream</a> · <a href="https://celestrak.org/NORAD/documentation/gp-data-formats.php">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,13 +16,14 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Space - public orbital data redistributed by CelesTrak
+> Global — satellite catalog (SATCAT) and GP orbital element sets, keyed by NORAD catalog number
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#celestrak) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#celestrak/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/celestrak.kql)
+[🗄️ **KQL schema**](kql/celestrak.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://celestrak.org/)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/celestrak/README.md
+++ b/feeders/celestrak/README.md
@@ -1,14 +1,14 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<div style="font-size:48px">🛰️</div><br>
-<sub><b>Space</b></sub>
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
 </td>
 <td valign="middle">
 
-# CelesTrak
+# CelesTrak Orbital Data
 
-<sub>public satellite catalog and orbital elements · Kafka · MQTT · AMQP · <a href="https://celestrak.org/">upstream</a> · <a href="https://celestrak.org/NORAD/documentation/gp-data-formats.php">GP docs</a> · <a href="https://celestrak.org/satcat/">SATCAT docs</a></sub>
+<sub>satellite catalog (SATCAT) and GP orbital element sets, keyed by NORAD catalog number · Kafka · MQTT · AMQP · <a href="https://celestrak.org/">upstream</a> · <a href="https://celestrak.org/NORAD/documentation/gp-data-formats.php">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,7 +16,7 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Space - public orbital data redistributed by CelesTrak
+> Global — satellite catalog (SATCAT) and GP orbital element sets, keyed by NORAD catalog number
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#celestrak) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#celestrak/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/datex2/CONTAINER.md
+++ b/feeders/datex2/CONTAINER.md
@@ -1,4 +1,31 @@
-# DATEX II Kafka, MQTT, and AMQP containers
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/eu.png" alt="Europe" width="64" height="48"><br>
+<sub><b>Europe</b></sub>
+</td>
+<td valign="middle">
+
+# DATEX II
+
+<sub>generalized DATEX II road traffic XML profiles · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Europe — generalized DATEX II road traffic XML profiles
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#datex2) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#datex2/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/datex2.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 DATEX II containers turn European road-traffic XML publications into CloudEvents for operational traffic dashboards, traveler-information services, safety analytics, and event-driven digital twins.
 

--- a/feeders/datex2/README.md
+++ b/feeders/datex2/README.md
@@ -1,4 +1,31 @@
-# DATEX II real-time traffic feeder
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/eu.png" alt="Europe" width="64" height="48"><br>
+<sub><b>Europe</b></sub>
+</td>
+<td valign="middle">
+
+# DATEX II
+
+<sub>generalized DATEX II road traffic XML profiles · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Europe — generalized DATEX II road traffic XML profiles
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#datex2) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#datex2/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/datex2.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Events](EVENTS.md) · [Container contract](CONTAINER.md) · [Source contract](xreg/datex2.xreg.json)
 

--- a/feeders/dmi/CONTAINER.md
+++ b/feeders/dmi/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # DMI
 
-<sub>meteorological observations, sea level, lightning strikes · Kafka · MQTT · AMQP · <a href="https://www.dmi.dk/">upstream</a> · <a href="https://opendataapi.dmi.dk/">API docs</a></sub>
+<sub>DMI observation triad (metObs + oceanObs + lightning) · Kafka · MQTT · AMQP · <a href="https://www.dmi.dk/">upstream</a> · <a href="https://opendatadocs.dmi.govcloud.dk/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,7 +16,7 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Denmark — meteorological observations, sea level, lightning strikes
+> Denmark — DMI observation triad (metObs + oceanObs + lightning)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#dmi) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dmi/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/dmi/README.md
+++ b/feeders/dmi/README.md
@@ -8,7 +8,7 @@
 
 # DMI
 
-<sub>meteorological observations, sea level, lightning strikes · Kafka · MQTT · AMQP · <a href="https://www.dmi.dk/">upstream</a> · <a href="https://opendataapi.dmi.dk/">API docs</a></sub>
+<sub>DMI observation triad (metObs + oceanObs + lightning) · Kafka · MQTT · AMQP · <a href="https://www.dmi.dk/">upstream</a> · <a href="https://opendatadocs.dmi.govcloud.dk/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,7 +16,7 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Denmark — meteorological observations, sea level, lightning strikes
+> Denmark — DMI observation triad (metObs + oceanObs + lightning)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#dmi) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dmi/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/dwd-pollenflug/CONTAINER.md
+++ b/feeders/dwd-pollenflug/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # DWD Pollenflug
 
-<sub>daily pollen forecasts, 27 regions · Kafka · MQTT · AMQP · <a href="https://dwd.de/DE/klimaumwelt/ku_beratung/gesundheit/pollen/pollen_node.html">upstream</a> · <a href="https://opendata.dwd.de/climate_environment/health/alerts/">API docs</a></sub>
+<sub>daily pollen forecasts, 27 regions · Kafka · MQTT · AMQP · <a href="https://www.dwd.de/EN/specialusers/medical/pollenflug/pollenflug_node.html">upstream</a> · <a href="https://opendata.dwd.de/climate_environment/health/alerts/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,8 +22,8 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dwd-pollenflug/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/dwd_pollenflug.kql) &nbsp;·&nbsp;
-[↗ **Upstream**](https://dwd.de/DE/klimaumwelt/ku_beratung/gesundheit/pollen/pollen_node.html)
+[🗄️ **KQL schema**](kql/dwd-pollenflug.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://www.dwd.de/EN/specialusers/medical/pollenflug/pollenflug_node.html)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/dwd-pollenflug/README.md
+++ b/feeders/dwd-pollenflug/README.md
@@ -8,7 +8,7 @@
 
 # DWD Pollenflug
 
-<sub>daily pollen forecasts, 27 regions · Kafka · MQTT · AMQP · <a href="https://dwd.de/DE/klimaumwelt/ku_beratung/gesundheit/pollen/pollen_node.html">upstream</a> · <a href="https://opendata.dwd.de/climate_environment/health/alerts/">API docs</a></sub>
+<sub>daily pollen forecasts, 27 regions · Kafka · MQTT · AMQP · <a href="https://www.dwd.de/EN/specialusers/medical/pollenflug/pollenflug_node.html">upstream</a> · <a href="https://opendata.dwd.de/climate_environment/health/alerts/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,8 +22,8 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dwd-pollenflug/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/dwd_pollenflug.kql) &nbsp;·&nbsp;
-[↗ **Upstream**](https://dwd.de/DE/klimaumwelt/ku_beratung/gesundheit/pollen/pollen_node.html)
+[🗄️ **KQL schema**](kql/dwd-pollenflug.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://www.dwd.de/EN/specialusers/medical/pollenflug/pollenflug_node.html)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/dwd/CONTAINER.md
+++ b/feeders/dwd/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Germany — ~1,450 stations, observations and CAP alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#dwd) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dwd/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/dwd.kql) &nbsp;·&nbsp;

--- a/feeders/dwd/README.md
+++ b/feeders/dwd/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Germany — ~1,450 stations, observations and CAP alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#dwd) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#dwd/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/dwd.kql) &nbsp;·&nbsp;

--- a/feeders/entsoe/CONTAINER.md
+++ b/feeders/entsoe/CONTAINER.md
@@ -12,16 +12,18 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-7_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-7_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — electricity generation, prices, load, flows (requires token)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#entsoe) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#entsoe/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/entsoe.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://transparency.entsoe.eu/)
 
 </td></tr></table>

--- a/feeders/entsoe/README.md
+++ b/feeders/entsoe/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-7_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-7_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
@@ -23,6 +23,7 @@
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/entsoe.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://transparency.entsoe.eu/)
 
 </td></tr></table>

--- a/feeders/entur-norway/CONTAINER.md
+++ b/feeders/entur-norway/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Norway — national real-time transit, SIRI ET/VM/SX
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#entur-norway) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#entur-norway/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/entur-norway.kql) &nbsp;·&nbsp;

--- a/feeders/entur-norway/README.md
+++ b/feeders/entur-norway/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Norway — national real-time transit, SIRI ET/VM/SX
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#entur-norway) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#entur-norway/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/entur-norway.kql) &nbsp;·&nbsp;

--- a/feeders/environment-canada/CONTAINER.md
+++ b/feeders/environment-canada/CONTAINER.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#environment-canada/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/environment_canada.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/environment-canada.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://weather.gc.ca/)
 
 </td></tr></table>

--- a/feeders/environment-canada/README.md
+++ b/feeders/environment-canada/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#environment-canada/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/environment_canada.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/environment-canada.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://weather.gc.ca/)
 
 </td></tr></table>

--- a/feeders/erddap/CONTAINER.md
+++ b/feeders/erddap/CONTAINER.md
@@ -1,4 +1,31 @@
-# ERDDAP container images — Kafka, MQTT, and AMQP
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
+# ERDDAP
+
+<sub>configurable ERDDAP tabledap station observations · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable ERDDAP tabledap station observations
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#erddap) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#erddap/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/erddap.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Project overview](README.md) · [Event schemas](EVENTS.md) · [KQL schema](kql/erddap.kql) · [Deploy portal](https://clemensv.github.io/real-time-sources#erddap)
 

--- a/feeders/erddap/README.md
+++ b/feeders/erddap/README.md
@@ -1,4 +1,31 @@
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
 # ERDDAP
+
+<sub>configurable ERDDAP tabledap station observations · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable ERDDAP tabledap station observations
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#erddap) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#erddap/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/erddap.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [🚀 Deploy to Azure](https://clemensv.github.io/real-time-sources#erddap) · [📓 Fabric Notebook](https://clemensv.github.io/real-time-sources#erddap/fabric-notebook) · [🐳 Container contract](CONTAINER.md) · [📑 Event schemas](EVENTS.md) · [🗄️ KQL schema](kql/erddap.kql)
 

--- a/feeders/eurdep-radiation/CONTAINER.md
+++ b/feeders/eurdep-radiation/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # EURDEP Radiation
 
-<sub>~5,500 stations, 39 countries, gamma dose · Kafka · MQTT · AMQP · <a href="https://remon.jrc.ec.europa.eu/">upstream</a> · <a href="https://remap.jrc.ec.europa.eu/">API docs</a></sub>
+<sub>~5,500 stations, 39 countries, gamma dose · Kafka · MQTT · AMQP · <a href="https://remon.jrc.ec.europa.eu/">upstream</a> · <a href="https://eurdep.jrc.ec.europa.eu/Basic/Pages/Public/Data/Default.aspx">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/eurdep-radiation/README.md
+++ b/feeders/eurdep-radiation/README.md
@@ -8,7 +8,7 @@
 
 # EURDEP Radiation
 
-<sub>~5,500 stations, 39 countries, gamma dose · Kafka · MQTT · AMQP · <a href="https://remon.jrc.ec.europa.eu/">upstream</a> · <a href="https://remap.jrc.ec.europa.eu/">API docs</a></sub>
+<sub>~5,500 stations, 39 countries, gamma dose · Kafka · MQTT · AMQP · <a href="https://remon.jrc.ec.europa.eu/">upstream</a> · <a href="https://eurdep.jrc.ec.europa.eu/Basic/Pages/Public/Data/Default.aspx">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/fdsn-seismology/CONTAINER.md
+++ b/feeders/fdsn-seismology/CONTAINER.md
@@ -8,11 +8,23 @@
 
 # FDSN Seismology
 
-<sub>9 cataloged FDSN nodes · Kafka · MQTT · AMQP · <a href="https://www.fdsn.org/webservices/">upstream</a> · <a href="https://geofon.gfz-potsdam.de/fdsnws/event/1/application.wadl">event WADL</a></sub>
+<sub>federated earthquake detections, 7 FDSN nodes · Kafka · MQTT · AMQP · <a href="https://www.fdsn.org/webservices/">upstream</a> · <a href="https://geofon.gfz-potsdam.de/fdsnws/event/1/application.wadl">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
 <img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — federated earthquake detections, 7 FDSN nodes
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#fdsn-seismology) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#fdsn-seismology/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/fdsn-seismology.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
+[↗ **Upstream**](https://www.fdsn.org/webservices/)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/fdsn-seismology/README.md
+++ b/feeders/fdsn-seismology/README.md
@@ -8,7 +8,7 @@
 
 # FDSN Seismology
 
-<sub>9 cataloged FDSN nodes · Kafka · MQTT · AMQP · <a href="https://www.fdsn.org/webservices/">upstream</a> · <a href="https://geofon.gfz-potsdam.de/fdsnws/event/1/application.wadl">event WADL</a></sub>
+<sub>federated earthquake detections, 7 FDSN nodes · Kafka · MQTT · AMQP · <a href="https://www.fdsn.org/webservices/">upstream</a> · <a href="https://geofon.gfz-potsdam.de/fdsnws/event/1/application.wadl">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,13 +16,14 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Global earthquake detections from pre-configured FDSN event-service nodes
+> Global — federated earthquake detections, 7 FDSN nodes
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#fdsn-seismology) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#fdsn-seismology/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/fdsn-seismology.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.fdsn.org/webservices/)
 
 </td></tr></table>

--- a/feeders/fienta/CONTAINER.md
+++ b/feeders/fienta/CONTAINER.md
@@ -8,17 +8,18 @@
 
 # Fienta
 
-<sub>ticketed public events with sale-status signals · Kafka · MQTT · AMQP · <a href="https://fienta.com/">upstream</a> · <a href="https://fienta.com/api/v1/public/events">API docs</a></sub>
+<sub>ticketed public events with sale-status signals · Kafka · MQTT · AMQP · <a href="https://fienta.com/">upstream</a> · <a href="https://fienta.com/api-public-events">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — ticketed public events with sale-status signals
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#fienta) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#fienta/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/fienta.kql) &nbsp;·&nbsp;

--- a/feeders/fienta/README.md
+++ b/feeders/fienta/README.md
@@ -8,17 +8,18 @@
 
 # Fienta
 
-<sub>ticketed public events with sale-status signals · Kafka · MQTT · AMQP · <a href="https://fienta.com/">upstream</a> · <a href="https://fienta.com/api/v1/public/events">API docs</a></sub>
+<sub>ticketed public events with sale-status signals · Kafka · MQTT · AMQP · <a href="https://fienta.com/">upstream</a> · <a href="https://fienta.com/api-public-events">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — ticketed public events with sale-status signals
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#fienta) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#fienta/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/fienta.kql) &nbsp;·&nbsp;

--- a/feeders/french-road-traffic/CONTAINER.md
+++ b/feeders/french-road-traffic/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/french-road-traffic/README.md
+++ b/feeders/french-road-traffic/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/gbfs-bikeshare/CONTAINER.md
+++ b/feeders/gbfs-bikeshare/CONTAINER.md
@@ -1,4 +1,32 @@
-# GBFS Bikeshare Kafka, MQTT, and AMQP containers
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global - user-configured GBFS micromobility systems" width="64" height="48"><br>
+<sub><b>Global - user-configured GBFS micromobility systems</b></sub>
+</td>
+<td valign="middle">
+
+# GBFS Bikeshare
+
+<sub>Global - user-configured GBFS micromobility systems · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global - user-configured GBFS micromobility systems
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gbfs-bikeshare) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gbfs-bikeshare/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/gbfs-bikeshare.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 For the source overview see [README.md](README.md); for the CloudEvents contract and routing metadata see [EVENTS.md](EVENTS.md).
 

--- a/feeders/gbfs-bikeshare/README.md
+++ b/feeders/gbfs-bikeshare/README.md
@@ -1,26 +1,29 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
-<sub><b>Global</b></sub>
+<img src="https://flagcdn.com/64x48/un.png" alt="Global - user-configured GBFS micromobility systems" width="64" height="48"><br>
+<sub><b>Global - user-configured GBFS micromobility systems</b></sub>
 </td>
 <td valign="middle">
 
 # GBFS Bikeshare
 
-<sub>Global micromobility systems via GBFS autodiscovery · Kafka · MQTT · AMQP · <a href="https://gbfs.org/">upstream</a> · <a href="https://github.com/MobilityData/gbfs/blob/master/gbfs.md">spec docs</a></sub>
+<sub>Global - user-configured GBFS micromobility systems · Kafka · MQTT · AMQP</sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-2_paths-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Global — configurable GBFS bikeshare, scooter-share, and micromobility availability feeds
+> Global - user-configured GBFS micromobility systems
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gbfs-bikeshare) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gbfs-bikeshare/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/gbfs-bikeshare.kql) &nbsp;·&nbsp;
-[↗ **Upstream**](https://gbfs.org/)
+[🗺️ **Fabric Map**](fabric/README.md)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/gdacs/CONTAINER.md
+++ b/feeders/gdacs/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Global — earthquakes, floods, cyclones, volcanoes, droughts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gdacs) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gdacs/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/gdacs.kql) &nbsp;·&nbsp;

--- a/feeders/gdacs/README.md
+++ b/feeders/gdacs/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Global — earthquakes, floods, cyclones, volcanoes, droughts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gdacs) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gdacs/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/gdacs.kql) &nbsp;·&nbsp;

--- a/feeders/german-waters/CONTAINER.md
+++ b/feeders/german-waters/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # German Waters
 
-<sub>12 state portals, ~2,724 stations · Kafka · MQTT · AMQP · <a href="https://hvz.lubw.baden-wuerttemberg.de/">upstream</a> · <a href="https://hvz.lubw.baden-wuerttemberg.de/">API docs</a></sub>
+<sub>12 state portals, ~2,724 stations · Kafka · MQTT · AMQP · <a href="https://hvz.lubw.baden-wuerttemberg.de/">upstream</a> · <a href="https://www.hvz.baden-wuerttemberg.de/php/datenfuerentwickler.php">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#german-waters/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/german_waters.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/german-waters.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://hvz.lubw.baden-wuerttemberg.de/)
 
 </td></tr></table>

--- a/feeders/german-waters/README.md
+++ b/feeders/german-waters/README.md
@@ -8,7 +8,7 @@
 
 # German Waters
 
-<sub>12 state portals, ~2,724 stations · Kafka · MQTT · AMQP · <a href="https://hvz.lubw.baden-wuerttemberg.de/">upstream</a> · <a href="https://hvz.lubw.baden-wuerttemberg.de/">API docs</a></sub>
+<sub>12 state portals, ~2,724 stations · Kafka · MQTT · AMQP · <a href="https://hvz.lubw.baden-wuerttemberg.de/">upstream</a> · <a href="https://www.hvz.baden-wuerttemberg.de/php/datenfuerentwickler.php">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#german-waters/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/german_waters.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/german-waters.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://hvz.lubw.baden-wuerttemberg.de/)
 
 </td></tr></table>

--- a/feeders/gracedb/CONTAINER.md
+++ b/feeders/gracedb/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/gracedb/README.md
+++ b/feeders/gracedb/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/gtfs/CONTAINER.md
+++ b/feeders/gtfs/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Global — 1,000+ transit agencies, vehicles, trips, alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gtfs) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gtfs/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/gtfs.kql) &nbsp;·&nbsp;

--- a/feeders/gtfs/README.md
+++ b/feeders/gtfs/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Global — 1,000+ transit agencies, vehicles, trips, alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#gtfs) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#gtfs/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/gtfs.kql) &nbsp;·&nbsp;

--- a/feeders/hongkong-epd/CONTAINER.md
+++ b/feeders/hongkong-epd/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # Hong Kong EPD AQHI
 
-<sub>18 AQHI stations, hourly health index · Kafka · MQTT · AMQP · <a href="https://www.aqhi.gov.hk/">upstream</a> · <a href="https://www.aqhi.gov.hk/en/">API docs</a></sub>
+<sub>18 AQHI stations, hourly health index · Kafka · MQTT · AMQP · <a href="https://www.aqhi.gov.hk/">upstream</a> · <a href="https://www.aqhi.gov.hk/en/aqhi/statistics-of-aqhi.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/hongkong-epd/README.md
+++ b/feeders/hongkong-epd/README.md
@@ -8,7 +8,7 @@
 
 # Hong Kong EPD AQHI
 
-<sub>18 AQHI stations, hourly health index · Kafka · MQTT · AMQP · <a href="https://www.aqhi.gov.hk/">upstream</a> · <a href="https://www.aqhi.gov.hk/en/">API docs</a></sub>
+<sub>18 AQHI stations, hourly health index · Kafka · MQTT · AMQP · <a href="https://www.aqhi.gov.hk/">upstream</a> · <a href="https://www.aqhi.gov.hk/en/aqhi/statistics-of-aqhi.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/hsl-hfp/CONTAINER.md
+++ b/feeders/hsl-hfp/CONTAINER.md
@@ -1,13 +1,4 @@
 <!-- source-hero:begin -->
-
-<!-- upstream-links:begin -->
-## Upstream
-
-- Home page: <https://www.hsl.fi/en/hsl/open-data>
-- API / data documentation: <https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/>
-
-<!-- upstream-links:end -->
-
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
 <img src="https://flagcdn.com/64x48/fi.png" alt="Finland / Helsinki" width="64" height="48"><br>
@@ -17,7 +8,7 @@
 
 # HSL HFP
 
-<sub>transit vehicle positions via MQTT, ~1,700 vehicles @ 1 Hz · Kafka · MQTT · AMQP · <a href="https://www.hsl.fi/en/hsl/open-data">upstream</a> · <a href="https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/">API docs</a></sub>
+<sub>transit vehicle positions via MQTT, ~1,700 vehicles @ 1 Hz · Kafka · MQTT · AMQP · <a href="https://www.hsl.fi/en/hsl/open-data">upstream</a> · <a href="https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/high-frequency-positioning/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -31,6 +22,7 @@
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/hsl-hfp.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.hsl.fi/en/hsl/open-data)
 
 </td></tr></table>

--- a/feeders/hsl-hfp/README.md
+++ b/feeders/hsl-hfp/README.md
@@ -1,13 +1,4 @@
 <!-- source-hero:begin -->
-
-<!-- upstream-links:begin -->
-## Upstream
-
-- Home page: <https://www.hsl.fi/en/hsl/open-data>
-- API / data documentation: <https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/>
-
-<!-- upstream-links:end -->
-
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
 <img src="https://flagcdn.com/64x48/fi.png" alt="Finland / Helsinki" width="64" height="48"><br>
@@ -17,7 +8,7 @@
 
 # HSL HFP
 
-<sub>transit vehicle positions via MQTT, ~1,700 vehicles @ 1 Hz · Kafka · MQTT · AMQP · <a href="https://www.hsl.fi/en/hsl/open-data">upstream</a> · <a href="https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/">API docs</a></sub>
+<sub>transit vehicle positions via MQTT, ~1,700 vehicles @ 1 Hz · Kafka · MQTT · AMQP · <a href="https://www.hsl.fi/en/hsl/open-data">upstream</a> · <a href="https://digitransit.fi/en/developers/apis/4-realtime-api/vehicle-positions/high-frequency-positioning/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/imgw-hydro/CONTAINER.md
+++ b/feeders/imgw-hydro/CONTAINER.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#imgw-hydro/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/imgw_hydro.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/imgw-hydro.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.imgw.pl/)
 
 </td></tr></table>

--- a/feeders/imgw-hydro/README.md
+++ b/feeders/imgw-hydro/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#imgw-hydro/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/imgw_hydro.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/imgw-hydro.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.imgw.pl/)
 
 </td></tr></table>

--- a/feeders/inpe-deter-brazil/CONTAINER.md
+++ b/feeders/inpe-deter-brazil/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Brazil — Amazon & Cerrado deforestation alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#inpe-deter-brazil) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#inpe-deter-brazil/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/inpe_deter_brazil.kql) &nbsp;·&nbsp;

--- a/feeders/inpe-deter-brazil/README.md
+++ b/feeders/inpe-deter-brazil/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Brazil — Amazon & Cerrado deforestation alerts
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#inpe-deter-brazil) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#inpe-deter-brazil/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/inpe_deter_brazil.kql) &nbsp;·&nbsp;

--- a/feeders/irceline-belgium/CONTAINER.md
+++ b/feeders/irceline-belgium/CONTAINER.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#irceline-belgium/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/irceline_belgium.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/irceline-belgium.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.irceline.be/)
 
 </td></tr></table>

--- a/feeders/irceline-belgium/README.md
+++ b/feeders/irceline-belgium/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#irceline-belgium/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/irceline_belgium.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/irceline-belgium.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.irceline.be/)
 
 </td></tr></table>

--- a/feeders/jma-bosai-quake/CONTAINER.md
+++ b/feeders/jma-bosai-quake/CONTAINER.md
@@ -8,11 +8,11 @@
 
 # JMA Bosai Quake
 
-<sub>JMA earthquake bulletins (hypocenter, magnitude, JMA intensity) · Kafka · MQTT · AMQP · <a href="https://www.jma.go.jp/bosai/map.html?contents=earthquake_map">upstream</a> · <a href="https://www.jma.go.jp/en/quake/">API docs</a></sub>
+<sub>JMA earthquake bulletins (hypocenter, magnitude, JMA intensity) · Kafka · MQTT · AMQP · <a href="https://www.jma.go.jp/bosai/map.html?contents=earthquake_map">upstream</a> · <a href="https://www.jma.go.jp/bosai/quake/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/jma-bosai-quake/README.md
+++ b/feeders/jma-bosai-quake/README.md
@@ -8,11 +8,11 @@
 
 # JMA Bosai Quake
 
-<sub>JMA earthquake bulletins (hypocenter, magnitude, JMA intensity) · Kafka · MQTT · AMQP · <a href="https://www.jma.go.jp/bosai/map.html?contents=earthquake_map">upstream</a> · <a href="https://www.jma.go.jp/en/quake/">API docs</a></sub>
+<sub>JMA earthquake bulletins (hypocenter, magnitude, JMA intensity) · Kafka · MQTT · AMQP · <a href="https://www.jma.go.jp/bosai/map.html?contents=earthquake_map">upstream</a> · <a href="https://www.jma.go.jp/bosai/quake/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/king-county-marine/CONTAINER.md
+++ b/feeders/king-county-marine/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # King County Marine
 
-<sub>buoy and mooring telemetry · Kafka · MQTT · AMQP · <a href="https://green2.kingcounty.gov/marine/">upstream</a> · <a href="https://data.kingcounty.gov/Environment-Waste-Management/Puget-Sound-Marine-Monitoring/t5pc-wkwc">API docs</a></sub>
+<sub>buoy and mooring telemetry · Kafka · MQTT · AMQP · <a href="https://green2.kingcounty.gov/marine/">upstream</a> · <a href="https://data.kingcounty.gov/Environment-Waste-Management/Marine-Buoy-Data/9j7t-rs5d">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/king-county-marine/README.md
+++ b/feeders/king-county-marine/README.md
@@ -8,7 +8,7 @@
 
 # King County Marine
 
-<sub>buoy and mooring telemetry · Kafka · MQTT · AMQP · <a href="https://green2.kingcounty.gov/marine/">upstream</a> · <a href="https://data.kingcounty.gov/Environment-Waste-Management/Puget-Sound-Marine-Monitoring/t5pc-wkwc">API docs</a></sub>
+<sub>buoy and mooring telemetry · Kafka · MQTT · AMQP · <a href="https://green2.kingcounty.gov/marine/">upstream</a> · <a href="https://data.kingcounty.gov/Environment-Waste-Management/Marine-Buoy-Data/9j7t-rs5d">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/kiwis/CONTAINER.md
+++ b/feeders/kiwis/CONTAINER.md
@@ -1,4 +1,31 @@
-# KiWIS container contract
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
+# KiWIS
+
+<sub>configurable KISTERS KiWIS hydrology endpoints · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable KISTERS KiWIS hydrology endpoints
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#kiwis) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#kiwis/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/kiwis.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Overview](README.md) · [Events](EVENTS.md) · [xRegistry contract](xreg/kiwis.xreg.json)
 

--- a/feeders/kiwis/README.md
+++ b/feeders/kiwis/README.md
@@ -1,4 +1,31 @@
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
 # KiWIS
+
+<sub>configurable KISTERS KiWIS hydrology endpoints · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — configurable KISTERS KiWIS hydrology endpoints
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#kiwis) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#kiwis/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/kiwis.kql)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [Events](EVENTS.md) · [Container deployment](CONTAINER.md) · [xRegistry contract](xreg/kiwis.xreg.json)
 

--- a/feeders/kystverket-ais/CONTAINER.md
+++ b/feeders/kystverket-ais/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/kystverket-ais/README.md
+++ b/feeders/kystverket-ais/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/meteoalarm/CONTAINER.md
+++ b/feeders/meteoalarm/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — 37 countries, severe weather warnings
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#meteoalarm) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#meteoalarm/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/meteoalarm.kql) &nbsp;·&nbsp;

--- a/feeders/meteoalarm/README.md
+++ b/feeders/meteoalarm/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — 37 countries, severe weather warnings
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#meteoalarm) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#meteoalarm/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/meteoalarm.kql) &nbsp;·&nbsp;

--- a/feeders/nasa-firms/CONTAINER.md
+++ b/feeders/nasa-firms/CONTAINER.md
@@ -1,22 +1,22 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<div style="font-size:48px">🌍</div>
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
 <sub><b>Global</b></sub>
 </td>
 <td valign="middle">
 
-# NASA FIRMS
+# NASA FIRMS Active Fire
 
-<sub>global active-fire detections · Kafka · MQTT · AMQP · <a href="https://firms.modaps.eosdis.nasa.gov/">upstream</a> · <a href="https://firms.modaps.eosdis.nasa.gov/api/area/">API docs</a></sub>
+<sub>active fire & thermal anomaly detections (VIIRS/MODIS), OSINT · Kafka · MQTT · AMQP · <a href="https://firms.modaps.eosdis.nasa.gov/">upstream</a> · <a href="https://firms.modaps.eosdis.nasa.gov/api/area/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-ACI_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_Map_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Global — active fires for OSINT and situational awareness
+> Global — active fire & thermal anomaly detections (VIIRS/MODIS), OSINT
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nasa-firms) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nasa-firms/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/nasa-firms/README.md
+++ b/feeders/nasa-firms/README.md
@@ -1,22 +1,22 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<div style="font-size:48px">🌍</div>
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
 <sub><b>Global</b></sub>
 </td>
 <td valign="middle">
 
-# NASA FIRMS
+# NASA FIRMS Active Fire
 
-<sub>global active-fire detections · Kafka · MQTT · AMQP · <a href="https://firms.modaps.eosdis.nasa.gov/">upstream</a> · <a href="https://firms.modaps.eosdis.nasa.gov/api/area/">API docs</a></sub>
+<sub>active fire & thermal anomaly detections (VIIRS/MODIS), OSINT · Kafka · MQTT · AMQP · <a href="https://firms.modaps.eosdis.nasa.gov/">upstream</a> · <a href="https://firms.modaps.eosdis.nasa.gov/api/area/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-ACI_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_Map_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Global — active fires for OSINT and situational awareness
+> Global — active fire & thermal anomaly detections (VIIRS/MODIS), OSINT
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nasa-firms) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nasa-firms/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/ndw-road-traffic/CONTAINER.md
+++ b/feeders/ndw-road-traffic/CONTAINER.md
@@ -19,6 +19,7 @@
 > Netherlands — national road traffic, DATEX II XML
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#ndw-road-traffic) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#ndw-road-traffic/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/ndw-road-traffic.kql) &nbsp;·&nbsp;

--- a/feeders/nextbus/CONTAINER.md
+++ b/feeders/nextbus/CONTAINER.md
@@ -12,15 +12,17 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > North America — public transit arrivals
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nextbus) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nextbus/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/nextbus.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.umoiq.com/)
 
 </td></tr></table>

--- a/feeders/nextbus/README.md
+++ b/feeders/nextbus/README.md
@@ -12,15 +12,17 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > North America — public transit arrivals
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nextbus) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nextbus/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/nextbus.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.umoiq.com/)
 
 </td></tr></table>

--- a/feeders/nifc-usa-wildfires/CONTAINER.md
+++ b/feeders/nifc-usa-wildfires/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > United States — active wildfire incidents, NIFC
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nifc-usa-wildfires) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nifc-usa-wildfires/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/nifc-usa-wildfires.kql) &nbsp;·&nbsp;

--- a/feeders/nina-bbk/CONTAINER.md
+++ b/feeders/nina-bbk/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Germany — MOWAS, KATWARN, BIWAPP, DWD, LHP, Police
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nina-bbk) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nina-bbk/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/nina-bbk.kql) &nbsp;·&nbsp;

--- a/feeders/nve-hydro/CONTAINER.md
+++ b/feeders/nve-hydro/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/nve-hydro/README.md
+++ b/feeders/nve-hydro/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/nws-alerts/CONTAINER.md
+++ b/feeders/nws-alerts/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > United States — active alerts via api.weather.gov
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nws-alerts) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nws-alerts/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/nws-alerts.kql) &nbsp;·&nbsp;

--- a/feeders/nws-alerts/README.md
+++ b/feeders/nws-alerts/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > United States — active alerts via api.weather.gov
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#nws-alerts) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#nws-alerts/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/nws-alerts.kql) &nbsp;·&nbsp;

--- a/feeders/open-charge-map/CONTAINER.md
+++ b/feeders/open-charge-map/CONTAINER.md
@@ -23,6 +23,7 @@
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/open-charge-map.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://openchargemap.org/)
 
 </td></tr></table>

--- a/feeders/open-charge-map/README.md
+++ b/feeders/open-charge-map/README.md
@@ -22,8 +22,8 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#open-charge-map/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/open-charge-map.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [↗ **Upstream**](https://openchargemap.org/)
 
 </td></tr></table>

--- a/feeders/openaq/CONTAINER.md
+++ b/feeders/openaq/CONTAINER.md
@@ -1,4 +1,32 @@
-# OpenAQ containers (Kafka, MQTT, AMQP)
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
+# OpenAQ
+
+<sub>locations, sensors, latest pollutant measurements · Kafka · MQTT · AMQP · <a href="https://openaq.org/">upstream</a> · <a href="https://docs.openaq.org/">API docs</a></sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — locations, sensors, latest pollutant measurements
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#openaq) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#openaq/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/openaq.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://openaq.org/)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [📘 README](README.md) · [📑 Events](EVENTS.md) · [↗ OpenAQ API docs](https://docs.openaq.org/)
 

--- a/feeders/openaq/README.md
+++ b/feeders/openaq/README.md
@@ -1,4 +1,32 @@
-# OpenAQ generalized air-quality feeder
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="Global" width="64" height="48"><br>
+<sub><b>Global</b></sub>
+</td>
+<td valign="middle">
+
+# OpenAQ
+
+<sub>locations, sensors, latest pollutant measurements · Kafka · MQTT · AMQP · <a href="https://openaq.org/">upstream</a> · <a href="https://docs.openaq.org/">API docs</a></sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Global — locations, sensors, latest pollutant measurements
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#openaq) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#openaq/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/openaq.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://openaq.org/)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [📑 Events](EVENTS.md) · [🐳 Container](CONTAINER.md) · [↗ OpenAQ API docs](https://docs.openaq.org/)
 

--- a/feeders/rws-waterwebservices/CONTAINER.md
+++ b/feeders/rws-waterwebservices/CONTAINER.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#rws-waterwebservices/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/rws_waterwebservices.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/rws-waterwebservices.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://waterinfo.rws.nl/)
 
 </td></tr></table>

--- a/feeders/rws-waterwebservices/README.md
+++ b/feeders/rws-waterwebservices/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#rws-waterwebservices/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/rws_waterwebservices.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/rws-waterwebservices.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://waterinfo.rws.nl/)
 
 </td></tr></table>

--- a/feeders/seattle-911/CONTAINER.md
+++ b/feeders/seattle-911/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/seattle-911/README.md
+++ b/feeders/seattle-911/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/seattle-street-closures/CONTAINER.md
+++ b/feeders/seattle-street-closures/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # Seattle Street Closures
 
-<sub>permit-driven street closure windows · Kafka · MQTT · AMQP · <a href="https://data.seattle.gov/">upstream</a> · <a href="https://data.seattle.gov/Built-Environment/Street-Closures/ium9-iqtc">API docs</a></sub>
+<sub>permit-driven street closure windows · Kafka · MQTT · AMQP · <a href="https://data.seattle.gov/">upstream</a> · <a href="https://data.seattle.gov/Transportation/Right-of-Way-Closure-Data/qhcj-3xgi">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/seattle-street-closures/README.md
+++ b/feeders/seattle-street-closures/README.md
@@ -8,7 +8,7 @@
 
 # Seattle Street Closures
 
-<sub>permit-driven street closure windows · Kafka · MQTT · AMQP · <a href="https://data.seattle.gov/">upstream</a> · <a href="https://data.seattle.gov/Built-Environment/Street-Closures/ium9-iqtc">API docs</a></sub>
+<sub>permit-driven street closure windows · Kafka · MQTT · AMQP · <a href="https://data.seattle.gov/">upstream</a> · <a href="https://data.seattle.gov/Transportation/Right-of-Way-Closure-Data/qhcj-3xgi">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/singapore-nea/CONTAINER.md
+++ b/feeders/singapore-nea/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # Singapore NEA
 
-<sub>62 weather stations + 5 air-quality regions · Kafka · MQTT · AMQP · <a href="https://www.nea.gov.sg/">upstream</a> · <a href="https://guide.data.gov.sg/developer-guide/real-time-apis">API docs</a></sub>
+<sub>62 weather stations + 5 air-quality regions · Kafka · MQTT · AMQP · <a href="https://www.nea.gov.sg/">upstream</a> · <a href="https://www.nea.gov.sg/corporate-functions/weather/weather-data-services">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/singapore-nea/README.md
+++ b/feeders/singapore-nea/README.md
@@ -8,7 +8,7 @@
 
 # Singapore NEA
 
-<sub>62 weather stations + 5 air-quality regions · Kafka · MQTT · AMQP · <a href="https://www.nea.gov.sg/">upstream</a> · <a href="https://guide.data.gov.sg/developer-guide/real-time-apis">API docs</a></sub>
+<sub>62 weather stations + 5 air-quality regions · Kafka · MQTT · AMQP · <a href="https://www.nea.gov.sg/">upstream</a> · <a href="https://www.nea.gov.sg/corporate-functions/weather/weather-data-services">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/siri/CONTAINER.md
+++ b/feeders/siri/CONTAINER.md
@@ -1,4 +1,32 @@
-# SIRI Kafka, MQTT, and AMQP containers
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="UK/EU" width="64" height="48"><br>
+<sub><b>UK/EU</b></sub>
+</td>
+<td valign="middle">
+
+# SIRI
+
+<sub>SIRI VehicleMonitoring real-time bus positions · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> UK/EU — SIRI VehicleMonitoring real-time bus positions
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#siri) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#siri/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/siri.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [📘 **Overview**](README.md) · [📑 **Event schemas**](EVENTS.md) · [🗄️ **KQL schema**](kql/siri.kql)
 

--- a/feeders/siri/README.md
+++ b/feeders/siri/README.md
@@ -1,4 +1,32 @@
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/un.png" alt="UK/EU" width="64" height="48"><br>
+<sub><b>UK/EU</b></sub>
+</td>
+<td valign="middle">
+
 # SIRI
+
+<sub>SIRI VehicleMonitoring real-time bus positions · Kafka · MQTT · AMQP</sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-4_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> UK/EU — SIRI VehicleMonitoring real-time bus positions
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#siri) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#siri/fabric-notebook) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/siri.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 [🐳 **Container images**](CONTAINER.md) · [📑 **Event schemas**](EVENTS.md) · [🗄️ **KQL schema**](kql/siri.kql)
 

--- a/feeders/smhi-hydro/CONTAINER.md
+++ b/feeders/smhi-hydro/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # SMHI Hydro
 
-<sub>SMHI · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata-download-hydroobs.smhi.se/api/">API docs</a></sub>
+<sub>SMHI · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata.smhi.se/apidocs/hydroobs/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/smhi-hydro/README.md
+++ b/feeders/smhi-hydro/README.md
@@ -8,7 +8,7 @@
 
 # SMHI Hydro
 
-<sub>SMHI · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata-download-hydroobs.smhi.se/api/">API docs</a></sub>
+<sub>SMHI · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata.smhi.se/apidocs/hydroobs/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/smhi-weather/CONTAINER.md
+++ b/feeders/smhi-weather/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # SMHI Weather
 
-<sub>~232 stations, hourly obs · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata-download-metobs.smhi.se/api/">API docs</a></sub>
+<sub>~232 stations, hourly obs · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata.smhi.se/apidocs/metobs/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/smhi-weather/README.md
+++ b/feeders/smhi-weather/README.md
@@ -8,7 +8,7 @@
 
 # SMHI Weather
 
-<sub>~232 stations, hourly obs · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata-download-metobs.smhi.se/api/">API docs</a></sub>
+<sub>~232 stations, hourly obs · Kafka · MQTT · AMQP · <a href="https://www.smhi.se/">upstream</a> · <a href="https://opendata.smhi.se/apidocs/metobs/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/snotel/CONTAINER.md
+++ b/feeders/snotel/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # SNOTEL Snow
 
-<sub>~900 snowpack stations, NRCS · Kafka · MQTT · AMQP · <a href="https://www.nrcs.usda.gov/wps/portal/wcc/home/">upstream</a> · <a href="https://wcc.sc.egov.usda.gov/awdbRestApi/swagger-ui/index.html">API docs</a></sub>
+<sub>~900 snowpack stations, NRCS · Kafka · MQTT · AMQP · <a href="https://www.nrcs.usda.gov/wps/portal/wcc/home/">upstream</a> · <a href="https://wcc.sc.egov.usda.gov/awdbRestWebService/swagger-ui/index.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/snotel/README.md
+++ b/feeders/snotel/README.md
@@ -8,7 +8,7 @@
 
 # SNOTEL Snow
 
-<sub>~900 snowpack stations, NRCS · Kafka · MQTT · AMQP · <a href="https://www.nrcs.usda.gov/wps/portal/wcc/home/">upstream</a> · <a href="https://wcc.sc.egov.usda.gov/awdbRestApi/swagger-ui/index.html">API docs</a></sub>
+<sub>~900 snowpack stations, NRCS · Kafka · MQTT · AMQP · <a href="https://www.nrcs.usda.gov/wps/portal/wcc/home/">upstream</a> · <a href="https://wcc.sc.egov.usda.gov/awdbRestWebService/swagger-ui/index.html">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/syke-hydro/CONTAINER.md
+++ b/feeders/syke-hydro/CONTAINER.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#syke-hydro/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/syke_hydro.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/syke-hydro.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.syke.fi/)
 
 </td></tr></table>

--- a/feeders/syke-hydro/README.md
+++ b/feeders/syke-hydro/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#syke-hydro/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/syke_hydro.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/syke-hydro.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.syke.fi/)
 
 </td></tr></table>

--- a/feeders/taipei-youbike/CONTAINER.md
+++ b/feeders/taipei-youbike/CONTAINER.md
@@ -22,7 +22,8 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#taipei-youbike/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/taipei-youbike.kql)
+[🗄️ **KQL schema**](kql/taipei-youbike.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/taipei-youbike/README.md
+++ b/feeders/taipei-youbike/README.md
@@ -22,7 +22,8 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#taipei-youbike/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/taipei-youbike.kql)
+[🗄️ **KQL schema**](kql/taipei-youbike.kql) &nbsp;·&nbsp;
+[🗺️ **Fabric Map**](fabric/README.md)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/tepco-denkiyoho/CONTAINER.md
+++ b/feeders/tepco-denkiyoho/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/tepco-denkiyoho/README.md
+++ b/feeders/tepco-denkiyoho/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/tfl-cycles/CONTAINER.md
+++ b/feeders/tfl-cycles/CONTAINER.md
@@ -1,14 +1,14 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<img src="https://flagcdn.com/64x48/gb.png" alt="United Kingdom" width="64" height="48"><br>
-<sub><b>United Kingdom</b></sub>
+<img src="https://flagcdn.com/64x48/gb.png" alt="London" width="64" height="48"><br>
+<sub><b>London</b></sub>
 </td>
 <td valign="middle">
 
 # TfL Santander Cycles
 
-<sub>London public bikeshare, ~798 docking stations · Kafka · MQTT · AMQP · <a href="https://tfl.gov.uk/modes/cycling/santander-cycles">upstream</a> · <a href="https://api.tfl.gov.uk/">API docs</a></sub>
+<sub>Santander Cycles bikeshare, ~798 docking stations · Kafka · MQTT · AMQP</sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,14 +16,14 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> United Kingdom — London Santander Cycles docking-station catalog and live availability
+> London, UK — Santander Cycles bikeshare, ~798 docking stations
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#tfl-cycles) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#tfl-cycles/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/tfl-cycles.kql) &nbsp;·&nbsp;
-[↗ **Upstream**](https://api.tfl.gov.uk/BikePoint)
+[🗺️ **Fabric Map**](fabric/README.md)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/tfl-cycles/README.md
+++ b/feeders/tfl-cycles/README.md
@@ -1,14 +1,14 @@
 <!-- source-hero:begin -->
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-<img src="https://flagcdn.com/64x48/gb.png" alt="United Kingdom" width="64" height="48"><br>
-<sub><b>United Kingdom</b></sub>
+<img src="https://flagcdn.com/64x48/gb.png" alt="London" width="64" height="48"><br>
+<sub><b>London</b></sub>
 </td>
 <td valign="middle">
 
 # TfL Santander Cycles
 
-<sub>London public bikeshare, ~798 docking stations · Kafka · MQTT · AMQP · <a href="https://tfl.gov.uk/modes/cycling/santander-cycles">upstream</a> · <a href="https://api.tfl.gov.uk/">API docs</a></sub>
+<sub>Santander Cycles bikeshare, ~798 docking stations · Kafka · MQTT · AMQP</sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
@@ -16,15 +16,14 @@
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> United Kingdom — London Santander Cycles docking-station catalog and live availability
+> London, UK — Santander Cycles bikeshare, ~798 docking stations
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#tfl-cycles) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#tfl-cycles/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗺️ **Fabric Map**](fabric/README.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/tfl-cycles.kql) &nbsp;·&nbsp;
-[↗ **Upstream**](https://api.tfl.gov.uk/BikePoint)
+[🗺️ **Fabric Map**](fabric/README.md)
 
 </td></tr></table>
 <!-- source-hero:end -->

--- a/feeders/tfl-road-traffic/CONTAINER.md
+++ b/feeders/tfl-road-traffic/CONTAINER.md
@@ -21,6 +21,7 @@
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#tfl-road-traffic) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/tfl-road-traffic.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://tfl.gov.uk/)
 
 </td></tr></table>

--- a/feeders/ticketmaster/CONTAINER.md
+++ b/feeders/ticketmaster/CONTAINER.md
@@ -21,6 +21,7 @@
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#ticketmaster) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/ticketmaster.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.ticketmaster.com/)
 
 </td></tr></table>

--- a/feeders/ticketmaster/README.md
+++ b/feeders/ticketmaster/README.md
@@ -21,6 +21,7 @@
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#ticketmaster) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/ticketmaster.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.ticketmaster.com/)
 
 </td></tr></table>

--- a/feeders/tokyo-docomo-bikeshare/CONTAINER.md
+++ b/feeders/tokyo-docomo-bikeshare/CONTAINER.md
@@ -1,4 +1,31 @@
-# Tokyo Docomo Bikeshare container images (Kafka, MQTT, AMQP)
+<!-- source-hero:begin -->
+<table width="100%"><tr>
+<td width="80" valign="middle" align="center">
+<img src="https://flagcdn.com/64x48/jp.png" alt="Tokyo" width="64" height="48"><br>
+<sub><b>Tokyo</b></sub>
+</td>
+<td valign="middle">
+
+# Tokyo Docomo Bikeshare
+
+<sub>Docomo Bikeshare GBFS via ODPT on gbfs-bikeshare · Kafka · <a href="https://docomo-cycle.jp/tokyo/">upstream</a> · <a href="https://developer.odpt.org/info">API docs</a></sub>
+
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
+
+> Tokyo, Japan — Docomo Bikeshare GBFS via ODPT on gbfs-bikeshare
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#tokyo-docomo-bikeshare) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
+[📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/tokyo-docomo-bikeshare.kql) &nbsp;·&nbsp;
+[↗ **Upstream**](https://docomo-cycle.jp/tokyo/)
+
+</td></tr></table>
+<!-- source-hero:end -->
 
 For the source overview see [README.md](README.md); for the CloudEvents contract and routing metadata see [EVENTS.md](EVENTS.md).
 

--- a/feeders/tokyo-docomo-bikeshare/README.md
+++ b/feeders/tokyo-docomo-bikeshare/README.md
@@ -8,13 +8,15 @@
 
 # Tokyo Docomo Bikeshare
 
-<sub>Configuration-only GBFS wrapper for docomo-cycle-tokyo via ODPT · Kafka · MQTT · AMQP · <a href="https://docomo-cycle.jp/tokyo/">upstream</a> · <a href="https://developer.odpt.org/info">API docs</a></sub>
+<sub>Docomo Bikeshare GBFS via ODPT on gbfs-bikeshare · Kafka · <a href="https://docomo-cycle.jp/tokyo/">upstream</a> · <a href="https://developer.odpt.org/info">API docs</a></sub>
 
-<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square">
 &nbsp;
 <img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Tokyo, Japan — Docomo Bikeshare GBFS feed running on the generalized gbfs-bikeshare feeder
+> Tokyo, Japan — Docomo Bikeshare GBFS via ODPT on gbfs-bikeshare
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#tokyo-docomo-bikeshare) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;

--- a/feeders/uba-airdata/CONTAINER.md
+++ b/feeders/uba-airdata/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # UBA AirData
 
-<sub>stations, pollutant components, hourly measures · Kafka · MQTT · AMQP · <a href="https://www.umweltbundesamt.de/">upstream</a> · <a href="https://luftdaten.umweltbundesamt.de/api/air-data/v2/doc">API docs</a></sub>
+<sub>stations, pollutant components, hourly measures · Kafka · MQTT · AMQP · <a href="https://www.umweltbundesamt.de/">upstream</a> · <a href="https://www.umweltbundesamt.de/daten/luft/luftdaten/doc">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/uba-airdata/README.md
+++ b/feeders/uba-airdata/README.md
@@ -8,7 +8,7 @@
 
 # UBA AirData
 
-<sub>stations, pollutant components, hourly measures · Kafka · MQTT · AMQP · <a href="https://www.umweltbundesamt.de/">upstream</a> · <a href="https://luftdaten.umweltbundesamt.de/api/air-data/v2/doc">API docs</a></sub>
+<sub>stations, pollutant components, hourly measures · Kafka · MQTT · AMQP · <a href="https://www.umweltbundesamt.de/">upstream</a> · <a href="https://www.umweltbundesamt.de/daten/luft/luftdaten/doc">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/uk-bods-siri/CONTAINER.md
+++ b/feeders/uk-bods-siri/CONTAINER.md
@@ -1,30 +1,29 @@
 <!-- source-hero:begin -->
-
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-
-<img src="https://flagcdn.com/64x48/gb.png" alt="United Kingdom" width="64" height="48"><br>
-
-<sub><b>United Kingdom</b></sub>
-
+<img src="https://flagcdn.com/64x48/un.png" alt="England" width="64" height="48"><br>
+<sub><b>England</b></sub>
 </td>
-
 <td valign="middle">
 
-# UK BODS SIRI container images
+# UK BODS SIRI
 
-<sub>configuration-only wrapper over <code>siri</code> · Kafka · MQTT · AMQP · <a href="https://www.bus-data.dft.gov.uk/">upstream</a></sub>
+<sub>BODS SIRI-VM via generalized siri feeder (requires free API key) · Kafka</sub>
 
-[📘 **Overview**](README.md) &nbsp;·&nbsp;
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square">
+&nbsp;
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
+> England — BODS SIRI-VM via generalized siri feeder (requires free API key)
+
+[🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#uk-bods-siri) &nbsp;·&nbsp;
+[🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-
-[🗄️ **KQL schema**](kql/uk-bods-siri.kql) &nbsp;·&nbsp;
-
-[↗ **Upstream**](https://www.bus-data.dft.gov.uk/)
+[🗄️ **KQL schema**](kql/uk-bods-siri.kql)
 
 </td></tr></table>
-
 <!-- source-hero:end -->
 
 This document covers the published OCI container images for the UK BODS SIRI thin wrapper, their environment-variable contract, authentication modes, and one-click Azure deployments. For the project overview see [README.md](README.md); for the CloudEvents contract see [EVENTS.md](EVENTS.md).

--- a/feeders/uk-bods-siri/README.md
+++ b/feeders/uk-bods-siri/README.md
@@ -1,40 +1,29 @@
 <!-- source-hero:begin -->
-
 <table width="100%"><tr>
 <td width="80" valign="middle" align="center">
-
-<img src="https://flagcdn.com/64x48/gb.png" alt="United Kingdom" width="64" height="48"><br>
-
-<sub><b>United Kingdom</b></sub>
-
+<img src="https://flagcdn.com/64x48/un.png" alt="England" width="64" height="48"><br>
+<sub><b>England</b></sub>
 </td>
-
 <td valign="middle">
 
 # UK BODS SIRI
 
-<sub>England bus AVL · BODS SIRI-VM · config-only wrapper over <code>siri</code> · <a href="https://www.bus-data.dft.gov.uk/">upstream</a> · <a href="https://data.bus-data.dft.gov.uk/avl/download/bulk_archive">bulk archive</a></sub>
+<sub>BODS SIRI-VM via generalized siri feeder (requires free API key) · Kafka</sub>
 
-<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
-
+<img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square">
 &nbsp;
-
 <img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+&nbsp;
+<a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> England — BODS bulk AVL VehicleMonitoring via the generalized `siri` feeder
+> England — BODS SIRI-VM via generalized siri feeder (requires free API key)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#uk-bods-siri) &nbsp;·&nbsp;
-
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
-
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-
-[🗄️ **KQL schema**](kql/uk-bods-siri.kql) &nbsp;·&nbsp;
-
-[↗ **Upstream**](https://www.bus-data.dft.gov.uk/)
+[🗄️ **KQL schema**](kql/uk-bods-siri.kql)
 
 </td></tr></table>
-
 <!-- source-hero:end -->
 
 ## At a glance

--- a/feeders/usgs-earthquakes/CONTAINER.md
+++ b/feeders/usgs-earthquakes/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/usgs-earthquakes/README.md
+++ b/feeders/usgs-earthquakes/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/usgs-geomag/CONTAINER.md
+++ b/feeders/usgs-geomag/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/usgs-iv/CONTAINER.md
+++ b/feeders/usgs-iv/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#usgs-iv/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/usgs-iv.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/codes.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://waterdata.usgs.gov/)
 
 </td></tr></table>

--- a/feeders/usgs-iv/README.md
+++ b/feeders/usgs-iv/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#usgs-iv/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/usgs-iv.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/codes.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://waterdata.usgs.gov/)
 
 </td></tr></table>

--- a/feeders/usgs-nwis-wq/CONTAINER.md
+++ b/feeders/usgs-nwis-wq/CONTAINER.md
@@ -8,7 +8,7 @@
 
 # USGS NWIS Water Quality
 
-<sub>~3,000 continuous WQ sites · Kafka · MQTT · AMQP · <a href="https://waterdata.usgs.gov/">upstream</a> · <a href="https://api.waterdata.usgs.gov/docs#samples">API docs</a></sub>
+<sub>~3,000 continuous WQ sites · Kafka · MQTT · AMQP · <a href="https://waterdata.usgs.gov/">upstream</a> · <a href="https://waterservices.usgs.gov/docs/water-quality-samples/water-quality-samples-details/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/usgs-nwis-wq/README.md
+++ b/feeders/usgs-nwis-wq/README.md
@@ -8,7 +8,7 @@
 
 # USGS NWIS Water Quality
 
-<sub>~3,000 continuous WQ sites · Kafka · MQTT · AMQP · <a href="https://waterdata.usgs.gov/">upstream</a> · <a href="https://api.waterdata.usgs.gov/docs#samples">API docs</a></sub>
+<sub>~3,000 continuous WQ sites · Kafka · MQTT · AMQP · <a href="https://waterdata.usgs.gov/">upstream</a> · <a href="https://waterservices.usgs.gov/docs/water-quality-samples/water-quality-samples-details/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;

--- a/feeders/vatsim/CONTAINER.md
+++ b/feeders/vatsim/CONTAINER.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/vatsim/README.md
+++ b/feeders/vatsim/README.md
@@ -12,7 +12,7 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 

--- a/feeders/wallonia-issep/CONTAINER.md
+++ b/feeders/wallonia-issep/CONTAINER.md
@@ -12,16 +12,17 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-3_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Belgium / Wallonia — low-cost air quality sensors
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#wallonia-issep) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#wallonia-issep/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/wallonia_issep.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/wallonia-issep.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.issep.be/)
 
 </td></tr></table>

--- a/feeders/wallonia-issep/README.md
+++ b/feeders/wallonia-issep/README.md
@@ -22,7 +22,7 @@
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#wallonia-issep/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
-[🗄️ **KQL schema**](kql/wallonia_issep.kql) &nbsp;·&nbsp;
+[🗄️ **KQL schema**](kql/wallonia-issep.kql) &nbsp;·&nbsp;
 [↗ **Upstream**](https://www.issep.be/)
 
 </td></tr></table>

--- a/feeders/wsdot/CONTAINER.md
+++ b/feeders/wsdot/CONTAINER.md
@@ -8,15 +8,15 @@
 
 # WSDOT
 
-<sub>~1,000 traffic flow sensors (requires free key) · Kafka · MQTT · AMQP · <a href="https://wsdot.wa.gov/">upstream</a> · <a href="https://wsdot.wa.gov/traffic/api/">API docs</a></sub>
+<sub>traffic, travel times, weather, road weather, alerts, cameras, bridge clearances, tolls, border waits & ferries (requires free key) · Kafka · MQTT · AMQP · <a href="https://wsdot.wa.gov/">upstream</a> · <a href="https://wsdot.wa.gov/traffic/api/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Washington State — ~1,000 traffic flow sensors (requires free key)
+> Washington State — traffic, travel times, weather, road weather, alerts, cameras, bridge clearances, tolls, border waits & ferries (requires free key)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#wsdot) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#wsdot/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/wsdot/README.md
+++ b/feeders/wsdot/README.md
@@ -8,15 +8,15 @@
 
 # WSDOT
 
-<sub>~1,000 traffic flow sensors (requires free key) · Kafka · MQTT · AMQP · <a href="https://wsdot.wa.gov/">upstream</a> · <a href="https://wsdot.wa.gov/traffic/api/">API docs</a></sub>
+<sub>traffic, travel times, weather, road weather, alerts, cameras, bridge clearances, tolls, border waits & ferries (requires free key) · Kafka · MQTT · AMQP · <a href="https://wsdot.wa.gov/">upstream</a> · <a href="https://wsdot.wa.gov/traffic/api/">API docs</a></sub>
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-4_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-5_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
-> Washington State — ~1,000 traffic flow sensors (requires free key)
+> Washington State — traffic, travel times, weather, road weather, alerts, cameras, bridge clearances, tolls, border waits & ferries (requires free key)
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#wsdot) &nbsp;·&nbsp;
 [📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#wsdot/fabric-notebook) &nbsp;·&nbsp;

--- a/feeders/xceed/CONTAINER.md
+++ b/feeders/xceed/CONTAINER.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — clubs, bars, parties, festivals — event schedules
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#xceed) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#xceed/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/xceed.kql) &nbsp;·&nbsp;

--- a/feeders/xceed/README.md
+++ b/feeders/xceed/README.md
@@ -12,13 +12,14 @@
 
 <img align="middle" alt="Kafka" src="https://img.shields.io/badge/-Kafka-231f20?style=flat-square"> <img align="middle" alt="MQTT" src="https://img.shields.io/badge/-MQTT-660066?style=flat-square"> <img align="middle" alt="AMQP" src="https://img.shields.io/badge/-AMQP-1a4a78?style=flat-square">
 &nbsp;
-<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
+<img align="middle" src="https://img.shields.io/badge/Azure-6_templates-0078d4?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Fabric-Notebook_%2B_ACI-117865?style=flat-square"> <img align="middle" src="https://img.shields.io/badge/Docker-3_images-2496ed?style=flat-square">
 &nbsp;
 <a href="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml"><img align="middle" alt="build" src="https://github.com/clemensv/real-time-sources/actions/workflows/build_containers.yml/badge.svg"></a>
 
 > Europe — clubs, bars, parties, festivals — event schedules
 
 [🚀 **Deploy to Azure**](https://clemensv.github.io/real-time-sources#xceed) &nbsp;·&nbsp;
+[📓 **Fabric Notebook**](https://clemensv.github.io/real-time-sources#xceed/fabric-notebook) &nbsp;·&nbsp;
 [🐳 **docker pull**](CONTAINER.md) &nbsp;·&nbsp;
 [📑 **Event schemas**](EVENTS.md) &nbsp;·&nbsp;
 [🗄️ **KQL schema**](kql/xceed.kql) &nbsp;·&nbsp;


### PR DESCRIPTION
Pure output of `tools/docs/generate_source_heroes.py` against the current 119-entry `catalog.json`. No hand edits.

### What changed
- **14 hero blocks inserted** where none existed, covering the six generalized feeders **cap-alerts, datex2, erddap, kiwis, openaq, siri** (README + CONTAINER).
- **118 blocks refreshed** for drift against current repo state:
  - stale Azure template counts (e.g. `vatsim` 3 -> 5 templates)
  - missing Fabric Notebook deploy link where the source now ships a notebook (e.g. `xceed`)

### Verification
- **Idempotent:** second generator run reports \238 no-op, 0 changes\.
- **Encoding:** \python tools/ci/lint_catalog_encoding.py\ -> \OK: 132 file(s) clean\ (same check as \lint-encoding.yml\).
- Documentation-only; no Python, Dockerfile, xreg or generated-producer changes, so the pre-commit code gates do not apply.

### Background
Found while auditing a stale detached-HEAD working copy. That copy held an older, unpushed variant of these hero blocks built on a pre-hsl-hfp base; it was discarded as superseded and the blocks regenerated from `main` instead, which also picks up the four newer feeders (celestrak, open-charge-map, taipei-youbike, tfl-cycles) the stale copy would have missed.