### PR TITLE
ci: tolerate GitHub Actions cache export failures in container builds

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -172,7 +172,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: the Actions cache is over the 10 GB repo limit and
+          # evicts constantly, so concurrent cache exports race and return
+          # "not_found". That must not fail a build whose image already pushed.
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
@@ -280,7 +283,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: the Actions cache is over the 10 GB repo limit and
+          # evicts constantly, so concurrent cache exports race and return
+          # "not_found". That must not fail a build whose image already pushed.
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Fixes the red `Build Containers` run [30191722848](https://github.com/clemensv/real-time-sources/actions/runs/30191722848) on `main` (3 of 364 jobs failed: `usgs-iv`, `vatsim`, `wikimedia-eventstreams` — all `Dockerfile.amqp`).

### Diagnosis

Every failing job ends the same way:

```
#14 exporting to image
#14 pushing manifest for ghcr.io/clemensv/real-time-sources-usgs-iv-amqp:latest ... done
#14 DONE 22.8s
#16 exporting to GitHub Actions Cache
#16 sending cache export 14.6s done
#16 ERROR: not_found
ERROR: failed to build: failed to solve: not_found
```

**The image built and pushed fine.** Only the *cache export* failed — and took the job down with it.

**Root cause is cache pressure, not the build.** `actions/cache/usage` reports **12.6 GB across 745 entries** against the 10 GB per-repo limit, so GitHub evicts continuously while ~360 concurrent `cache-to: type=gha,mode=max` exports are writing. The exports race those evictions and get `not_found`. This is consistent with only 3/364 legs failing, and with the previous main runs (2026-07-16) passing before the cache grew past the cap.

### Fix

Add buildx's documented `ignore-error=true` to both `cache-to` exporters (base + transport matrices). A lost cache export degrades to a warning instead of failing a build whose image already shipped.

### Not related to the artifact fix

`DOCKER_BUILD_RECORD_UPLOAD` / `DOCKER_BUILD_SUMMARY` (#1547) only gate the post-build record upload; this failure is inside buildx's cache exporter. Verified independently — that run and run 30191747988 both completed emitting **zero** artifacts, confirming #1547 works.

### Follow-up worth considering (not in this PR)

Every container shares one unscoped `type=gha` cache, so ~120 images continuously overwrite each other's entries — that is what drives the 12.6 GB churn and makes hit rates poor. Adding a per-image `scope=` to `cache-from`/`cache-to` would isolate them.