### PR TITLE
fix(usgs-iv): resilient atomic write for last-polled state file (BlockingIOError crash)

### DIFF
--- a/feeders/usgs-iv/tests/test_usgs_integration.py
+++ b/feeders/usgs-iv/tests/test_usgs_integration.py
@@ -216,8 +216,9 @@ class TestLastPolledTimes:
                 result = poller.load_last_polled_times()
                 assert result == {}
 
+    @patch('os.replace')
     @patch('builtins.open')
-    def test_save_last_polled_times(self, mock_open):
+    def test_save_last_polled_times(self, mock_open, mock_replace):
         """Test saving last polled times to file."""
         mock_file = Mock()
         mock_file.__enter__ = Mock(return_value=mock_file)
@@ -242,6 +243,7 @@ class TestLastPolledTimes:
                 poller.save_last_polled_times(test_times)
                 
                 mock_dump.assert_called_once()
+                mock_replace.assert_called_once()
                 saved_data = mock_dump.call_args[0][0]
                 assert '00060' in saved_data
                 assert '01646500' in saved_data['00060']

--- a/feeders/usgs-iv/usgs_iv/usgs_iv.py
+++ b/feeders/usgs-iv/usgs_iv/usgs_iv.py
@@ -59,6 +59,44 @@ except ModuleNotFoundError:
 # pylint: enable=import-error, line-too-long
 
 
+def _atomic_write_json(path: str, data: Dict, retries: int = 5, backoff_seconds: float = 0.5) -> None:
+    """
+    Write JSON to `path` resiliently against transient BlockingIOError/OSError
+    from shared network filesystems (e.g. Azure Files/NFS lock contention),
+    and atomically (write-to-temp-then-rename) so a failed or interrupted
+    write never leaves a truncated/corrupt state file behind.
+    """
+    import errno
+    import time
+    import uuid
+
+    tmp_path = f"{path}.{uuid.uuid4().hex}.tmp"
+    last_exc: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            with open(tmp_path, 'w', encoding='utf-8') as file:
+                json.dump(data, file)
+            os.replace(tmp_path, path)
+            return
+        except (BlockingIOError, OSError) as exc:
+            last_exc = exc
+            transient = isinstance(exc, BlockingIOError) or getattr(exc, "errno", None) in (
+                errno.EAGAIN,
+                errno.EWOULDBLOCK,
+                errno.EBUSY,
+            )
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+            if not transient or attempt >= retries:
+                raise
+            time.sleep(backoff_seconds * (2 ** attempt))
+    if last_exc is not None:
+        raise last_exc
+
+
 if sys.gettrace() is not None:
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 else:
@@ -290,8 +328,7 @@ class USGSDataPoller:
                 saved_times[parameter][site_no] = timestamp.isoformat()
         if not self.last_polled_file:
             return
-        with open(self.last_polled_file, 'w', encoding='utf-8') as file:
-            json.dump(saved_times, file)
+        _atomic_write_json(self.last_polled_file, saved_times)
 
     async def poll_and_send(self):
         """
@@ -535,7 +572,13 @@ class USGSDataPoller:
                     if count_records % 1000 == 0:
                         await flush_transport(self.values_producer)
                 await flush_transport(self.values_producer)
-                self.save_last_polled_times(last_polled_times)
+                try:
+                    self.save_last_polled_times(last_polled_times)
+                except OSError as exc:
+                    # Do not let a transient state-file write failure (e.g.
+                    # shared fileshare lock contention) crash the whole
+                    # poller -- log and retry on the next cycle instead.
+                    logger.warning("Failed to save last-polled state (will retry next cycle): %s", exc)
                 logger.info("Processed records for state %s: %d", state_code, count_records)
                 counts_str = ', '.join([f"{k}: {v}" for k, v in counts.items()])
                 logger.info("Counts for state %s: %s", state_code, counts_str)

--- a/feeders/usgs-iv/usgs_iv_amqp/usgs_iv_amqp/app.py
+++ b/feeders/usgs-iv/usgs_iv_amqp/usgs_iv_amqp/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import logging
 import os
 from datetime import datetime, timezone
@@ -114,15 +115,33 @@ class _AmqpPublishFacade:
         if target is None:
             raise AttributeError(f"send_{suffix}")
 
+        # Some AMQP-generated send_* methods declare their CloudEvents time
+        # attribute as a required '_datetime' placeholder (when the xreg
+        # message group's time template is '{datetime}'), rather than the
+        # generic optional '_time' the Kafka producer variant accepts.
+        # Dropping the caller's time value unconditionally (as this used to
+        # do) silently satisfied methods with an auto-generated time, but
+        # left required-'_datetime' methods missing a positional argument --
+        # a "shipped but never ran" class of bug: it only surfaces the first
+        # time a real send is attempted. Forward the value under whichever
+        # name the target actually declares, instead of always dropping it.
+        target_params = inspect.signature(target).parameters
+        time_param_name = "_datetime" if "_datetime" in target_params else "_time" if "_time" in target_params else None
+
         async def _publish(**kwargs):
             call = {}
+            time_value = None
             for key, value in kwargs.items():
                 if key in ("data", "content_type"):
                     call[key] = value
-                elif key in ("flush_producer", "time", "_time"):
+                elif key in ("flush_producer",):
                     continue
+                elif key in ("time", "_time"):
+                    time_value = value
                 else:
                     call["_" + key.lstrip("_")] = value
+            if time_param_name is not None and time_value is not None:
+                call[time_param_name] = time_value
             target(**call)
 
         return _publish


### PR DESCRIPTION
Fixes #1577

## Summary
`usgs-iv` crashed with `BlockingIOError: [Errno 11] Resource temporarily unavailable: '/mnt/fileshare/usgs_last_polled.json'` when writing its last-polled-state file to the shared Azure Files mount, right after successfully processing a full multi-state poll cycle. Kubernetes restarted the pod (restart count observed: 1), losing that cycle's freshly-computed per-state cursor. Same root cause and identical signature as `noaa-puget` (#1576, merged as #1580).

## Fix 1: resilient atomic state-file write
Added `_atomic_write_json()` (same pattern as the companion `noaa` fix):
- Retries with exponential backoff (5 attempts, 0.5s base) on `BlockingIOError`/`OSError` with `EAGAIN`/`EWOULDBLOCK`/`EBUSY`, instead of crashing on the first transient lock-contention hit against the shared fileshare.
- Writes to a unique temp file then atomically `os.replace()`s it into place, so an interrupted write can never leave a truncated/corrupt state file behind.

`save_last_polled_times()` now uses this helper, and its call site catches `OSError` so an exhausted-retry write failure logs a warning and retries on the next cycle instead of taking down the whole poller mid-run.

Also updated `test_save_last_polled_times` to mock `os.replace()` to match the new write-then-atomic-rename behavior.

## Fix 2 (found by this PR's own CI): AMQP companion crash on every send
This PR's Docker Kafka Flow AMQP job caught a real, **pre-existing**, unrelated bug in the same feeder -- a "shipped but never ran" AMQP defect (the exact class called out in this repo's `stream-bridge-implementation` skill):

```
TypeError: USGSInstantaneousValuesAmqpProducer.send_other_parameter() missing 1 required positional argument: '_datetime'
```

`_AmqpPublishFacade._publish()` in `usgs_iv_amqp/app.py` unconditionally dropped the caller's `time`/`_time` kwarg on every call. That's harmless for AMQP `send_*` methods with an auto-generated time attribute, but this message group's xreg time template is `{datetime}` (a required placeholder), so every `send_usgs_instantaneous_values_*` AMQP method actually declares a required `_datetime` parameter -- dropping the value left it unfilled and crashed on the first real send, which is why it was never caught before (no prior CI run had exercised a real send on this transport).

Fixed the facade to inspect each target `send_*` method's signature and forward the time value under whichever parameter name it actually declares (`_datetime` if present, else `_time`, else drop) instead of always dropping it. Verified standalone (signature inspection + call construction) since this sandbox's Docker network blocks PyPI installs for full image builds; CI's Docker Kafka Flow AMQP job is the authoritative verification and is expected to go green with this fix.

## Testing
- `feeders/usgs-iv`: `pytest tests/ -m "not e2e"` → 33 passed
- `mypy feeders/usgs-iv --config-file mypy.ini --exclude /build/` → Success, no issues
- `python -m py_compile usgs_iv/usgs_iv.py usgs_iv_amqp/usgs_iv_amqp/app.py` → OK
- Standalone verification of the facade's time-parameter forwarding logic (signature inspection correctly resolves `_datetime` and forwards the value)
- CI (this PR): Docker Kafka Flow re-run pending after the amqp fix push

## Diagnostics context
Found via live health check of `aks-rts-feeders` AKS cluster (`feeders` namespace). Cross-reference: noaa-puget PR #1580 (same state-file root cause, same fix pattern).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>