### PR TITLE
fix(king-county-marine): surface upstream data staleness instead of silent zero-delivery

### DIFF
--- a/feeders/king-county-marine/king_county_marine/king_county_marine.py
+++ b/feeders/king-county-marine/king_county_marine/king_county_marine.py
@@ -28,6 +28,12 @@ VIEW_URL = "https://data.kingcounty.gov/api/views/{dataset_id}"
 ROWS_URL = "https://data.kingcounty.gov/resource/{dataset_id}.json"
 DEFAULT_POLL_INTERVAL_SECONDS = 900
 REFERENCE_REFRESH_SECONDS = 86400
+# King County's own buoy telemetry pipeline occasionally stalls upstream
+# (observed: rows stop advancing for 9+ days while the API keeps returning
+# 200 OK with the same stale tail). When that happens "Sent 0 readings" is
+# expected behavior, not a bridge bug -- but it should be visible as a
+# WARNING instead of blending into routine idle-cycle INFO logs.
+UPSTREAM_STALENESS_WARNING_THRESHOLD = timedelta(hours=2)
 MAX_SEEN_IDS = 50000
 PST_FIXED = timezone(timedelta(hours=-8))
 HTTP_TIMEOUT = (15, 60)
@@ -345,6 +351,7 @@ class KingCountyMarineBridge:
                             raise
 
                 sent = 0
+                newest_observation: Optional[datetime] = None
                 for dataset_id in list(self.station_metadata.keys()):
                     try:
                         rows = self.fetch_rows(dataset_id)
@@ -354,6 +361,9 @@ class KingCountyMarineBridge:
 
                     for row in rows:
                         reading = self.build_reading(dataset_id, row)
+                        observed_at = datetime.fromisoformat(reading.observation_time.replace("Z", "+00:00"))
+                        if newest_observation is None or observed_at > newest_observation:
+                            newest_observation = observed_at
                         reading_id = f"{reading.station_id}|{reading.observation_time}"
                         if reading_id in self.seen_reading_ids:
                             continue
@@ -366,7 +376,21 @@ class KingCountyMarineBridge:
                         sent += 1
                 producer.producer.flush()
                 self.save_state()
-                LOGGER.info("Sent %d King County marine readings", sent)
+                if sent == 0 and newest_observation is not None:
+                    staleness = datetime.now(timezone.utc) - newest_observation
+                    if staleness >= UPSTREAM_STALENESS_WARNING_THRESHOLD:
+                        LOGGER.warning(
+                            "Sent 0 King County marine readings; newest available upstream "
+                            "observation is %s old (observed_at=%s). This looks like an "
+                            "upstream data staleness issue at King County, not a bridge bug -- "
+                            "the fetched rows are simply not advancing.",
+                            staleness,
+                            newest_observation.isoformat(),
+                        )
+                    else:
+                        LOGGER.info("Sent %d King County marine readings", sent)
+                else:
+                    LOGGER.info("Sent %d King County marine readings", sent)
             except (KeyError, OSError, ValueError, requests.RequestException) as exc:
                 LOGGER.exception("Error during King County marine poll: %s", exc)
 


### PR DESCRIPTION
Fixes #1574

## Root cause: not a bridge bug -- upstream data has genuinely stalled
Investigated the "sends 0 readings on every poll for 72h+" report. Verified directly against the King County Socrata API (`data.kingcounty.gov`) for the datasets this feeder tracks:

- Port Susan Buoy (`d5u3-dkbj`): newest row is `2026-08-04T01:00:00` PST
- A second dataset (`59w7-7h7b`): newest row is also `2026-08-04T09:30:00` PST

Both are 9+ days stale relative to when this was investigated (2026-08-13). The bridge's own persisted dedup state (`/mnt/fileshare/king_county_marine_state.json`) confirms the same thing: the most recently inserted `seen_reading_id` for every station is also dated 2026-08-02, i.e. nothing new has arrived since then.

Station discovery is succeeding (`Sent 4 station reference events` daily) and row fetches mostly succeed (only occasional transient read-timeouts, already retried by the existing `Retry` policy). There is simply no new data upstream to publish -- King County's own buoy telemetry pipeline has stalled.

## Fix
Since the bridge cannot manufacture data upstream never produced, this change makes a stalled-upstream condition **observable** instead of indistinguishable from a normal quiet period:

- Track the newest observation timestamp seen across all datasets on every poll cycle.
- When `sent == 0` **and** the newest available upstream data is more than 2 hours stale, log a `WARNING` naming the staleness age and explicitly noting this looks like an upstream issue, not a bridge bug.
- Otherwise (normal quiet cycles with fresh-but-no-new data, or when new data was sent), keep the existing `INFO` log unchanged.

This does not change publishing behavior -- it only adds visibility so an operator (or alerting on the WARNING level) can catch a real upstream stall instead of a dashboard showing a healthy `Running` pod silently delivering nothing for over a week.

## Testing
- `feeders/king-county-marine`: `pytest tests/` → 10 passed
- `mypy feeders/king-county-marine --config-file mypy.ini --exclude /build/` → Success, no issues
- `python -m py_compile king_county_marine/king_county_marine.py` → OK

## Diagnostics context
Found via live health check of `aks-rts-feeders` AKS cluster (`feeders` namespace).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>