### PR TITLE
fix(gtfs): correct Cause/Effect decode off-by-one (silent alert corruption)

### DIFF
--- a/feeders/gtfs/gtfs_core/gtfs_core/core.py
+++ b/feeders/gtfs/gtfs_core/gtfs_core/core.py
@@ -991,8 +991,8 @@ def map_alert(entity):
                         schedule_relationship=selector.trip.schedule_relationship
                     )
                 ) for selector in entity.alert.informed_entity],
-                cause=Cause.from_ordinal(entity.alert.cause),
-                effect=Effect.from_ordinal(entity.alert.effect),
+                cause=Cause[gtfs_realtime_pb2.Alert.Cause.Name(entity.alert.cause)],
+                effect=Effect[gtfs_realtime_pb2.Alert.Effect.Name(entity.alert.effect)],
                 url=TranslatedString(translation=[Translation(language=translation.language, text=translation.text) for translation in entity.alert.url.translation]),
                 header_text=TranslatedString(translation=[Translation(language=translation.language, text=translation.text) for translation in entity.alert.header_text.translation]),
                 description_text=TranslatedString(translation=[Translation(language=translation.language, text=translation.text) for translation in entity.alert.description_text.translation])


### PR DESCRIPTION
Fixes #1575

## Correction of my earlier description
PR #1578 (merged) already correctly added the missing `NO_EFFECT`/`ACCESSIBILITY_ISSUE` `Effect` enum values and fixed the Kafka queue-full crash -- that part of #1578 was done properly. This PR fixes a second, separate, genuinely still-present bug that I found while re-verifying #1578's fix live against `king-cty-metro`, which kept raising `Ordinal out of range for enum` even after the enum-completeness fix was deployed and the image confirmed freshly pulled.

## The bug: Cause/Effect decode off-by-one
`gtfs_core.core` mapped `entity.alert.cause` / `entity.alert.effect` via the generated `Enum.from_ordinal()`, which does 0-based `list(cls)[ordinal]` indexing with a `0 <= ordinal < len(members)` range check. But GTFS-RT's official `Cause` and `Effect` enums are explicitly **1-based** in the upstream `.proto` (`UNKNOWN_CAUSE = 1`, `NO_SERVICE = 1`, ...). Two consequences:

1. **Off-by-one corruption**: `from_ordinal(1)` silently returns the *second* list member instead of the first -- every alert's cause and effect value has been mislabeled by one position, with no error raised, for as long as this bridge has been running.
2. **False-negative range check**: with `Effect` now correctly declaring 11 members (valid list indices 0-10), a real upstream ordinal of 11 (`ACCESSIBILITY_ISSUE`, protobuf wire value 11) *still* raises `Ordinal out of range for enum`, because the range check treats valid ordinals as 0-10 while the wire value is 1-11. **The enum-completeness fix in #1578 alone cannot close this gap** -- which is exactly what I was seeing live.

## Fix
Decode via the protobuf enum's own `.Name()` and do a by-member-name lookup (`Cause[name]` / `Effect[name]`) instead of positional `from_ordinal`, which is correct regardless of the enum's numeric base or any gaps:
```python
cause=Cause[gtfs_realtime_pb2.Alert.Cause.Name(entity.alert.cause)],
effect=Effect[gtfs_realtime_pb2.Alert.Effect.Name(entity.alert.effect)],
```

**Scope check performed**: verified the other GTFS-RT protobuf enums this bridge decodes via `from_ordinal` (`TripDescriptor`/`StopTimeUpdate` `ScheduleRelationship`, `VehicleStopStatus`, `CongestionLevel`, `OccupancyStatus`) are all explicitly 0-based and contiguous in the official proto, so positional `from_ordinal` is correct for those today. Flagging the generator's `from_ordinal` as fragile for any non-zero-based or gapped enum (e.g. `TripDescriptor.ScheduleRelationship`'s officially-reserved value 4, whose `REPLACEMENT=5`/`DUPLICATED=6` aren't even in this repo's schema) as a follow-up xrcg hardening item -- out of scope here.

## Testing
- `feeders/gtfs`: `pytest tests/` → 54 passed
- `mypy feeders/gtfs --config-file mypy.ini --exclude /build/` → Success, no issues
- Verified `Cause[Name(1..12)]` and `Effect[Name(1..11)]` resolve to the correct symbol for every ordinal in both enums (previously off by one, and ordinal 11 previously raised `IndexError`)

## Diagnostics context
Found via live health check of `aks-rts-feeders` AKS cluster, re-confirmed after redeploying #1578's image that `king-cty-metro`'s alerts feed was still erroring -- which surfaced this deeper decode bug.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>