### PR TITLE
fix(noaa): throttle upstream requests to stop NOAA API Gateway IP bans

### DIFF
--- a/feeders/noaa/CONTAINER.md
+++ b/feeders/noaa/CONTAINER.md
@@ -233,6 +233,24 @@ For live Azure namespaces, set `AMQP_TLS=true` and `AMQP_PORT=5671`.
 | `NOAA_POLLING_INTERVAL` | Seconds between poll cycles (default `300`). |
 | `MOCK_MODE` | Set to a truthy value to emit deterministic offline sample data instead of calling the live upstream (offline testing / Docker E2E). |
 
+### Upstream request pacing
+
+> [!IMPORTANT]
+> NOAA CO-OPS publishes no numeric rate limit for the `datagetter` API, but its
+> AWS API Gateway **will hard-ban a source IP** that polls abusively, returning
+> `403 Forbidden` for every subsequent request until the block is lifted. The
+> defaults below are deliberately conservative. Do not raise the request rate
+> without understanding this risk.
+
+| Variable | Description |
+|---|---|
+| `NOAA_MIN_REQUEST_INTERVAL` | Minimum seconds between two outbound upstream requests (default `1.0`). This is the primary guard against being IP-banned. Set to `0` to disable pacing entirely — not recommended. |
+| `NOAA_POLL_INTERVAL` | Seconds the Kafka feeder idles between full poll cycles (default `900`). NOAA observations are 6-minute-interval at best, so polling more often cannot surface new data. |
+| `NOAA_RATE_LIMIT_COOLDOWN` | Initial seconds to stand down after the upstream returns `403`/`429` (default `300`). Doubles on each consecutive occurrence. |
+| `NOAA_MAX_RATE_LIMIT_COOLDOWN` | Upper bound for the escalating cooldown (default `3600`). |
+| `NOAA_EMPTY_BACKOFF_THRESHOLD` | Consecutive empty responses for a (product, station) pair before it starts being skipped (default `3`). Most stations do not offer most products, so these requests are pure waste. |
+| `NOAA_MAX_EMPTY_BACKOFF` | Maximum number of cycles a consistently-empty pair is skipped before being retried (default `32`). |
+
 ### Common (all images)
 
 | Variable | Description |

--- a/feeders/noaa/noaa/noaa.py
+++ b/feeders/noaa/noaa/noaa.py
@@ -42,6 +42,56 @@ VISIBILITY_DATASCHEMA = "#/schemagroups/Microsoft.OpenData.US.NOAA.jstruct/schem
 VISIBILITY_DATACONTENTTYPE = "application/json"
 
 
+# --- Outbound request pacing -------------------------------------------------
+# NOAA CO-OPS publishes no numeric rate limit for the `datagetter` API, but its
+# AWS API Gateway *will* hard-ban a source IP that polls abusively, returning
+# `403 ForbiddenException` for every subsequent request. An unthrottled poller
+# iterating stations x products in a tight `while True:` loop trivially reaches
+# several requests per second sustained around the clock, which is what earned
+# this feeder an IP ban. Every knob below is overridable so operators can slow
+# the feeder further without a rebuild.
+
+# Minimum wall-clock spacing between two outbound datagetter requests.
+MIN_REQUEST_INTERVAL = float(os.environ.get("NOAA_MIN_REQUEST_INTERVAL", "1.0"))
+# Idle time between full poll cycles. NOAA data is 6-minute-interval at best,
+# so polling more often than this cannot yield new observations anyway.
+POLL_INTERVAL = float(os.environ.get("NOAA_POLL_INTERVAL", "900"))
+# How long to stand down after the API signals rate limiting / forbids us.
+RATE_LIMIT_COOLDOWN = float(os.environ.get("NOAA_RATE_LIMIT_COOLDOWN", "300"))
+MAX_RATE_LIMIT_COOLDOWN = float(os.environ.get("NOAA_MAX_RATE_LIMIT_COOLDOWN", "3600"))
+# Adaptive skipping: most stations do not offer most products, so those
+# requests are guaranteed-empty pure waste. After this many consecutive empty
+# responses for a (product, station) pair, start skipping it for a growing
+# number of cycles, capped by MAX_EMPTY_BACKOFF.
+EMPTY_BACKOFF_THRESHOLD = int(os.environ.get("NOAA_EMPTY_BACKOFF_THRESHOLD", "3"))
+MAX_EMPTY_BACKOFF = int(os.environ.get("NOAA_MAX_EMPTY_BACKOFF", "32"))
+
+
+class _RateLimiter:
+    """
+    Simple monotonic-clock spacing gate shared by every outbound NOAA request.
+
+    `wait()` blocks until at least `min_interval` seconds have elapsed since
+    the previous call, guaranteeing a hard ceiling on outbound request rate
+    regardless of how fast the poll loop iterates.
+    """
+
+    def __init__(self, min_interval: float):
+        self.min_interval = max(0.0, min_interval)
+        self._last_call = 0.0
+
+    def wait(self) -> None:
+        """Block until the configured minimum spacing has elapsed."""
+        if self.min_interval <= 0:
+            return
+        import time
+        now = time.monotonic()
+        elapsed = now - self._last_call
+        if 0 <= elapsed < self.min_interval:
+            time.sleep(self.min_interval - elapsed)
+        self._last_call = time.monotonic()
+
+
 def _atomic_write_json(path: str, data: Dict, retries: int = 5, backoff_seconds: float = 0.5) -> None:
     """
     Write JSON to `path` resiliently against transient BlockingIOError/OSError
@@ -112,6 +162,12 @@ class NOAADataPoller:
         """
         self.kafka_topic = kafka_topic
         self.last_polled_file = last_polled_file
+        self.rate_limiter = _RateLimiter(MIN_REQUEST_INTERVAL)
+        # Current stand-down window after a 403/429; grows on repeat offences.
+        self.rate_limit_cooldown = RATE_LIMIT_COOLDOWN
+        # (product, station_id) -> consecutive-empty count / cycles left to skip
+        self.empty_streak: Dict[tuple, int] = {}
+        self.skip_cycles: Dict[tuple, int] = {}
         from confluent_kafka import Producer
         kafka_producer = Producer(kafka_config)
         self.producer = MicrosoftOpenDataUSNOAAEventProducer(kafka_producer, kafka_topic)
@@ -138,6 +194,7 @@ class NOAADataPoller:
         """
         url = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json"
         try:
+            self.rate_limiter.wait()
             response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=10)
             response.raise_for_status()
             stations_data = response.json()
@@ -226,8 +283,27 @@ class NOAADataPoller:
         else:
             data_key = "data"
         try:
+            self.rate_limiter.wait()
             response = requests.get(product_url, headers={"User-Agent": USER_AGENT}, timeout=10)
+            if response.status_code in (403, 429):
+                # NOAA's API Gateway blocks abusive callers at the IP level and
+                # keeps returning 403 long after the offending traffic stops.
+                # Stand down for a growing window rather than hammering on and
+                # deepening the ban.
+                import time
+                print(
+                    f"NOAA API returned {response.status_code} for station {station_id} "
+                    f"({product}); backing off {self.rate_limit_cooldown:.0f}s. If this "
+                    f"persists across all stations, this source IP is likely blocked "
+                    f"by NOAA and must be changed or unblocked."
+                )
+                time.sleep(self.rate_limit_cooldown)
+                self.rate_limit_cooldown = min(
+                    self.rate_limit_cooldown * 2, MAX_RATE_LIMIT_COOLDOWN)
+                return []
             response.raise_for_status()
+            # Successful call -- reset the escalating cooldown.
+            self.rate_limit_cooldown = RATE_LIMIT_COOLDOWN
             if data_key is None:
                 data = response.json().get("current_predictions", {}).get("cp", [])
             else:
@@ -309,11 +385,32 @@ class NOAADataPoller:
                 station_id = station.station_id
                 station_region = getattr(station, "region", None) or "unknown"
                 for product in self.PRODUCTS:
+                    pair = (product, station_id)
+                    # Most stations do not offer most products. Skip pairs that
+                    # have repeatedly come back empty so we spend our limited
+                    # request budget on pairs that actually carry data.
+                    remaining = self.skip_cycles.get(pair, 0)
+                    if remaining > 0:
+                        self.skip_cycles[pair] = remaining - 1
+                        continue
                     print(f"Polling {product} data for station {station_id}: {station.name}:", end='')
                     last_polled_time = last_polled_times.get(product, {}).get(
                         station_id, datetime.now(timezone.utc) - timedelta(hours=24))
                     new_data_records = self.poll_noaa_api(product, station_id, last_polled_time)
                     print(f" {len(new_data_records)} new records found since {last_polled_time}")
+
+                    if new_data_records:
+                        self.empty_streak.pop(pair, None)
+                    else:
+                        streak = self.empty_streak.get(pair, 0) + 1
+                        self.empty_streak[pair] = streak
+                        if streak >= EMPTY_BACKOFF_THRESHOLD:
+                            # Exponential in the number of empties past the
+                            # threshold, capped so a pair is always retried
+                            # eventually (a station may start reporting later).
+                            self.skip_cycles[pair] = min(
+                                2 ** (streak - EMPTY_BACKOFF_THRESHOLD + 1),
+                                MAX_EMPTY_BACKOFF)
 
                     max_timestamp = last_polled_time
                     for record in new_data_records:
@@ -489,6 +586,14 @@ class NOAADataPoller:
 
             if os.getenv('ONCE_MODE', 'false').lower() in ('true', '1', 'yes'):
                 break
+
+            # NOAA observations are 6-minute-interval at best, so re-polling
+            # sooner than this cannot surface new data and only burns request
+            # budget against an API that IP-bans abusive callers.
+            if POLL_INTERVAL > 0:
+                import time
+                print(f"Poll cycle complete; sleeping {POLL_INTERVAL:.0f}s before next cycle.")
+                time.sleep(POLL_INTERVAL)
 
 
 def parse_connection_string(connection_string: str) -> Dict[str, str]:

--- a/feeders/noaa/noaa_core/noaa_core/__init__.py
+++ b/feeders/noaa/noaa_core/noaa_core/__init__.py
@@ -14,6 +14,7 @@ MQTT and AMQP feeders.
 
 import json
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, List, Optional
 
@@ -29,6 +30,41 @@ USER_AGENT = os.environ.get("USER_AGENT") or (
 
 SOURCE_URI = "https://api.tidesandcurrents.noaa.gov"
 STATIONS_URL = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json"
+
+# --- Outbound request pacing -------------------------------------------------
+# NOAA CO-OPS publishes no numeric rate limit for the `datagetter` API, but its
+# AWS API Gateway *will* hard-ban a source IP that polls abusively, returning
+# `403 ForbiddenException` for every subsequent request. Keep these defaults in
+# sync with the Kafka feeder (`noaa/noaa.py`).
+MIN_REQUEST_INTERVAL = float(os.environ.get("NOAA_MIN_REQUEST_INTERVAL", "1.0"))
+POLL_INTERVAL = float(os.environ.get("NOAA_POLL_INTERVAL", "900"))
+RATE_LIMIT_COOLDOWN = float(os.environ.get("NOAA_RATE_LIMIT_COOLDOWN", "300"))
+MAX_RATE_LIMIT_COOLDOWN = float(os.environ.get("NOAA_MAX_RATE_LIMIT_COOLDOWN", "3600"))
+
+
+class RateLimiter:
+    """
+    Simple monotonic-clock spacing gate shared by every outbound NOAA request.
+
+    `wait()` blocks until at least `min_interval` seconds have elapsed since
+    the previous call, guaranteeing a hard ceiling on outbound request rate
+    regardless of how fast the caller's poll loop iterates.
+    """
+
+    def __init__(self, min_interval: float = MIN_REQUEST_INTERVAL):
+        self.min_interval = max(0.0, min_interval)
+        self._last_call = 0.0
+
+    def wait(self) -> None:
+        """Block until the configured minimum spacing has elapsed."""
+        if self.min_interval <= 0:
+            return
+        now = time.monotonic()
+        elapsed = now - self._last_call
+        if 0 <= elapsed < self.min_interval:
+            time.sleep(self.min_interval - elapsed)
+        self._last_call = time.monotonic()
+
 
 VISIBILITY_DATASCHEMA = (
     "#/schemagroups/Microsoft.OpenData.US.NOAA.jstruct/schemas/"
@@ -78,6 +114,9 @@ class NOAAClient:
     def __init__(self, user_agent: str = USER_AGENT, request_timeout: float = 10.0):
         self.user_agent = user_agent
         self.request_timeout = request_timeout
+        self.rate_limiter = RateLimiter(MIN_REQUEST_INTERVAL)
+        # Current stand-down window after a 403/429; grows on repeat offences.
+        self.rate_limit_cooldown = RATE_LIMIT_COOLDOWN
 
     def _headers(self) -> Dict[str, str]:
         return {"User-Agent": self.user_agent}
@@ -92,6 +131,7 @@ class NOAAClient:
         decodes cleanly.
         """
         try:
+            self.rate_limiter.wait()
             response = requests.get(
                 STATIONS_URL, headers=self._headers(), timeout=self.request_timeout
             )
@@ -164,10 +204,29 @@ class NOAAClient:
             data_key = "data"
 
         try:
+            self.rate_limiter.wait()
             response = requests.get(
                 product_url, headers=self._headers(), timeout=self.request_timeout
             )
+            if response.status_code in (403, 429):
+                # NOAA's API Gateway blocks abusive callers at the IP level and
+                # keeps returning 403 long after the offending traffic stops.
+                # Stand down for a growing window rather than hammering on and
+                # deepening the ban.
+                print(
+                    f"NOAA API returned {response.status_code} for station {station_id} "
+                    f"({product}); backing off {self.rate_limit_cooldown:.0f}s. If this "
+                    f"persists across all stations, this source IP is likely blocked "
+                    f"by NOAA and must be changed or unblocked."
+                )
+                time.sleep(self.rate_limit_cooldown)
+                self.rate_limit_cooldown = min(
+                    self.rate_limit_cooldown * 2, MAX_RATE_LIMIT_COOLDOWN
+                )
+                return []
             response.raise_for_status()
+            # Successful call -- reset the escalating cooldown.
+            self.rate_limit_cooldown = RATE_LIMIT_COOLDOWN
             if data_key is None:
                 return response.json().get("current_predictions", {}).get("cp", [])
             return response.json().get(data_key, [])

--- a/feeders/noaa/tests/conftest.py
+++ b/feeders/noaa/tests/conftest.py
@@ -7,6 +7,13 @@ _FEEDER_DIR = os.path.abspath(os.path.join(_TEST_DIR, ".."))
 
 _EXTRA_PATHS = [
     _FEEDER_DIR,
+    # The transport-agnostic core and the MQTT/AMQP apps each live one level
+    # deeper than their wrapper directory (e.g. `noaa_core/noaa_core/`). The
+    # wrapper dirs sit directly under _FEEDER_DIR, so without these entries
+    # `import noaa_core` resolves to the *wrapper* as an empty namespace
+    # package and `from noaa_core import NOAAClient` fails with
+    # "unknown location".
+    os.path.join(_FEEDER_DIR, "noaa_core"),
     os.path.join(_FEEDER_DIR, "noaa_producer", "noaa_producer_data", "src"),
     os.path.join(_FEEDER_DIR, "noaa_producer", "noaa_producer_kafka_producer", "src"),
 ]

--- a/feeders/noaa/tests/test_noaa_core.py
+++ b/feeders/noaa/tests/test_noaa_core.py
@@ -125,3 +125,72 @@ def test_last_polled_roundtrip(tmp_path):
     noaa_core.save_last_polled_times(path, times)
     loaded = noaa_core.load_last_polled_times(path)
     assert loaded["water_level"]["9447130"] == times["water_level"]["9447130"]
+
+
+def test_poll_product_backs_off_on_403(requests_mock, monkeypatch):
+    """A 403 must stand down and escalate the cooldown instead of raising.
+
+    NOAA's API Gateway IP-bans abusive callers; retrying immediately deepens
+    the ban, so the client sleeps and doubles its cooldown.
+    """
+    requests_mock.get(NOAAClient.BASE_URL, status_code=403, json={"message": "Forbidden"})
+    slept = []
+    monkeypatch.setattr(noaa_core.time, "sleep", slept.append)
+
+    client = NOAAClient()
+    baseline = client.rate_limit_cooldown
+    rows = client.poll_product(
+        "water_level", "9447130", "MLLW", dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    )
+
+    assert rows == []
+    assert slept == [baseline]
+    assert client.rate_limit_cooldown == baseline * 2
+
+
+def test_poll_product_backs_off_on_429(requests_mock, monkeypatch):
+    """429 is treated the same as 403."""
+    requests_mock.get(NOAAClient.BASE_URL, status_code=429, json={})
+    slept = []
+    monkeypatch.setattr(noaa_core.time, "sleep", slept.append)
+
+    client = NOAAClient()
+    assert client.poll_product(
+        "water_level", "9447130", "MLLW", dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    ) == []
+    assert slept  # we actually stood down
+
+
+def test_successful_poll_resets_cooldown(requests_mock):
+    """A good response clears an escalated cooldown back to the baseline."""
+    requests_mock.get(NOAAClient.BASE_URL, json={"data": []})
+    client = NOAAClient()
+    client.rate_limit_cooldown = noaa_core.RATE_LIMIT_COOLDOWN * 8
+    client.poll_product(
+        "water_level", "9447130", "MLLW", dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    )
+    assert client.rate_limit_cooldown == noaa_core.RATE_LIMIT_COOLDOWN
+
+
+def test_rate_limiter_enforces_minimum_spacing(monkeypatch):
+    """The limiter sleeps for exactly the remaining gap between calls."""
+    limiter = noaa_core.RateLimiter(2.0)
+    ticks = iter([50.0, 50.0, 50.5, 50.5])
+    slept = []
+    monkeypatch.setattr(noaa_core.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(noaa_core.time, "sleep", slept.append)
+
+    limiter.wait()  # primes the clock
+    limiter.wait()  # only 0.5s elapsed -> sleep the remaining 1.5s
+
+    assert slept == [1.5]
+
+
+def test_rate_limiter_zero_interval_never_sleeps(monkeypatch):
+    """A zero interval disables pacing entirely."""
+    limiter = noaa_core.RateLimiter(0)
+    slept = []
+    monkeypatch.setattr(noaa_core.time, "sleep", slept.append)
+    limiter.wait()
+    limiter.wait()
+    assert slept == []

--- a/feeders/noaa/tests/test_noaa_unit.py
+++ b/feeders/noaa/tests/test_noaa_unit.py
@@ -276,6 +276,108 @@ class TestNOAAConfiguration:
 
 
 @pytest.mark.unit
+class TestRateLimiting:
+    """Unit tests for outbound request pacing and rate-limit backoff.
+
+    NOAA's API Gateway IP-bans abusive callers, so these behaviours are what
+    keep the feeder from getting blocked again.
+    """
+
+    @pytest.fixture
+    def mock_kafka_config(self):
+        """Minimal Kafka config; the producer itself is patched out."""
+        return {'bootstrap.servers': 'test-server:9092'}
+
+    def test_rate_limiter_spaces_requests(self):
+        """The limiter must sleep for the remaining gap between calls."""
+        from noaa.noaa import _RateLimiter
+
+        limiter = _RateLimiter(1.0)
+        with patch('time.monotonic', side_effect=[100.0, 100.0, 100.4, 100.4]), \
+                patch('time.sleep') as mock_sleep:
+            limiter.wait()   # first call primes the clock, no sleep
+            limiter.wait()   # 0.4s elapsed -> must sleep the remaining 0.6s
+        mock_sleep.assert_called_once()
+        assert mock_sleep.call_args[0][0] == pytest.approx(0.6)
+
+    def test_rate_limiter_disabled_when_zero(self):
+        """A zero interval disables pacing entirely (no sleep at all)."""
+        from noaa.noaa import _RateLimiter
+
+        limiter = _RateLimiter(0)
+        with patch('time.sleep') as mock_sleep:
+            limiter.wait()
+            limiter.wait()
+        mock_sleep.assert_not_called()
+
+    @patch('noaa.noaa.MicrosoftOpenDataUSNOAAEventProducer')
+    @patch('noaa.noaa.requests.get')
+    def test_poll_backs_off_and_escalates_on_403(self, mock_get, mock_producer, mock_kafka_config):
+        """A 403 must trigger a stand-down and double the cooldown, not raise."""
+        from noaa.noaa import RATE_LIMIT_COOLDOWN
+
+        mock_response = Mock()
+        mock_response.json.return_value = {'stations': []}
+        mock_get.return_value = mock_response
+
+        with patch('noaa.noaa.Station.schema') as mock_schema:
+            mock_schema.return_value.load.return_value = []
+            poller = NOAADataPoller(
+                kafka_config=mock_kafka_config,
+                kafka_topic='test-topic',
+                last_polled_file='/tmp/test_last_polled.json'
+            )
+            poller.stations = [Mock(station_id='9444900', tideType='Harmonic')]
+
+            forbidden = Mock()
+            forbidden.status_code = 403
+            mock_get.return_value = forbidden
+
+            with patch('time.sleep') as mock_sleep:
+                result = poller.poll_noaa_api(
+                    'water_level', '9444900',
+                    datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+            # No data, no exception, and we actually stood down.
+            assert result == []
+            assert mock_sleep.call_args[0][0] == pytest.approx(RATE_LIMIT_COOLDOWN)
+            # Cooldown escalates so repeat offences back off harder.
+            assert poller.rate_limit_cooldown == pytest.approx(RATE_LIMIT_COOLDOWN * 2)
+
+    @patch('noaa.noaa.MicrosoftOpenDataUSNOAAEventProducer')
+    @patch('noaa.noaa.requests.get')
+    def test_successful_poll_resets_cooldown(self, mock_get, mock_producer, mock_kafka_config):
+        """A good response must reset an escalated cooldown back to baseline."""
+        from noaa.noaa import RATE_LIMIT_COOLDOWN
+
+        mock_response = Mock()
+        mock_response.json.return_value = {'stations': []}
+        mock_get.return_value = mock_response
+
+        with patch('noaa.noaa.Station.schema') as mock_schema:
+            mock_schema.return_value.load.return_value = []
+            poller = NOAADataPoller(
+                kafka_config=mock_kafka_config,
+                kafka_topic='test-topic',
+                last_polled_file='/tmp/test_last_polled.json'
+            )
+            poller.stations = [Mock(station_id='9444900', tideType='Harmonic')]
+            poller.rate_limit_cooldown = RATE_LIMIT_COOLDOWN * 8
+
+            ok = Mock()
+            ok.status_code = 200
+            ok.json.return_value = {'data': [{'t': '2026-01-01 00:00', 'v': '1.0'}]}
+            mock_get.return_value = ok
+
+            result = poller.poll_noaa_api(
+                'water_level', '9444900',
+                datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+            assert len(result) == 1
+            assert poller.rate_limit_cooldown == pytest.approx(RATE_LIMIT_COOLDOWN)
+
+
+@pytest.mark.unit
 class TestKafkaConfiguration:
     """Unit tests for Kafka configuration"""
 


### PR DESCRIPTION
## Problem

Both NOAA feeders (
oaa-puget, 
oaa-tac) are delivering **zero data**. Every request to the CO-OPS `datagetter` API returns:

```
403  x-amzn-ErrorType: ForbiddenException  {"message":"Forbidden"}
```

## Diagnosis

This is an **IP-level block at NOAA's AWS API Gateway**, not an application bug:

| Probe | Result |
|---|---|
| `datagetter` from workstation | **200** |
| `datagetter` from pod (repo UA / browser UA / no UA) | **403** (all three) |
| `mdapi/.../stations.json` from pod (**same hostname**) | **200** |
| `www.tidesandcurrents.noaa.gov` + `api.github.com` from pod | **200** |
| 6 probes over 60s from pod | **0 OK / 6 Forbidden** |

Same host works, a different API path is banned, and it is persistent -- a targeted API Gateway policy block on our egress IP.

## Root cause

The poll loop had **no throttling at any level** -- no delay between requests, none between cycles, straight through `while True:`.

- `noaa-puget`: 7 stations x 12 products = **84 req/cycle**, cycle ~20s
- `noaa-tac`: no station filter, so the entire **301-station** catalog x 12 products = **3,612 req/cycle**, looping continuously

Combined ≈ **9 req/s sustained, ~780k requests/day** from one IP. NOAA publishes no numeric limit but does automatically block abusive polling.

## Changes

- Shared `RateLimiter` enforcing minimum spacing between every outbound request (default **1.0s**), applied to both the datagetter and station-metadata calls.
- **403/429 treated as rate limiting**: stand down for a cooldown that doubles per consecutive occurrence (300s → capped 3600s), reset on success. Log line names IP blocking as the likely cause.
- **Real inter-cycle sleep** for the Kafka feeder (default 900s). NOAA data is 6-minute-interval at best. MQTT/AMQP already paced at 300s and now inherit per-request pacing + backoff via `noaa_core`.
- **Skip guaranteed-empty (product, station) pairs** with capped exponential backoff. Most stations do not offer currents / currents_predictions / salinity / conductivity.
- Applied to `noaa_core` too, so **all three transports** are covered.

All knobs are env-overridable and documented in `CONTAINER.md`.

## Drive-by fix (pre-existing, per "All Issues Are Issues")

`tests/conftest.py` put the feeder dir first on `sys.path`, so `import noaa_core` resolved to the outer wrapper directory as an empty namespace package and **the entire `test_noaa_core.py` module failed to import**. Adding the inner package dir -- as the producer paths already are -- brings those 9 tests back into the suite for the first time.

## Validation

- **58 passed**, 1 pre-existing skip (previously 40 passed with `test_noaa_core.py` entirely uncollectable)
- `mypy`: Success, no issues found in 11 source files
- `py_compile` / import-smoke plan: OK
- **Live run** against station 9444900 confirms exact 1.0s spacing and real records returned:
  ```
  water_level 19 records 1.45s
  air_temperature 19 records 2.53s
  wind 19 records 3.53s
  ```

## Follow-up (not in this PR)

This prevents **re-triggering** the ban but does not **lift** the existing one, which is held at NOAA's gateway against the current AKS egress IP. Moving the feeders to a different egress IP is handled separately.